### PR TITLE
Optimized fuse inode cache

### DIFF
--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -28,7 +28,7 @@ class ItemCache:
 
     def get(self, inode):
         self.fd.seek(inode - self.offset, io.SEEK_SET)
-        return next(msgpack.Unpacker(self.fd))
+        return next(msgpack.Unpacker(self.fd, read_size=512))
 
 
 class FuseOperations(llfuse.Operations):


### PR DESCRIPTION
 Single-shot unpacker read buffer decreased from (default) 1Mb to 512b.
"ls -alR" on ~100k files backup mounted with fuse went from ~7min to 30 seconds.