### PR TITLE
remove --progress magic, fixes #476

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -798,10 +798,9 @@ class Archiver:
         subparser.add_argument('-s', '--stats', dest='stats',
                                action='store_true', default=False,
                                help='print statistics for the created archive')
-        subparser.add_argument('-p', '--progress', '--no-progress',
-                               dest='progress', default=sys.stdin.isatty(),
-                               action=ToggleAction, nargs=0,
-                               help="""toggle progress display while creating the archive, showing Original,
+        subparser.add_argument('-p', '--progress', dest='progress',
+                               action='store_true', default=False,
+                               help="""show progress display while creating the archive, showing Original,
                                Compressed and Deduplicated sizes, followed by the Number of files seen
                                and the path being processed, default: %(default)s""")
         subparser.add_argument('--filter', dest='output_filter', metavar='STATUSCHARS',

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -676,32 +676,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd('create', '--progress', self.repository_location + '::test4', 'input')
         self.assert_in("\r", output)
         # progress forced off
-        output = self.cmd('create', '--no-progress', self.repository_location + '::test5', 'input')
-        self.assert_not_in("\r", output)
-
-    @unittest.skipUnless(sys.stdout.isatty(), 'need a tty to test auto-detection')
-    def test_progress_tty(self):
-        """test that the --progress and --no-progress flags work,
-        overriding defaults from the terminal auto-detection"""
-        self.create_regular_file('file1', size=1024 * 80)
-        self.cmd('init', self.repository_location)
-        # without a terminal, no progress expected
-        output = self.cmd('create', self.repository_location + '::test1', 'input', fork=False)
-        self.assert_not_in("\r", output)
-        # with a terminal, progress expected
-        output = self.cmd('create', self.repository_location + '::test2', 'input', fork=True)
-        self.assert_in("\r", output)
-        # without a terminal, progress forced on
-        output = self.cmd('create', '--progress', self.repository_location + '::test3', 'input', fork=False)
-        self.assert_in("\r", output)
-        # with a terminal, progress forced on
-        output = self.cmd('create', '--progress', self.repository_location + '::test4', 'input', fork=True)
-        self.assert_in("\r", output)
-        # without a terminal, progress forced off
-        output = self.cmd('create', '--no-progress', self.repository_location + '::test5', 'input', fork=False)
-        self.assert_not_in("\r", output)
-        # with a terminal, progress forced off
-        output = self.cmd('create', '--no-progress', self.repository_location + '::test6', 'input', fork=True)
+        output = self.cmd('create', self.repository_location + '::test5', 'input')
         self.assert_not_in("\r", output)
 
     def test_file_status(self):


### PR DESCRIPTION
For 0.29 we worked towards a "silent by default" behaviour, so interactive usage will include -v more frequently in future.

But I noticed that this conflicts with the progress display. This would be no problem if users willingly decide which one
of --verbose or --progress they want to see, but before this fix, the progress display was activated magically when
a tty was detected. So, to counteract this magic, users would need to use --no-progress.

That's backwards imho, so I removed the magic again and users have to give --progress when they want
to see a progress indicator. Or (alternatively) they give --verbose when they want to see the long file list.