### PR TITLE
add a --no-progress flag to forcibly disable progress info

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -772,7 +772,7 @@ class Archiver:
             """
             def __call__(self, parser, ns, values, option):
                 """set the given flag to true unless ``--no`` is passed"""
-                setattr(ns, self.dest, not '--no' in option)
+                setattr(ns, self.dest, option.startswith('--no-'))
 
         subparser = subparsers.add_parser('create', parents=[common_parser],
                                           description=self.do_create.__doc__,

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -761,6 +761,19 @@ class Archiver:
         See the output of the "borg help patterns" command for more help on exclude patterns.
         """)
 
+        class ToggleAction(argparse.Action):
+            """argparse action to handle "toggle" flags easily
+
+            toggle flags are in the form of ``--foo``, ``--no-foo``.
+
+            the ``--no-foo`` argument still needs to be passed to the
+            ``add_argument()`` call, but it simplifies the ``--no``
+            detection.
+            """
+            def __call__(self, parser, ns, values, option):
+                """set the given flag to true unless ``--no`` is passed"""
+                setattr(ns, self.dest, not '--no' in option)
+
         subparser = subparsers.add_parser('create', parents=[common_parser],
                                           description=self.do_create.__doc__,
                                           epilog=create_epilog,
@@ -769,8 +782,9 @@ class Archiver:
         subparser.add_argument('-s', '--stats', dest='stats',
                                action='store_true', default=False,
                                help='print statistics for the created archive')
-        subparser.add_argument('-p', '--progress', dest='progress', const=not sys.stderr.isatty(),
-                               action='store_const', default=sys.stdin.isatty(),
+        subparser.add_argument('-p', '--progress', '--no-progress',
+                               dest='progress', default=sys.stdin.isatty(),
+                               action=ToggleAction, nargs=0,
                                help="""toggle progress display while creating the archive, showing Original,
                                Compressed and Deduplicated sizes, followed by the Number of files seen
                                and the path being processed, default: %(default)s""")


### PR DESCRIPTION
--progress isn't a "toggle" anymore, in that it will never disable progress information: always enable it.

example:

$ borg create ~/test/borg2::test$(date +%s) . ; echo ^shows progress
reading files cache
processing files
^shows progress
$ borg create ~/test/borg2::test$(date +%s) . < /dev/null; echo ^no progress
reading files cache
processing files
^no progress
$ borg create --progress ~/test/borg2::test$(date +%s) . < /dev/null; echo ^progress forced
reading files cache
processing files
^progress forced
$ borg create --no-progress ~/test/borg2::test$(date +%s) . ; echo ^no progress
reading files cache
processing files
^no progress

we introduce a ToggleAction that can be used for other options, but
right now is just slapped in there near the code, which isn't that
elegant. inspired by:

http://stackoverflow.com/questions/11507756/python-argparse-toggle-flags

note that this is supported out of the box by click:
http://click.pocoo.org/5/options/#boolean-flags

fixes #398