### PR TITLE
hashindex_add C implementation

### DIFF
--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -391,20 +391,23 @@ hashindex_summarize(HashIndex *index, long long *total_size, long long *total_cs
 }
 
 static void
+hashindex_add(HashIndex *index, const void *key, int32_t *other_values)
+{
+    int32_t *my_values = (int32_t *)hashindex_get(index, key);
+    if(my_values == NULL) {
+        hashindex_set(index, key, other_values);
+    } else {
+        *my_values += *other_values;
+    }
+}
+
+static void
 hashindex_merge(HashIndex *index, HashIndex *other)
 {
     int32_t key_size = index->key_size;
-    const int32_t *other_values;
-    int32_t *my_values;
     void *key = NULL;
 
     while((key = hashindex_next_key(other, key))) {
-        other_values = key + key_size;
-        my_values = (int32_t *)hashindex_get(index, key);
-        if(my_values == NULL) {
-            hashindex_set(index, key, other_values);
-        } else {
-            *my_values += *other_values;
-        }
+        hashindex_add(index, key, key + key_size);
     }
 }

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -15,6 +15,7 @@ cdef extern from "_hashindex.c":
                              long long *unique_size, long long *unique_csize,
                              long long *total_unique_chunks, long long *total_chunks)
     void hashindex_merge(HashIndex *index, HashIndex *other)
+    void hashindex_add(HashIndex *index, void *key, void *value)
     int hashindex_get_size(HashIndex *index)
     int hashindex_write(HashIndex *index, char *path)
     void *hashindex_get(HashIndex *index, void *key)
@@ -195,6 +196,14 @@ cdef class ChunkIndex(IndexBase):
                             &unique_size, &unique_csize,
                             &total_unique_chunks, &total_chunks)
         return total_size, total_csize, unique_size, unique_csize, total_unique_chunks, total_chunks
+
+    def add(self, key, refs, size, csize):
+        assert len(key) == self.key_size
+        cdef int[3] data
+        data[0] = _htole32(refs)
+        data[1] = _htole32(size)
+        data[2] = _htole32(csize)
+        hashindex_add(self.index, <char *>key, data)
 
     def merge(self, ChunkIndex other):
         hashindex_merge(self.index, other.index)


### PR DESCRIPTION
this was also the loop contents of hashindex_merge, but we also need it callable from Cython/Python code.

this saves some cycles, esp. if the key is already present in the index.