### PR TITLE
docs: Correct small typos in changes and usage

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -161,7 +161,7 @@ Other changes:
 
 - improve file size displays, more flexible size formatters
 - explicitly commit to the units standard, #289
-- archiver: add E status (means that an error occured when processing this
+- archiver: add E status (means that an error occurred when processing this
   (single) item
 - do binary releases via "github releases", closes #214
 - create: use -x and --one-file-system (was: --do-not-cross-mountpoints), #296

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -441,7 +441,7 @@ Miscellaneous Help
 
 Debug Commands
 --------------
-There are some more commands (all starting with "debug-") wich are are all
+There are some more commands (all starting with "debug-") which are all
 **not intended for normal use** and **potentially very dangerous** if used incorrectly.
 
 They exist to improve debugging capabilities without direct system access, e.g.


### PR DESCRIPTION
I've come across these while working on the debian package (they were actually detected by lintian (a Debian QA tool) because they got copied into the manpage) and I've dropped one "are" in the usage.rst sentence.