### PR TITLE
Feature/list formatting

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -15,7 +15,7 @@ import textwrap
 import traceback
 
 from . import __version__
-from .helpers import Error, location_validator, format_time, format_file_size, \
+from .helpers import Error, location_validator, format_time, format_line, safe_timestamp, format_file_size, \
     parse_pattern, PathPrefixPattern, to_localtime, timestamp, \
     get_cache_dir, get_keys_dir, prune_within, prune_split, \
     Manifest, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
@@ -442,6 +442,13 @@ class Archiver:
                 for item in archive.iter_items():
                     print(remove_surrogates(item[b'path']))
             else:
+                longformat="{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NEWLINE}"
+                userformat=longformat
+                if args.listformat:
+                    userformat=args.listformat                
+                
+                archive_name=archive.name
+
                 for item in archive.iter_items():
                     mode = stat.filemode(item[b'mode'])
                     type = mode[0]
@@ -451,12 +458,12 @@ class Archiver:
                             size = sum(size for _, size, _ in item[b'chunks'])
                         except KeyError:
                             pass
-                    try:
-                        mtime = datetime.fromtimestamp(bigint_to_int(item[b'mtime']) / 1e9)
-                    except OverflowError:
-                        # likely a broken mtime and datetime did not want to go beyond year 9999
-                        mtime = datetime(9999, 12, 31, 23, 59, 59)
+                    atime=safe_timestamp(item[b'atime'])
+                    ctime=safe_timestamp(item[b'ctime'])
+                    mtime=safe_timestamp(item[b'mtime'])
+                    
                     if b'source' in item:
+                        source = item[b'source']
                         if type == 'l':
                             extra = ' -> %s' % item[b'source']
                         else:
@@ -464,10 +471,40 @@ class Archiver:
                             extra = ' link to %s' % item[b'source']
                     else:
                         extra = ''
-                    print('%s %-6s %-6s %8d %s %s%s' % (
-                        mode, item[b'user'] or item[b'uid'],
-                        item[b'group'] or item[b'gid'], size, format_time(mtime),
-                        remove_surrogates(item[b'path']), extra))
+                        source = ''
+                     
+                    formatdata={
+                        'mode': mode,
+                        'bmode': item[b'mode'],
+                        'type': type,
+                        'source': source,
+                        'linktarget': source,
+                        'user': item[b'user'] or item[b'uid'],
+                        'uid': item[b'uid'],
+                        'group': item[b'group'] or item[b'gid'],
+                        'gid': item[b'gid'],
+                        'size': size,
+                        'isomtime': format_time(mtime),
+                        'mtime': mtime,
+                        'isoctime': format_time(ctime),
+                        'ctime': ctime,
+                        'isoatime': format_time(atime),
+                        'atime': atime,
+                        'path': remove_surrogates(item[b'path']), 
+                        'extra': extra,
+                        'archivename': archive_name,
+                        'SPACE': " ",
+                        'TAB': "\t",
+                        'LF': "\n",
+                        'CR': "\r",
+                        'NEWLINE': os.linesep,
+                        'formatkeys': ()
+                        }
+                    formatdata["formatkeys"]=list(formatdata.keys())
+                    
+
+                    print(format_line(userformat, formatdata), end='')
+
         else:
             for archive_info in manifest.list_archive_infos(sort_by='ts'):
                 if args.prefix and not archive_info.name.startswith(args.prefix):
@@ -1098,6 +1135,8 @@ class Archiver:
         subparser.add_argument('--short', dest='short',
                                action='store_true', default=False,
                                help='only print file/directory names, nothing else')
