### PR TITLE
Avoid orphan locks, see #285

### DIFF
--- a/borg/remote.py
+++ b/borg/remote.py
@@ -97,7 +97,7 @@ class RepositoryServer:  # pragma: no cover
     def negotiate(self, versions):
         return 1
 
-    def open(self, path, create=False):
+    def open(self, path, create=False, lock_wait=None):
         path = os.fsdecode(path)
         if path.startswith('/~'):
             path = path[1:]
@@ -108,7 +108,7 @@ class RepositoryServer:  # pragma: no cover
                     break
             else:
                 raise PathNotAllowed(path)
-        self.repository = Repository(path, create)
+        self.repository = Repository(path, create, lock_wait=lock_wait)
         return self.repository.id
 
 
@@ -122,7 +122,7 @@ class RemoteRepository:
         def __init__(self, name):
             self.name = name
 
-    def __init__(self, location, create=False):
+    def __init__(self, location, create=False, lock_wait=None):
         self.location = location
         self.preload_ids = []
         self.msgid = 0
@@ -154,7 +154,7 @@ class RemoteRepository:
             raise ConnectionClosedWithHint('Is borg working on the server?')
         if version != 1:
             raise Exception('Server insisted on using unsupported protocol version %d' % version)
-        self.id = self.call('open', location.path, create)
+        self.id = self.call('open', location.path, create, lock_wait)
 
     def __del__(self):
         self.close()

--- a/borg/testsuite/repository.py
+++ b/borg/testsuite/repository.py
@@ -6,7 +6,7 @@ from mock import patch
 
 from ..hashindex import NSIndex
 from ..helpers import Location, IntegrityError
-from ..locking import UpgradableLock
+from ..locking import UpgradableLock, LockFailed
 from ..remote import RemoteRepository, InvalidRPCMethod
 from ..repository import Repository
 from . import BaseTestCase
@@ -158,9 +158,9 @@ class RepositoryCommitTestCase(RepositoryTestCaseBase):
         for name in os.listdir(self.repository.path):
             if name.startswith('index.'):
                 os.unlink(os.path.join(self.repository.path, name))
-        with patch.object(UpgradableLock, 'upgrade', side_effect=UpgradableLock.ExclusiveLockFailed) as upgrade:
+        with patch.object(UpgradableLock, 'upgrade', side_effect=LockFailed) as upgrade:
             self.reopen()
-            self.assert_raises(UpgradableLock.ExclusiveLockFailed, lambda: len(self.repository))
+            self.assert_raises(LockFailed, lambda: len(self.repository))
             upgrade.assert_called_once_with()
 
     def test_crash_before_write_index(self):


### PR DESCRIPTION
based on PR#438.

one small fix to avoid orphan locks at a specific place.

but: it will still happen, as the exclusive lock is held over a long time (e.g. while a backup is running) and the current method to release it relies on `__del__` methods in Cache and Repository, which is maybe not the most reliable thing.