### PR TITLE
refactor --verbose and silence borg by default

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -75,7 +75,7 @@ class Archiver:
 
     def print_file_status(self, status, path):
         if self.args.changed:
-            logger.info("%1s %s" % (status, remove_surrogates(path)))
+            print("%1s %s" % (status, remove_surrogates(path)), file=sys.stderr)
 
     def do_serve(self, args):
         """Start in server mode. This command is usually not used manually.
@@ -663,9 +663,9 @@ class Archiver:
     def build_parser(self, args=None, prog=None):
         common_parser = argparse.ArgumentParser(add_help=False, prog=prog)
         common_parser.add_argument('-v', '--verbose', dest='log_level',
-                                   action='store_const', const='info', default='info',
+                                   action='store_const', const='info', default='warning',
                                    help='verbose output, same as --log-level=info')
-        common_parser.add_argument('--log-level', dest='log_level', default='info', metavar='LEVEL',
+        common_parser.add_argument('--log-level', dest='log_level', default='warning', metavar='LEVEL',
                                    choices=('debug', 'info', 'warning', 'error', 'critical'),
                                    help='set the log level to LEVEL, default: %(default)s)')
         common_parser.add_argument('--lock-wait', dest='lock_wait', type=int, metavar='N', default=1,

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -51,9 +51,8 @@ class ToggleAction(argparse.Action):
 
 class Archiver:
 
-    def __init__(self, verbose=False, lock_wait=None):
+    def __init__(self, lock_wait=None):
         self.exit_code = EXIT_SUCCESS
-        self.verbose = verbose
         self.lock_wait = lock_wait
 
     def open_repository(self, location, create=False, exclusive=False, lock=True):
@@ -74,10 +73,8 @@ class Archiver:
         self.exit_code = EXIT_WARNING  # we do not terminate here, so it is a warning
         logger.warning(msg)
 
-    def print_verbose(self, msg, *args):
-        if self.verbose:
-            msg = args and msg % args or msg
-            logger.info(msg)
+    def print_file_status(self, status, path):
+        logger.info("1s %s", status, remove_surrogates(path))
 
     def do_serve(self, args):
         """Start in server mode. This command is usually not used manually.
@@ -166,7 +163,7 @@ class Archiver:
                         self.print_warning('%s: %s', path, e)
                 else:
                     status = '-'
-                self.print_verbose("%1s %s", status, remove_surrogates(path))
+                self.print_file_status(status, path)
                 continue
             path = os.path.normpath(path)
             if args.one_file_system:
@@ -265,9 +262,7 @@ class Archiver:
                 status = '?'  # need to add a status code somewhere
             else:
                 status = '-'  # dry run, item was not backed up
-        # output ALL the stuff - it can be easily filtered using grep.
-        # even stuff considered unchanged might be interesting.
-        self.print_verbose("%1s %s", status, remove_surrogates(path))
+        self.print_file_status(status, path)
 
     def do_extract(self, args):
         """Extract archive contents"""
@@ -295,7 +290,7 @@ class Archiver:
             if not args.dry_run:
                 while dirs and not item[b'path'].startswith(dirs[-1][b'path']):
                     archive.extract_item(dirs.pop(-1), stdout=stdout)
-            self.print_verbose(remove_surrogates(orig_path))
+            logger.info(remove_surrogates(orig_path))
             try:
                 if dry_run:
                     archive.extract_item(item, dry_run=True)
@@ -381,7 +376,7 @@ class Archiver:
             else:
                 archive = None
             operations = FuseOperations(key, repository, manifest, archive)
-            self.print_verbose("Mounting filesystem")
+            logger.info("Mounting filesystem")
             try:
                 operations.mount(args.mountpoint, args.options, args.foreground)
             except RuntimeError:
@@ -484,12 +479,12 @@ class Archiver:
         to_delete = [a for a in archives if a not in keep]
         stats = Statistics()
         for archive in keep:
