### PR TITLE
Ignore SIG_PIPE signal

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1646,6 +1646,8 @@ def setup_signal_handlers():  # pragma: no cover
     for sig in sigs:
         signal.signal(sig, sig_info_handler)
 
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
 
 def main():  # pragma: no cover
     # provide 'borg mount' behaviour when the main script/executable is named borgfs


### PR DESCRIPTION
Without this change borg will print errors and stack trace when it's output is interrupted with command line pipes. For example:
```
$ borg diff ::a b | less # then quit with 'q'
```

There error without this was:
```
BrokenPipeError: [Errno 32] Broken pipe
```