### PR TITLE
Remote: don't print tracebacks for Error exceptions handled downstream

### DIFF
--- a/borg/remote.py
+++ b/borg/remote.py
@@ -93,8 +93,12 @@ class RepositoryServer:  # pragma: no cover
                             f = getattr(self.repository, method)
                         res = f(*args)
                     except BaseException as e:
-                        logging.exception('Borg %s: exception in RPC call:', __version__)
-                        logging.error(sysinfo())
+                        # These exceptions are reconstructed on the client end in RemoteRepository.call_many(),
+                        # and will be handled just like locally raised exceptions. Suppress the remote traceback
+                        # for these, except ErrorWithTraceback, which should always display a traceback.
+                        if not isinstance(e, (Repository.DoesNotExist, Repository.AlreadyExists, PathNotAllowed)):
+                            logging.exception('Borg %s: exception in RPC call:', __version__)
+                            logging.error(sysinfo())
                         exc = "Remote Exception (see remote log for the traceback)"
                         os.write(stdout_fd, msgpack.packb((1, msgid, e.__class__.__name__, exc)))
                     else:

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -81,6 +81,7 @@ class RepositoryServer:  # pragma: no cover
                 unpacker.feed(data)
                 for unpacked in unpacker:
                     if not (isinstance(unpacked, tuple) and len(unpacked) == 4):
+                        self.repository.close()
                         raise Exception("Unexpected RPC data format.")
                     type, msgid, method, args = unpacked
                     method = method.decode('ascii')
@@ -165,7 +166,11 @@ class RemoteRepository:
             raise ConnectionClosedWithHint('Is borg working on the server?') from None
         if version != RPC_PROTOCOL_VERSION:
             raise Exception('Server insisted on using unsupported protocol version %d' % version)
-        self.id = self.call('open', location.path, create, lock_wait, lock)
+        try:
+            self.id = self.call('open', self.location.path, create, lock_wait, lock)
+        except Exception:
+            self.close()
+            raise
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
(GH wanted to put this into master before)