### PR TITLE
borg mount: cache partially read data chunks

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1533,6 +1533,11 @@ class Archiver:
 
         To allow a regular user to use fstab entries, add the ``user`` option:
         ``/path/to/repo /mnt/point fuse.borgfs defaults,noauto,user 0 0``
+
+        The BORG_MOUNT_DATA_CACHE_ENTRIES environment variable is meant for advanced users
+        to tweak the performance. It sets the number of cached data chunks; additional
+        memory usage can be up to ~8 MiB times this number. The default is the number
+        of CPU cores.
         """)
         subparser = subparsers.add_parser('mount', parents=[common_parser], add_help=False,
                                           description=self.do_mount.__doc__,


### PR DESCRIPTION
This fixes performance issues of FUSE mounted archives with programs that do small reads.

An extreme case are the shaXXXsum family of programs which read 32 kB blocks. This leads to chunks being decrypted and decompressed excessively often, the slowdown for these approaches a factor 60. This patch caches partially read chunks in a bounded cache with LRU-eviction (LRUCache), which brings md5sum and the like to the speed of the native "borg list" functionality.