### PR TITLE
Cache: update add_chunk to use ChunkIndex.add

### DIFF
--- a/borg/cache.py
+++ b/borg/cache.py
@@ -378,8 +378,8 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         data = self.key.encrypt(data)
         csize = len(data)
         self.repository.put(id, data, wait=False)
-        self.chunks[id] = ChunkIndexEntry(refcount + 1, size, csize)
-        stats.update(size, csize, True)
+        self.chunks.add(id, 1, size, csize)
+        stats.update(size, csize, not refcount)
         return ChunkListEntry(id, size, csize)
 
     def seen_chunk(self, id, size=None):

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -313,6 +313,8 @@ cdef class ChunkIndex(IndexBase):
             assert refcount2 <= _MAX_VALUE
             result64 = refcount1 + refcount2
             values[0] = _htole32(min(result64, _MAX_VALUE))
+            values[1] = data[1]
+            values[2] = data[2]
         else:
             hashindex_set(self.index, key, data)
 

--- a/borg/testsuite/hashindex.py
+++ b/borg/testsuite/hashindex.py
@@ -174,8 +174,8 @@ class HashIndexRefcountingTestCase(BaseTestCase):
         idx1 = ChunkIndex()
         idx1.add(H(1), 5, 6, 7)
         assert idx1[H(1)] == (5, 6, 7)
-        idx1.add(H(1), 1, 0, 0)
-        assert idx1[H(1)] == (6, 6, 7)
+        idx1.add(H(1), 1, 2, 3)
+        assert idx1[H(1)] == (6, 2, 3)
 
     def test_incref_limit(self):
         idx1 = ChunkIndex()
@@ -266,7 +266,7 @@ class HashIndexDataTestCase(BaseTestCase):
         idx2 = ChunkIndex()
         idx2[H(3)] = 2**32 - 123456, 6, 7
         idx1.merge(idx2)
-        assert idx1[H(3)] == (hashindex.MAX_VALUE, 0, 0)
+        assert idx1[H(3)] == (hashindex.MAX_VALUE, 6, 7)
 
 
 def test_nsindex_segment_limit():


### PR DESCRIPTION
Also fixes a small cosmetic bug (would only affect recreate) where with add_chunk(overwrite=True) chunks that aren't unique would count towards the unique/deduplicated size.