### PR TITLE
[WIP] Optimize argparse args to give consistent messages

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1035,7 +1035,7 @@ class Archiver:
         subparser.add_argument('location', metavar='ARCHIVE',
                                type=location_validator(archive=True),
                                help='archive to extract')
-        subparser.add_argument('paths', metavar='PATH', nargs='+', type=str,
+        subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
                                help='paths to extract; patterns are supported')
 
         rename_epilog = textwrap.dedent("""

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -803,7 +803,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='initialize empty repository')
         subparser.set_defaults(func=self.do_init)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='repository to create')
         subparser.add_argument('-e', '--encryption', dest='encryption',
@@ -852,7 +852,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='verify repository')
         subparser.set_defaults(func=self.do_check)
-        subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE',
                                type=location_validator(),
                                help='repository or archive to check consistency of')
         subparser.add_argument('--repository-only', dest='repo_only', action='store_true',
@@ -883,7 +883,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='change repository passphrase')
         subparser.set_defaults(func=self.do_change_passphrase)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False))
 
         migrate_to_repokey_epilog = textwrap.dedent("""
@@ -910,7 +910,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='migrate passphrase-mode repository to repokey')
         subparser.set_defaults(func=self.do_migrate_to_repokey)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False))
 
         create_epilog = textwrap.dedent("""
@@ -1035,7 +1035,7 @@ class Archiver:
         subparser.add_argument('location', metavar='ARCHIVE',
                                type=location_validator(archive=True),
                                help='archive to extract')
-        subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
+        subparser.add_argument('paths', metavar='PATH', nargs='+', type=str,
                                help='paths to extract; patterns are supported')
 
         rename_epilog = textwrap.dedent("""
@@ -1076,7 +1076,7 @@ class Archiver:
         subparser.add_argument('--save-space', dest='save_space', action='store_true',
                                default=False,
                                help='work slower, but using less space')
-        subparser.add_argument('location', metavar='TARGET', nargs='?', default='',
+        subparser.add_argument('location', metavar='TARGET',
                                type=location_validator(),
                                help='archive or repository to delete')
 
@@ -1094,7 +1094,7 @@ class Archiver:
                                help='only print file/directory names, nothing else')
         subparser.add_argument('-P', '--prefix', dest='prefix', type=str,
                                help='only consider archive names starting with this prefix')
-        subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE',
                                type=location_validator(),
                                help='repository/archive to list contents of')
 
@@ -1201,7 +1201,7 @@ class Archiver:
         subparser.add_argument('--save-space', dest='save_space', action='store_true',
                                default=False,
                                help='work slower, but using less space')
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='repository to prune')
 
@@ -1259,7 +1259,7 @@ class Archiver:
                                default=False, action='store_true',
                                help="""rewrite repository in place, with no chance of going back to older
                                versions of the repository.""")
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='path to the repository to be upgraded')
 
@@ -1295,7 +1295,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='get object from repository (debug)')
         subparser.set_defaults(func=self.do_debug_get_obj)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='repository to use')
         subparser.add_argument('id', metavar='ID', type=str,
@@ -1312,7 +1312,7 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='put object to repository (debug)')
         subparser.set_defaults(func=self.do_debug_put_obj)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='repository to use')
         subparser.add_argument('paths', metavar='PATH', nargs='+', type=str,
@@ -1327,10 +1327,10 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='delete object from repository (debug)')
         subparser.set_defaults(func=self.do_debug_delete_obj)
-        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+        subparser.add_argument('location', metavar='REPOSITORY',
                                type=location_validator(archive=False),
                                help='repository to use')
-        subparser.add_argument('ids', metavar='IDs', nargs='+', type=str,
+        subparser.add_argument('ids', metavar='ID', nargs='+', type=str,
                                help='hex object ID(s) to delete from the repo')
         return parser
 


### PR DESCRIPTION
This PR makes error messages for missing arguments more consistent across borg commands. Also the help file gets a bit more instructive.

**Old Behavior**

    borg upgrade
    usage: borg upgrade [-h] [-v] [--debug] [--lock-wait N] [--show-rc]
                        [--no-files-cache] [--umask M] [--remote-path PATH] [-p]
                        [-n] [-i]
                        [REPOSITORY]
    borg upgrade: error: argument REPOSITORY: Invalid location format: ""



**New Behavior**

    borg upgrade
    usage: borg upgrade [-h] [-v] [--debug] [--lock-wait N] [--show-rc]
                        [--no-files-cache] [--umask M] [--remote-path PATH] [-p]
                        [-n] [-i]
                        REPOSITORY
    borg upgrade: error: the following arguments are required: REPOSITORY

----

    borg upgrade ""
    usage: borg upgrade [-h] [-v] [--debug] [--lock-wait N] [--show-rc]
                        [--no-files-cache] [--umask M] [--remote-path PATH] [-p]
                        [-n] [-i]
                        REPOSITORY
    borg upgrade: error: argument REPOSITORY: Invalid location format: ""