### PR TITLE
Auto-recover from corrupted index/hints file(s)

### DIFF
--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -63,7 +63,7 @@ cdef class IndexBase:
             path = os.fsencode(path)
             self.index = hashindex_read(path)
             if not self.index:
-                raise Exception('hashindex_read failed')
+                raise RuntimeError('hashindex_read failed')
         else:
             self.index = hashindex_init(capacity, self.key_size, self.value_size)
             if not self.index:

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import namedtuple
+import locale
 import os
 
 cimport cython
@@ -60,6 +61,11 @@ MAX_VALUE = _MAX_VALUE
 
 assert _MAX_VALUE % 2 == 1
 
+
+def decoded_strerror(errno):
+    return strerror(errno).decode(locale.getpreferredencoding(), 'surrogateescape')
+
+
 @cython.internal
 cdef class IndexBase:
     cdef HashIndex *index
@@ -72,7 +78,7 @@ cdef class IndexBase:
             self.index = hashindex_read(path)
             if not self.index:
                 if errno:
-                    raise OSError(errno, strerror(errno), path)
+                    raise OSError(errno, decoded_strerror(errno), os.fsdecode(path))
                 raise RuntimeError('hashindex_read failed')
         else:
             self.index = hashindex_init(capacity, self.key_size, self.value_size)

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -27,6 +27,14 @@ cdef extern from "_hashindex.c":
     uint32_t _le32toh(uint32_t v)
 
 
+cdef extern from "errno.h":
+    int errno
+
+
+cdef extern from "string.h":
+    char *strerror(int errnum)
+
+
 cdef _NoDefault = object()
 
 """
@@ -63,6 +71,8 @@ cdef class IndexBase:
             path = os.fsencode(path)
             self.index = hashindex_read(path)
             if not self.index:
+                if errno:
+                    raise OSError(errno, strerror(errno), path)
                 raise RuntimeError('hashindex_read failed')
         else:
             self.index = hashindex_init(capacity, self.key_size, self.value_size)

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -65,6 +65,10 @@ class ErrorWithTraceback(Error):
     traceback = True
 
 
+class InternalOSError(ErrorWithTraceback):
+    """Error while accessing repository / cache files"""
+
+
 class IntegrityError(ErrorWithTraceback):
     """Data integrity error"""
 

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -65,8 +65,16 @@ class ErrorWithTraceback(Error):
     traceback = True
 
 
-class InternalOSError(ErrorWithTraceback):
-    """Error while accessing repository / cache files"""
+class InternalOSError(Error):
+    """Error while accessing repository: [Errno {}] {}: {}"""
+
+    def __init__(self, os_error):
+        self.errno = os_error.errno
+        self.strerror = os_error.strerror
+        self.filename = os_error.filename
+
+    def get_message(self):
+        return self.__doc__.format(self.errno, self.strerror, self.filename)
 
 
 class IntegrityError(ErrorWithTraceback):

--- a/borg/testsuite/repository.py
+++ b/borg/testsuite/repository.py
@@ -283,12 +283,16 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
             self.repository.commit()
 
     def test_corrupted_hints(self):
-        with open(os.path.join(self.repository.path, 'hints.0'), 'ab') as fp:
-            fp.write(b'123456789')
+        with open(os.path.join(self.repository.path, 'hints.0'), 'ab') as fd:
+            fd.write(b'123456789')
         self.do_commit()
 
     def test_deleted_hints(self):
         os.unlink(os.path.join(self.repository.path, 'hints.0'))
+        self.do_commit()
+
+    def test_deleted_index(self):
+        os.unlink(os.path.join(self.repository.path, 'index.0'))
         self.do_commit()
 
     def test_unreadable_hints(self):
@@ -299,15 +303,22 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
             self.do_commit()
 
     def test_index(self):
-        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fp:
-            fp.write(b'123456789')
+        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fd:
+            fd.write(b'123456789')
         self.do_commit()
 
     def test_index_outside_transaction(self):
-        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fp:
-            fp.write(b'123456789')
+        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fd:
+            fd.write(b'123456789')
         with self.repository:
             assert len(self.repository) == 1
+
+    def test_unreadable_index(self):
+        index = os.path.join(self.repository.path, 'index.0')
+        os.unlink(index)
+        os.mkdir(index)
+        with self.assert_raises(InternalOSError):
+            self.do_commit()
 
 
 class RepositoryCheckTestCase(RepositoryTestCaseBase):

--- a/borg/testsuite/repository.py
+++ b/borg/testsuite/repository.py
@@ -283,38 +283,38 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
             self.repository.commit()
 
     def test_corrupted_hints(self):
-        with open(os.path.join(self.repository.path, 'hints.0'), 'ab') as fd:
+        with open(os.path.join(self.repository.path, 'hints.1'), 'ab') as fd:
             fd.write(b'123456789')
         self.do_commit()
 
     def test_deleted_hints(self):
-        os.unlink(os.path.join(self.repository.path, 'hints.0'))
+        os.unlink(os.path.join(self.repository.path, 'hints.1'))
         self.do_commit()
 
     def test_deleted_index(self):
-        os.unlink(os.path.join(self.repository.path, 'index.0'))
+        os.unlink(os.path.join(self.repository.path, 'index.1'))
         self.do_commit()
 
     def test_unreadable_hints(self):
-        hints = os.path.join(self.repository.path, 'hints.0')
+        hints = os.path.join(self.repository.path, 'hints.1')
         os.unlink(hints)
         os.mkdir(hints)
         with self.assert_raises(InternalOSError):
             self.do_commit()
 
     def test_index(self):
-        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fd:
+        with open(os.path.join(self.repository.path, 'index.1'), 'wb') as fd:
             fd.write(b'123456789')
         self.do_commit()
 
     def test_index_outside_transaction(self):
-        with open(os.path.join(self.repository.path, 'index.0'), 'wb') as fd:
+        with open(os.path.join(self.repository.path, 'index.1'), 'wb') as fd:
             fd.write(b'123456789')
         with self.repository:
             assert len(self.repository) == 1
 
     def test_unreadable_index(self):
-        index = os.path.join(self.repository.path, 'index.0')
+        index = os.path.join(self.repository.path, 'index.1')
         os.unlink(index)
         os.mkdir(index)
         with self.assert_raises(InternalOSError):


### PR DESCRIPTION
> And don't swallow all OSErrors when creating archives. We need to work on
> that on a more general level....

[One approach](/enkore/borg/tree/map_internal_oserror) (which I don't particularly like. I think it'd be better to carefully inspect all FS operations and add appropriate error handling - but this could also be a lot of additional code). --- I'll open another ticket for discussion about that issue.