### PR TITLE
fix build on readthedocs.org

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -12,9 +12,10 @@ import sys
 import time
 from io import BytesIO
 from . import xattr
-from .platform import acl_get, acl_set
-from .chunker import Chunker
-from .hashindex import ChunkIndex
+if not os.environ.get('BORG_GEN_USAGE', False):
+    from .platform import acl_get, acl_set
+    from .chunker import Chunker
+    from .hashindex import ChunkIndex
 from .helpers import parse_timestamp, Error, uid2user, user2uid, gid2group, group2gid, \
     Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int
 

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -12,12 +12,12 @@ import sys
 import time
 from io import BytesIO
 from . import xattr
-if not os.environ.get('BORG_GEN_USAGE', False):
+from .helpers import parse_timestamp, Error, uid2user, user2uid, gid2group, group2gid, \
+    Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int, detect_cython
+if not detect_cython():
     from .platform import acl_get, acl_set
     from .chunker import Chunker
     from .hashindex import ChunkIndex
-from .helpers import parse_timestamp, Error, uid2user, user2uid, gid2group, group2gid, \
-    Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int
 
 ITEMS_BUFFER = 1024 * 1024
 

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -13,8 +13,8 @@ import time
 from io import BytesIO
 from . import xattr
 from .helpers import parse_timestamp, Error, uid2user, user2uid, gid2group, group2gid, \
-    Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int, detect_cython
-if detect_cython():
+    Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int, have_cython
+if have_cython():
     from .platform import acl_get, acl_set
     from .chunker import Chunker
     from .hashindex import ChunkIndex

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from . import xattr
 from .helpers import parse_timestamp, Error, uid2user, user2uid, gid2group, group2gid, \
     Manifest, Statistics, decode_dict, st_mtime_ns, make_path_safe, StableDict, int_to_bigint, bigint_to_int, detect_cython
-if not detect_cython():
+if detect_cython():
     from .platform import acl_get, acl_set
     from .chunker import Chunker
     from .hashindex import ChunkIndex

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -15,18 +15,18 @@ import textwrap
 import traceback
 
 from . import __version__
-if not os.environ.get('BORG_GEN_USAGE', False):
+from .helpers import Error, location_validator, format_time, format_file_size, \
+    format_file_mode, ExcludePattern, IncludePattern, exclude_path, adjust_patterns, to_localtime, timestamp, \
+    get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
+    Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
+    is_cachedir, bigint_to_int, ChunkerParams, CompressionSpec, detect_cython
+if not detect_cython():
     from .compress import Compressor, COMPR_BUFFER
     from .upgrader import AtticRepositoryUpgrader
     from .repository import Repository
     from .cache import Cache
     from .key import key_creator
 from .archive import Archive, ArchiveChecker, CHUNKER_PARAMS
-from .helpers import Error, location_validator, format_time, format_file_size, \
-    format_file_mode, ExcludePattern, IncludePattern, exclude_path, adjust_patterns, to_localtime, timestamp, \
-    get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
-    Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
-    is_cachedir, bigint_to_int, ChunkerParams, CompressionSpec
 from .remote import RepositoryServer, RemoteRepository
 
 has_lchflags = hasattr(os, 'lchflags')

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -19,8 +19,8 @@ from .helpers import Error, location_validator, format_time, format_file_size, \
     format_file_mode, ExcludePattern, IncludePattern, exclude_path, adjust_patterns, to_localtime, timestamp, \
     get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
     Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
-    is_cachedir, bigint_to_int, ChunkerParams, CompressionSpec, detect_cython
-if detect_cython():
+    is_cachedir, bigint_to_int, ChunkerParams, CompressionSpec, have_cython
+if have_cython():
     from .compress import Compressor, COMPR_BUFFER
     from .upgrader import AtticRepositoryUpgrader
     from .repository import Repository

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -548,24 +548,8 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                     print(warning)
         return args
 
