### PR TITLE
avoid hidden import, make it easy for pyinstaller

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -237,7 +237,7 @@ def build_binary_with_pyinstaller(boxname)
     cd /vagrant/borg
     . borg-env/bin/activate
     cd borg
-    pyinstaller -F -n borg.exe --distpath=/vagrant/borg --clean --hidden-import=logging.config borg/__main__.py
+    pyinstaller -F -n borg.exe --distpath=/vagrant/borg --clean borg/__main__.py
   EOF
 end
 

--- a/borg/logger.py
+++ b/borg/logger.py
@@ -33,6 +33,10 @@ The way to use this is as follows:
 import inspect
 import logging
 
+# make it easy for PyInstaller (it does not discover the dependency on this
+# module automatically, because it is lazy-loaded by logging, see #218):
+import logging.config
+
 
 def setup_logging(stream=None):
     """setup logging module according to the arguments provided

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -129,7 +129,7 @@ When using the Vagrant VMs, pyinstaller will already be installed.
 With virtual env activated::
 
   pip install pyinstaller>=3.0  # or git checkout master
-  pyinstaller -F -n borg-PLATFORM --hidden-import=logging.config borg/__main__.py
+  pyinstaller -F -n borg-PLATFORM borg/__main__.py
   for file in dist/borg-*; do gpg --armor --detach-sign $file; done
 
 If you encounter issues, see also our `Vagrantfile` for details.


### PR DESCRIPTION
this fixes #218 in an easier way so one doesn't have to type
--hidden-import=logging.config all the time when using pyinstaller.