### PR TITLE
Factorize and test loading of excludes from file

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -235,16 +235,21 @@ def parse_timestamp(timestamp):
         return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc)
 
 
+def load_excludes(fh):
+    """Load and parse exclude patterns from file object. Empty lines and lines starting with '#' are ignored, but
+    whitespace is not stripped.
+    """
+    patterns = (line.rstrip('\r\n') for line in fh if not line.startswith('#'))
+    return [ExcludePattern(pattern) for pattern in patterns if pattern]
+
+
 def update_excludes(args):
-    """Merge exclude patterns from files with those on command line.
-    Empty lines and lines starting with '#' are ignored, but whitespace
-    is not stripped."""
+    """Merge exclude patterns from files with those on command line."""
     if hasattr(args, 'exclude_files') and args.exclude_files:
         if not hasattr(args, 'excludes') or args.excludes is None:
             args.excludes = []
         for file in args.exclude_files:
-            patterns = [line.rstrip('\r\n') for line in file if not line.startswith('#')]
-            args.excludes += [ExcludePattern(pattern) for pattern in patterns if pattern]
+            args.excludes += load_excludes(file)
             file.close()
 
 


### PR DESCRIPTION
The parsing code for exclude files (given via `--exclude-from`) was not tested.
The core is factorized into its own function to facilitate an easier test.