### PR TITLE
Add Windows support.

### DIFF
--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -12,6 +12,10 @@
 #include <sys/isa_defs.h>
 #endif
 
+#if defined __MINGW32__ && defined _WIN32
+    #define BYTE_ORDER LITTLE_ENDIAN
+#endif // __MINGW32__
+
 #if (defined(BYTE_ORDER)&&(BYTE_ORDER == BIG_ENDIAN)) ||  \
     (defined(_BIG_ENDIAN)&&defined(__SVR4)&&defined(__sun))
 #define _le32toh(x) __builtin_bswap32(x)

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -319,7 +319,7 @@ Number of files: {0.stats.nfiles}'''.format(
 
         original_path = original_path or item[b'path']
         dest = self.cwd
-        if item[b'path'].startswith('/') or item[b'path'].startswith('..'):
+        if item[b'path'].startswith('/') or item[b'path'].startswith('..') or (sys.platform == 'win32' and item[b'path'][1] == ':'):
             raise Exception('Path should be relative and local')
         path = os.path.join(dest, item[b'path'])
         # Attempt to remove existing files, ignore errors on failure

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -413,36 +413,37 @@ Number of files: {0.stats.nfiles}'''.format(
         uid = item[b'uid'] if uid is None else uid
         gid = item[b'gid'] if gid is None else gid
         # This code is a bit of a mess due to os specific differences
-        try:
-            if fd:
-                os.fchown(fd, uid, gid)
-            else:
-                os.lchown(path, uid, gid)
-        except OSError:
-            pass
-        if fd:
-            os.fchmod(fd, item[b'mode'])
-        elif not symlink:
-            os.chmod(path, item[b'mode'])
-        elif has_lchmod:  # Not available on Linux
-            os.lchmod(path, item[b'mode'])
-        mtime = bigint_to_int(item[b'mtime'])
-        if b'atime' in item:
-            atime = bigint_to_int(item[b'atime'])
-        else:
-            # old archives only had mtime in item metadata
-            atime = mtime
-        if fd:
-            os.utime(fd, None, ns=(atime, mtime))
-        else:
-            os.utime(path, None, ns=(atime, mtime), follow_symlinks=False)
-        acl_set(path, item, self.numeric_owner)
-        # Only available on OS X and FreeBSD
-        if has_lchflags and b'bsdflags' in item:
+        if sys.platform != 'win32':
             try:
-                os.lchflags(path, item[b'bsdflags'])
+                if fd:
+                    os.fchown(fd, uid, gid)
+                else:
+                    os.lchown(path, uid, gid)
             except OSError:
                 pass
+            if fd:
+                os.fchmod(fd, item[b'mode'])
+            elif not symlink:
+                os.chmod(path, item[b'mode'])
+            elif has_lchmod:  # Not available on Linux
+                os.lchmod(path, item[b'mode'])
+            mtime = bigint_to_int(item[b'mtime'])
+            if b'atime' in item:
+                atime = bigint_to_int(item[b'atime'])
+            else:
+                # old archives only had mtime in item metadata
+                atime = mtime
+            if fd:
+                os.utime(fd, None, ns=(atime, mtime))
+            else:
+                os.utime(path, None, ns=(atime, mtime), follow_symlinks=False)
+            acl_set(path, item, self.numeric_owner)
+            # Only available on OS X and FreeBSD
+            if has_lchflags and b'bsdflags' in item:
+                try:
+                    os.lchflags(path, item[b'bsdflags'])
+                except OSError:
+                    pass
 
     def set_meta(self, key, value):
         metadata = StableDict(self._load_meta(self.id))

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -697,7 +697,7 @@ def gid2group(gid, default=None):
         if sys.platform != 'win32':
             return grp.getgrgid(gid).gr_name
         else:
-            ''
+            return ''
     except KeyError:
         return default
 
@@ -801,56 +801,39 @@ class Location:
         return True
 
     def _parse(self, text):
-        if sys.platform != 'win32':
-            m = self.ssh_re.match(text)
-            if m:
-                self.proto = m.group('proto')
-                self.user = m.group('user')
-                self.host = m.group('host')
-                self.port = m.group('port') and int(m.group('port')) or None
-                self.path = os.path.normpath(m.group('path'))
-                self.archive = m.group('archive')
-                return True
-            m = self.file_re.match(text)
-            if m:
-                self.proto = m.group('proto')
-                self.path = os.path.normpath(m.group('path'))
-                self.archive = m.group('archive')
-                return True
-            m = self.scp_re.match(text)
-            if m:
-                self.user = m.group('user')
-                self.host = m.group('host')
-                self.path = os.path.normpath(m.group('path'))
-                self.archive = m.group('archive')
-                self.proto = self.host and 'ssh' or 'file'
-                return True
-            return False
-        else:
+        if sys.platform == 'win32':
             m = self.file_re.match(text)
             if m:
                 self.proto = m.group('proto')
                 self.path = os.path.normpath(m.group('drive') + ":\\" + m.group('path'))
                 self.archive = m.group('archive')
                 return True
-            m = self.ssh_re.match(text)
+
+        m = self.ssh_re.match(text)
+        if m:
+            self.proto = m.group('proto')
+            self.user = m.group('user')
+            self.host = m.group('host')
+            self.port = m.group('port') and int(m.group('port')) or None
+            self.path = os.path.normpath(m.group('path'))
+            self.archive = m.group('archive')
+            return True
+        if sys.platform != 'win32':
+            m = self.file_re.match(text)
             if m:
                 self.proto = m.group('proto')
-                self.user = m.group('user')
-                self.host = m.group('host')
-                self.port = m.group('port') and int(m.group('port')) or None
                 self.path = os.path.normpath(m.group('path'))
                 self.archive = m.group('archive')
                 return True
-            m = self.scp_re.match(text)
-            if m:
-                self.user = m.group('user')
-                self.host = m.group('host')
-                self.path = os.path.normpath(m.group('path'))
-                self.archive = m.group('archive')
-                self.proto = self.host and 'ssh' or 'file'
-                return True
-            return False
+        m = self.scp_re.match(text)
+        if m:
+            self.user = m.group('user')
+            self.host = m.group('host')
+            self.path = os.path.normpath(m.group('path'))
+            self.archive = m.group('archive')
+            self.proto = self.host and 'ssh' or 'file'
+            return True
+        return False
 
     def __str__(self):
         items = [

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -683,7 +683,10 @@ def uid2user(uid, default=None):
 @memoize
 def user2uid(user, default=None):
     try:
-        return user and 0
+        if sys.platform != 'win32':
+            return user and pwd.getpwnam(user).pw_uid
+        else:
+            return user and 0
     except KeyError:
         return default
 
@@ -694,7 +697,7 @@ def gid2group(gid, default=None):
         if sys.platform != 'win32':
             return grp.getgrgid(gid).gr_name
         else:
-            ""
+            ''
     except KeyError:
         return default
 
@@ -926,7 +929,10 @@ _safe_re = re.compile(r'^((\.\.)?/+)+')
 def make_path_safe(path):
     """Make path safe by making it relative and local
     """
-    return _safe_re.sub('', path) or '.'
+    if sys.platform != 'win32':
+        return _safe_re.sub('', path) or '.'
+    else:
+        return os.path.relpath(path)
 
 
 def daemonize():

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -932,7 +932,10 @@ def make_path_safe(path):
     if sys.platform != 'win32':
         return _safe_re.sub('', path) or '.'
     else:
-        return os.path.relpath(path)
+        tail = path
+        if path[0:2] == '//' or path[0:2] == '\\\\' or path[1] == ':':
+            drive, tail = os.path.splitdrive(path)
+        return _safe_re.sub('', tail) or '.'
 
 
 def daemonize():

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -39,6 +39,7 @@ import msgpack.fallback
 
 import socket
 
+
 class Error(Exception):
     """Error base class"""
 
@@ -682,7 +683,7 @@ def uid2user(uid, default=None):
 @memoize
 def user2uid(user, default=None):
     try:
-        return user and pwd.getpwnam(user).pw_uid
+        return user and 0
     except KeyError:
         return default
 
@@ -704,6 +705,7 @@ def group2gid(group, default=None):
         return group and grp.getgrnam(group).gr_gid
     except KeyError:
         return default
+
 
 def getuid():
     if sys.platform != 'win32':

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -1,11 +1,12 @@
 import errno
-import fcntl
+import sys
+if sys.platform != 'win32':
+    import fcntl
 import logging
 import os
 import select
 import shlex
 from subprocess import Popen, PIPE
-import sys
 import tempfile
 
 from . import __version__
@@ -157,9 +158,10 @@ class RemoteRepository:
         self.stdin_fd = self.p.stdin.fileno()
         self.stdout_fd = self.p.stdout.fileno()
         self.stderr_fd = self.p.stderr.fileno()
-        fcntl.fcntl(self.stdin_fd, fcntl.F_SETFL, fcntl.fcntl(self.stdin_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
-        fcntl.fcntl(self.stdout_fd, fcntl.F_SETFL, fcntl.fcntl(self.stdout_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
-        fcntl.fcntl(self.stderr_fd, fcntl.F_SETFL, fcntl.fcntl(self.stderr_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+        if sys.platform != 'win32':
+            fcntl.fcntl(self.stdin_fd, fcntl.F_SETFL, fcntl.fcntl(self.stdin_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+            fcntl.fcntl(self.stdout_fd, fcntl.F_SETFL, fcntl.fcntl(self.stdout_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+            fcntl.fcntl(self.stderr_fd, fcntl.F_SETFL, fcntl.fcntl(self.stderr_fd, fcntl.F_GETFL) | os.O_NONBLOCK)
         self.r_fds = [self.stdout_fd, self.stderr_fd]
         self.x_fds = [self.stdin_fd, self.stdout_fd, self.stderr_fd]
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if sys.platform == 'win32':
             gccpath = p
             break
     windowsIncludeDirs.append(os.path.abspath(os.path.join(gccpath, "..")))
-    windowsIncludeDirs.append(os.path.abspath(os.path.join(os.path.join(gccpath, ".."), "..")))
+    windowsIncludeDirs.append(os.path.abspath(os.path.join(gccpath, "..", "..")))
 
 
 possible_openssl_prefixes = None
@@ -314,15 +314,13 @@ if not on_rtd:
 def parse(root, describe_command=None):
     return subprocess.check_output("git describe --tags --long").decode().strip()
 
-parsefunction = None
-if sys.platform == 'win32':
-    parsefunction = parse
+parse_function = parse if sys.platform == 'win32' else None
 
 setup(
     name='borgbackup',
     use_scm_version={
         'write_to': 'borg/_version.py',
-        'parse': parsefunction,
+        'parse': parse_function,
     },
     author='The Borg Collective (see AUTHORS file)',
     author_email='borgbackup@python.org',

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,9 @@ if sys.platform == 'win32':
     for p in os.environ["PATH"].split(";"):
         if os.path.exists(p + "/gcc.exe"):
             gccpath = p
-    windowsIncludeDirs.append(os.path.abspath(gccpath + "/.."))
-    windowsIncludeDirs.append(os.path.abspath(gccpath + "/../.."))
+            break
+    windowsIncludeDirs.append(os.path.abspath(os.path.join(gccpath, "..")))
+    windowsIncludeDirs.append(os.path.abspath(os.path.join(os.path.join(gccpath, ".."), "..")))
 
 
 possible_openssl_prefixes = None

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if sys.platform == 'win32':
             gccpath = p
     windowsIncludeDirs.append(os.path.abspath(gccpath + "/.."))
     windowsIncludeDirs.append(os.path.abspath(gccpath + "/../.."))
-    
+
 
 possible_openssl_prefixes = None
 if sys.platform == 'win32':
@@ -309,8 +309,7 @@ if not on_rtd:
     elif sys.platform == 'darwin':
         ext_modules.append(Extension('borg.platform_darwin', [platform_darwin_source]))
 
-        
-        
+
 def parse(root, describe_command=None):
     return subprocess.check_output("git describe --tags --long").decode().strip()
 


### PR DESCRIPTION
Initial native windows support.
This way borg is using Windows platform natively without Cygwin.
I used msys2 console to get dependencies and run
```
easy_install-3.5 pip
pip install -r requirements.d/development.txt
pip install -e .
```
Then I used windows 10 cmd to run borg commands
I created repository with `python3 -m borg init D:/temp/borgtest --encryption=none` Default encryption crashes python.

Tested and working commands:

- create, With all compressions
- list
- info
- delete
- diff
- extract

I did run it without virtualenv as it had problems.