### PR TITLE
make sure to always give segment and offset in repo IntegrityError ex…

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -301,7 +301,7 @@ class Repository:
             try:
                 objects = list(self.io.iter_objects(segment))
             except IntegrityError as err:
-                report_error('Error reading segment {}: {}'.format(segment, err))
+                report_error(str(err))
                 objects = []
                 if repair:
                     self.io.recover_segment(segment, filename)
@@ -530,11 +530,12 @@ class LoggedIO:
         fd = self.get_fd(segment)
         fd.seek(0)
         if fd.read(MAGIC_LEN) != MAGIC:
-            raise IntegrityError('Invalid segment magic')
+            raise IntegrityError('Invalid segment magic [segment {}, offset {}]'.format(segment, 0))
         offset = MAGIC_LEN
         header = fd.read(self.header_fmt.size)
         while header:
-            size, tag, key, data = self._read(fd, self.header_fmt, header, offset, (TAG_PUT, TAG_DELETE, TAG_COMMIT))
+            size, tag, key, data = self._read(fd, self.header_fmt, header, segment, offset,
+                                              (TAG_PUT, TAG_DELETE, TAG_COMMIT))
             if include_data:
                 yield tag, key, offset, data
             else:
@@ -569,17 +570,19 @@ class LoggedIO:
         fd = self.get_fd(segment)
         fd.seek(offset)
         header = fd.read(self.put_header_fmt.size)
-        size, tag, key, data = self._read(fd, self.put_header_fmt, header, offset, (TAG_PUT, ))
+        size, tag, key, data = self._read(fd, self.put_header_fmt, header, segment, offset, (TAG_PUT, ))
         if id != key:
-            raise IntegrityError('Invalid segment entry header, is not for wanted id [offset {}]'.format(offset))
+            raise IntegrityError('Invalid segment entry header, is not for wanted id [segment {}, offset {}]'.format(
+                segment, offset))
         return data
 
-    def _read(self, fd, fmt, header, offset, acceptable_tags):
+    def _read(self, fd, fmt, header, segment, offset, acceptable_tags):
         # some code shared by read() and iter_objects()
         try:
             hdr_tuple = fmt.unpack(header)
         except struct.error as err:
-            raise IntegrityError('Invalid segment entry header [offset {}]: {}'.format(offset, err))
+            raise IntegrityError('Invalid segment entry header [segment {}, offset {}]: {}'.format(
+                segment, offset, err))
         if fmt is self.put_header_fmt:
             crc, size, tag, key = hdr_tuple
         elif fmt is self.header_fmt:
@@ -588,16 +591,19 @@ class LoggedIO:
         else:
             raise TypeError("_read called with unsupported format")
         if size > MAX_OBJECT_SIZE or size < fmt.size:
-            raise IntegrityError('Invalid segment entry size [offset {}]'.format(offset))
+            raise IntegrityError('Invalid segment entry size [segment {}, offset {}]'.format(
+                segment, offset))
         length = size - fmt.size
         data = fd.read(length)
         if len(data) != length:
-            raise IntegrityError('Segment entry data short read [offset {}]: expected: {}, got {} bytes'.format(
-                                 offset, length, len(data)))
+            raise IntegrityError('Segment entry data short read [segment {}, offset {}]: expected {}, got {} bytes'.format(
+                segment, offset, length, len(data)))
         if crc32(data, crc32(memoryview(header)[4:])) & 0xffffffff != crc:
-            raise IntegrityError('Segment entry checksum mismatch [offset {}]'.format(offset))
+            raise IntegrityError('Segment entry checksum mismatch [segment {}, offset {}]'.format(
+                segment, offset))
         if tag not in acceptable_tags:
-            raise IntegrityError('Invalid segment entry header, did not get acceptable tag [offset {}]'.format(offset))
+            raise IntegrityError('Invalid segment entry header, did not get acceptable tag [segment {}, offset {}]'.format(
+                segment, offset))
         if key is None and tag in (TAG_PUT, TAG_DELETE):
             key, data = data[:32], data[32:]
         return size, tag, key, data


### PR DESCRIPTION
…ception messages

this was only handled correctly at one place, by adding the segment number afterwards.
now the segment number is always included.