### PR TITLE
Fix upgrade without ~/attic/keys existing.

### DIFF
--- a/borg/upgrader.py
+++ b/borg/upgrader.py
@@ -267,10 +267,12 @@ class AtticKeyfileKey(KeyfileKey):
         get_keys_dir = cls.get_keys_dir
         id = hexlify(repository.id).decode('ascii')
         keys_dir = get_keys_dir()
+        if not os.path.exists(keys_dir):
+            raise KeyfileNotFoundError(repository.path, keys_dir)
         for name in os.listdir(keys_dir):
             filename = os.path.join(keys_dir, name)
             with open(filename, 'r') as fd:
                 line = fd.readline().strip()
                 if line and line.startswith(cls.FILE_ID) and line[10:] == id:
                     return filename
-        raise KeyfileNotFoundError(repository.path, get_keys_dir())
+        raise KeyfileNotFoundError(repository.path, keys_dir)


### PR DESCRIPTION
fixes #576 

Maybe a different error should be output? atm it’s:
    no key file found for repository

Maybe something like:

    No key folder found, assuming no keys exist

Or even an error, prompting for folder generation? Although that might be a bit much.