### PR TITLE
fix spelling, as of lintian.debian.org

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -666,7 +666,7 @@ class Archiver:
 
     @with_repository()
     def do_mount(self, args, repository, manifest, key):
-        """Mount archive or an entire repository as a FUSE fileystem"""
+        """Mount archive or an entire repository as a FUSE filesystem"""
         try:
             from .fuse import FuseOperations
         except ImportError as e:


### PR DESCRIPTION
fix spelling, as shown on 
https://lintian.debian.org/full/debian@danny-edel.de.html#borgbackup_1.0.1-1
( and I have a typo in commit-message.. haha)