### PR TITLE
cleanup ubuntu in install list

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,8 +39,7 @@ GNU Guix     `GNU Guix`_                                   ``guix package --inst
 NetBSD       `pkgsrc`_                                     ``pkg_add py-borgbackup``
 NixOS        `.nix file`_                                  N/A
 OS X         `Brew cask`_                                  ``brew cask install borgbackup``
-Ubuntu       `Xenial 16.04`_, `Wily 15.10 (backport PPA)`_ ``apt install borgbackup``
-Ubuntu       `Trusty 14.04 (backport PPA)`_                ``apt install borgbackup``
+Ubuntu       `16.04`_, backports (PPA): `15.10`_, `14.04`_ ``apt install borgbackup``
 ============ ============================================= =======
 
 .. _[community]: https://www.archlinux.org/packages/?name=borg
@@ -49,9 +48,9 @@ Ubuntu       `Trusty 14.04 (backport PPA)`_                ``apt install borgbac
 .. _unstable/sid: https://packages.debian.org/sid/borgbackup
 .. _ebuild: https://packages.gentoo.org/packages/app-backup/borgbackup
 .. _pkgsrc: http://pkgsrc.se/sysutils/py-borgbackup
-.. _Xenial 16.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
-.. _Wily 15.10 (backport PPA): https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
-.. _Trusty 14.04 (backport PPA): https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
+.. _16.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
+.. _15.10: https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
+.. _14.04: https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
 .. _.nix file: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/borg/default.nix
 .. _Brew cask: http://caskroom.io/
 .. _GNU Guix: https://www.gnu.org/software/guix/package-list.html#borg


### PR DESCRIPTION
ubuntu was showing up twice in the list of supported OSes... it seems it was because the line was getting too long, so I removed the "names" and kept only the numbers to keep the line short.