### PR TITLE
style and cosmetic fixes, no semantic changes

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -107,7 +107,7 @@ class ChunkBuffer:
 class CacheChunkBuffer(ChunkBuffer):
 
     def __init__(self, cache, key, stats, chunker_params=CHUNKER_PARAMS):
-        super(CacheChunkBuffer, self).__init__(key, chunker_params)
+        super().__init__(key, chunker_params)
         self.cache = cache
         self.stats = stats
 
@@ -126,7 +126,6 @@ class Archive:
 
     class IncompatibleFilesystemEncodingError(Error):
         """Failed to encode filename "{}" into file system encoding "{}". Consider configuring the LANG environment variable."""
-
 
     def __init__(self, repository, key, manifest, name, cache=None, create=False,
                  checkpoint_interval=300, numeric_owner=False, progress=False,
@@ -232,9 +231,11 @@ class Archive:
             count, size, csize = cache.chunks[id]
             stats.update(size, csize, count == 1)
             cache.chunks[id] = count - 1, size, csize
+
         def add_file_chunks(chunks):
             for id, _, _ in chunks:
                 add(id)
+
         # This function is a bit evil since it abuses the cache to calculate
         # the stats. The cache transaction must be rolled back afterwards
         unpacker = msgpack.Unpacker(use_list=False)
@@ -551,7 +552,7 @@ class RobustUnpacker():
     item_keys = [msgpack.packb(name) for name in ('path', 'mode', 'source', 'chunks', 'rdev', 'xattrs', 'user', 'group', 'uid', 'gid', 'mtime')]
 
     def __init__(self, validator):
-        super(RobustUnpacker, self).__init__()
+        super().__init__()
         self.validator = validator
         self._buffered_data = []
         self._resync = False
@@ -810,4 +811,3 @@ class ArchiveChecker:
                 self.repository.delete(id_)
             self.manifest.write()
             self.repository.commit()
-

--- a/borg/cache.py
+++ b/borg/cache.py
@@ -21,7 +21,6 @@ class Cache:
     class RepositoryReplay(Error):
         """Cache is newer than repository, refusing to continue"""
 
-
     class CacheInitAbortedError(Error):
         """Cache initialization aborted"""
 

--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -34,7 +34,7 @@ class FuseOperations(llfuse.Operations):
     """Export archive as a fuse filesystem
     """
     def __init__(self, key, repository, manifest, archive):
-        super(FuseOperations, self).__init__()
+        super().__init__()
         self._inode_count = 0
         self.key = key
         self.repository = cache_if_remote(repository)

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -73,10 +73,13 @@ class UpgradableLock:
 
 def check_extension_modules():
     from . import platform
-    if (hashindex.API_VERSION != 2 or
-        chunker.API_VERSION != 2 or
-        crypto.API_VERSION != 2 or
-        platform.API_VERSION != 2):
+    if hashindex.API_VERSION != 2:
+        raise ExtensionModuleError
+    if chunker.API_VERSION != 2:
+        raise ExtensionModuleError
+    if crypto.API_VERSION != 2:
+        raise ExtensionModuleError
+    if platform.API_VERSION != 2:
         raise ExtensionModuleError
 
 
@@ -529,9 +532,9 @@ class Location:
             else:
                 path = self.path
             return 'ssh://{}{}{}{}'.format('{}@'.format(self.user) if self.user else '',
-                                                        self.host,
-                                                        ':{}'.format(self.port) if self.port else '',
-                                                        path)
+                                           self.host,
+                                           ':{}'.format(self.port) if self.port else '',
+                                           path)
 
 
 def location_validator(archive=None):
@@ -606,7 +609,7 @@ def daemonize():
 class StableDict(dict):
     """A dict subclass with stable items() ordering"""
     def items(self):
-        return sorted(super(StableDict, self).items())
+        return sorted(super().items())
 
 
 if sys.version < '3.3':
