### PR TITLE
chunker - fix 4GB files on 32-bit systems

### DIFF
--- a/borg/_chunker.c
+++ b/borg/_chunker.c
@@ -163,7 +163,7 @@ chunker_fill(Chunker *c)
         // size limit) kick out data from the cache that might be still useful
         // for the OS or other processes.
         if (length > 0) {
-            posix_fadvise(c->fh, (off_t) offset, (off_t) length, POSIX_FADV_DONTNEED);
+            posix_fadvise(c->fh, offset, length, POSIX_FADV_DONTNEED);
         }
         #endif
     }

--- a/borg/_chunker.c
+++ b/borg/_chunker.c
@@ -83,7 +83,8 @@ typedef struct {
     PyObject *fd;
     int fh;
     int done, eof;
-    size_t remaining, bytes_read, bytes_yielded, position, last;
+    size_t remaining, position, last;
+    off_t bytes_read, bytes_yielded;
 } Chunker;
 
 static Chunker *

--- a/borg/_chunker.c
+++ b/borg/_chunker.c
@@ -96,6 +96,7 @@ chunker_init(int window_size, int chunk_mask, int min_size, int max_size, uint32
     c->table = buzhash_init_table(seed);
     c->buf_size = max_size;
     c->data = malloc(c->buf_size);
+    c->fh = -1;
     return c;
 }
 


### PR DESCRIPTION
From code inspection - effect has not actually been tested.

Also initialize ->fh to -1, so we can't accidentally read from STDIN_FILENO (unix fd 0).