### PR TITLE
fix issue #873 - running borg with --one-file-system traverses in excluded filesystems

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -262,7 +262,7 @@ class Archiver:
         if (st.st_ino, st.st_dev) in skip_inodes:
             return
         # Entering a new filesystem?
-        if restrict_dev and st.st_dev != restrict_dev:
+        if restrict_dev is not None and st.st_dev != restrict_dev:
             return
         status = None
         # Ignore if nodump flag is set


### PR DESCRIPTION
This fixes issue #873. Discussed in #borgbackup. Solution by nachtgeist/rts/ThomasWaldmann:

OpenBSD uses st_dev=0 for '/' on OpenBSD. Code below evaluates to false as '/' has st_dev=0:

if restrict_dev and st.st>_dev != restrict_dev: