### PR TITLE
CSS !important overwrite. Fix borgbackup/borg#727

### DIFF
--- a/docs/borg_theme/css/borg.css
+++ b/docs/borg_theme/css/borg.css
@@ -6,7 +6,7 @@
  */
 
 .wy-side-nav-search {
-    background-color: black;
+    background-color: #000000 !important;
 }
 
 .wy-side-nav-search > a {


### PR DESCRIPTION
I know !important is generally discouraged, but it's the easiest solution by far here, and I can't see it causing much harm.