@@ -642,4 +645,3 @@ def int_to_bigint(value):
     if value.bit_length() > 63:
         return value.to_bytes((value.bit_length() + 9) // 8, 'little', signed=True)
     return value
-

--- a/borg/key.py
+++ b/borg/key.py
@@ -17,6 +17,7 @@ class UnsupportedPayloadError(Error):
     """Unsupported payload type {}. A newer version is required to access this repository.
     """
 
+
 class KeyfileNotFoundError(Error):
     """No key file for repository {} found in {}.
     """
@@ -231,8 +232,7 @@ class KeyfileKey(AESKeyBase):
             filename = os.path.join(keys_dir, name)
             with open(filename, 'r') as fd:
                 line = fd.readline().strip()
-                if (line and line.startswith(cls.FILE_ID) and
-                    line[len(cls.FILE_ID)+1:] == id):
+                if line and line.startswith(cls.FILE_ID) and line[len(cls.FILE_ID)+1:] == id:
                     return filename
         raise KeyfileNotFoundError(repository._location.canonical_path(), get_keys_dir())
 

--- a/borg/lrucache.py
+++ b/borg/lrucache.py
@@ -1,7 +1,7 @@
 class LRUCache(dict):
 
     def __init__(self, capacity):
-        super(LRUCache, self).__init__()
+        super().__init__()
         self._lru = []
         self._capacity = capacity
 
@@ -13,7 +13,7 @@ class LRUCache(dict):
         self._lru.append(key)
         while len(self._lru) > self._capacity:
             del self[self._lru[0]]
-        return super(LRUCache, self).__setitem__(key, value)
+        return super().__setitem__(key, value)
 
     def __getitem__(self, key):
         try:
@@ -21,21 +21,21 @@ class LRUCache(dict):
             self._lru.append(key)
         except ValueError:
             pass
-        return super(LRUCache, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __delitem__(self, key):
         try:
             self._lru.remove(key)
         except ValueError:
             pass
-        return super(LRUCache, self).__delitem__(key)
+        return super().__delitem__(key)
 
     def pop(self, key, default=None):
         try:
             self._lru.remove(key)
         except ValueError:
             pass
-        return super(LRUCache, self).pop(key, default)
+        return super().pop(key, default)
 
     def _not_implemented(self, *args, **kw):
         raise NotImplementedError

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -25,24 +25,25 @@ class ConnectionClosed(Error):
 class PathNotAllowed(Error):
     """Repository path not allowed"""
 
+
 class InvalidRPCMethod(Error):
     """RPC method is not valid"""
 
 
 class RepositoryServer:
     rpc_methods = (
-            '__len__',
-            'check',
-            'commit',
-            'delete',
-            'get',
-            'list',
-            'negotiate',
-            'open',
-            'put',
-            'repair',
-            'rollback',
-            )
+        '__len__',
+        'check',
+        'commit',
+        'delete',
+        'get',
+        'list',
+        'negotiate',
+        'open',
+        'put',
+        'repair',
+        'rollback',
+    )
 
     def __init__(self, restrict_to_paths):
         self.repository = None
@@ -71,7 +72,7 @@ class RepositoryServer:
                     type, msgid, method, args = unpacked
                     method = method.decode('ascii')
                     try:
-                        if not method in self.rpc_methods:
+                        if method not in self.rpc_methods:
                             raise InvalidRPCMethod(method)
                         try:
                             f = getattr(self, method)

--- a/borg/testsuite/__init__.py
+++ b/borg/testsuite/__init__.py
@@ -119,5 +119,3 @@ class TestLoader(unittest.TestLoader):
             if pattern.lower() in test.id().lower():
                 tests.addTest(test)
         return tests
-
-

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -24,7 +24,7 @@ from .mock import patch
 
 try:
     import llfuse
-    has_llfuse = True
+    has_llfuse = True or llfuse  # avoids "unused import"
 except ImportError:
     has_llfuse = False
 
@@ -143,7 +143,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.create_regular_file('empty', size=0)
         # next code line raises OverflowError on 32bit cpu (raspberry pi 2):
         # 2600-01-01 > 2**64 ns
-        #os.utime('input/empty', (19880895600, 19880895600))
+        # os.utime('input/empty', (19880895600, 19880895600))
         # thus, we better test with something not that far in future:
         # 2038-01-19 (1970 + 2^31 - 1 seconds) is the 32bit "deadline":
         os.utime('input/empty', (2**31 - 1, 2**31 - 1))
@@ -157,9 +157,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         os.chmod('input/file1', 0o7755)
         os.chmod('input/dir2', 0o555)
         # Block device
-        os.mknod('input/bdev', 0o600 | stat.S_IFBLK,  os.makedev(10, 20))
+        os.mknod('input/bdev', 0o600 | stat.S_IFBLK, os.makedev(10, 20))
         # Char device
-        os.mknod('input/cdev', 0o600 | stat.S_IFCHR,  os.makedev(30, 40))
+        os.mknod('input/cdev', 0o600 | stat.S_IFCHR, os.makedev(30, 40))
         # Hard link
         os.link(os.path.join(self.input_path, 'file1'),
                 os.path.join(self.input_path, 'hardlink'))
@@ -172,7 +172,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             # same for newer ubuntu and centos.
             # if this is supported just on specific platform, platform should be checked first,
             # so that the test setup for all tests using it does not fail here always for others.
-            #xattr.setxattr(os.path.join(self.input_path, 'link1'), 'user.foo_symlink', b'bar_symlink', follow_symlinks=False)
+            # xattr.setxattr(os.path.join(self.input_path, 'link1'), 'user.foo_symlink', b'bar_symlink', follow_symlinks=False)
         # FIFO node
         os.mkfifo(os.path.join(self.input_path, 'fifo1'))
         if has_lchflags:
@@ -253,7 +253,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=none', self.repository_location)
         self._set_repository_id(self.repository_path, repository_id)
         self.assert_equal(repository_id, self._extract_repository_id(self.repository_path))
-        self.assert_raises(Cache.EncryptionMethodMismatch, lambda :self.cmd('create', self.repository_location + '::test.2', 'input'))
+        self.assert_raises(Cache.EncryptionMethodMismatch, lambda: self.cmd('create', self.repository_location + '::test.2', 'input'))
 
     def test_repository_swap_detection2(self):
         self.create_test_files()
@@ -263,7 +263,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('create', self.repository_location + '_encrypted::test', 'input')
         shutil.rmtree(self.repository_path + '_encrypted')
         os.rename(self.repository_path + '_unencrypted', self.repository_path + '_encrypted')
-        self.assert_raises(Cache.RepositoryAccessAborted, lambda :self.cmd('create', self.repository_location + '_encrypted::test.2', 'input'))
+        self.assert_raises(Cache.RepositoryAccessAborted, lambda: self.cmd('create', self.repository_location + '_encrypted::test.2', 'input'))
 
     def test_strip_components(self):
         self.cmd('init', self.repository_location)
@@ -524,7 +524,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 class ArchiverCheckTestCase(ArchiverTestCaseBase):
 
     def setUp(self):
-        super(ArchiverCheckTestCase, self).setUp()
+        super().setUp()
         with patch.object(ChunkBuffer, 'BUFFER_SIZE', 10):
             self.cmd('init', self.repository_location)
             self.create_src_archive('archive1')

--- a/borg/testsuite/helpers.py
+++ b/borg/testsuite/helpers.py
@@ -7,7 +7,7 @@ import unittest
 
 import msgpack
 
-from ..helpers import adjust_patterns, exclude_path, Location, format_timedelta, IncludePattern, ExcludePattern, make_path_safe, UpgradableLock, prune_within, prune_split, to_localtime, \
+from ..helpers import adjust_patterns, exclude_path, Location, format_timedelta, ExcludePattern, make_path_safe, UpgradableLock, prune_within, prune_split, \
     StableDict, int_to_bigint, bigint_to_int, parse_timestamp
 from . import BaseTestCase
 
@@ -96,7 +96,7 @@ class PatternTestCase(BaseTestCase):
                           ['/etc/passwd', '/etc/hosts', '/home', '/var/log/messages', '/var/log/dmesg'])
         self.assert_equal(self.evaluate(['/home/u'], []), [])
         self.assert_equal(self.evaluate(['/', '/home', '/etc/hosts'], ['/']), [])
