### PR TITLE
do not try to build api / usage docs for production install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,11 +202,6 @@ API Documentation
     :undoc-members:
 """ % mod)
 
-# (function, predicate), see http://docs.python.org/2/distutils/apiref.html#distutils.cmd.Command.sub_commands
-# seems like this doesn't work on RTD, see below for build_py hack.
-build.sub_commands.append(('build_api', None))
-build.sub_commands.append(('build_usage', None))
-
 
 class build_py_custom(build_py):
     """override build_py to also build our stuff
@@ -227,8 +222,13 @@ class build_py_custom(build_py):
         super().run()
         self.announce('calling custom build steps', level=log.INFO)
         self.run_command('build_ext')
-        self.run_command('build_api')
-        self.run_command('build_usage')
+        if on_rtd:
+            # only build these files if running on readthedocs, but not
+            # for a normal production install. It requires "mock" and we
+            # do not have that as a build dependency. Also, for really
+            # building the docs, it would also require sphinx, etc.
+            self.run_command('build_api')
+            self.run_command('build_usage')
 
 
 cmdclass = {


### PR DESCRIPTION
it requires "mock" (and later also sphinx) and we do not (want to) have that in setup_requires.

I removed the build.sub_commands.append(...) because that made setup.py install run build_api
and build_usage automatically for production installs. the comment said it does not work on
readthedocs anyway.

build_api and build_usage can still be run manually.