### PR TITLE
add automatically generated API

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -36,7 +36,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html: usage
+html: usage api.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -153,3 +153,18 @@ usage/%.rst.inc: ../borg/archiver.py
 	@borg help $* --usage-only | sed -e 's/^/    /' >> $@
 	@printf "\nDescription\n~~~~~~~~~~~\n" >> $@
 	@borg help $* --epilog-only >> $@
+
+api.rst: Makefile
+	@echo "auto-generating API documentation"
+	@echo "Borg Backup API documentation" > $@
+	@echo "=============================" >> $@
+	@echo "" >> $@
+	@for mod in ../borg/*.pyx ../borg/*.py; do \
+		if echo "$$mod" | grep -q "/_"; then \
+			continue ; \
+		fi ; \
+		printf ".. automodule:: "; \
+		echo "$$mod" | sed "s!\.\./!!;s/\.pyx\?//;s!/!.!"; \
+		echo "    :members:"; \
+		echo "    :undoc-members:"; \
+	done >> $@

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,7 +218,7 @@ latex_documents = [
 #     ['see "AUTHORS" file'], 1)
 #]
 
-extensions = ['sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks', 'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode']
 
 extlinks = {
     'issue': ('https://github.com/borgbackup/borg/issues/%s', '#'),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,3 +16,4 @@ Borg Documentation
    changes
    internals
    development
+   api


### PR DESCRIPTION
this is a crude hack for now, and could use a better table of contents

but at least we have some way of linking and showing the different
internal functions

the next phase here is obviously to document that API through the
addition of docstrings. a static api.rst could also be easier to read,
but maybe that could go through some docstrings as well, to be tested