### PR TITLE
docs: standalone binary needs exec on temp

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,6 +69,8 @@ make borg readable and executable for its users and then you can run ``borg``::
     sudo chown root:root /usr/local/bin/borg
     sudo chmod 755 /usr/local/bin/borg
 
+Note that pyinstaller uses /tmp for executable dependencies. |project_name| will fail if /tmp has less than 40M of free space or is mounted with the ``noxece`` option. You can change the temporary directory by setting the ``TEMP`` environment variable before running borg.
+
 If a new version is released, you will have to manually download it and replace
 the old version using the same steps as shown above.
 


### PR DESCRIPTION
Documentation: Standalone binary / pyinstaller extracts dependencies into /tmp. Currently /tmp requires about ~28MB of space, but 40MB should be safe. It also needs exec permissions.
Closes #499