### PR TITLE
fix .coverragerc omits, fixes #319

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit =
     */borg/__init__.py
     */borg/__main__.py
     */borg/_version.py
+    */borg/fuse.py
     */borg/support/*
     */borg/testsuite/*
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,8 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
+    pragma: freebsd only
+    pragma: unknown platform only
     def __repr__
     raise AssertionError
     raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     */borg/__main__.py
     */borg/_version.py
     */borg/support/*
+    */borg/testsuite/*
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,10 +2,10 @@
 branch = True
 source = borg
 omit =
-    borg/__init__.py
-    borg/__main__.py
-    borg/_version.py
-    borg/support/*.py
+    */borg/__init__.py
+    */borg/__main__.py
+    */borg/_version.py
+    */borg/support/*
 
 [report]
 exclude_lines =

--- a/borg/platform.py
+++ b/borg/platform.py
@@ -1,12 +1,12 @@
 import sys
 
-if sys.platform.startswith('linux'):
+if sys.platform.startswith('linux'):  # pragma: linux only
     from .platform_linux import acl_get, acl_set, API_VERSION
-elif sys.platform.startswith('freebsd'):
+elif sys.platform.startswith('freebsd'):  # pragma: freebsd only
     from .platform_freebsd import acl_get, acl_set, API_VERSION
-elif sys.platform == 'darwin':
+elif sys.platform == 'darwin':  # pragma: darwin only
     from .platform_darwin import acl_get, acl_set, API_VERSION
-else:
+else:  # pragma: unknown platform only
     API_VERSION = 2
 
     def acl_get(path, item, st, numeric_owner=False):

--- a/borg/xattr.py
+++ b/borg/xattr.py
@@ -36,7 +36,7 @@ def _check(rv, path=None):
         raise OSError(get_errno(), path)
     return rv
 
-if sys.platform.startswith('linux'):
+if sys.platform.startswith('linux'):  # pragma: linux only
     libc.llistxattr.argtypes = (c_char_p, c_char_p, c_size_t)
     libc.llistxattr.restype = c_ssize_t
     libc.flistxattr.argtypes = (c_int, c_char_p, c_size_t)
@@ -100,7 +100,7 @@ if sys.platform.startswith('linux'):
             func = libc.lsetxattr
         _check(func(path, name, value, len(value) if value else 0, 0), path)
 
-elif sys.platform == 'darwin':
+elif sys.platform == 'darwin':  # pragma: darwin only
     libc.listxattr.argtypes = (c_char_p, c_char_p, c_size_t, c_int)
     libc.listxattr.restype = c_ssize_t
     libc.flistxattr.argtypes = (c_int, c_char_p, c_size_t)
@@ -166,7 +166,7 @@ elif sys.platform == 'darwin':
             flags = XATTR_NOFOLLOW
         _check(func(path, name, value, len(value) if value else 0, 0, flags), path)
 
-elif sys.platform.startswith('freebsd'):
+elif sys.platform.startswith('freebsd'):  # pragma: freebsd only
     EXTATTR_NAMESPACE_USER = 0x0001
     libc.extattr_list_fd.argtypes = (c_int, c_int, c_char_p, c_size_t)
     libc.extattr_list_fd.restype = c_ssize_t
@@ -247,7 +247,7 @@ elif sys.platform.startswith('freebsd'):
             func = libc.extattr_set_link
         _check(func(path, EXTATTR_NAMESPACE_USER, name, value, len(value) if value else 0), path)
 
-else:
+else:  # pragma: unknown platform only
     def listxattr(path, *, follow_symlinks=True):
         return []
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ changedir = {toxworkdir}
 deps =
      -rrequirements.d/development.txt
      attic
-commands = py.test --cov=borg --benchmark-skip --pyargs {posargs:borg.testsuite}
+commands = py.test --cov=borg --cov-config=../.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:
 passenv = *


### PR DESCRIPTION
seems like they need a */ prefix

also: exclude everything below support/ - this is 3rd party stuff.