### PR TITLE
use entrypoints instead of scripts, for better use of the wheel format and modern installs

### DIFF
--- a/scripts/borg
+++ b/scripts/borg
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from borg.archiver import main
-main()
-

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,8 @@ if sys.version_info < min_python:
     print("Borg requires Python %d.%d or later" % min_python)
     sys.exit(1)
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+
+from setuptools import setup, Extension
 
 crypto_source = 'borg/crypto.pyx'
 chunker_source = 'borg/chunker.pyx'

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,11 @@ setup(
         'Topic :: System :: Archiving :: Backup',
     ],
     packages=['borg', 'borg.testsuite'],
-    scripts=['scripts/borg'],
+    entry_points={
+        'console_scripts': [
+            'borg = borg.archiver:main',
+        ]
+    },
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     # msgpack pure python data corruption was fixed in 0.4.6.


### PR DESCRIPTION
also kills the dist-utils fallback