### PR TITLE
Turn utf-8 string into Unicode string literal

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Borg - Deduplicating Archiver'
-copyright = '2010-2014 Jonas Borgström, 2015-2016 The Borg Collective (see AUTHORS file)'
+copyright = u'2010-2014 Jonas Borgström, 2015-2016 The Borg Collective (see AUTHORS file)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Python2 has broken string handling, so when running sphinx-build under
python2 instead of python3 strings containing UTF-8 characters need to
be Unicode string literals.

Popped up during #208 