### PR TITLE
move away from RawConfigParser to ConfigParser

### DIFF
--- a/borg/cache.py
+++ b/borg/cache.py
@@ -112,7 +112,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         os.makedirs(self.path)
         with open(os.path.join(self.path, 'README'), 'w') as fd:
             fd.write('This is a Borg cache')
-        config = configparser.RawConfigParser()
+        config = configparser.ConfigParser(interpolation=None)
         config.add_section('cache')
         config.set('cache', 'version', '1')
         config.set('cache', 'repository', hexlify(self.repository.id).decode('ascii'))
@@ -132,7 +132,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         shutil.rmtree(self.path)
 
     def _do_open(self):
-        self.config = configparser.RawConfigParser()
+        self.config = configparser.ConfigParser(interpolation=None)
         config_path = os.path.join(self.path, 'config')
         self.config.read(config_path)
         try:

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -1,4 +1,4 @@
-from configparser import RawConfigParser
+from configparser import ConfigParser
 from binascii import hexlify
 from itertools import islice
 import errno
@@ -79,11 +79,11 @@ class Repository:
         with open(os.path.join(path, 'README'), 'w') as fd:
             fd.write('This is a Borg repository\n')
         os.mkdir(os.path.join(path, 'data'))
-        config = RawConfigParser()
+        config = ConfigParser(interpolation=None)
         config.add_section('repository')
         config.set('repository', 'version', '1')
-        config.set('repository', 'segments_per_dir', self.DEFAULT_SEGMENTS_PER_DIR)
-        config.set('repository', 'max_segment_size', self.DEFAULT_MAX_SEGMENT_SIZE)
+        config.set('repository', 'segments_per_dir', str(self.DEFAULT_SEGMENTS_PER_DIR))
+        config.set('repository', 'max_segment_size', str(self.DEFAULT_MAX_SEGMENT_SIZE))
         config.set('repository', 'id', hexlify(os.urandom(32)).decode('ascii'))
         self.save_config(path, config)
 
@@ -136,7 +136,7 @@ class Repository:
         if not os.path.isdir(path):
             raise self.DoesNotExist(path)
         self.lock = UpgradableLock(os.path.join(path, 'lock'), exclusive).acquire()
-        self.config = RawConfigParser()
+        self.config = ConfigParser(interpolation=None)
         self.config.read(os.path.join(self.path, 'config'))
         if 'repository' not in self.config.sections() or self.config.getint('repository', 'version') != 1:
             raise self.InvalidRepository(path)

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -1,5 +1,5 @@
 from binascii import hexlify
-from configparser import RawConfigParser
+from configparser import ConfigParser
 import errno
 import os
 from io import StringIO
@@ -318,7 +318,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         return Repository(self.repository_path).id
 
     def _set_repository_id(self, path, id):
-        config = RawConfigParser()
+        config = ConfigParser(interpolation=None)
         config.read(os.path.join(path, 'config'))
         config.set('repository', 'id', hexlify(id).decode('ascii'))
         with open(os.path.join(path, 'config'), 'w') as fd:


### PR DESCRIPTION
this is a recommended thing since direct use of RawConfigParser
is not recommended and deprecated according to python docs.