### PR TITLE
Fix 'borg diff' when symlink is replacing or being replaced

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -471,7 +471,7 @@ class Archiver:
                 return 'added link'
             elif item2.get(b'deleted'):
                 return 'removed link'
-            elif item1[b'source'] != item2[b'source']:
+            elif b'source' in item1 and b'source' in item2 and item1[b'source'] != item2[b'source']:
                 return 'changed link'
 
         def contents_changed(item1, item2):


### PR DESCRIPTION
Previously on some cases where symlink replaced something else or was replaced by something else, `borg diff` failed with `KeyError: b'source'`. This commit fixes the issue. There are now also tests that catch this issue.

(I remember testing this case when developing the feature, but I guess I dropped it when refactoring the hardlink behavior.)