### PR TITLE
Issue #761: Links fail for extracting subtrees

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -286,6 +286,9 @@ class PatternMatcher:
         # Value to return from match function when none of the patterns match.
         self.fallback = fallback
 
+    def empty(self):
+        return not len(self._items)
+
     def add(self, patterns, value):
         """Add list of patterns to internal list. The given value is returned from the match function when one of the
         given patterns matches.


### PR DESCRIPTION
**Issue summary:**

When extracting subtrees ("partial_extract") by using any of (excludes, PATH, strip-components) hard links might fail, because Borg tried to link to non-existing files, if the first appearance of a (inode, device) tuple (which uniquely identifies files and is identical across hard links) was not extracted.

**Implementation:**

* creating a mapping that stores *all* file paths so far and their chunk list or link source. (We need to store all seen files, because we can't tell if a file is hard-linked)
* when extracting a hard link: resolving whether an instance of the link was extracted
  * if it was not, the file contents will be extracted
     * and the entry in our "master file mapping" will be changed to point to this file
  * if it was, a hard link is created

**Drawbacks:**

* a possibly very significant increase in memory usage when extracting subtrees, because the "master file mapping" will essentially grow until all files in the archive were visited, and at that point it will contain all file paths and chunk lists.

However, if no partial extraction is done, the "MFM" is not created, not used and has therefore no impact.

**Won't somebody please think of the ~~children~~ soft links?**

Soft links are always stored as absolute paths and always extracted as such and are not affected by this.

**TODO**

* [x] check whether this handles link metadata correctly / as expected, create test or validate that test exists and indeed covers this additional code path
   * they are the same files, so same U/G ID, permissions, xattrs and ACLs, even on Windows/NTFS.
* [x] Xcode builds broken (some minor thing with output paths or something)
* [x] This "breaks" preloading (now only for "old" archives)
* [x] Memory hit (now only for "old" archives)
   * [x] DONE We could include a nlink / a flag whether nlink > 1 for hard link items. That way the "MFM" would only need to contain these items, and items can be directly filtered again (patternmatcher or nlink), which also fixes preloading (*but only for new archives*). We can't use this for reverse ref-counting, though, because nlink = x doesn't necessarily imply that there are (x-1) items hardlinked to it.