-            self.print_verbose('Keeping archive: %s' % format_archive(archive))
+            logger.info('Keeping archive: %s' % format_archive(archive))
         for archive in to_delete:
             if args.dry_run:
-                self.print_verbose('Would prune:     %s' % format_archive(archive))
+                logger.info('Would prune:     %s' % format_archive(archive))
             else:
-                self.print_verbose('Pruning archive: %s' % format_archive(archive))
+                logger.info('Pruning archive: %s' % format_archive(archive))
                 Archive(repository, key, manifest, archive.name, cache).delete(stats)
         if to_delete and not args.dry_run:
             manifest.write()
@@ -666,8 +661,9 @@ class Archiver:
 
     def build_parser(self, args=None, prog=None):
         common_parser = argparse.ArgumentParser(add_help=False, prog=prog)
-        common_parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', default=False,
-                                   help='verbose output')
+        common_parser.add_argument('-v', '--verbose', dest='log_level',
+                                   action='store_const', const='info', default='info',
+                                   help='verbose output, same as --log-level=info')
         common_parser.add_argument('--log-level', dest='log_level', default='info', metavar='LEVEL',
                                    choices=('debug', 'info', 'warning', 'error', 'critical'),
                                    help='set the log level to LEVEL, default: %(default)s)')
@@ -1180,7 +1176,6 @@ class Archiver:
 
     def run(self, args):
         os.umask(args.umask)  # early, before opening files
-        self.verbose = args.verbose
         self.lock_wait = args.lock_wait
         RemoteRepository.remote_path = args.remote_path
         RemoteRepository.umask = args.umask

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -74,7 +74,7 @@ class Archiver:
         logger.warning(msg)
 
     def print_file_status(self, status, path):
-        if self.args.changed:
+        if self.changed:
             print("%1s %s" % (status, remove_surrogates(path)), file=sys.stderr)
 
     def do_serve(self, args):
@@ -1174,13 +1174,14 @@ class Archiver:
             args = self.preprocess_args(args)
         parser = self.build_parser(args)
         args = parser.parse_args(args or ['-h'])
-        self.args = args
         update_excludes(args)
         return args
 
     def run(self, args):
         os.umask(args.umask)  # early, before opening files
         self.lock_wait = args.lock_wait
+        self.changed = getattr(args, 'changed', False)
+        self.unchanged = getattr(args, 'unchanged', False)
         RemoteRepository.remote_path = args.remote_path
         RemoteRepository.umask = args.umask
         setup_logging(level=args.log_level)  # do not use loggers before this!

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -74,8 +74,12 @@ class Archiver:
         logger.warning(msg)
 
     def print_file_status(self, status, path):
-        if self.changed:
-            print("%1s %s" % (status, remove_surrogates(path)), file=sys.stderr)
+        if status == 'U':
+            if self.unchanged:
+                print("%1s %s" % (status, remove_surrogates(path)), file=sys.stderr)
+        else:
+            if self.changed:
+                print("%1s %s" % (status, remove_surrogates(path)), file=sys.stderr)
 
     def do_serve(self, args):
         """Start in server mode. This command is usually not used manually.
@@ -804,6 +808,8 @@ class Archiver:
                                and the path being processed, default: %(default)s""")
         subparser.add_argument('--changed', action='store_true', dest='changed', default=False,
                                help="""display which files were added to the archive""")
+        subparser.add_argument('--unchanged', action='store_true', dest='unchanged', default=False,
+                               help="""display which files were *not* added to the archive""")
         subparser.add_argument('-e', '--exclude', dest='excludes',
                                type=ExcludePattern, action='append',
                                metavar="PATTERN", help='exclude paths matching PATTERN')

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -74,7 +74,8 @@ class Archiver:
         logger.warning(msg)
 
     def print_file_status(self, status, path):
