### PR TITLE
docs: Give project name in usage example.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -409,7 +409,7 @@ Examples
 ~~~~~~~~
 ::
 
-    # Allow an SSH keypair to only run |project_name|, and only have access to /mnt/backup.
+    # Allow an SSH keypair to only run borg, and only have access to /mnt/backup.
     # This will help to secure an automated remote backup system.
     $ cat ~/.ssh/authorized_keys
     command="borg serve --restrict-to-path /mnt/backup" ssh-rsa AAAAB3[...]


### PR DESCRIPTION
* docs/usage.rst: Replace "|project_name|" with "borg" because the
abstraction doesn't work in usage examples.

Currently, this displays as "|project_name|" in the docs. This patch
updates it to display "borg".

I don't know rst so I don't know if there is a better way to do this.