### PR TITLE
cache: faster chunks cache resync if archives were only added, fixes #235

### DIFF
--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -391,7 +391,7 @@ hashindex_summarize(HashIndex *index, long long *total_size, long long *total_cs
     *total_chunks = chunks;
 }
 
-static void
+static int
 hashindex_merge(HashIndex *index, HashIndex *other)
 {
     int32_t key_size = index->key_size;
@@ -403,9 +403,11 @@ hashindex_merge(HashIndex *index, HashIndex *other)
         other_values = key + key_size;
         my_values = (int32_t *)hashindex_get(index, key);
         if(my_values == NULL) {
-            hashindex_set(index, key, other_values);
+            if(!hashindex_set(index, key, other_values))
+                return 0;
         } else {
             *my_values += *other_values;
         }
     }
+    return 1;
 }

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -253,7 +253,7 @@ Number of files: {0.stats.nfiles}
         self.manifest.archives[name] = {'id': self.id, 'time': metadata['time']}
         self.manifest.write()
         self.repository.commit()
-        self.cache.commit()
+        self.cache.commit(added=[self.id])
 
     def calc_stats(self, cache):
         def add(id):

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -308,7 +308,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
             archive.delete(stats)
             manifest.write()
             repository.commit()
-            cache.commit()
+            cache.commit(removed=[archive.id])
             if args.stats:
                 logger.info(stats.print_('Deleted data:', cache))
         else:
@@ -454,7 +454,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         if to_delete and not args.dry_run:
             manifest.write()
             repository.commit()
-            cache.commit()
+            cache.commit(removed=[archive.id for archive in to_delete])
         if args.stats:
             logger.info(stats.print_('Deleted data:', cache))
         return self.exit_code

--- a/borg/cache.py
+++ b/borg/cache.py
@@ -7,8 +7,6 @@ import stat
 import sys
 from binascii import hexlify
 import shutil
-import tarfile
-import tempfile
 
 from .key import PlaintextKey
 from .logger import create_logger
@@ -115,6 +113,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
         config.set('cache', 'version', '1')
         config.set('cache', 'repository', hexlify(self.repository.id).decode('ascii'))
         config.set('cache', 'manifest', '')
+        config.set('cache', 'archives', '')
         with open(os.path.join(self.path, 'config'), 'w') as fd:
             config.write(fd)
         ChunkIndex().write(os.path.join(self.path, 'chunks').encode('utf-8'))
@@ -146,6 +145,9 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
         self.timestamp = self.config.get('cache', 'timestamp', fallback=None)
         self.key_type = self.config.get('cache', 'key_type', fallback=None)
         self.previous_location = self.config.get('cache', 'previous_location', fallback=None)
+        self.chunks_index_archives = set(unhexlify(hexid)
+                                         for hexid in self.config.get('cache', 'archives').split(',\n')
+                                         if len(hexid) == 64)
         self.chunks = ChunkIndex.read(os.path.join(self.path, 'chunks').encode('utf-8'))
         self.files = None
 
@@ -186,7 +188,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
                   os.path.join(self.path, 'txn.active'))
         self.txn_active = True
 
-    def commit(self):
+    def commit(self, added=None, removed=None):
         """Commit transaction
         """
         if not self.txn_active:
@@ -203,6 +205,10 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
         self.config.set('cache', 'timestamp', self.manifest.timestamp)
         self.config.set('cache', 'key_type', str(self.key.TYPE))
         self.config.set('cache', 'previous_location', self.repository._location.canonical_path())
+        self.chunks_index_archives |= set(added or [])
+        self.chunks_index_archives -= set(removed or [])
+        self.config.set('cache', 'archives', ',\n'.join(hexlify(id).decode('ascii')
+                                                        for id in self.chunks_index_archives))
         with open(os.path.join(self.path, 'config'), 'w') as fd:
             self.config.write(fd)
         self.chunks.write(os.path.join(self.path, 'chunks').encode('utf-8'))
@@ -232,12 +238,13 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
     def sync(self):
         """Re-synchronize chunks cache with repository.
 
-        Maintains a directory with known backup archive indexes, so it only
-        needs to fetch infos from repo and build a chunk index once per backup
-        archive.
-        If out of sync, missing archive indexes get added, outdated indexes
-        get removed and a new master chunks index is built by merging all
-        archive indexes.
+        This assumes that the current chunks cache contains a valid index
+        for some known set of archives.
+        To re-synchronize, we check if there were archives deleted from the repo -
+        in that case, we must do a full rebuild merging all the indexes of the
+        remaining archives.
+        If only archives were added, we can just merge the added archives' indexes
+        into our existing master index (== chunks cache).
         """
         archive_path = os.path.join(self.path, 'chunks.archive.d')
 
@@ -305,35 +312,54 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
                 if info[b'id'] == archive_id:
                     return name
 
-        def create_master_idx(chunk_idx):
+        def fetch(archive_id, archive_name, cached_ids):
+            if archive_id in cached_ids:
+                logger.info("Reading cached archive chunk index for %s ..." % archive_name)
+                archive_chunk_idx = ChunkIndex.read(mkpath(archive_id))
+            else:
+                logger.info('Fetching and building archive index for %s ...' % archive_name)
+                archive_chunk_idx = fetch_and_build_idx(archive_id, repository, self.key)
+            return archive_chunk_idx
+
+        def update_master_idx(chunk_idx):
             logger.info('Synchronizing chunks cache...')
             cached_ids = cached_archives()
