### PR TITLE
WIP / Feature recompress (2)

### DIFF
--- a/borg/compress.pyx
+++ b/borg/compress.pyx
@@ -182,16 +182,20 @@ class Compressor:
         self.params = kwargs
         self.compressor = get_compressor(name, **self.params)
 
+    @staticmethod
+    def detect(data):
+        hdr = bytes(data[:2])  # detect() does not work with memoryview
+        for cls in COMPRESSOR_LIST:
+            if cls.detect(hdr):
+                return cls
+        else:
+            raise ValueError('No decompressor for this data found: %r.', data[:2])
+
     def compress(self, data):
         return self.compressor.compress(data)
 
     def decompress(self, data):
-        hdr = bytes(data[:2])  # detect() does not work with memoryview
-        for cls in COMPRESSOR_LIST:
-            if cls.detect(hdr):
-                return cls(**self.params).decompress(data)
-        else:
-            raise ValueError('No decompressor for this data found: %r.', data[:2])
+        return self.detect(data)(**self.params).decompress(data)
 
 
 # a buffer used for (de)compression result, which can be slightly bigger

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -233,9 +233,6 @@ class ArchiverTestCaseBase(BaseTestCase):
     def create_src_archive(self, name):
         self.cmd('create', self.repository_location + '::' + name, src_dir)
 
-
-class ArchiverTestCase(ArchiverTestCaseBase):
-
     def create_regular_file(self, name, size=0, contents=None):
         filename = os.path.join(self.input_path, name)
         if not os.path.exists(os.path.dirname(filename)):
@@ -274,7 +271,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             # same for newer ubuntu and centos.
             # if this is supported just on specific platform, platform should be checked first,
             # so that the test setup for all tests using it does not fail here always for others.
-            # xattr.setxattr(os.path.join(self.input_path, 'link1'), 'user.foo_symlink', b'bar_symlink', follow_symlinks=False)
+            # xattr.setxattr(os.path.join(self.input_path, 'link1'), 'user.foo_symlink', b'bar_symlink',
+            # follow_symlinks=False)
         # FIFO node
         os.mkfifo(os.path.join(self.input_path, 'fifo1'))
         if has_lchflags:
@@ -293,6 +291,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             have_root = False
         return have_root
 
+
+class ArchiverTestCase(ArchiverTestCaseBase):
     def test_basic_functionality(self):
         have_root = self.create_test_files()
         self.cmd('init', self.repository_location)
@@ -1221,9 +1221,6 @@ class RemoteArchiverTestCase(ArchiverTestCase):
 
 
 class DiffArchiverTestCase(ArchiverTestCaseBase):
-    create_test_files = ArchiverTestCase.create_test_files
-    create_regular_file = ArchiverTestCase.create_regular_file
-
     def test_basic_functionality(self):
         self.create_test_files()
         self.cmd('init', self.repository_location)

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -1254,6 +1254,17 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
         do_asserts(self.cmd('diff', self.repository_location + '::test0', 'test1b', exit_code=1), '1b')
 
 
+class RecompressArchiverTestCase(ArchiverTestCaseBase):
+    def test_basic_functionality(self):
+        self.create_test_files()
+        self.cmd('init', self.repository_location)
+        self.cmd('create', self.repository_location + '::test0', 'input')
+        ref_hashlist = self.cmd('list', '--format', '{sha512} {path}{NL}', self.repository_location + '::test0')
+        self.cmd('recompress', self.repository_location, '-spC', 'lz4')
+        after_hashlist = self.cmd('list', '--format', '{sha512} {path}{NL}', self.repository_location + '::test0')
+        assert after_hashlist == ref_hashlist
+
+
 def test_get_args():
     archiver = Archiver()
     # everything normal:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -549,6 +549,15 @@ Examples
     no key file found for repository
 
 
+
+.. include:: usage/recompress.rst.inc
+
+Examples
+~~~~~~~~
+::
+
+    TODO/later
+
 Miscellaneous Help
 ------------------
 

