### PR TITLE
expand install docs table

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,6 +34,7 @@ Distribution Source                Command
 ============ ===================== =======
 Arch Linux   `[community]`_        ``pacman -S borg``
 Debian       `stretch`_, `unstable/sid`_ ``apt install borgbackup``
+NixOS        `.nix file`_
 OS X         `Brew cask`_          ``brew cask install borgbackup``
 Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgbackup``
 ============ ===================== =======
@@ -42,6 +43,7 @@ Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgba
 .. _unstable/sid: https://packages.debian.org/sid/borgbackup
 .. _Xenial 15.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
 .. _Wily 15.10 (backport PPA): https://launchpad.net/~neoatnhng/+archive/ubuntu/ppa
+.. _.nix file: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/borg/default.nix
 .. _Brew cask: http://caskroom.io/
 
 Please ask package maintainers to build a package or, if you can package /

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,8 +34,8 @@ Distribution Source                Command
 ============ ===================== =======
 Arch Linux   `[community]`_        ``pacman -S borg``
 Debian       `stretch`_, `unstable/sid`_ ``apt install borgbackup``
-Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgbackup``
 OS X         `Brew cask`_          ``brew cask install borgbackup``
+Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgbackup``
 ============ ===================== =======
 
 .. _[community]: https://www.archlinux.org/packages/?name=borg

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,19 +29,20 @@ package which can be installed with the package manager.  As |project_name| is
 still a young project, such a package might be not available for your system
 yet.
 
-============ ===================== =======
-Distribution Source                Command
-============ ===================== =======
-Arch Linux   `[community]`_        ``pacman -S borg``
-Debian       `stretch`_, `unstable/sid`_ ``apt install borgbackup``
-NixOS        `.nix file`_
-OS X         `Brew cask`_          ``brew cask install borgbackup``
-Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgbackup``
-============ ===================== =======
+============ ============================================= =======
+Distribution Source                                        Command
+============ ============================================= =======
+Arch Linux   `[community]`_                                ``pacman -S borg``
+Debian       `stretch`_, `unstable/sid`_                   ``apt install borgbackup``
+NixOS        `.nix file`_                                  N/A
+OS X         `Brew cask`_                                  ``brew cask install borgbackup``
+Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_ ``apt install borgbackup``
+============ ============================================= =======
 
 .. _[community]: https://www.archlinux.org/packages/?name=borg
+.. _stretch: https://packages.debian.org/stretch/borgbackup
 .. _unstable/sid: https://packages.debian.org/sid/borgbackup
-.. _Xenial 15.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
+.. _Xenial 16.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
 .. _Wily 15.10 (backport PPA): https://launchpad.net/~neoatnhng/+archive/ubuntu/ppa
 .. _.nix file: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/borg/default.nix
 .. _Brew cask: http://caskroom.io/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,14 +33,15 @@ yet.
 Distribution Source                Command
 ============ ===================== =======
 Arch Linux   `[community]`_        ``pacman -S borg``
-Debian       `unstable/sid`_       ``apt install borgbackup``
-Ubuntu       `Xenial Xerus 16.04`_ ``apt install borgbackup``
+Debian       `stretch`_, `unstable/sid`_ ``apt install borgbackup``
+Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_  ``apt install borgbackup``
 OS X         `Brew cask`_          ``brew cask install borgbackup``
 ============ ===================== =======
 
 .. _[community]: https://www.archlinux.org/packages/?name=borg
 .. _unstable/sid: https://packages.debian.org/sid/borgbackup
-.. _Xenial Xerus 15.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
+.. _Xenial 15.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
+.. _Wily 15.10 (backport PPA): https://launchpad.net/~neoatnhng/+archive/ubuntu/ppa
 .. _Brew cask: http://caskroom.io/
 
 Please ask package maintainers to build a package or, if you can package /


### PR DESCRIPTION
we have new OS supported, as per #105. this adds Debian stretch and Ubuntu Wily to the list, along with NixOS. i also reorder the table so that it's sorted alphabetically - i originally kept OSX in the end as a separate distribution, but let's drop that distinction, since this will also cover *BSDs, which are not Linux derived either.