-            archive_ids = repo_archives()
-            logger.info('Archives: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.' % (
-                len(archive_ids), len(cached_ids),
-                len(cached_ids - archive_ids), len(archive_ids - cached_ids), ))
-            # deallocates old hashindex, creates empty hashindex:
-            chunk_idx.clear()
-            cleanup_outdated(cached_ids - archive_ids)
-            if archive_ids:
-                chunk_idx = None
-                for archive_id in archive_ids:
-                    archive_name = lookup_name(archive_id)
-                    if archive_id in cached_ids:
-                        archive_chunk_idx_path = mkpath(archive_id)
-                        logger.info("Reading cached archive chunk index for %s ..." % archive_name)
-                        archive_chunk_idx = ChunkIndex.read(archive_chunk_idx_path)
-                    else:
-                        logger.info('Fetching and building archive index for %s ...' % archive_name)
-                        archive_chunk_idx = fetch_and_build_idx(archive_id, repository, self.key)
-                    logger.info("Merging into master chunks index ...")
-                    if chunk_idx is None:
-                        # we just use the first archive's idx as starting point,
-                        # to avoid growing the hash table from 0 size and also
-                        # to save 1 merge call.
-                        chunk_idx = archive_chunk_idx
-                    else:
-                        chunk_idx.merge(archive_chunk_idx)
+            repo_ids = repo_archives()
+            index_ids = self.chunks_index_archives
+            logger.info('Archives: %d, in Master Idx: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.' % (
+                len(repo_ids), len(index_ids), len(cached_ids),
+                len(cached_ids - repo_ids), len(repo_ids - cached_ids), ))
+            cleanup_outdated(cached_ids - repo_ids)
+            removed_ids = index_ids - repo_ids
+            if not removed_ids:
+                # if only stuff was added, we can quickly update our index
+                added_ids = repo_ids - index_ids
+                if added_ids:
+                    logger.info("Archives were added to repository, will do a quick chunks cache resync.")
+                    for id in added_ids:
+                        archive_name = lookup_name(id)
+                        idx = fetch(id, archive_name, cached_ids)
+                        logger.info("Merging index of %s ..." % archive_name)
+                        if not chunk_idx.merge(idx):
+                            raise Exception("chunk index merge failed")
+            else:
+                # de-allocates old hashindex, creates empty hashindex:
+                chunk_idx.clear()
+                if repo_ids:
+                    logger.info("Archives were deleted from repository, must do a full chunks cache rebuild.")
+                    chunk_idx = None
+                    for id in repo_ids:
+                        archive_name = lookup_name(id)
+                        idx = fetch(id, archive_name, cached_ids)
+                        logger.info("Merging index of %s ..." % archive_name)
+                        if chunk_idx is None:
+                            # we just use the first archive's idx as starting point,
+                            # to avoid growing the hash table from 0 size and also
+                            # to save 1 merge call.
+                            chunk_idx = idx
+                        else:
+                            chunk_idx.merge(idx)
+            self.chunks_index_archives = repo_ids
             logger.info('Done.')
             return chunk_idx
 
@@ -358,7 +384,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}""")
         # TEMPORARY HACK: to avoid archive index caching, create a FILE named ~/.cache/borg/REPOID/chunks.archive.d -
         # this is only recommended if you have a fast, low latency connection to your repo (e.g. if repo is local disk)
         self.do_cache = os.path.isdir(archive_path)
-        self.chunks = create_master_idx(self.chunks)
+        self.chunks = update_master_idx(self.chunks)
 
     def add_chunk(self, id, data, stats):
         if not self.txn_active:

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -14,7 +14,7 @@ cdef extern from "_hashindex.c":
     void hashindex_summarize(HashIndex *index, long long *total_size, long long *total_csize,
                              long long *unique_size, long long *unique_csize,
                              long long *total_unique_chunks, long long *total_chunks)
-    void hashindex_merge(HashIndex *index, HashIndex *other)
+    int hashindex_merge(HashIndex *index, HashIndex *other)
     int hashindex_get_size(HashIndex *index)
     int hashindex_write(HashIndex *index, char *path)
     void *hashindex_get(HashIndex *index, void *key)
@@ -197,7 +197,7 @@ cdef class ChunkIndex(IndexBase):
         return total_size, total_csize, unique_size, unique_csize, total_unique_chunks, total_chunks
 
     def merge(self, ChunkIndex other):
-        hashindex_merge(self.index, other.index)
+        return hashindex_merge(self.index, other.index)
 
 
 cdef class ChunkKeyIterator:


### PR DESCRIPTION
TEST AND REVIEW THIS VERY CAREFULLY!

if archives are added, we just add their chunk refcounts to our chunks index.
this is relatively quick if only a few archives were added, so even for remote repos,
one can live without the locally cached per-archive indexes, saving a lot of space.

but: if archives are deleted from the repo, borg will do a full index rebuild.
if one wants this to be relatively fast and has a slow repo connection,
the locally cached per-archive indexes are useful.
thus: use delete / prune less frequently than create.

also: added error check in hashindex_merge in case hashindex_set fails
