### PR TITLE
Fix capabilities extraction on Linux

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -372,17 +372,6 @@ Number of files: {0.stats.nfiles}'''.format(
             raise Exception('Unknown archive item type %r' % item[b'mode'])
 
     def restore_attrs(self, path, item, symlink=False, fd=None):
-        xattrs = item.get(b'xattrs', {})
-        for k, v in xattrs.items():
-            try:
-                xattr.setxattr(fd or path, k, v, follow_symlinks=False)
-            except OSError as e:
-                if e.errno not in (errno.ENOTSUP, errno.EACCES, ):
-                    # only raise if the errno is not on our ignore list:
-                    # ENOTSUP == xattrs not supported here
-                    # EACCES == permission denied to set this specific xattr
-                    #           (this may happen related to security.* keys)
-                    raise
         uid = gid = None
         if not self.numeric_owner:
             uid = user2uid(item[b'user'])
@@ -420,6 +409,19 @@ Number of files: {0.stats.nfiles}'''.format(
                 os.lchflags(path, item[b'bsdflags'])
             except OSError:
                 pass
+        # chown removes Linux capabilities, so set the extended attributes at the end, after chown, since they include
+        # the Linux capabilities in the "security.capability" attribute.
+        xattrs = item.get(b'xattrs', {})
+        for k, v in xattrs.items():
+            try:
+                xattr.setxattr(fd or path, k, v, follow_symlinks=False)
+            except OSError as e:
+                if e.errno not in (errno.ENOTSUP, errno.EACCES):
+                    # only raise if the errno is not on our ignore list:
+                    # ENOTSUP == xattrs not supported here
+                    # EACCES == permission denied to set this specific xattr
+                    #           (this may happen related to security.* keys)
+                    raise
 
     def rename(self, name):
         if name in self.manifest.archives:

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -639,6 +639,27 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_equal(sorted(os.listdir('output/input/taggedall')),
                           ['.NOBACKUP1', '.NOBACKUP2', 'CACHEDIR.TAG', ])
 
+    @pytest.mark.skipif(not xattr.XATTR_FAKEROOT, reason='Linux capabilities test, requires fakeroot >= 1.20.2')
+    def test_extract_capabilities(self):
+        fchown = os.fchown
+
+        # We need to manually patch chown to get the behaviour Linux has, since fakeroot does not
+        # accurately model the interaction of chown(2) and Linux capabilities, i.e. it does not remove them.
+        def patched_fchown(fd, uid, gid):
+            xattr.setxattr(fd, 'security.capability', None, follow_symlinks=False)
+            fchown(fd, uid, gid)
+
+        # The capability descriptor used here is valid and taken from a /usr/bin/ping
+        capabilities = b'\x01\x00\x00\x02\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        self.create_regular_file('file')
+        xattr.setxattr('input/file', 'security.capability', capabilities)
+        self.cmd('init', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        with changedir('output'):
+            with patch.object(os, 'fchown', patched_fchown):
+                self.cmd('extract', self.repository_location + '::test')
+            assert xattr.getxattr('input/file', 'security.capability') == capabilities
+
     def test_path_normalization(self):
         self.cmd('init', self.repository_location)
         self.create_regular_file('dir1/dir2/file', size=1024 * 80)


### PR DESCRIPTION
They are extracted correctly, for a little while at least, since chown()
resets call capabilities on the chowned file[1]. Which I find curious,
since chown() is a privileged syscall. Probably a safeguard for
sysadmins who are unaware of capabilities.

The solution is to set the xattrs last, after chowing

[1] Even though I know this now I cannot find **any** documentation indicating this behaviour.
