### PR TITLE
add --warning, --error, --critical for completeness, fixes #826

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -818,12 +818,21 @@ class Archiver:
 
     def build_parser(self, args=None, prog=None):
         common_parser = argparse.ArgumentParser(add_help=False, prog=prog)
+        common_parser.add_argument('--critical', dest='log_level',
+                                   action='store_const', const='critical', default='warning',
+                                   help='work on log level CRITICAL')
+        common_parser.add_argument('--error', dest='log_level',
+                                   action='store_const', const='error', default='warning',
+                                   help='work on log level ERROR')
+        common_parser.add_argument('--warning', dest='log_level',
+                                   action='store_const', const='warning', default='warning',
+                                   help='work on log level WARNING (default)')
         common_parser.add_argument('-v', '--verbose', '--info', dest='log_level',
                                    action='store_const', const='info', default='warning',
-                                   help='enable informative (verbose) output, work on log level INFO')
+                                   help='work on log level INFO')
         common_parser.add_argument('--debug', dest='log_level',
                                    action='store_const', const='debug', default='warning',
-                                   help='enable debug output, work on log level DEBUG')
+                                   help='work on log level DEBUG')
         common_parser.add_argument('--lock-wait', dest='lock_wait', type=int, metavar='N', default=1,
                                    help='wait for the lock, but max. N seconds (default: %(default)d).')
         common_parser.add_argument('--show-rc', dest='show_rc', action='store_true', default=False,

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -195,6 +195,10 @@ class RemoteRepository:
                 opts.append('--info')
             elif root_logger.isEnabledFor(logging.WARNING):
                 pass  # warning is default
+            elif root_logger.isEnabledFor(logging.ERROR):
+                opts.append('--error')
+            elif root_logger.isEnabledFor(logging.CRITICAL):
+                opts.append('--critical')
             else:
                 raise ValueError('log level missing, fix this code')
         if testing:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,18 +16,30 @@ Type of log output
 
 The log level of the builtin logging configuration defaults to WARNING.
 This is because we want |project_name| to be mostly silent and only output
-warnings (plus errors and critical messages).
-
-Use ``--verbose`` or ``--info`` to set INFO (you will get informative output then
-additionally to warnings, errors, critical messages).
-Use ``--debug`` to set DEBUG to get output made for debugging.
-
-All log messages created with at least the set level will be output.
+warnings, errors and critical messages.
 
 Log levels: DEBUG < INFO < WARNING < ERROR < CRITICAL
 
+Use ``--debug`` to set DEBUG log level -
+to get debug, info, warning, error and critical level output.
+
+Use ``--info`` (or ``-v`` or ``--verbose``) to set INFO log level -
+to get info, warning, error and critical level output.
+
+Use ``--warning`` (default) to set WARNING log level -
+to get warning, error and critical level output.
+
+Use ``--error`` to set ERROR log level -
+to get error and critical level output.
+
+Use ``--critical`` to set CRITICAL log level -
+to get critical level output.
+
 While you can set misc. log levels, do not expect that every command will
 give different output on different log levels - it's just a possibility.
+
+.. warning:: Options --critical and --error are provided for completeness,
+             their usage is not recommended as you might miss important information.
 
 .. warning:: While some options (like ``--stats`` or ``--list``) will emit more
              informational messages, you have to use INFO (or lower) log level to make


### PR DESCRIPTION
it's not recommended to suppress warnings or errors,
but the user may decide this on his own.

note: --warning is not given to borg serve so a <= 1.0.0 borg
will still work as server. it is not needed as it is the default.