-    def run(self, args=None):
-        check_extension_modules()
-        keys_dir = get_keys_dir()
-        if not os.path.exists(keys_dir):
-            os.makedirs(keys_dir)
-            os.chmod(keys_dir, stat.S_IRWXU)
-        cache_dir = get_cache_dir()
-        if not os.path.exists(cache_dir):
-            os.makedirs(cache_dir)
-            os.chmod(cache_dir, stat.S_IRWXU)
-            with open(os.path.join(cache_dir, 'CACHEDIR.TAG'), 'w') as fd:
-                fd.write(textwrap.dedent("""
-                    Signature: 8a477f597d28d172789f06886806bc55
-                    # This file is a cache directory tag created by Borg.
-                    # For information about cache directory tags, see:
-                    #       http://www.brynosaurus.com/cachedir/
-                    """).lstrip())
-        common_parser = argparse.ArgumentParser(add_help=False)
+    def build_parser(self, args=None, prog=None):
+        common_parser = argparse.ArgumentParser(add_help=False, prog=prog)
         common_parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                                    default=False,
                                    help='verbose output')
@@ -576,11 +560,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         common_parser.add_argument('--remote-path', dest='remote_path', default=RemoteRepository.remote_path, metavar='PATH',
                                    help='set remote path to executable (default: "%(default)s")')
 
