### PR TITLE
Fix wrong installation instructions for archlinux

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,7 +32,7 @@ yet.
 ============ ===================== =======
 Distribution Source                Command
 ============ ===================== =======
-Arch Linux   `[community]`_        ``pacman -Syu borg``
+Arch Linux   `[community]`_        ``pacman -S borg``
 Debian       `unstable/sid`_       ``apt install borgbackup``
 Ubuntu       `Xenial Xerus 16.04`_ ``apt install borgbackup``
 OS X         `Brew cask`_          ``brew cask install borgbackup``


### PR DESCRIPTION
On arch I don't want to perform a full system upgrade when installing a new package; so let's drop the "yu" part.