+        subparser.add_argument('--list-format', dest='listformat', type=str,
+                               help='Format archive listing line')
         subparser.add_argument('-P', '--prefix', dest='prefix', type=str,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -442,18 +442,18 @@ class Archiver:
                 for item in archive.iter_items():
                     print(remove_surrogates(item[b'path']))
             else:
-                longformat="{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}"
-                userformat=longformat
+                long_format = "{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}"
+                user_format = long_format
                 """use_user_format flag is used to speed up default listing.
                 When user issues format options, listing is a bit slower, but more keys are available and
                 precalculated
-                """ 
-                use_user_format=False
+                """
+                use_user_format = False
                 if args.listformat:
-                    userformat=args.listformat
-                    use_user_format=True
-                
-                archive_name=archive.name
+                    user_format = args.listformat
+                    use_user_format = True
+
+                archive_name = archive.name
 
                 for item in archive.iter_items():
                     mode = stat.filemode(item[b'mode'])
@@ -464,13 +464,12 @@ class Archiver:
                             size = sum(size for _, size, _ in item[b'chunks'])
                         except KeyError:
                             pass
-                    mtime=safe_timestamp(item[b'mtime'])
-                    
+                    mtime = safe_timestamp(item[b'mtime'])
+
                     if use_user_format:
-                        atime=safe_timestamp(item[b'atime'])
-                        ctime=safe_timestamp(item[b'ctime'])
-                    
-                    
+                        atime = safe_timestamp(item[b'atime'])
+                        ctime = safe_timestamp(item[b'ctime'])
+
                     if b'source' in item:
                         source = item[b'source']
                         if type == 'l':
@@ -481,18 +480,18 @@ class Archiver:
                     else:
                         extra = ''
                         source = ''
-                    
-                    formatdata={
+
+                    item_data = {
                             'mode': mode,
                             'user': item[b'user'] or item[b'uid'],
-                            'group': item[b'group'] or item[b'gid'],                        
+                            'group': item[b'group'] or item[b'gid'],
                             'size': size,
-                            'isomtime': format_time(mtime),                        
-                            'path': remove_surrogates(item[b'path']), 
+                            'isomtime': format_time(mtime),
+                            'path': remove_surrogates(item[b'path']),
                             'extra': extra,
                             }
                     if use_user_format:
-                        formatdata_user_format={
+                        item_data_advanced = {
                             'bmode': item[b'mode'],
                             'type': type,
                             'source': source,
@@ -512,13 +511,13 @@ class Archiver:
                             'NEWLINE': os.linesep,
                             'formatkeys': ()
                             }
-                        formatdata_user_format["formatkeys"]=list(formatdata.keys())
-                        formatdata.update(formatdata_user_format)
-                    
+                        item_data_advanced["formatkeys"] = list(item_data.keys())
+                        item_data.update(item_data_advanced)
+
                     if use_user_format:
-                        print(format_line(userformat, formatdata), end='')
+                        print(format_line(user_format, item_data), end='')
                     else:
-                        print(format_line(userformat, formatdata))
+                        print(format_line(user_format, item_data))
 
         else:
             for archive_info in manifest.list_archive_infos(sort_by='ts'):
@@ -1151,7 +1150,9 @@ class Archiver:
                                action='store_true', default=False,
                                help='only print file/directory names, nothing else')
         subparser.add_argument('--list-format', dest='listformat', type=str,
-                               help='Format archive listing line')
+                               help="""specify format for archive file listing
+                                (default: "{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NEWLINE}")
+                                Special "{formatkeys}" exists to list available keys""")
         subparser.add_argument('-P', '--prefix', dest='prefix', type=str,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -518,6 +518,28 @@ def dir_is_tagged(path, exclude_caches, exclude_if_present):
                 tag_paths.append(tag_path)
     return tag_paths
 
+def format_line(formatstr, data):
+    """Filter out unwanted properties of str.format(), because "formatstr" 
+    is user provided. 
+    """    
+    try:
+        return(formatstr.format(**data))
+    except KeyError as e:
+        print('Error in lineformat: "{}" - reason "{}"'.format(formatstr, str(e)))
+    except ValueError as e:
+        print('Error in lineformat: "{}" - reason "{}"'.format(formatstr, str(e)))
+    except:
+        print('Line format error')
+        raise   
+    return ''
+
+def safe_timestamp(timedata):    
+    try:
+        return datetime.fromtimestamp(bigint_to_int(timedata) / 1e9)
+    except OverflowError:
+        # likely a broken file time and datetime did not want to go beyond year 9999
+        return datetime(9999, 12, 31, 23, 59, 59)
+
 
 def format_time(t):
     """use ISO-8601 date and time format

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -518,24 +518,25 @@ def dir_is_tagged(path, exclude_caches, exclude_if_present):
                 tag_paths.append(tag_path)
     return tag_paths
 
-def format_line(formatstr, data):
-    """Filter out unwanted properties of str.format(), because "formatstr" 
-    is user provided. 
-    """    
+
+def format_line(format, data):
+    # TODO: Filter out unwanted properties of str.format(), because "format" is user provided.
+
     try:
-        return(formatstr.format(**data))
-    except KeyError as e:
-        print('Error in lineformat: "{}" - reason "{}"'.format(formatstr, str(e)))
-    except ValueError as e:
-        print('Error in lineformat: "{}" - reason "{}"'.format(formatstr, str(e)))
+        return format.format(**data)
+    except (KeyError, ValueError) as e:
+        # this should catch format errors
+        print('Error in lineformat: "{}" - reason "{}"'.format(format, str(e)))
     except:
-        print('Line format error')
-        raise   
+        # something unexpected, print error and raise exception
+        print('Error in lineformat: "{}" - reason "{}"'.format(format, str(e)))
+        raise
     return ''
 
-def safe_timestamp(timedata):    
+
+def safe_timestamp(item_timestamp_ns):
     try:
-        return datetime.fromtimestamp(bigint_to_int(timedata) / 1e9)
+        return datetime.fromtimestamp(bigint_to_int(item_timestamp_ns) / 1e9)
     except OverflowError:
         # likely a broken file time and datetime did not want to go beyond year 9999
         return datetime(9999, 12, 31, 23, 59, 59)

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -892,6 +892,16 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in('test-2', output)
         self.assert_not_in('something-else', output)
 
+    def test_list_list_format(self):
+        self.cmd('init', self.repository_location)
+        test_archive = self.repository_location + '::test'
+        self.cmd('create', test_archive, src_dir)
+        output_1 = self.cmd('list', test_archive)
+        output_2 = self.cmd('list', '--list-format', '{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NEWLINE}', test_archive)
+        output_not_equel = self.cmd('list', '--list-format', '{mtime:%s} {path}{NL}', test_archive)
+        self.assertEqual(output_1, output_2)
+        self.assertNotEqual(output_1, output_not_equel)
+
     def test_break_lock(self):
         self.cmd('init', self.repository_location)
         self.cmd('break-lock', self.repository_location)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -334,7 +334,23 @@ Examples
     -rw-r--r-- root   root       1383 May 22 22:25 etc/ImageMagick-6/colors.xml
     ...
 
+    $ borg list /mnt/backup::archiveA --list-format="{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NEWLINE}"
+    drwxrwxr-x user   user          0 Sun, 2015-02-01 11:00:00 .
+    drwxrwxr-x user   user          0 Sun, 2015-02-01 11:00:00 code
+    drwxrwxr-x user   user          0 Sun, 2015-02-01 11:00:00 code/myproject
+    -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.ext
+    ...
 
+    # see what is change between archives, based on file modification time, size and file path
+    $ borg list /mnt/backup::archiveA --list-format="{mtime:%s}{TAB}{size}{TAB}{path}{LF}" |sort -n > /tmp/list.archiveA
+    $ borg list /mnt/backup::archiveB --list-format="{mtime:%s}{TAB}{size}{TAB}{path}{LF}" |sort -n > /tmp/list.archiveB
+    $ diff -y /tmp/list.archiveA /tmp/list.archiveB
+    1422781200      0       .                                       1422781200      0       .
+    1422781200      0       code                                    1422781200      0       code
+    1422781200      0       code/myproject                          1422781200      0       code/myproject
+    1422781200      1416192 code/myproject/file.ext               | 1454664653      1416192 code/myproject/file.ext
+    ...
+    
 .. include:: usage/prune.rst.inc
 
 Examples


### PR DESCRIPTION
Adding --list-format FORMAT option to list for user specified file listing support
E.G. List files with unix timestamp mtime, size and path.
borg-linux list /tmp/testrepo::archivea --list-format="{mtime:%s}{TAB}{size}{TAB}{path}{LF}"

Tested with repository containing about 400 000 files.
Using list-format slows listing down a bit (about 30% on my tests), but when user does not issue --list-format option, then only default fields are calculated and there is only small slowdown (28 s -> 30 s)

This feature makes it easier to add new customization features to listing (like inner repo file hashing etc). 

Usecase: Find which files have change between two archives (based on mtime, filesize and path)

borg-linux list /tmp/testrepo::archvivea --list-format="{mtime:%s}{TAB}{size}{TAB}{path}{LF}" |sort -n > /tmp/archivea.list
borg-linux list /tmp/testrepo::archviveb --list-format="{mtime:%s}{TAB}{size}{TAB}{path}{LF}" |sort -n > /tmp/archiveb.list
diff /tmp/archivea.list /tmp/archiveb.list