-        logger.info("1s %s", status, remove_surrogates(path))
+        if self.args.changed:
+            logger.info("%1s %s" % (status, remove_surrogates(path)))
 
     def do_serve(self, args):
         """Start in server mode. This command is usually not used manually.
@@ -801,6 +802,8 @@ class Archiver:
                                help="""toggle progress display while creating the archive, showing Original,
                                Compressed and Deduplicated sizes, followed by the Number of files seen
                                and the path being processed, default: %(default)s""")
+        subparser.add_argument('--changed', action='store_true', dest='changed', default=False,
+                               help="""display which files were added to the archive""")
         subparser.add_argument('-e', '--exclude', dest='excludes',
                                type=ExcludePattern, action='append',
                                metavar="PATTERN", help='exclude paths matching PATTERN')
@@ -1171,6 +1174,7 @@ class Archiver:
             args = self.preprocess_args(args)
         parser = self.build_parser(args)
         args = parser.parse_args(args or ['-h'])
+        self.args = args
         update_excludes(args)
         return args
 

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -724,7 +724,10 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in("A input/file2", output)
 
     def test_create_topical(self):
+        now = time.time()
         self.create_regular_file('file1', size=1024 * 80)
+        os.utime('input/file1', (now-5, now-5))
+        self.create_regular_file('file2', size=1024 * 80)
         self.cmd('init', self.repository_location)
         # no listing by default
         output = self.cmd('create', self.repository_location + '::test', 'input')
@@ -733,11 +736,11 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd('create', self.repository_location + '::test0', 'input')
         self.assert_not_in('file1', output)
         # should list the file as unchanged
-        #output = self.cmd('create', '--unchanged', self.repository_location + '::test1', 'input')
-        #self.assert_in('file1', output)
+        output = self.cmd('create', '--unchanged', self.repository_location + '::test1', 'input')
+        self.assert_in('file1', output)
         # should *not* list the file as changed
-        #output = self.cmd('create', '--changed', self.repository_location + '::test2', 'input')
-        #self.assert_not_in('file1', output)
+        output = self.cmd('create', '--changed', self.repository_location + '::test2', 'input')
+        self.assert_not_in('file1', output)
         # change the file
         self.create_regular_file('file1', size=1024 * 100)
         # should list the file as changed

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -713,11 +713,11 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         os.utime('input/file1', (now - 5, now - 5)) # 5 seconds ago
         self.create_regular_file('file2', size=1024 * 80)
         self.cmd('init', self.repository_location)
-        output = self.cmd('create', '--verbose', self.repository_location + '::test', 'input')
+        output = self.cmd('create', '--changed', '--unchanged', self.repository_location + '::test', 'input')
         self.assert_in("A input/file1", output)
         self.assert_in("A input/file2", output)
         # should find first file as unmodified
-        output = self.cmd('create', '--verbose', self.repository_location + '::test1', 'input')
+        output = self.cmd('create', '--changed', '--unchanged', self.repository_location + '::test1', 'input')
         self.assert_in("U input/file1", output)
         # this is expected, although surprising, for why, see:
         # http://borgbackup.readthedocs.org/en/latest/faq.html#i-am-seeing-a-added-status-for-a-unchanged-file

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -947,13 +947,13 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         return archive, repository
 
     def test_check_usage(self):
-        output = self.cmd('check', self.repository_location, exit_code=0)
+        output = self.cmd('check', '--log-level=info', self.repository_location, exit_code=0)
         self.assert_in('Starting repository check', output)
         self.assert_in('Starting archive consistency check', output)
-        output = self.cmd('check', '--repository-only', self.repository_location, exit_code=0)
+        output = self.cmd('check', '--log-level=info', '--repository-only', self.repository_location, exit_code=0)
         self.assert_in('Starting repository check', output)
         self.assert_not_in('Starting archive consistency check', output)
-        output = self.cmd('check', '--archives-only', self.repository_location, exit_code=0)
+        output = self.cmd('check', '--log-level=info', '--archives-only', self.repository_location, exit_code=0)
         self.assert_not_in('Starting repository check', output)
         self.assert_in('Starting archive consistency check', output)
 

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -723,6 +723,27 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         # http://borgbackup.readthedocs.org/en/latest/faq.html#i-am-seeing-a-added-status-for-a-unchanged-file
         self.assert_in("A input/file2", output)
 
+    def test_create_topical(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', self.repository_location)
+        # no listing by default
+        output = self.cmd('create', self.repository_location + '::test', 'input')
+        self.assert_not_in('file1', output)
+        # shouldn't be listed even if unchanged
+        output = self.cmd('create', self.repository_location + '::test0', 'input')
+        self.assert_not_in('file1', output)
+        # should list the file as unchanged
+        #output = self.cmd('create', '--unchanged', self.repository_location + '::test1', 'input')
+        #self.assert_in('file1', output)
+        # should *not* list the file as changed
+        #output = self.cmd('create', '--changed', self.repository_location + '::test2', 'input')
+        #self.assert_not_in('file1', output)
+        # change the file
+        self.create_regular_file('file1', size=1024 * 100)
+        # should list the file as changed
+        output = self.cmd('create', '--changed', self.repository_location + '::test3', 'input')
+        self.assert_in('file1', output)
+
     def test_cmdline_compatibility(self):
         self.create_regular_file('file1', size=1024 * 80)
         self.cmd('init', self.repository_location)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -430,7 +430,8 @@ Item flags
 ~~~~~~~~~~
 
 `borg create --changed` outputs a verbose list of all files, directories and other
-file system items it considered. For each item, it prefixes a single-letter
+file system items it considered, with the exception of unchanged files
+(for this, also add `--unchanged`). For each item, it prefixes a single-letter
 flag that indicates type and/or status of the item.
 
 A uppercase character represents the status of a regular file relative to the
@@ -440,7 +441,7 @@ chunks are stored. For 'U' all data chunks refer to already existing chunks.
 
 - 'A' = regular file, added (see also :ref:`a_status_oddity` in the FAQ)
 - 'M' = regular file, modified
-- 'U' = regular file, unchanged
+- 'U' = regular file, unchanged (only if `--unchanged` is specified)
 - 'E' = regular file, an error happened while accessing/reading *this* file
 
 A lowercase character means a file type other than a regular file,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,12 +21,6 @@ Supported levels: ``debug``, ``info``, ``warning``, ``error``, ``critical``.
 
 All log messages created with at least the given level will be output.
 
-Amount of informational output
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For some subcommands, using the ``-v`` or ``--verbose`` option will give you
-more informational output (at ``info`` level).
-
 Return codes
 ~~~~~~~~~~~~
 
@@ -435,7 +429,7 @@ Here are misc. notes about topics that are maybe not covered in enough detail in
 Item flags
 ~~~~~~~~~~
 
-`borg create -v` outputs a verbose list of all files, directories and other
+`borg create --changed` outputs a verbose list of all files, directories and other
 file system items it considered. For each item, it prefixes a single-letter
 flag that indicates type and/or status of the item.
 


### PR DESCRIPTION
this aims at fixing #427. the idea here is that --verbose does very little: it only lists pruned archives and triggers the file listing in `create`. i think it is expected that borg be silent by default, since it is mostly designed to be ran automatically (see #425 for an example). It is also confusing to have both `--log-level` and `--verbose` that do basically the same thing, that is: control how much messages the users see when borg runs.

this merges the `verbose` and `log-level` arguments together, and default them to `warning`, which silences most of borg's normal operations by default. file listing is also moved to a different topical flag, `--changed`, that is not displayed by default anymore, even if `--verbose` is specified.

`--unchanged` will eventually be added but, during my tests, it seems that `U` is not displayed when expected (see the commented out tests for examples).