-        # We can't use argparse for "serve" since we don't want it to show up in "Available commands"
-        if args:
-            args = self.preprocess_args(args)
-
-        parser = argparse.ArgumentParser(description='Borg %s - Deduplicated Backups' % __version__)
+        parser = argparse.ArgumentParser(prog=prog, description='Borg %s - Deduplicated Backups' % __version__)
         subparsers = parser.add_subparsers(title='Available commands')
 
         serve_epilog = textwrap.dedent("""
@@ -976,6 +956,30 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         subparser.set_defaults(func=functools.partial(self.do_help, parser, subparsers.choices))
         subparser.add_argument('topic', metavar='TOPIC', type=str, nargs='?',
                                help='additional help on TOPIC')
+        return parser
+
+    def run(self, args=None):
+        check_extension_modules()
+        keys_dir = get_keys_dir()
+        if not os.path.exists(keys_dir):
+            os.makedirs(keys_dir)
+            os.chmod(keys_dir, stat.S_IRWXU)
+        cache_dir = get_cache_dir()
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+            os.chmod(cache_dir, stat.S_IRWXU)
+            with open(os.path.join(cache_dir, 'CACHEDIR.TAG'), 'w') as fd:
+                fd.write(textwrap.dedent("""
+                    Signature: 8a477f597d28d172789f06886806bc55
+                    # This file is a cache directory tag created by Borg.
+                    # For information about cache directory tags, see:
+                    #       http://www.brynosaurus.com/cachedir/
+                    """).lstrip())
+
+        # We can't use argparse for "serve" since we don't want it to show up in "Available commands"
+        if args:
+            args = self.preprocess_args(args)
+        parser = self.build_parser(args)
 
         args = parser.parse_args(args or ['-h'])
         self.verbose = args.verbose

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -20,7 +20,7 @@ from .helpers import Error, location_validator, format_time, format_file_size, \
     get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
     Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
     is_cachedir, bigint_to_int, ChunkerParams, CompressionSpec, detect_cython
-if not detect_cython():
+if detect_cython():
     from .compress import Compressor, COMPR_BUFFER
     from .upgrader import AtticRepositoryUpgrader
     from .repository import Repository

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -15,12 +15,13 @@ import textwrap
 import traceback
 
 from . import __version__
+if not os.environ.get('BORG_GEN_USAGE', False):
+    from .compress import Compressor, COMPR_BUFFER
+    from .upgrader import AtticRepositoryUpgrader
+    from .repository import Repository
+    from .cache import Cache
+    from .key import key_creator
 from .archive import Archive, ArchiveChecker, CHUNKER_PARAMS
-from .compress import Compressor, COMPR_BUFFER
-from .upgrader import AtticRepositoryUpgrader
-from .repository import Repository
-from .cache import Cache
-from .key import key_creator
 from .helpers import Error, location_validator, format_time, format_file_size, \
     format_file_mode, ExcludePattern, IncludePattern, exclude_path, adjust_patterns, to_localtime, timestamp, \
     get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -29,9 +29,9 @@ def detect_cython():
     which, when set (to anything) will disable includes of Cython
     libraries in key places to enable usage docs to be built.
     """
-    return os.environ.get('BORG_CYTHON_DISABLE')
+    return not os.environ.get('BORG_CYTHON_DISABLE')
 
-if not detect_cython():
+if detect_cython():
     from . import hashindex
     from . import chunker
     from . import crypto

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -18,7 +18,7 @@ from operator import attrgetter
 
 import msgpack
 
-def detect_cython():
+def have_cython():
     """allow for a way to disable Cython includes
 
     this is used during usage docs build, in setup.py. It is to avoid
@@ -33,7 +33,7 @@ def detect_cython():
     """
     return not os.environ.get('BORG_CYTHON_DISABLE')
 
-if detect_cython():
+if have_cython():
     from . import hashindex
     from . import chunker
     from . import crypto

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -28,6 +28,8 @@ def detect_cython():
     we simply check an environment variable (``BORG_CYTHON_DISABLE``)
     which, when set (to anything) will disable includes of Cython
     libraries in key places to enable usage docs to be built.
+
+    :returns: True if Cython is available, False otherwise.
     """
     return not os.environ.get('BORG_CYTHON_DISABLE')
 

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -18,9 +18,10 @@ from operator import attrgetter
 
 import msgpack
 
-from . import hashindex
-from . import chunker
-from . import crypto
+if not os.environ.get('BORG_GEN_USAGE', False):
+    from . import hashindex
+    from . import chunker
+    from . import crypto
 
 
 class Error(Exception):

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -18,7 +18,20 @@ from operator import attrgetter
 
 import msgpack
 
-if not os.environ.get('BORG_GEN_USAGE', False):
+def detect_cython():
+    """allow for a way to disable Cython includes
+
+    this is used during usage docs build, in setup.py. It is to avoid
+    loading the Cython libraries which are built, but sometimes not in
+    the search path (namely, during Tox runs).
+
+    we simply check an environment variable (``BORG_CYTHON_DISABLE``)
+    which, when set (to anything) will disable includes of Cython
+    libraries in key places to enable usage docs to be built.
+    """
+    return os.environ.get('BORG_CYTHON_DISABLE')
+
+if not detect_cython():
     from . import hashindex
     from . import chunker
     from . import crypto

--- a/borg/key.py
+++ b/borg/key.py
@@ -7,10 +7,10 @@ import textwrap
 import hmac
 from hashlib import sha256
 
-if not os.environ.get('BORG_GEN_USAGE', False):
+from .helpers import IntegrityError, get_keys_dir, Error, detect_cython
+if not detect_cython():
     from .crypto import pbkdf2_sha256, get_random_bytes, AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks
     from .compress import Compressor, COMPR_BUFFER
-from .helpers import IntegrityError, get_keys_dir, Error
 
 PREFIX = b'\0' * 8
 

--- a/borg/key.py
+++ b/borg/key.py
@@ -7,8 +7,8 @@ import textwrap
 import hmac
 from hashlib import sha256
 
-from .helpers import IntegrityError, get_keys_dir, Error, detect_cython
-if detect_cython():
+from .helpers import IntegrityError, get_keys_dir, Error, have_cython
+if have_cython():
     from .crypto import pbkdf2_sha256, get_random_bytes, AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks
     from .compress import Compressor, COMPR_BUFFER
 

--- a/borg/key.py
+++ b/borg/key.py
@@ -8,7 +8,7 @@ import hmac
 from hashlib import sha256
 
 from .helpers import IntegrityError, get_keys_dir, Error, detect_cython
-if not detect_cython():
+if detect_cython():
     from .crypto import pbkdf2_sha256, get_random_bytes, AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks
     from .compress import Compressor, COMPR_BUFFER
 

--- a/borg/key.py
+++ b/borg/key.py
@@ -7,8 +7,9 @@ import textwrap
 import hmac
 from hashlib import sha256
 
-from .crypto import pbkdf2_sha256, get_random_bytes, AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks
-from .compress import Compressor, COMPR_BUFFER
+if not os.environ.get('BORG_GEN_USAGE', False):
+    from .crypto import pbkdf2_sha256, get_random_bytes, AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks
+    from .compress import Compressor, COMPR_BUFFER
 from .helpers import IntegrityError, get_keys_dir, Error
 
 PREFIX = b'\0' * 8

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -8,9 +8,9 @@ import struct
 import sys
 from zlib import crc32
 
-if not os.environ.get('BORG_GEN_USAGE', False):
+from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify, detect_cython
+if not detect_cython():
     from .hashindex import NSIndex
-from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify
 from .locking import UpgradableLock
 from .lrucache import LRUCache
 

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -8,8 +8,8 @@ import struct
 import sys
 from zlib import crc32
 
-from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify, detect_cython
-if detect_cython():
+from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify, have_cython
+if have_cython():
     from .hashindex import NSIndex
 from .locking import UpgradableLock
 from .lrucache import LRUCache

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -9,7 +9,7 @@ import sys
 from zlib import crc32
 
 from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify, detect_cython
-if not detect_cython():
+if detect_cython():
     from .hashindex import NSIndex
 from .locking import UpgradableLock
 from .lrucache import LRUCache

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -8,7 +8,8 @@ import struct
 import sys
 from zlib import crc32
 
-from .hashindex import NSIndex
+if not os.environ.get('BORG_GEN_USAGE', False):
+    from .hashindex import NSIndex
 from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify
 from .locking import UpgradableLock
 from .lrucache import LRUCache

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -36,7 +36,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html: usage
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -139,17 +139,3 @@ gh-io: html
 
 inotify: html
 	while inotifywait -r . --exclude usage.rst --exclude '_build/*' ; do make html ; done
-
-# generate list of targets
-usage: $(shell borg help | grep -A1 "Available commands:" | tail -1 | sed 's/[{} ]//g;s/,\|^/.rst.inc usage\//g;s/^.rst.inc//;s/usage\/help//')
-
-# generate help file based on usage
-usage/%.rst.inc: ../borg/archiver.py
-	@echo generating usage for $*
-	@printf ".. _borg_$*:\n\n" > $@
-	@printf "borg $*\n" >> $@
-	@echo -n borg $* | tr 'a-z- ' '-' >> $@
-	@printf "\n::\n\n" >> $@
-	@borg help $* --usage-only | sed -e 's/^/    /' >> $@
-	@printf "\nDescription\n~~~~~~~~~~~\n" >> $@
-	@borg help $* --epilog-only >> $@

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -36,7 +36,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html: usage api.rst
+html: usage
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -153,18 +153,3 @@ usage/%.rst.inc: ../borg/archiver.py
 	@borg help $* --usage-only | sed -e 's/^/    /' >> $@
 	@printf "\nDescription\n~~~~~~~~~~~\n" >> $@
 	@borg help $* --epilog-only >> $@
-
-api.rst: Makefile
-	@echo "auto-generating API documentation"
-	@echo "Borg Backup API documentation" > $@
-	@echo "=============================" >> $@
-	@echo "" >> $@
-	@for mod in ../borg/*.pyx ../borg/*.py; do \
-		if echo "$$mod" | grep -q "/_"; then \
-			continue ; \
-		fi ; \
-		printf ".. automodule:: "; \
-		echo "$$mod" | sed "s!\.\./!!;s/\.pyx\?//;s!/!.!"; \
-		echo "    :members:"; \
-		echo "    :undoc-members:"; \
-	done >> $@

--- a/docs/_themes/local/sidebarusefullinks.html
+++ b/docs/_themes/local/sidebarusefullinks.html
@@ -3,6 +3,7 @@
 
 <h3>Useful Links</h3>
 <ul>
+  <li><a href="https://borgbackup.readthedocs.org/">Main Web Site</a></li>
   <li><a href="https://github.com/borgbackup/borg/releases">Releases</a></li>
   <li><a href="https://pypi.python.org/pypi/borgbackup">PyPI packages</a></li>
   <li><a href="https://github.com/borgbackup/borg/blob/master/CHANGES.rst">Current ChangeLog</a></li>

--- a/docs/_themes/local/sidebarusefullinks.html
+++ b/docs/_themes/local/sidebarusefullinks.html
@@ -3,7 +3,6 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://borgbackup.github.io/borgbackup/">Main Web Site</a></li>
   <li><a href="https://github.com/borgbackup/borg/releases">Releases</a></li>
   <li><a href="https://pypi.python.org/pypi/borgbackup">PyPI packages</a></li>
   <li><a href="https://github.com/borgbackup/borg/blob/master/CHANGES.rst">Current ChangeLog</a></li>

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -62,8 +62,8 @@ Some "yes" sayers (if set, they automatically confirm that you really want to do
         For "Warning: 'check --repair' is an experimental feature that might result in data loss."
     BORG_CYTHON_DISABLE
         Disables the loading of Cython modules. This is currently
-        experimentaly and is used only to generate usage docs at build
-        time, it's unlikely to produce good results on a regular
+        experimental and is used only to generate usage docs at build
+        time. It is unlikely to produce good results on a regular
         run. The variable should be set to the calling class, and
         should be unique. It is currently only used by ``build_usage``.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,6 +60,12 @@ Some "yes" sayers (if set, they automatically confirm that you really want to do
         For "Warning: The repository at location ... was previously located at ..."
     BORG_CHECK_I_KNOW_WHAT_I_AM_DOING
         For "Warning: 'check --repair' is an experimental feature that might result in data loss."
+    BORG_CYTHON_DISABLE
+        Disables the loading of Cython modules. This is currently
+        experimentaly and is used only to generate usage docs at build
+        time, it's unlikely to produce good results on a regular
+        run. The variable should be set to the calling class, and
+        should be unique. It is currently only used by ``build_usage``.
 
 Directories:
     BORG_KEYS_DIR

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,8 +64,8 @@ Some "yes" sayers (if set, they automatically confirm that you really want to do
         Disables the loading of Cython modules. This is currently
         experimental and is used only to generate usage docs at build
         time. It is unlikely to produce good results on a regular
-        run. The variable should be set to the calling class, and
-        should be unique. It is currently only used by ``build_usage``.
+        run. The variable should be set to the name of the  calling class, and
+        should be unique across all of borg. It is currently only used by ``build_usage``.
 
 Directories:
     BORG_KEYS_DIR

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ import os
 import sys
 from glob import glob
 
+from distutils.command.build import build
+from distutils.core import Command
+from distutils.errors import DistutilsOptionError
+
 min_python = (3, 2)
 my_python = sys.version_info
 
@@ -115,8 +119,42 @@ elif not on_rtd:
 
 with open('README.rst', 'r') as fd:
     long_description = fd.read()
+class build_api(Command):
+    description = "generate a basic api.rst file based on the modules available"
 
-cmdclass = {'build_ext': build_ext, 'sdist': Sdist}
+    user_options = [
+        ('output=', 'O', 'output directory'),
+    ]
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print("auto-generating API documentation")
+        with open("docs/api.rst", "w") as api:
+            api.write("""
+Borg Backup API documentation"
+=============================
+""")
+            for mod in glob('borg/*.py') + glob('borg/*.pyx'):
+                print("examining module %s" % mod)
+                if "/_" not in mod:
+                    api.write("""
+.. automodule:: %s
+    :members:
+    :undoc-members:
+""" % mod)
+
+# (function, predicate), see http://docs.python.org/2/distutils/apiref.html#distutils.cmd.Command.sub_commands
+build.sub_commands.append(('build_api', None))
+
+cmdclass = {
+    'build_ext': build_ext,
+    'build_api': build_api,
+    'sdist': Sdist
+}
 
 ext_modules = []
 if not on_rtd:

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ build.sub_commands.append(('build_usage', None))
 
 
 class build_py_custom(build_py):
-    """override build_py to also build our stuf
+    """override build_py to also build our stuff
 
     it is unclear why this is necessary, but in some environments
     (Readthedocs.org, specifically), the above

--- a/setup.py
+++ b/setup.py
@@ -135,10 +135,14 @@ class build_usage(Command):
 
     def run(self):
         print('generating usage docs')
-        # XXX: gross hack: allows us to skip loading C modules during help generation
-        os.environ['BORG_GEN_USAGE'] = "True"
+        # allows us to build docs without the C modules fully loaded during help generation
+        if 'BORG_CYTHON_DISABLE' not in os.environ:
+            os.environ['BORG_CYTHON_DISABLE'] = self.__class__.__name__
         from borg.archiver import Archiver
         parser = Archiver().build_parser(prog='borg')
+        # return to regular Cython configuration, if we changed it
+        if os.environ.get('BORG_CYTHON_DISABLE') == self.__class__.__name__:
+            del os.environ['BORG_CYTHON_DISABLE']
         choices = {}
         for action in parser._actions:
             if action.choices is not None:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if my_python < min_python:
     sys.exit(1)
 
 # Are we building on ReadTheDocs?
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get('READTHEDOCS')
 
 # msgpack pure python data corruption was fixed in 0.4.6.
 # Also, we might use some rather recent API features.

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,8 @@ class build_usage(Command):
     def run(self):
         import pdb
         print('generating usage docs')
+        # XXX: gross hack: allows us to skip loading C modules during help generation
+        os.environ['BORG_GEN_USAGE'] = "True"
         from borg.archiver import Archiver
         parser = Archiver().build_parser(prog='borg')
         choices = {}

--- a/setup.py
+++ b/setup.py
@@ -151,21 +151,14 @@ class build_usage(Command):
                 continue
             with open('docs/usage/%s.rst.inc' % command, 'w') as cmdfile:
                 print('generating help for %s' % command)
-                cmdfile.write(""".. _borg_{command}:
-
-borg {command}
-{underline}
-::
-
-""".format(**{"command": command,
-                              "underline": '-' * len('borg ' + command)}))
+                params = {"command": command,
+                          "underline": '-' * len('borg ' + command)}
+                cmdfile.write(".. _borg_{command}:\n\n".format(**params))
+                cmdfile.write("borg {command}\n{underline}\n::\n\n".format(**params))
                 epilog = parser.epilog
                 parser.epilog = None
                 cmdfile.write(re.sub("^", "    ", parser.format_help(), flags=re.M))
-                cmdfile.write("""
-Description
-~~~~~~~~~~~
-""")
+                cmdfile.write("\nDescription\n~~~~~~~~~~~\n")
                 cmdfile.write(epilog)
 
 

--- a/setup.py
+++ b/setup.py
@@ -182,15 +182,15 @@ class build_api(Command):
 
     def run(self):
         print("auto-generating API documentation")
-        with open("docs/api.rst", "w") as api:
-            api.write("""
+        with open("docs/api.rst", "w") as doc:
+            doc.write("""
 Borg Backup API documentation"
 =============================
 """)
             for mod in glob('borg/*.py') + glob('borg/*.pyx'):
                 print("examining module %s" % mod)
                 if "/_" not in mod:
-                    api.write("""
+                    doc.write("""
 .. automodule:: %s
     :members:
     :undoc-members:

--- a/setup.py
+++ b/setup.py
@@ -153,17 +153,17 @@ class build_usage(Command):
         for command, parser in choices.items():
             if command is 'help':
                 continue
-            with open('docs/usage/%s.rst.inc' % command, 'w') as cmdfile:
+            with open('docs/usage/%s.rst.inc' % command, 'w') as doc:
                 print('generating help for %s' % command)
                 params = {"command": command,
                           "underline": '-' * len('borg ' + command)}
-                cmdfile.write(".. _borg_{command}:\n\n".format(**params))
-                cmdfile.write("borg {command}\n{underline}\n::\n\n".format(**params))
+                doc.write(".. _borg_{command}:\n\n".format(**params))
+                doc.write("borg {command}\n{underline}\n::\n\n".format(**params))
                 epilog = parser.epilog
                 parser.epilog = None
-                cmdfile.write(re.sub("^", "    ", parser.format_help(), flags=re.M))
-                cmdfile.write("\nDescription\n~~~~~~~~~~~\n")
-                cmdfile.write(epilog)
+                doc.write(re.sub("^", "    ", parser.format_help(), flags=re.M))
+                doc.write("\nDescription\n~~~~~~~~~~~\n")
+                doc.write(epilog)
 
 
 class build_api(Command):

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ class build_py_custom(build_py):
     def run(self):
         super().run()
         self.announce('calling custom build steps', level=log.INFO)
+        self.run_command('build_ext')
         self.run_command('build_api')
         self.run_command('build_usage')
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,6 @@ class build_usage(Command):
         pass
 
     def run(self):
-        import pdb
         print('generating usage docs')
         # XXX: gross hack: allows us to skip loading C modules during help generation
         os.environ['BORG_GEN_USAGE'] = "True"

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,9 @@ except ImportError:
     platform_freebsd_source = platform_freebsd_source.replace('.pyx', '.c')
     platform_darwin_source = platform_darwin_source.replace('.pyx', '.c')
     from distutils.command.build_ext import build_ext
-    if not all(os.path.exists(path) for path in [
+    if not on_rtd and not all(os.path.exists(path) for path in [
         compress_source, crypto_source, chunker_source, hashindex_source,
-        platform_linux_source, platform_freebsd_source]) and not on_rtd:
+        platform_linux_source, platform_freebsd_source]):
         raise ImportError('The GIT version of Borg needs Cython. Install Cython or use a released version.')
 
 


### PR DESCRIPTION
this should close #155, minus changes to point all "homepage" urls to RTD. turns out i simply had to disable all C code building and a few other checks in order to make that work. A magic `READTHEDOCS` environment variable is available for that (found *that* sucker in https://github.com/andsor/pypercolate/blob/master/setup.py#L30).

it required rewriting the makefile code into hairy Python code, with an unfortunate cleanroom reimplementation of the code mentionned in #208 - which will need to be rewritten once we switch to click - ouch! (#251) the code is not very pretty, and setup.py is growing like crazy now, maybe it would be worth moving some of that code into a borg.documenation module.

anyways, the usage build is *much* faster than it was in the makefile, so that's good, and now the main website should automatically once we pull this.

a rendering can be seen here:

http://borgbackup-anarcat.readthedocs.org/en/rtfd-fixup/

along with automated updates, we get PDF and ePUB manuals, although the version number shown there is, for some reason, "0.15.dev661+ng13d3568" there:

https://media.readthedocs.org/pdf/borgbackup-anarcat/rtfd-fixup/borgbackup-anarcat.pdf

anyways, it seems to me this would be a really worthy switch! :)