-        self.assert_equal(self.evaluate(['/home/'], ['/home/user2']), 
+        self.assert_equal(self.evaluate(['/home/'], ['/home/user2']),
                           ['/home', '/home/user/.profile', '/home/user/.bashrc'])
         self.assert_equal(self.evaluate(['/'], ['*.profile', '/var/log']),
                           ['/etc/passwd', '/etc/hosts', '/home', '/home/user/.bashrc', '/home/user2/public_html/index.html'])
@@ -117,6 +117,7 @@ class MakePathSafeTestCase(BaseTestCase):
         self.assert_equal(make_path_safe('../../foo/bar'), 'foo/bar')
         self.assert_equal(make_path_safe('/'), '.')
         self.assert_equal(make_path_safe('/'), '.')
+
 
 class UpgradableLockTestCase(BaseTestCase):
 
@@ -161,7 +162,7 @@ class PruneSplitTestCase(BaseTestCase):
             for ta in test_archives, reversed(test_archives):
                 self.assert_equal(set(prune_split(ta, '%Y-%m', n, skip)),
                                   subset(test_archives, indices))
-            
+
         test_pairs = [(1, 1), (2, 1), (2, 28), (3, 1), (3, 2), (3, 31), (5, 1)]
         test_dates = [local_to_UTC(month, day) for month, day in test_pairs]
         test_archives = [MockArchive(date) for date in test_dates]
@@ -185,24 +186,24 @@ class PruneWithinTestCase(BaseTestCase):
             for ta in test_archives, reversed(test_archives):
                 self.assert_equal(set(prune_within(ta, within)),
                                   subset(test_archives, indices))
-            
+
         # 1 minute, 1.5 hours, 2.5 hours, 3.5 hours, 25 hours, 49 hours
         test_offsets = [60, 90*60, 150*60, 210*60, 25*60*60, 49*60*60]
         now = datetime.now(timezone.utc)
         test_dates = [now - timedelta(seconds=s) for s in test_offsets]
         test_archives = [MockArchive(date) for date in test_dates]
 
-        dotest(test_archives, '1H',  [0])
-        dotest(test_archives, '2H',  [0, 1])
-        dotest(test_archives, '3H',  [0, 1, 2])
+        dotest(test_archives, '1H', [0])
+        dotest(test_archives, '2H', [0, 1])
+        dotest(test_archives, '3H', [0, 1, 2])
         dotest(test_archives, '24H', [0, 1, 2, 3])
         dotest(test_archives, '26H', [0, 1, 2, 3, 4])
-        dotest(test_archives, '2d',  [0, 1, 2, 3, 4])
+        dotest(test_archives, '2d', [0, 1, 2, 3, 4])
         dotest(test_archives, '50H', [0, 1, 2, 3, 4, 5])
-        dotest(test_archives, '3d',  [0, 1, 2, 3, 4, 5])
-        dotest(test_archives, '1w',  [0, 1, 2, 3, 4, 5])
-        dotest(test_archives, '1m',  [0, 1, 2, 3, 4, 5])
-        dotest(test_archives, '1y',  [0, 1, 2, 3, 4, 5])
+        dotest(test_archives, '3d', [0, 1, 2, 3, 4, 5])
+        dotest(test_archives, '1w', [0, 1, 2, 3, 4, 5])
+        dotest(test_archives, '1m', [0, 1, 2, 3, 4, 5])
+        dotest(test_archives, '1y', [0, 1, 2, 3, 4, 5])
 
 
 class StableDictTestCase(BaseTestCase):

--- a/borg/testsuite/platform.py
+++ b/borg/testsuite/platform.py
@@ -102,4 +102,3 @@ class PlatformDarwinTestCase(BaseTestCase):
         self.set_acl(file2.name, b'!#acl 1\ngroup:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\nuser:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n', numeric_owner=True)
         self.assert_in(b'group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read', self.get_acl(file2.name)[b'acl_extended'])
         self.assert_in(b'group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read', self.get_acl(file2.name, numeric_owner=True)[b'acl_extended'])
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 python_files = testsuite/*.py
 
 [flake8]
-ignore = E123,E126,E127,E129,E203,E221,E226,E231,E241,E265,E301,E302,E303,E713,F401,F403,W291,W293,W391
+ignore = E226,F403
 max-line-length = 250
-exclude = versioneer.py,docs/conf.py,borg/_version.py
+exclude = versioneer.py,docs/conf.py,borg/_version.py,build,dist,.git,.idea,.cache
 max-complexity = 100

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ try:
                 'borg/platform_freebsd.c',
                 'borg/platform_darwin.c',
             ])
-            super(Sdist, self).make_distribution()
+            super().make_distribution()
 
 except ImportError:
     class Sdist(versioneer.cmd_sdist):


### PR DESCRIPTION
use simpler super() syntax of python 3.x

remove fixed errors/warnings' codes from setup.cfg flake8 configuration

fix file exclusion list for flake8