### PR TITLE
borg prune --save-space, fixes #239

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -476,7 +476,11 @@ class Archiver:
             else:
                 self.print_info('Pruning archive: %s' % format_archive(archive))
                 Archive(repository, key, manifest, archive.name, cache).delete(stats)
-        if to_delete and not args.dry_run:
+                if args.save_space:
+                    manifest.write()
+                    repository.commit()
+                    cache.commit()
+        if to_delete and not args.dry_run and not args.save_space:
             manifest.write()
             repository.commit()
             cache.commit()
@@ -987,6 +991,9 @@ class Archiver:
         subparser.add_argument('-s', '--stats', dest='stats',
                                action='store_true', default=False,
                                help='print statistics for the deleted archive')
+        subparser.add_argument('--save-space', dest='save_space',
+                               action='store_true', default=False,
+                               help='prune in a slower, but space-saving way')
         subparser.add_argument('--keep-within', dest='within', type=str, metavar='WITHIN',
                                help='keep all archives within this time interval')
         subparser.add_argument('-H', '--keep-hourly', dest='hourly', type=int, default=0,

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -993,7 +993,7 @@ class Archiver:
                                help='print statistics for the deleted archive')
         subparser.add_argument('--save-space', dest='save_space',
                                action='store_true', default=False,
-                               help='prune in a slower, but space-saving way')
+                               help='prune in a slower, but space efficient way')
         subparser.add_argument('--keep-within', dest='within', type=str, metavar='WITHIN',
                                help='keep all archives within this time interval')
         subparser.add_argument('-H', '--keep-hourly', dest='hourly', type=int, default=0,

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -210,6 +210,12 @@ class Repository:
     def compact_segments(self):
         """Compact sparse segments by copying data into new segments
         """
+        # note: this first copies (potentially lots of) segments to new segments,
+        # needing (potentially lots of) additional space (which might be problematic
+        # in low space conditions). then it commits, then deletes the old segments
+        # (finally freeing up space).
+        # when trying to optimize this for low space conditions, make sure not to
+        # create lots of segment files significantly smaller than the target size.
         if not self.compact:
             return
         index_transaction_id = self.get_index_transaction_id()

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -683,6 +683,21 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_not_in('test1', output)
         self.assert_in('test2', output)
 
+    def test_prune_repository_save_space(self):
+        self.cmd('init', self.repository_location)
+        self.cmd('create', self.repository_location + '::test1', src_dir)
+        self.cmd('create', self.repository_location + '::test2', src_dir)
+        output = self.cmd('prune', '-v', '--dry-run', self.repository_location, '--keep-daily=2')
+        self.assert_in('Keeping archive: test2', output)
+        self.assert_in('Would prune:     test1', output)
+        output = self.cmd('list', self.repository_location)
+        self.assert_in('test1', output)
+        self.assert_in('test2', output)
+        self.cmd('prune', '--save-space', self.repository_location, '--keep-daily=2')
+        output = self.cmd('list', self.repository_location)
+        self.assert_not_in('test1', output)
+        self.assert_in('test2', output)
+
     def test_prune_repository_prefix(self):
         self.cmd('init', self.repository_location)
         self.cmd('create', self.repository_location + '::foo-2015-08-12-10:00', src_dir)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,7 +29,7 @@ Also helpful:
   some unallocated PEs you can add to the LV.
 - consider using quotas
 - use `prune` regularly
-
+- if you do not have much free disk space, use `borg prune --save-space ...`
 
 A step by step example
 ----------------------


### PR DESCRIPTION
please review!

standard pruning:
Per chunk that is deleted, it writes a DELETE tag into the repo (and remembers the segment for later compaction).
When it does a commit (it does that AFTER pruning all archives!), it calls compact_segments, which writes the remaining chunks into new segments.
At the very very end, it deletes the segments it does not need any more. This uses a lot of additional space to free up space - bad if you are low on space.

space-saving pruning:
delete one archive, then commit (and compact), repeat.
this is slower, but uses less additional disk space.

also: added some notes to compact_segments() for future optimization