### PR TITLE
remove useless/misleading libc version display, fixes #738

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -1051,7 +1051,7 @@ def sysinfo():
     info = []
     info.append('Platform: %s' % (' '.join(platform.uname()), ))
     if sys.platform.startswith('linux'):
-        info.append('Linux: %s %s %s  LibC: %s %s' % (platform.linux_distribution() + platform.libc_ver()))
+        info.append('Linux: %s %s %s' % platform.linux_distribution())
     info.append('Borg: %s  Python: %s %s' % (borg_version, platform.python_implementation(), platform.python_version()))
     info.append('PID: %d  CWD: %s' % (os.getpid(), os.getcwd()))
     info.append('sys.argv: %r' % sys.argv)


### PR DESCRIPTION
platform.libc_ver() is broken, it uses string comparison to compare version numbers.