### PR TITLE
Do not handle intentional aborts as errors

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1730,11 +1730,11 @@ def main():  # pragma: no cover
     except RemoteRepository.RPCError as e:
         msg = '%s\n%s' % (str(e), sysinfo())
         exit_code = EXIT_ERROR
+    except (KeyboardInterrupt, BrokenPipeError):
+        sys.stderr.close()
+        exit_code = EXIT_ERROR
     except Exception:
         msg = 'Local Exception.\n%s\n%s' % (traceback.format_exc(), sysinfo())
-        exit_code = EXIT_ERROR
-    except KeyboardInterrupt:
-        msg = 'Keyboard interrupt.\n%s\n%s' % (traceback.format_exc(), sysinfo())
         exit_code = EXIT_ERROR
     if msg:
         logger.error(msg)


### PR DESCRIPTION
KeyboardInterrupts (`Ctrl-C` / `SIGINT`) or BrokenPipeErrors (`SIGPIPE`) are usually done intentionally by the user. With this commit borg aborts silently without printing error messages or stack traces. Command line users should understand what is happening if they abort the process. Intentional aborts are often part of the command usage or scripts. Additional messages or traces would only disturb the user or make output parsing more difficult. This is especially true with read-only commands like info, list, and diff.

It might be argued that BrokenPipeError is sometimes an actual, unexpected error, but in that case there is no way to print any error messages or stack traces anyway.

Borg should abort gracefully so that it doesn't corrupt the repository or otherwise leave it in a state where further operations would be obstructed. This should already be the case; this commit only affects error message printing ~~and the return code~~. If there are problems in the abort behaviour with some commands, then it is a separate issue that needs to be fixed.

This commit is continuation of #790. The previous pull request was problematic since catching the signal like that didn't give Python a change to exit properly. With this new pull request borg will release the repository locks and run any other clean up code correctly.