### PR TITLE
decrypt integrity test + some other tests

### DIFF
--- a/borg/testsuite/__init__.py
+++ b/borg/testsuite/__init__.py
@@ -45,6 +45,8 @@ class BaseTestCase(unittest.TestCase):
     assert_not_in = unittest.TestCase.assertNotIn
     assert_equal = unittest.TestCase.assertEqual
     assert_not_equal = unittest.TestCase.assertNotEqual
+    assert_raises = unittest.TestCase.assertRaises
+    assert_raises_regex = unittest.TestCase.assertRaisesRegex
     assert_true = unittest.TestCase.assertTrue
 
     if raises:

--- a/borg/testsuite/__init__.py
+++ b/borg/testsuite/__init__.py
@@ -45,8 +45,6 @@ class BaseTestCase(unittest.TestCase):
     assert_not_in = unittest.TestCase.assertNotIn
     assert_equal = unittest.TestCase.assertEqual
     assert_not_equal = unittest.TestCase.assertNotEqual
-    assert_raises = unittest.TestCase.assertRaises
-    assert_raises_regex = unittest.TestCase.assertRaisesRegex
     assert_true = unittest.TestCase.assertTrue
 
     if raises:

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -353,6 +353,14 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         # the interesting parts of info_output2 and info_output should be same
         self.assert_equal(filter(info_output), filter(info_output2))
 
+    def test_symlink_extract(self):
+        self.create_test_files()
+        self.cmd('init', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        with changedir('output'):
+            self.cmd('extract', self.repository_location + '::test')
+            assert os.readlink('input/link1') == 'somewhere'
+
     def test_atime(self):
         self.create_test_files()
         atime, mtime = 123456780, 234567890


### PR DESCRIPTION
test_symlink_extract doesn't do anything for the coverage, but verifies symlink extraction where there was no test previously.

test_decrypt_integrity tests the various kinds of integrity errors AESKeyBase.decrypt can/should raise; was not covered previously.

These commits are a bit older. Oops.

---

WIP. I'll make this a collective PR for some other tests I want to write. I.e. changeset constrained to borg/testsuite/ _only_.

TODO

- [x] passphrase tests
- [x] rebase
- [x] https://github.com/borgbackup/borg/issues/945#issuecomment-211770238
- [ ] archive, process_stdin has no coverage at all
- [ ] hardlink_master logic in archiverecreater has no coverage