### PR TITLE
some fixes to the release engineering docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -113,18 +113,27 @@ Checklist::
   cd docs ; make html
 
 - update website with the html (XXX: how?)
-- create a release on PyPi::
+- write a release notes announcement, with:
+
+  1. a single summary paragraph, outlining major changes, security
+     issues, or deprecation warnings, and generally the severity of
+     the release, with a pointer to ``CHANGES.rst``
+  2. instructions for installing and upgrading borg (pointers to the
+     regular install docs, except for new installation/upgrade methods)
+  3. known issues (to be updated as we go along)
+
+- create a release on PyPi with the above release notes::
 
     python setup.py register sdist upload --identity="Thomas Waldmann" --sign
 
-- close release milestone on Github
-- announce on::
+- announce the release notes on::
 
   - `mailing list <mailto:borgbackup@librelist.org>`_
   - Twitter (XXX: how? where?)
   - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
-- create standalone binaries (see below) and upload them to the Github release
+- create standalone binaries (see below)
+- upload standalone binaries to the Github release, integrate release notes
 
 
 Creating standalone binaries

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -94,7 +94,7 @@ Usage::
 Creating a new release
 ----------------------
 
-Checklist::
+Checklist:
 
 - make sure all issues for this milestone are closed or moved them to
   the next milestone
@@ -106,11 +106,11 @@ Checklist::
 - verify that ``MANIFEST.in`` and ``setup.py`` are complete
 - tag the release::
 
-  git tag -s -m "tagged release" 0.26.0
+    git tag -s -m "tagged release" 0.26.0
 
 - update usage include files::
 
-  cd docs ; make html
+    cd docs ; make html
 
 - update website with the html (XXX: how?)
 - write a release notes announcement, with:
@@ -126,11 +126,11 @@ Checklist::
 
     python setup.py register sdist upload --identity="Thomas Waldmann" --sign
 
-- announce the release notes on::
+- announce the release notes on:
 
-  - `mailing list <mailto:borgbackup@librelist.org>`_
-  - Twitter (XXX: how? where?)
-  - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
+ - `mailing list <mailto:borgbackup@librelist.org>`_
+ - Twitter (XXX: how? where?)
+ - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
 - create standalone binaries (see below)
 - upload standalone binaries to the Github release, integrate release notes

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -124,7 +124,9 @@ Checklist:
  - Twitter (your personnal account, if you have one)
  - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
-- create standalone binaries (see below) and upload them to the Github release
+- create a Github release, include:
+  * standalone binaries (see below for how to create them)
+  * a link to ``CHANGES.rst``
 
 
 Creating standalone binaries

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -100,26 +100,27 @@ Checklist::
 - any low hanging fruit left on the issue tracker?
 - run tox on all supported platforms via vagrant, check for test fails.
 - is Travis CI happy also?
-- update CHANGES.rst (compare to git log). check version number of upcoming release.
+- update CHANGES.rst (compare to git log)
+- check version number of upcoming release
 - check MANIFEST.in and setup.py - are they complete?
 - tag the release::
 
   git tag -s -m "tagged release" 0.26.0
 
 - cd docs ; make html  # to update the usage include files
-- update website with the html
+- update website with the html (XXX: how?)
 - create a release on PyPi::
 
     python setup.py register sdist upload --identity="Thomas Waldmann" --sign
 
-- close release milestone.
+- close release milestone
 - announce on::
 
-  - mailing list
-  - Twitter
-  - IRC channel (topic)
+  - `mailing list <mailto:borgbackup@librelist.org>`_
+  - Twitter (XXX: how? where?)
+  - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
-- create standalone binaries and link them from issue tracker: https://github.com/borgbackup/borg/issues/214
+- create standalone binaries and upload them to the Github release
 
 
 Creating standalone binaries

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -113,27 +113,18 @@ Checklist:
     cd docs ; make html
 
 - update website with the html (XXX: how?)
-- write a release notes announcement, with:
-
-  1. a single summary paragraph, outlining major changes, security
-     issues, or deprecation warnings, and generally the severity of
-     the release, with a pointer to ``CHANGES.rst``
-  2. instructions for installing and upgrading borg (pointers to the
-     regular install docs, except for new installation/upgrade methods)
-  3. known issues (to be updated as we go along)
-
-- create a release on PyPi with the above release notes::
+- create a release on PyPi::
 
     python setup.py register sdist upload --identity="Thomas Waldmann" --sign
 
