### PR TITLE
add test for the weird unchanged file status

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -165,6 +165,8 @@ Yes, if you want to detect accidental data damage (like bit rot), use the
 If you want to be able to detect malicious tampering also, use a encrypted
 repo. It will then be able to check using CRCs and HMACs.
 
+.. _a_status_oddity:
+
 I am seeing 'A' (added) status for a unchanged file!?
 -----------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -168,9 +168,9 @@ repo. It will then be able to check using CRCs and HMACs.
 I am seeing 'A' (added) status for a unchanged file!?
 -----------------------------------------------------
 
-The files cache (which is used to determine whether |project_name| already
-"knows" / has backed up a file and if so, to skip the file from chunking)
-does intentionally *not* contain files that:
+The files cache is used to determine whether |project_name| already
+"knows" / has backed up a file and if so, to skip the file from
+chunking. It does intentionally *not* contain files that:
 
 - have >= 10 as "entry age" (|project_name| has not seen this file for a while)
 - have a modification time (mtime) same as the newest mtime in the created
@@ -190,6 +190,10 @@ This does not affect deduplication, the file will be chunked, but as the chunks
 will often be the same and already stored in the repo (except in the above
 mentioned rare condition), it will just re-use them as usual and not store new
 data chunks.
+
+Since only the files cache is used in the display of files status,
+those files are reported as being added when, really, chunks are
+already used.
 
 Why was Borg forked from Attic?
 -------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -444,7 +444,7 @@ A uppercase character represents the status of a regular file relative to the
 is not used). Metadata is stored in any case and for 'A' and 'M' also new data
 chunks are stored. For 'U' all data chunks refer to already existing chunks.
 
-- 'A' = regular file, added
+- 'A' = regular file, added (see also :ref:`a_status_oddity` in the FAQ)
 - 'M' = regular file, modified
 - 'U' = regular file, unchanged
 - 'E' = regular file, an error happened while accessing/reading *this* file


### PR DESCRIPTION
this tests the behaviour found in #403 and documented in #418, but doesn't fail on the unexpected A

this also clarifies the documentation on this issue to hilight that the reason this is okay is because we only look at the files cache for status. also link in the usage.