### PR TITLE
Implement exclusions using regular expressions

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -18,7 +18,7 @@ import traceback
 from . import __version__
 from .helpers import Error, location_validator, format_time, format_file_size, \
     format_file_mode, ExcludePattern, IncludePattern, exclude_path, adjust_patterns, to_localtime, timestamp, \
-    get_cache_dir, get_keys_dir, prune_within, prune_split, unhexlify, \
+    get_cache_dir, get_keys_dir, prune_within, prune_split, unhexlify, ExcludeRegex, \
     Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
     dir_is_tagged, bigint_to_int, ChunkerParams, CompressionSpec, is_slow_msgpack, yes, sysinfo, \
     EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
@@ -817,6 +817,9 @@ class Archiver:
         subparser.add_argument('--exclude-from', dest='exclude_files',
                                type=argparse.FileType('r'), action='append',
                                metavar='EXCLUDEFILE', help='read exclude patterns from EXCLUDEFILE, one per line')
+        subparser.add_argument('--exclude-regex', dest='excludes',
+                               type=ExcludeRegex, action='append',
+                               metavar="REGEX", help='exclude paths matching regular expression')
         subparser.add_argument('--exclude-caches', dest='exclude_caches',
                                action='store_true', default=False,
                                help='exclude directories that contain a CACHEDIR.TAG file (http://www.brynosaurus.com/cachedir/spec.html)')
@@ -887,6 +890,9 @@ class Archiver:
         subparser.add_argument('--exclude-from', dest='exclude_files',
                                type=argparse.FileType('r'), action='append',
                                metavar='EXCLUDEFILE', help='read exclude patterns from EXCLUDEFILE, one per line')
+        subparser.add_argument('--exclude-regex', dest='excludes',
+                               type=ExcludeRegex, action='append',
+                               metavar="REGEX", help='exclude paths matching regular expression')
         subparser.add_argument('--numeric-owner', dest='numeric_owner',
                                action='store_true', default=False,
                                help='only obey numeric user and group identifiers')

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -488,6 +488,37 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             self.cmd('extract', '--exclude-from=' + self.exclude_file_path, self.repository_location + '::test')
         self.assert_equal(sorted(os.listdir('output/input')), ['file1', 'file3'])
 
+    def test_extract_include_exclude_regex(self):
+        self.cmd('init', self.repository_location)
+        self.create_regular_file('file1', size=1024 * 80)
+        self.create_regular_file('file2', size=1024 * 80)
+        self.create_regular_file('file3', size=1024 * 80)
+        self.create_regular_file('file4', size=1024 * 80)
+
+        # Create with --exclude-regex
+        self.cmd('create', '--exclude-regex=input/file4$', self.repository_location + '::test', 'input')
+        with changedir('output'):
+            self.cmd('extract', self.repository_location + '::test')
+        self.assert_equal(sorted(os.listdir('output/input')), ['file1', 'file2', 'file3'])
+        shutil.rmtree('output/input')
+
+        # Extract with --exclude-regex
+        with changedir('output'):
+            self.cmd('extract', '--exclude-regex=file3+', self.repository_location + '::test')
+        self.assert_equal(sorted(os.listdir('output/input')), ['file1', 'file2'])
+        shutil.rmtree('output/input')
+
+        # Combine --exclude and --exclude-regex
+        with changedir('output'):
+            self.cmd('extract', '--exclude=input/file2', '--exclude-regex=file[01]', self.repository_location + '::test')
+        self.assert_equal(sorted(os.listdir('output/input')), ['file3'])
+        shutil.rmtree('output/input')
+
+        # Combine --exclude-from and --exclude-regex
+        with changedir('output'):
+            self.cmd('extract', '--exclude-from=' + self.exclude_file_path, '--exclude-regex=file1', self.repository_location + '::test')
+        self.assert_equal(sorted(os.listdir('output/input')), ['file3'])
+
     def test_exclude_caches(self):
         self.cmd('init', self.repository_location)
         self.create_regular_file('file1', size=1024 * 80)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -229,6 +229,10 @@ Examples
         ~/src                             \
         --exclude '*.pyc'
 
+    # Backup home directories excluding directories containing image thumbnails
+    $ borg create /mnt/backup::my-files /home \
+        --exclude-regex '^/home/[^/]/\.thumbnails/'
+
     # Backup the root filesystem into an archive named "root-YYYY-MM-DD"
     # use zlib compression (good, but slow) - default is no compression
     NAME="root-`date +%Y-%m-%d`"


### PR DESCRIPTION
The existing option to exclude files and directories, “--exclude”, is
implemented using fnmatch[1]. fnmatch matches the slash (“/”) with “*”
and thus makes it impossible to write patterns where a directory with
a given name should be excluded at a given location in the directory
hierarchy, but not at any other place. Consider this structure:

  home/
  home/aaa
  home/aaa/.thumbnails
  home/user
  home/user/img
  home/user/img/.thumbnails

The intention is to exclude “.thumbnails” in all home directories while
retaining directories with the same name in all other locations. With
fnmatch the pattern “home/*/.thumbnails” matches
“home/user/img/.thumbnails” too.

The desired exclusion can be implemented using the “--exclude-regex”
option introduced with this change:

  --exclude-regex 'home/[^/]+/\.thumbnails'

This change has been discussed in issue #43.

[1] https://docs.python.org/3/library/fnmatch.html
