### PR TITLE
fix locking, partial fix for #502

### DIFF
--- a/borg/locking.py
+++ b/borg/locking.py
@@ -278,9 +278,11 @@ class UpgradableLock:
             try:
                 if remove is not None:
                     self._roster.modify(remove, REMOVE)
-                    remove = None
                 if len(self._roster.get(SHARED)) == 0:
                     return  # we are the only one and we keep the lock!
+                # restore the roster state as before (undo the roster change):
+                if remove is not None:
+                    self._roster.modify(remove, ADD)
             except:
                 # avoid orphan lock when an exception happens here, e.g. Ctrl-C!
                 self._lock.release()


### PR DESCRIPTION
the problem was that the borg process removed its own shared lock when upgrading it to an exclusive lock.
this is fine if we get the exclusive lock, but if we don't, we must re-add our shared lock.

this fixes the KeyError in locking.py:217