### PR TITLE
ArchiveChecker: move "orphaned objects check skipped" to INFO log level

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -911,7 +911,7 @@ class ArchiveChecker:
                 for id_ in unused:
                     self.repository.delete(id_)
         else:
-            logger.warning('Orphaned objects check skipped (needs all archives checked).')
+            logger.info('Orphaned objects check skipped (needs all archives checked).')
 
     def finish(self, save_space=False):
         if self.repair:


### PR DESCRIPTION
Fixes #826 

(Or into 1.0-maint?)