### PR TITLE
Fix Fedora installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -162,7 +162,7 @@ Install the dependencies with development headers::
     sudo dnf install libacl-devel libacl
     sudo dnf install lz4-devel
     sudo dnf install gcc gcc-c++
-    sudo dnf install redhat-rpm-config
+    sudo dnf install redhat-rpm-config                 # not needed in Korora
     sudo dnf install fuse-devel fuse pkgconfig         # optional, for FUSE support
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -162,6 +162,7 @@ Install the dependencies with development headers::
     sudo dnf install libacl-devel libacl
     sudo dnf install lz4-devel
     sudo dnf install gcc gcc-c++
+    sudo dnf install redhat-rpm-config
     sudo dnf install fuse-devel fuse pkgconfig         # optional, for FUSE support
 
 


### PR DESCRIPTION
Update installation instructions so that the following error won't occur:

gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
error: command 'gcc' failed with exit status 1