### PR TITLE
do not upgrade repositories in place by default

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -925,7 +925,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         backup copy.
 
         WARNING: running the upgrade in place will make the current
-        copy unuseable with older version, with no way of going back
+        copy unusable with older version, with no way of going back
         to previous versions. this can PERMANENTLY DAMAGE YOUR
         REPOSITORY!  Attic CAN NOT READ BORG REPOSITORIES, as the
         magic strings have changed. you have been warned.""")
@@ -939,7 +939,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                                help='do not change repository')
         subparser.add_argument('-i', '--inplace', dest='inplace',
                                default=False, action='store_true',
-                               help="""rewrite repository in-place, with no chance of going back to older
+                               help="""rewrite repository in place, with no chance of going back to older
                                versions of the repository.""")
         subparser.add_argument('repository', metavar='REPOSITORY', nargs='?', default='',
                                type=location_validator(archive=False),

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -185,8 +185,8 @@ def test_hardlink(tmpdir, inplace):
     """test that we handle hard links properly
 
     that is, if we are in "inplace" mode, hardlinks should *not*
-    change (ie. we write the file directly, so not the whole file, and
-    not re-create the file).
+    change (ie. we write to the file directly, so we do not rewrite the
+    whole file, and we do not re-create the file).
 
     if we are *not* in inplace mode, then the inode should change, as
     we are supposed to leave the original inode alone."""

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -16,9 +16,6 @@ from ..helpers import get_keys_dir
 from ..key import KeyfileKey
 from ..repository import Repository, MAGIC
 
-pytestmark = pytest.mark.skipif(attic is None,
-                                reason='cannot find an attic install')
-
 
 def repo_valid(path):
     """
@@ -67,6 +64,7 @@ def attic_repo(tmpdir):
 def inplace(request):
     return request.param
 
+@pytest.mark.skipif(attic is None, reason='cannot find an attic install')
 def test_convert_segments(tmpdir, attic_repo, inplace):
     """test segment conversion
 
@@ -126,6 +124,7 @@ def attic_key_file(attic_repo, tmpdir):
                                        MockArgs(keys_dir))
 
 
+@pytest.mark.skipif(attic is None, reason='cannot find an attic install')
 def test_keys(tmpdir, attic_repo, attic_key_file):
     """test key conversion
 
@@ -144,6 +143,7 @@ def test_keys(tmpdir, attic_repo, attic_key_file):
     assert key_valid(attic_key_file.path)
 
 
+@pytest.mark.skipif(attic is None, reason='cannot find an attic install')
 def test_convert_all(tmpdir, attic_repo, attic_key_file, inplace):
     """test all conversion steps
 

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -63,8 +63,11 @@ def attic_repo(tmpdir):
     attic_repo.close()
     return attic_repo
 
+@pytest.fixture(params=[True, False])
+def inplace(request):
+    return request.param
 
-def test_convert_segments(tmpdir, attic_repo):
+def test_convert_segments(tmpdir, attic_repo, inplace):
     """test segment conversion
 
     this will load the given attic repository, list all the segments
@@ -80,7 +83,7 @@ def test_convert_segments(tmpdir, attic_repo):
     repo = AtticRepositoryUpgrader(str(tmpdir), create=False)
     segments = [filename for i, filename in repo.io.segment_iterator()]
     repo.close()
-    repo.convert_segments(segments, dryrun=False)
+    repo.convert_segments(segments, dryrun=False, inplace=inplace)
     repo.convert_cache(dryrun=False)
     assert repo_valid(tmpdir)
 
@@ -141,7 +144,7 @@ def test_keys(tmpdir, attic_repo, attic_key_file):
     assert key_valid(attic_key_file.path)
 
 
-def test_convert_all(tmpdir, attic_repo, attic_key_file):
+def test_convert_all(tmpdir, attic_repo, attic_key_file, inplace):
     """test all conversion steps
 
     this runs everything. mostly redundant test, since everything is
