### PR TITLE
Added example to BORG_RSH documentation.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -65,7 +65,8 @@ General:
     BORG_LOGGING_CONF
         When set, use the given filename as INI_-style logging configuration.
     BORG_RSH
-        When set, use this command instead of ``ssh``.
+        When set, use this command instead of ``ssh``. This can be used to specify ssh options, such as
+        a custom identity file ``ssh -i /path/to/private/key``. See ``ssh man`` for other options.
     TMPDIR
         where temporary files are stored (might need a lot of temporary space for some operations)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -66,7 +66,7 @@ General:
         When set, use the given filename as INI_-style logging configuration.
     BORG_RSH
         When set, use this command instead of ``ssh``. This can be used to specify ssh options, such as
-        a custom identity file ``ssh -i /path/to/private/key``. See ``ssh man`` for other options.
+        a custom identity file ``ssh -i /path/to/private/key``. See ``man ssh`` for other options.
     TMPDIR
         where temporary files are stored (might need a lot of temporary space for some operations)
 


### PR DESCRIPTION
I couldn't figure out how to specify a custom private key for SSH communication until I read one of the tests covering `BORG_RSH`. The original documentation wasn't clear to me at the time. This pull request adds to the documentation so that other's may not waste the same time as I. :smile: 