### PR TITLE
Fix capabilities extraction on Linux

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -372,17 +372,6 @@ Number of files: {0.stats.nfiles}'''.format(
             raise Exception('Unknown archive item type %r' % item[b'mode'])
 
     def restore_attrs(self, path, item, symlink=False, fd=None):
-        xattrs = item.get(b'xattrs', {})
-        for k, v in xattrs.items():
-            try:
-                xattr.setxattr(fd or path, k, v, follow_symlinks=False)
-            except OSError as e:
-                if e.errno not in (errno.ENOTSUP, errno.EACCES, ):
-                    # only raise if the errno is not on our ignore list:
-                    # ENOTSUP == xattrs not supported here
-                    # EACCES == permission denied to set this specific xattr
-                    #           (this may happen related to security.* keys)
-                    raise
         uid = gid = None
         if not self.numeric_owner:
             uid = user2uid(item[b'user'])
@@ -420,6 +409,17 @@ Number of files: {0.stats.nfiles}'''.format(
                 os.lchflags(path, item[b'bsdflags'])
             except OSError:
                 pass
+        xattrs = item.get(b'xattrs', {})
+        for k, v in xattrs.items():
+            try:
+                xattr.setxattr(fd or path, k, v, follow_symlinks=True)
+            except OSError as e:
+                if e.errno not in (errno.ENOTSUP, errno.EACCES, ):
+                    # only raise if the errno is not on our ignore list:
+                    # ENOTSUP == xattrs not supported here
+                    # EACCES == permission denied to set this specific xattr
+                    #           (this may happen related to security.* keys)
+                    raise
 
     def rename(self, name):
         if name in self.manifest.archives:


### PR DESCRIPTION
They are extracted correctly, for a little while at least, since chown()
*resets* call capabilities on the chowned file[1]. Which I find curious,
since chown() is a privileged syscall. Probably a safeguard for
sysadmins who are unaware of capabilities.

The solution is to set the xattrs last, after chowingn

[1] Even though I know this now I cannot find *any* documentation indicating this behaviour.