### PR TITLE
Archive name formatting on create

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -27,6 +27,7 @@ from . import shellpattern
 import msgpack
 import msgpack.fallback
 
+import socket
 
 # return codes returned by borg command
 # when borg is killed by signal N, rc = 128 + N
@@ -688,7 +689,21 @@ class Location:
         if not self.parse(self.orig):
             raise ValueError
 
+    def preformat_text(self, text):
+        """Format repository and archive path with common tags"""
+        current_time = datetime.now()
+        data = {
+            'pid': os.getpid(),
+            'fqdn': socket.getfqdn(),
+            'hostname': socket.gethostname(),
+            'now': current_time.now(),
+            'utcnow': current_time.utcnow(),
+            'user': uid2user(os.getuid(), os.getuid())
+            }
+        return format_line(text, data)
+
     def parse(self, text):
+        text = self.preformat_text(text)
         valid = self._parse(text)
         if valid:
             return True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -251,8 +251,7 @@ Examples
 
     # Backup the root filesystem into an archive named "root-YYYY-MM-DD"
     # use zlib compression (good, but slow) - default is no compression
-    NAME="root-`date +%Y-%m-%d`"
-    $ borg create -C zlib,6 /mnt/backup::$NAME / --one-file-system
+    $ borg create -C zlib,6 /mnt/backup::root-{now:%Y-%m-%d} / --one-file-system
 
     # Make a big effort in fine granular deduplication (big chunk management
     # overhead, needs a lot of RAM and disk space, see formula in internals
@@ -273,6 +272,11 @@ Examples
 
     # Even slower, even higher compression (N = 0..9)
     $ borg create --compression lzma,N /mnt/backup::repo ~
+
+    # Format tags available for archive name:
+    # {now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}
+    # add short hostname, backup username and current unixtime (seconds from epoch)
+    $ borg create  /mnt/backup::{hostname}-{user}-{now:%s} ~
 
 .. include:: usage/extract.rst.inc
 


### PR DESCRIPTION
Format tags available for archive name:
`{now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}
`
Example:
add short hostname, backup username and current unixtime (seconds from epoch)
`$ borg create  /mnt/backup::{hostname}-{user}-{now:%s} ~`
See issue #650 for discussion of this feature 