@@ -155,7 +158,39 @@ def test_convert_all(tmpdir, attic_repo, attic_key_file):
     """
     # check should fail because of magic number
     assert not repo_valid(tmpdir)
+    def first_inode(path):
+        return os.stat(os.path.join(path, 'data', '0', '0')).st_ino
+    orig_inode = first_inode(attic_repo.path)
     repo = AtticRepositoryUpgrader(str(tmpdir), create=False)
-    repo.upgrade(dryrun=False)
+    backup = repo.upgrade(dryrun=False, inplace=inplace)
+    if inplace:
+        assert backup is None
+        assert first_inode(repo.path) == orig_inode
+    else:
+        assert backup
+        assert first_inode(repo.path) != first_inode(backup)
+
     assert key_valid(attic_key_file.path)
     assert repo_valid(tmpdir)
+
+def test_hardlink(tmpdir, inplace):
+    """test that we handle hard links properly
+
+    that is, if we are in "inplace" mode, hardlinks should *not*
+    change (ie. we write the file directly, so not the whole file, and
+    not re-create the file).
+
+    if we are *not* in inplace mode, then the inode should change, as
+    we are supposed to leave the original inode alone."""
+    a = str(tmpdir.join('a'))
+    with open(a, 'wb') as tmp:
+        tmp.write(b'aXXX')
+    b = str(tmpdir.join('b'))
+    os.link(a, b)
+    AtticRepositoryUpgrader.header_replace(b, b'a', b'b', inplace=inplace)
+    if not inplace:
+        assert os.stat(a).st_ino != os.stat(b).st_ino
+    else:
+        assert os.stat(a).st_ino == os.stat(b).st_ino
+    with open(b, 'rb') as tmp:
+        assert tmp.read() == b'bXXX'

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -166,7 +166,7 @@ def test_convert_all(tmpdir, attic_repo, attic_key_file, inplace):
     orig_inode = first_inode(attic_repo.path)
     repo = AtticRepositoryUpgrader(str(tmpdir), create=False)
     # replicate command dispatch, partly
-    os.umask(attic_repo.umask)
+    os.umask(RemoteRepository.umask)
     backup = repo.upgrade(dryrun=False, inplace=inplace)
     if inplace:
         assert backup is None

--- a/borg/upgrader.py
+++ b/borg/upgrader.py
@@ -91,10 +91,14 @@ class AtticRepositoryUpgrader(Repository):
                     # works because our old file handle is still open
                     # so even though the file is removed, we can still
                     # read it until the file is closed.
-                    os.unlink(filename)
+                    os.rename(filename, filename + '.tmp')
                     with open(filename, 'wb') as new_segment:
                         new_segment.write(new_magic)
                         new_segment.write(segment.read())
+                    # the little dance with the .tmp file is necessary
+                    # because Windows won't allow overwriting an open
+                    # file.
+                    os.unlink(filename + '.tmp')
 
     def find_attic_keyfile(self):
         """find the attic keyfiles

--- a/borg/upgrader.py
+++ b/borg/upgrader.py
@@ -32,7 +32,7 @@ class AtticRepositoryUpgrader(Repository):
             backup = '{}.upgrade-{:%Y-%m-%d-%H:%M:%S}'.format(self.path, datetime.datetime.now())
             logger.info('making a hardlink copy in %s', backup)
             if not dryrun:
-                shutil.copytree(self.path, backup, copy_function=lambda src, dst: os.link(src, dst))
+                shutil.copytree(self.path, backup, copy_function=os.link)
         logger.info("opening attic repository with borg and converting")
         # we need to open the repo to load configuration, keyfiles and segments
         self.open(self.path, exclusive=False)


### PR DESCRIPTION
instead, we perform the equivalent of `cp -al` on the repository to
keep a backup, and then rewrite the files, breaking the hardlinks as
necessary.

it has to be confirmed that the rest of Borg will also break hardlinks
when operating on files in the repository. if Borg operates in place
on any files of the repository, it could jeoperdize the backup, so
this needs to be verified. I believe that most files are written to a
temporary file and moved into place, however, so the backup should be
safe.

the rationale behind the backup copy is that we want to be extra
careful with user's data by default. the old behavior is retained
through the `--inplace`/`-i` commandline flag. plus, this way we don't
need to tell users to go through extra steps (`cp -a`, in particular)
before running the command.

also, it can take a long time to do the copy of the attic repository
we wish to work on. since `cp -a` doesn't provide progress
information, the new default behavior provides a nicer user experience
of giving an overall impression of the upgrade progress, while
retaining compatibility with Attic by default (in a separate
repository, of course).

this makes the upgrade command much less scary to use and hopefully
will convert drones to the borg collective.

the only place where the default inplace behavior is retained is in
the header_replace() function, to avoid breaking the cache conversion
code and to keep API stability and semantic coherence ("replace" by
defaults means in place).

this is a reroll of #280.