--- a/docs/usage/recompress.rst.inc
+++ b/docs/usage/recompress.rst.inc
@@ -1,0 +1,47 @@
+.. _borg_recompress:
+
+borg recompress
+---------------
+::
+
+    usage: borg recompress [-h] [-v] [--debug] [--lock-wait N] [--show-version]
+                           [--show-rc] [--no-files-cache] [--umask M]
+                           [--remote-path PATH] [-f] [-s] [-p] [-C COMPRESSION]
+                           [-n]
+                           REPOSITORY
+    
+    Recompress data
+    
+    positional arguments:
+      REPOSITORY            repository to recompress
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v, --verbose, --info
+                            enable informative (verbose) output, work on log level
+                            INFO
+      --debug               enable debug output, work on log level DEBUG
+      --lock-wait N         wait for the lock, but max. N seconds (default: 1).
+      --show-version        show/log the borg version
+      --show-rc             show/log the return code (rc)
+      --no-files-cache      do not load/update the file metadata cache used to
+                            detect unchanged files
+      --umask M             set umask to M (local and remote, default: 0077)
+      --remote-path PATH    set remote path to executable (default: "borg")
+      -f, --force           even recompress chunks already compressed with the
+                            algorithm set with --compression
+      -s, --stats           print statistics at end
+      -p, --progress        show progress, one dot is printed for each processed
+                            chunk
+      -C COMPRESSION, --compression COMPRESSION
+                            select compression algorithm (and level): none == no
+                            compression (default), lz4 == lz4, zlib == zlib
+                            (default level 6), zlib,0 .. zlib,9 == zlib (with
+                            level 0..9), lzma == lzma (default level 6), lzma,0 ..
+                            lzma,9 == lzma (with level 0..9).
+      -n, --dry-run         do not write any data
+    
+Description
+~~~~~~~~~~~
+
+Recompress data in a repository.


### PR DESCRIPTION
This is teh announced successor to #756 

I've crunched now a few hundred GB through a few versions of this (including the multi-threaded prototype) and so far no data loss (diff of SHA-512 `borg list`s) and no complaints from `borg check`.

Improvements over older prototypes now include "really clean exit" (i.e. no stale locks, everything nice and committed, it even prints stats if asked to), proper progress indication and reverse processing (see 5c2ea3a for rationale). And now we *really* don't write anything on --dry-runs.

Additional space usage bound: Depends on what the data is stored with and what you're compressing with. You can use recompress to decompress stuff (`-C none`). Generally speaking, it's about 10 * max_segment_size[1].

[1] I'm going with 10 MSS currently, because I'm assuming that commit's are costly (and I think they are, since they do all the clean up of over-written (in the key-value store sense) segments).

Also, additional space use will obviously be much larger if you aren't compressing.

**TODO**

- [ ] Code clean up
- [ ] Tests (some more manual and units)
   - What I really want to do in terms of manual testing is write a small script that calls recompress-list-diff in a loop like before, *but also kills it at random*. (So that we get good real-life coverage of this scenario, something which I'd say wouldn't be practical in unit tests)
   - What about TAG_DELETE?
     - I don't think it matters here. If it does, we could simply add a `id_ not in repository` => `continue` check, to only recompress objects in the index.
- [ ] Docs (Examples, better epilogue-explanation)
- [ ] Possibly change stats output
- [ ] doesn't work for RemoteRepository, because it works *below* they key/value store abstraction. ATM I don't consider this a todo, because it would be quite hard to make it work for RRs.
   - OTOH it could be implemented purely on top of the Repo interface. That would make space usage unpredictable and can/will touch a lot of segments after each other, though. So the performance hit (both time and space) could be quite drastic.

**Feature list**

- [x] recompress stuff
- [x] skip stuff
- [x] option to not skip stuff
- [x] option to skip stuff really fast