### PR TITLE
prettier error messages, fixes #57

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1062,7 +1062,9 @@ def main():  # pragma: no cover
         msg = None
         exit_code = archiver.run(sys.argv[1:])
     except Error as e:
-        msg = e.get_message() + "\n%s" % traceback.format_exc()
+        msg = e.get_message()
+        if e.traceback:
+            msg += "\n%s" % traceback.format_exc()
         exit_code = e.exit_code
     except RemoteRepository.RPCError as e:
         msg = 'Remote Exception.\n%s' % str(e)

--- a/borg/cache.py
+++ b/borg/cache.py
@@ -35,8 +35,7 @@ class Cache:
         """Repository access aborted"""
 
     class EncryptionMethodMismatch(Error):
-        """Repository encryption method changed since last acccess, refusing to continue
-        """
+        """Repository encryption method changed since last access, refusing to continue"""
 
     def __init__(self, repository, key, manifest, path=None, sync=True, do_files=False, warn_if_unencrypted=True):
         self.lock = None

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -58,12 +58,19 @@ class Error(Exception):
     # exception handler (that exits short after with the given exit_code),
     # it is always a (fatal and abrupt) EXIT_ERROR, never just a warning.
     exit_code = EXIT_ERROR
+    # show a traceback?
+    traceback = False
 
     def get_message(self):
         return type(self).__doc__.format(*self.args)
 
 
-class IntegrityError(Error):
+class ErrorWithTraceback(Error):
+    """like Error, but show a traceback also"""
+    traceback = True
+
+
+class IntegrityError(ErrorWithTraceback):
     """Data integrity error"""
 
 

--- a/borg/key.py
+++ b/borg/key.py
@@ -19,18 +19,15 @@ PREFIX = b'\0' * 8
 
 
 class UnsupportedPayloadError(Error):
-    """Unsupported payload type {}. A newer version is required to access this repository.
-    """
+    """Unsupported payload type {}. A newer version is required to access this repository."""
 
 
 class KeyfileNotFoundError(Error):
-    """No key file for repository {} found in {}.
-    """
+    """No key file for repository {} found in {}."""
 
 
 class RepoKeyNotFoundError(Error):
-    """No key entry found in the config of repository {}.
-    """
+    """No key entry found in the config of repository {}."""
 
 
 class HMAC(hmac.HMAC):

--- a/borg/locking.py
+++ b/borg/locking.py
@@ -4,7 +4,7 @@ import os
 import socket
 import time
 
-from borg.helpers import Error
+from borg.helpers import Error, ErrorWithTraceback
 
 ADD, REMOVE = 'add', 'remove'
 SHARED, EXCLUSIVE = 'shared', 'exclusive'
@@ -76,7 +76,7 @@ class TimeoutTimer:
 
 class ExclusiveLock:
     """An exclusive Lock based on mkdir fs operation being atomic"""
-    class LockError(Error):
+    class LockError(ErrorWithTraceback):
         """Failed to acquire the lock {}."""
 
     class LockTimeout(LockError):
@@ -85,7 +85,7 @@ class ExclusiveLock:
     class LockFailed(LockError):
         """Failed to create/acquire the lock {} ({})."""
 
-    class UnlockError(Error):
+    class UnlockError(ErrorWithTraceback):
         """Failed to release the lock {}."""
 
     class NotLocked(UnlockError):
@@ -215,10 +215,10 @@ class UpgradableLock:
     noone is allowed reading) and read access to a resource needs a shared
     lock (multiple readers are allowed).
     """
-    class SharedLockFailed(Error):
+    class SharedLockFailed(ErrorWithTraceback):
         """Failed to acquire shared lock [{}]"""
 
-    class ExclusiveLockFailed(Error):
+    class ExclusiveLockFailed(ErrorWithTraceback):
         """Failed to acquire write lock [{}]"""
 
     def __init__(self, path, exclusive=False, sleep=None, id=None):

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -28,7 +28,7 @@ class PathNotAllowed(Error):
 
 
 class InvalidRPCMethod(Error):
-    """RPC method is not valid"""
+    """RPC method {} is not valid"""
 
 
 class RepositoryServer:  # pragma: no cover

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -11,7 +11,7 @@ import struct
 import sys
 from zlib import crc32
 
-from .helpers import Error, IntegrityError, read_msgpack, write_msgpack, unhexlify, have_cython
+from .helpers import Error, ErrorWithTraceback, IntegrityError, read_msgpack, write_msgpack, unhexlify, have_cython
 if have_cython():
     from .hashindex import NSIndex
 from .locking import UpgradableLock
@@ -45,12 +45,12 @@ class Repository:
         """Repository {} already exists."""
 
     class InvalidRepository(Error):
-        """{} is not a valid repository."""
+        """{} is not a valid repository. Check repo config."""
 
-    class CheckNeeded(Error):
+    class CheckNeeded(ErrorWithTraceback):
         """Inconsistency detected. Please run "borg check {}"."""
 
-    class ObjectNotFound(Error):
+    class ObjectNotFound(ErrorWithTraceback):
         """Object with key {} not found in repository {}."""
 
     def __init__(self, path, create=False, exclusive=False):


### PR DESCRIPTION
subclasses of "Error": do not show traceback
(this is used when a failure is expected and has rather trivial reasons and usually
does not need debugging)

subclasses of "ErrorWithTraceback": show a traceback
(this is for severe and rather unexpected stuff, like consistency / corruption issues
or stuff that might need debugging)

I reviewed all the Error subclasses whether they fit into the one or other class.

Also: fixed docstring typo, docstring formatting