### PR TITLE
toplevel error handler: show tracebacks

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -146,10 +146,10 @@ or::
 Remote operations over SSH can be automated with SSH keys. You can restrict the
 use of the SSH keypair by prepending a forced command to the SSH public key in
 the remote server's authorized_keys file. Only the forced command will be run
-when the key authenticates a connection. This example will start attic in server
-mode, and limit the attic server to a specific filesystem path::
+when the key authenticates a connection. This example will start |project_name| in server
+mode, and limit the |project_name| server to a specific filesystem path::
 
-  command="attic serve --restrict-to-path /mnt/backup" ssh-rsa AAAAB3[...]
+  command="borg serve --restrict-to-path /mnt/backup" ssh-rsa AAAAB3[...]
 
 If it is not possible to install |project_name| on the remote host,
 it is still possible to use the remote host to store a repository by

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -175,8 +175,8 @@ Examples
 ~~~~~~~~
 ::
 
-    # Allow an SSH keypair to only run attic, and only have access to /mnt/backup.
+    # Allow an SSH keypair to only run |project_name|, and only have access to /mnt/backup.
     # This will help to secure an automated remote backup system.
     $ cat ~/.ssh/authorized_keys
-    command="attic serve --restrict-to-path /mnt/backup" ssh-rsa AAAAB3[...]
+    command="borg serve --restrict-to-path /mnt/backup" ssh-rsa AAAAB3[...]
 


### PR DESCRIPTION
do not hide useful information