### PR TITLE
log stats consistently, fixes #526

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -18,6 +18,10 @@ import platform
 import time
 import unicodedata
 
+import logging
+from .logger import create_logger
+logger = create_logger()
+
 from datetime import datetime, timezone, timedelta
 from fnmatch import translate
 from operator import attrgetter
@@ -971,3 +975,16 @@ def sysinfo():
     info.append('Python: %s %s' % (platform.python_implementation(), platform.python_version()))
     info.append('')
     return '\n'.join(info)
+
+
+def log_multi(*msgs, level=logging.INFO):
+    """
+    log multiple lines of text, each line by a separate logging call for cosmetic reasons
+
+    each positional argument may be a single or multiple lines (separated by \n) of text.
+    """
+    lines = []
+    for msg in msgs:
+        lines.extend(msg.splitlines())
+    for line in lines:
+        logger.log(level, line)


### PR DESCRIPTION
prune and create now both require --verbose --stats to show stats.
it was implemented in this way (and not with print) so you can feed the stats data
into the logging system, too.

delete now says "Archive deleted" in verbose mode (for consistency,
it already said "Repository deleted" when deleting a repo).

also: add helpers.log_multi to comfortably and prettily output a block of log lines