-- announce the release notes on:
+- close release milestone on Github
+- announce on::
 
  - `mailing list <mailto:borgbackup@librelist.org>`_
  - Twitter (your personnal account, if you have one)
  - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
-- create standalone binaries (see below)
-- upload standalone binaries to the Github release, integrate release notes
+- create standalone binaries (see below) and upload them to the Github release
 
 
 Creating standalone binaries

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -129,7 +129,7 @@ Checklist:
 - announce the release notes on:
 
  - `mailing list <mailto:borgbackup@librelist.org>`_
- - Twitter (XXX: how? where?)
+ - Twitter (your personnal account, if you have one)
  - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
 - create standalone binaries (see below)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -138,7 +138,7 @@ With virtual env activated::
 
   pip install pyinstaller>=3.0  # or git checkout master
   pyinstaller -F -n borg-PLATFORM --hidden-import=logging.config borg/__main__.py
-  gpg --armor --detach-sign dist/borg-*
+  for file in dist/borg-*; do gpg --armor --detach-sign $file; done
 
 If you encounter issues, see also our `Vagrantfile` for details.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -96,8 +96,8 @@ Creating a new release
 
 Checklist:
 
-- make sure all issues for this milestone are closed or moved them to
-  the next milestone
+- make sure all issues for this milestone are closed or move to the
+  next milestone
 - look and fix any low hanging fruit left on the issue tracker
 - run tox on all supported platforms via vagrant, check for test failures
 - check that Travis CI is also happy

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -98,7 +98,7 @@ Checklist:
 
 - make sure all issues for this milestone are closed or move to the
   next milestone
-- look and fix any low hanging fruit left on the issue tracker
+- find and fix any low hanging fruit left on the issue tracker
 - run tox on all supported platforms via vagrant, check for test failures
 - check that Travis CI is also happy
 - update ``CHANGES.rst``, based on ``git log $PREVIOUS_RELEASE..``

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -96,31 +96,35 @@ Creating a new release
 
 Checklist::
 
-- all issues for this milestone closed?
-- any low hanging fruit left on the issue tracker?
-- run tox on all supported platforms via vagrant, check for test fails.
-- is Travis CI happy also?
-- update CHANGES.rst (compare to git log)
-- check version number of upcoming release
-- check MANIFEST.in and setup.py - are they complete?
+- make sure all issues for this milestone are closed or moved them to
+  the next milestone
+- look and fix any low hanging fruit left on the issue tracker
+- run tox on all supported platforms via vagrant, check for test failures
+- check that Travis CI is also happy
+- update ``CHANGES.rst``, based on ``git log $PREVIOUS_RELEASE..``
+- check version number of upcoming release in ``CHANGES.rst``
+- verify that ``MANIFEST.in`` and ``setup.py`` are complete
 - tag the release::
 
   git tag -s -m "tagged release" 0.26.0
 
-- cd docs ; make html  # to update the usage include files
+- update usage include files::
+
+  cd docs ; make html
+
 - update website with the html (XXX: how?)
 - create a release on PyPi::
 
     python setup.py register sdist upload --identity="Thomas Waldmann" --sign
 
-- close release milestone
+- close release milestone on Github
 - announce on::
 
   - `mailing list <mailto:borgbackup@librelist.org>`_
   - Twitter (XXX: how? where?)
   - `IRC channel <irc://irc.freenode.net/borgbackup>`_ (change ``/topic``
 
-- create standalone binaries and upload them to the Github release
+- create standalone binaries (see below) and upload them to the Github release
 
 
 Creating standalone binaries
@@ -132,9 +136,10 @@ With virtual env activated::
 
   pip install pyinstaller>=3.0  # or git checkout master
   pyinstaller -F -n borg-PLATFORM --hidden-import=logging.config borg/__main__.py
-  ls -l dist/*
+  gpg --armor --detach-sign dist/borg-*
 
 If you encounter issues, see also our `Vagrantfile` for details.
 
-Note: Standalone binaries built with pyinstaller are supposed to work on same OS,
-      same architecture (x86 32bit, amd64 64bit) without external dependencies.
+.. note:: Standalone binaries built with pyinstaller are supposed to
+          work on same OS, same architecture (x86 32bit, amd64 64bit)
+          without external dependencies.


### PR DESCRIPTION
link to the locations of different tools when I know them. i marked
the ones I don't know about specially so we can document those as
well.

point to the Github releases for the standalone binaries upload

this is in progress, a continuation of the discussion in #214.