### PR TITLE
Catch msgpack error in archive.py

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -605,10 +605,9 @@ ITEM_KEYS = set([b'path', b'source', b'rdev', b'chunks',
 class RobustUnpacker:
     """A restartable/robust version of the streaming msgpack unpacker
     """
-    item_keys = [msgpack.packb(name) for name in ITEM_KEYS]
-
     def __init__(self, validator):
         super().__init__()
+        self.item_keys = [msgpack.packb(name) for name in ITEM_KEYS]
         self.validator = validator
         self._buffered_data = []
         self._resync = False


### PR DESCRIPTION
This solves:

  File
  "/storage/8899fc1454db04de.a/home/code/ports/pobj/borgbackup-0.28.0/borgbackup-0.28.0/borg/archive.py",
  line 605, in <listcomp>
      item_keys = [msgpack.packb(name) for name in ITEM_KEYS]
      NameError: name 'msgpack' is not defined