### PR TITLE
pass meta-data around, fixes #765

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -121,14 +121,14 @@ class Archiver:
                 a = next(chunks1, end)
                 if a is end:
                     return not blen - bi and next(chunks2, end) is end
-                a = memoryview(a)
+                a = memoryview(a.data)
                 alen = len(a)
                 ai = 0
             if not blen - bi:
                 b = next(chunks2, end)
                 if b is end:
                     return not alen - ai and next(chunks1, end) is end
-                b = memoryview(b)
+                b = memoryview(b.data)
                 blen = len(b)
                 bi = 0
             slicelen = min(alen - ai, blen - bi)
@@ -868,7 +868,7 @@ class Archiver:
         """dump (decrypted, decompressed) archive items metadata (not: data)"""
         archive = Archive(repository, key, manifest, args.location.archive)
         for i, item_id in enumerate(archive.metadata[b'items']):
-            data = key.decrypt(item_id, repository.get(item_id))
+            _, data = key.decrypt(item_id, repository.get(item_id))
             filename = '%06d_%s.items' % (i, hexlify(item_id).decode('ascii'))
             print('Dumping', filename)
             with open(filename, 'wb') as fd:

--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -73,7 +73,7 @@ class FuseOperations(llfuse.Operations):
         """
         unpacker = msgpack.Unpacker()
         for key, chunk in zip(archive.metadata[b'items'], self.repository.get_many(archive.metadata[b'items'])):
-            data = self.key.decrypt(key, chunk)
+            _, data = self.key.decrypt(key, chunk)
             unpacker.feed(data)
             for item in unpacker:
                 segments = prefix + os.fsencode(os.path.normpath(item[b'path'])).split(b'/')
@@ -229,8 +229,8 @@ class FuseOperations(llfuse.Operations):
                 offset -= s
                 continue
             n = min(size, s - offset)
-            chunk = self.key.decrypt(id, self.repository.get(id))
-            parts.append(chunk[offset:offset + n])
+            _, data = self.key.decrypt(id, self.repository.get(id))
+            parts.append(data[offset:offset + n])
             offset = 0
             size -= n
             if not size:

--- a/borg/testsuite/archive.py
+++ b/borg/testsuite/archive.py
@@ -14,9 +14,9 @@ class MockCache:
     def __init__(self):
         self.objects = {}
 
-    def add_chunk(self, id, data, stats=None):
-        self.objects[id] = data
-        return id, len(data), len(data)
+    def add_chunk(self, id, chunk, stats=None):
+        self.objects[id] = chunk.data
+        return id, len(chunk.data), len(chunk.data)
 
 
 class ArchiveTimestampTestCase(BaseTestCase):

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -23,7 +23,7 @@ from ..archiver import Archiver
 from ..cache import Cache
 from ..constants import *  # NOQA
 from ..crypto import bytes_to_long, num_aes_blocks
-from ..helpers import Manifest
+from ..helpers import Chunk, Manifest, EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
 from ..key import KeyfileKeyBase
 from ..remote import RemoteRepository, PathNotAllowed
 from ..repository import Repository
@@ -1677,8 +1677,10 @@ def test_get_args():
 
 def test_compare_chunk_contents():
     def ccc(a, b):
-        compare1 = Archiver.compare_chunk_contents(iter(a), iter(b))
-        compare2 = Archiver.compare_chunk_contents(iter(b), iter(a))
+        chunks_a = [Chunk(data) for data in a]
+        chunks_b = [Chunk(data) for data in b]
+        compare1 = Archiver.compare_chunk_contents(iter(chunks_a), iter(chunks_b))
+        compare2 = Archiver.compare_chunk_contents(iter(chunks_b), iter(chunks_a))
         assert compare1 == compare2
         return compare1
     assert ccc([

--- a/borg/testsuite/helpers.py
+++ b/borg/testsuite/helpers.py
@@ -13,7 +13,7 @@ import time
 from ..helpers import Location, format_file_size, format_timedelta, make_path_safe, \
     prune_within, prune_split, get_cache_dir, get_keys_dir, Statistics, is_slow_msgpack, \
     yes, TRUISH, FALSISH, DEFAULTISH, \
-    StableDict, int_to_bigint, bigint_to_int, parse_timestamp, CompressionSpec, ChunkerParams, \
+    StableDict, int_to_bigint, bigint_to_int, parse_timestamp, CompressionSpec, ChunkerParams, Chunk, \
     ProgressIndicatorPercent, ProgressIndicatorEndless, load_excludes, parse_pattern, \
     PatternMatcher, RegexPattern, PathPrefixPattern, FnmatchPattern, ShellPattern, partial_format, ChunkIteratorFileWrapper
 from . import BaseTestCase, environment_variable, FakeInputs
@@ -902,7 +902,7 @@ def test_partial_format():
 
 
 def test_chunk_file_wrapper():
-    cfw = ChunkIteratorFileWrapper(iter([b'abc', b'def']))
+    cfw = ChunkIteratorFileWrapper(iter([Chunk(b'abc'), Chunk(b'def')]))
     assert cfw.read(2) == b'ab'
     assert cfw.read(50) == b'cdef'
     assert cfw.exhausted

--- a/borg/testsuite/key.py
+++ b/borg/testsuite/key.py
@@ -6,7 +6,7 @@ from binascii import hexlify, unhexlify
 
 from ..crypto import bytes_to_long, num_aes_blocks
 from ..key import PlaintextKey, PassphraseKey, KeyfileKey
-from ..helpers import Location
+from ..helpers import Location, Chunk
 from . import BaseTestCase
 
 
@@ -47,17 +47,17 @@ class KeyTestCase(BaseTestCase):
 
     def test_plaintext(self):
         key = PlaintextKey.create(None, None)
-        data = b'foo'
-        self.assert_equal(hexlify(key.id_hash(data)), b'2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')
-        self.assert_equal(data, key.decrypt(key.id_hash(data), key.encrypt(data)))
+        chunk = Chunk(b'foo')
+        self.assert_equal(hexlify(key.id_hash(chunk.data)), b'2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')
+        self.assert_equal(chunk, key.decrypt(key.id_hash(chunk.data), key.encrypt(chunk)))
 
     def test_keyfile(self):
         os.environ['BORG_PASSPHRASE'] = 'test'
         key = KeyfileKey.create(self.MockRepository(), self.MockArgs())
         self.assert_equal(bytes_to_long(key.enc_cipher.iv, 8), 0)
-        manifest = key.encrypt(b'XXX')
+        manifest = key.encrypt(Chunk(b'XXX'))
         self.assert_equal(key.extract_nonce(manifest), 0)
-        manifest2 = key.encrypt(b'XXX')
+        manifest2 = key.encrypt(Chunk(b'XXX'))
         self.assert_not_equal(manifest, manifest2)
         self.assert_equal(key.decrypt(None, manifest), key.decrypt(None, manifest2))
         self.assert_equal(key.extract_nonce(manifest2), 1)
@@ -67,15 +67,15 @@ class KeyTestCase(BaseTestCase):
         # Key data sanity check
         self.assert_equal(len(set([key2.id_key, key2.enc_key, key2.enc_hmac_key])), 3)
         self.assert_equal(key2.chunk_seed == 0, False)
-        data = b'foo'
-        self.assert_equal(data, key2.decrypt(key.id_hash(data), key.encrypt(data)))
+        chunk = Chunk(b'foo')
+        self.assert_equal(chunk, key2.decrypt(key.id_hash(chunk.data), key.encrypt(chunk)))
 
     def test_keyfile2(self):
         with open(os.path.join(os.environ['BORG_KEYS_DIR'], 'keyfile'), 'w') as fd:
             fd.write(self.keyfile2_key_file)
         os.environ['BORG_PASSPHRASE'] = 'passphrase'
         key = KeyfileKey.detect(self.MockRepository(), self.keyfile2_cdata)
-        self.assert_equal(key.decrypt(self.keyfile2_id, self.keyfile2_cdata), b'payload')
+        self.assert_equal(key.decrypt(self.keyfile2_id, self.keyfile2_cdata).data, b'payload')
 
     def test_passphrase(self):
         os.environ['BORG_PASSPHRASE'] = 'test'
@@ -85,9 +85,9 @@ class KeyTestCase(BaseTestCase):
         self.assert_equal(hexlify(key.enc_hmac_key), b'b885a05d329a086627412a6142aaeb9f6c54ab7950f996dd65587251f6bc0901')
         self.assert_equal(hexlify(key.enc_key), b'2ff3654c6daf7381dbbe718d2b20b4f1ea1e34caa6cc65f6bb3ac376b93fed2a')
         self.assert_equal(key.chunk_seed, -775740477)
-        manifest = key.encrypt(b'XXX')
+        manifest = key.encrypt(Chunk(b'XXX'))
         self.assert_equal(key.extract_nonce(manifest), 0)
-        manifest2 = key.encrypt(b'XXX')
+        manifest2 = key.encrypt(Chunk(b'XXX'))
         self.assert_not_equal(manifest, manifest2)
         self.assert_equal(key.decrypt(None, manifest), key.decrypt(None, manifest2))
         self.assert_equal(key.extract_nonce(manifest2), 1)
@@ -98,6 +98,6 @@ class KeyTestCase(BaseTestCase):
         self.assert_equal(key.enc_hmac_key, key2.enc_hmac_key)
         self.assert_equal(key.enc_key, key2.enc_key)
         self.assert_equal(key.chunk_seed, key2.chunk_seed)
-        data = b'foo'
-        self.assert_equal(hexlify(key.id_hash(data)), b'818217cf07d37efad3860766dcdf1d21e401650fed2d76ed1d797d3aae925990')
-        self.assert_equal(data, key2.decrypt(key2.id_hash(data), key.encrypt(data)))
+        chunk = Chunk(b'foo')
+        self.assert_equal(hexlify(key.id_hash(chunk.data)), b'818217cf07d37efad3860766dcdf1d21e401650fed2d76ed1d797d3aae925990')
+        self.assert_equal(chunk, key2.decrypt(key2.id_hash(chunk.data), key.encrypt(chunk)))


### PR DESCRIPTION
Chunk is a namedtuple of (meta, data), create chunks using mkchunk(data, **meta).

This does not yet have any visible functionality, meta is always empty dict right now.