### PR TITLE
sphinx configuration: fix to create a simple man page from usage docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,10 +228,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-#man_pages = [
-#    ('man', 'borg', 'Borg',
-#     ['see "AUTHORS" file'], 1)
-#]
+man_pages = [
+        ('usage', 'borg',
+         'BorgBackup is a deduplicating backup program with optional compression and authenticated encryption.',
+         ['The Borg Collective (see AUTHORS file)'],
+         1),
+]
 
 extensions = ['sphinx.ext.extlinks', 'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode']
 


### PR DESCRIPTION
relates to issue #541 

now that we can build a simple man page with sphinx, shall we bundle it with borg?
like in docs/_build/man/borg.1?

shall we also bundle rendered html docs in docs/_build/html/* then?
