### PR TITLE
fix virtualenv path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ MANIFEST
 docs/_build
 build
 dist
-env
+borg-env
 .tox
 hashindex.c
 chunker.c


### PR DESCRIPTION
the current instructions create a dirty tree that `git add .` would
commit into git. this is error prone and somewhat unclean.

i found it preferable to change the `.gitignore` than to change the instructions, since there are probably `borg-env` environments lying around everywhere already.