### PR TITLE
small flake8 changes

### DIFF
--- a/borg/testsuite/logger.py
+++ b/borg/testsuite/logger.py
@@ -1,6 +1,5 @@
 import logging
 from io import StringIO
-import sys
 
 from mock import Mock
 import pytest

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-import tempfile
 
 import pytest
 
@@ -15,7 +13,6 @@ from ..upgrader import AtticRepositoryUpgrader, AtticKeyfileKey
 from ..helpers import get_keys_dir
 from ..key import KeyfileKey
 from ..remote import RemoteRepository
-from ..repository import Repository, MAGIC
 
 
 def repo_valid(path):
@@ -61,9 +58,11 @@ def attic_repo(tmpdir):
     attic_repo.close()
     return attic_repo
 
+
 @pytest.fixture(params=[True, False])
 def inplace(request):
     return request.param
+
 
 @pytest.mark.skipif(attic is None, reason='cannot find an attic install')
 def test_convert_segments(tmpdir, attic_repo, inplace):
@@ -159,10 +158,13 @@ def test_convert_all(tmpdir, attic_repo, attic_key_file, inplace):
     """
     # check should fail because of magic number
     assert not repo_valid(tmpdir)
+
     def stat_segment(path):
         return os.stat(os.path.join(path, 'data', '0', '0'))
+
     def first_inode(path):
         return stat_segment(path).st_ino
+
     orig_inode = first_inode(attic_repo.path)
     repo = AtticRepositoryUpgrader(str(tmpdir), create=False)
     # replicate command dispatch, partly
@@ -176,10 +178,11 @@ def test_convert_all(tmpdir, attic_repo, attic_key_file, inplace):
         assert first_inode(repo.path) != first_inode(backup)
         # i have seen cases where the copied tree has world-readable
         # permissions, which is wrong
-        assert stat_segment(backup).st_mode & 0o007== 0
+        assert stat_segment(backup).st_mode & 0o007 == 0
 
     assert key_valid(attic_key_file.path)
     assert repo_valid(tmpdir)
+
 
 def test_hardlink(tmpdir, inplace):
     """test that we handle hard links properly

--- a/borg/testsuite/upgrader.py
+++ b/borg/testsuite/upgrader.py
@@ -13,6 +13,7 @@ from ..upgrader import AtticRepositoryUpgrader, AtticKeyfileKey
 from ..helpers import get_keys_dir
 from ..key import KeyfileKey
 from ..remote import RemoteRepository
+from ..repository import Repository
 
 
 def repo_valid(path):

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -9,6 +9,15 @@ This chapter will get you started with |project_name|' development.
 |project_name| is written in Python (with a little bit of Cython and C for
 the performance critical parts).
 
+Style guide
+-----------
+
+We generally follow `pep8
+<https://www.python.org/dev/peps/pep-0008/>`_, with 120 columns
+instead of 79. We do *not* use form-feed (``^L``) characters to
+separate sections either. The `flake8
+<https://flake8.readthedocs.org/>`_ commandline tool should be used to
+check for style errors before sending pull requests.
 
 Building a development environment
 ----------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,5 @@
 python_files = testsuite/*.py
 
 [flake8]
-ignore = E226,F403
-max-line-length = 250
-exclude = docs/conf.py,borg/_version.py,build,dist,.git,.idea,.cache
-max-complexity = 100
+max-line-length = 120
+exclude = build,dist,.git,.idea,.cache,.tox


### PR DESCRIPTION
followup for #4: we configure flake8 to be a little more strict so that new contributions are cleaner. i also fix errors i introduced in recent pull requests, to try to play catchup at *least* with the new stuff i submitted.

finally, i added a blurb to the development docs about flake8, because i had forgotten about it...

before this PR:

```
1       E121 continuation line indentation is not a multiple of four
1       E125 continuation line does not distinguish itself from next logical line
25      E127 continuation line over-indented for visual indent
1       E128 continuation line under-indented for visual indent
1       E202 whitespace before ']'
1       E203 whitespace before ','
1       E221 multiple spaces before operator
1       E222 multiple spaces after operator
1       E225 missing whitespace around operator
1       E261 at least two spaces before inline comment
3       E271 multiple spaces after keyword
5       E301 expected 1 blank line, found 0
12      E302 expected 2 blank lines, found 1
1       E303 too many blank lines (2)
12      F401 '__version__' imported but unused
10      F811 redefinition of unused 'cmd' from line 13
4       F812 list comprehension redefines 'action' from line 1463
2       F821 undefined name 'sys'
2       F841 local variable 'e' is assigned to but never used
1       W291 trailing whitespace
3       W293 blank line contains whitespace
4       W391 blank line at end of file
93
```

(and in the above, i deliberately skipped recursing into `.tox`, which it does by default now, which triples everything. this PR also fixes that.)

after this PR:

```
2       E121 continuation line indentation is not a multiple of four
5       E122 continuation line missing indentation or outdented
2       E125 continuation line does not distinguish itself from next logical line
25      E127 continuation line over-indented for visual indent
1       E128 continuation line under-indented for visual indent
1       E202 whitespace before ']'
1       E203 whitespace before ','
1       E221 multiple spaces before operator
1       E222 multiple spaces after operator
1       E225 missing whitespace around operator
1       E261 at least two spaces before inline comment
3       E271 multiple spaces after keyword
5       E301 expected 1 blank line, found 0
10      E302 expected 2 blank lines, found 1
1       E303 too many blank lines (2)
1       E401 multiple imports on one line
62      E501 line too long (149 > 120 characters)
9       F401 'DistutilsOptionError' imported but unused
10      F811 redefinition of unused 'cmd' from line 13
4       F812 list comprehension redefines 'action' from line 1463
3       F821 undefined name 'sys'
2       F841 local variable 'e' is assigned to but never used
1       W291 trailing whitespace
3       W293 blank line contains whitespace
4       W391 blank line at end of file
159
```

about 30 of those are fixed in #316 as well.