### PR TITLE
WIP: implement msgpack wrapper so that bytes and str roundtrip

### DIFF
--- a/borg/constants.py
+++ b/borg/constants.py
@@ -1,10 +1,10 @@
 # this set must be kept complete, otherwise the RobustUnpacker might malfunction:
-ITEM_KEYS = set([b'path', b'source', b'rdev', b'chunks', b'hardlink_master',
-                 b'mode', b'user', b'group', b'uid', b'gid', b'mtime', b'atime', b'ctime',
-                 b'xattrs', b'bsdflags', b'acl_nfs4', b'acl_access', b'acl_default', b'acl_extended', ])
+ITEM_KEYS = set(['path', 'source', 'rdev', 'chunks', 'hardlink_master',
+                 'mode', 'user', 'group', 'uid', 'gid', 'mtime', 'atime', 'ctime',
+                 'xattrs', 'bsdflags', 'acl_nfs4', 'acl_access', 'acl_default', 'acl_extended', ])
 
-ARCHIVE_TEXT_KEYS = (b'name', b'comment', b'hostname', b'username', b'time', b'time_end')
-ITEM_TEXT_KEYS = (b'path', b'source', b'user', b'group')
+ARCHIVE_TEXT_KEYS = ('name', 'comment', 'hostname', 'username', 'time', 'time_end')
+ITEM_TEXT_KEYS = ('path', 'source', 'user', 'group')
 
 # default umask, overriden by --umask, defaults to read/write only for owner
 UMASK_DEFAULT = 0o077

--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -9,7 +9,7 @@ import time
 from .archive import Archive
 from .helpers import daemonize, bigint_to_int
 from distutils.version import LooseVersion
-import msgpack
+from . import msg_pack
 
 # Does this version of llfuse support ns precision?
 have_fuse_xtime_ns = hasattr(llfuse.EntryAttributes, 'st_mtime_ns')
@@ -31,12 +31,12 @@ class ItemCache:
 
     def add(self, item):
         pos = self.fd.seek(0, io.SEEK_END)
-        self.fd.write(msgpack.packb(item))
+        self.fd.write(msg_pack.packb(item))
         return pos + self.offset
 
     def get(self, inode):
         self.fd.seek(inode - self.offset, io.SEEK_SET)
-        return next(msgpack.Unpacker(self.fd, read_size=1024))
+        return next(msg_pack.Unpacker(self.fd, read_size=1024))
 
 
 class FuseOperations(llfuse.Operations):
@@ -71,8 +71,8 @@ class FuseOperations(llfuse.Operations):
     def process_archive(self, archive, prefix=[]):
         """Build fuse inode hierarchy from archive metadata
         """
-        unpacker = msgpack.Unpacker()
-        for key, chunk in zip(archive.metadata[b'items'], self.repository.get_many(archive.metadata[b'items'])):
+        unpacker = msg_pack.Unpacker()
+        for key, chunk in zip(archive.metadata['items'], self.repository.get_many(archive.metadata['items'])):
             _, data = self.key.decrypt(key, chunk)
             unpacker.feed(data)
             for item in unpacker:

--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -50,7 +50,7 @@ class FuseOperations(llfuse.Operations):
         self.items = {}
         self.parent = {}
         self.contents = defaultdict(dict)
-        self.default_dir = {b'mode': 0o40755, b'mtime': int(time.time() * 1e9), b'uid': os.getuid(), b'gid': os.getgid()}
+        self.default_dir = {'mode': 0o40755, 'mtime': int(time.time() * 1e9), 'uid': os.getuid(), 'gid': os.getgid()}
         self.pending_archives = {}
         self.accounted_chunks = {}
         self.cache = ItemCache()
@@ -76,8 +76,8 @@ class FuseOperations(llfuse.Operations):
             _, data = self.key.decrypt(key, chunk)
             unpacker.feed(data)
             for item in unpacker:
-                segments = prefix + os.fsencode(os.path.normpath(item[b'path'])).split(b'/')
-                del item[b'path']
+                segments = prefix + os.fsencode(os.path.normpath(item['path'])).split(b'/')
+                del item['path']
                 num_segments = len(segments)
                 parent = 1
                 for i, segment in enumerate(segments, 1):
@@ -88,10 +88,10 @@ class FuseOperations(llfuse.Operations):
                         self.parent[archive_inode] = parent
                     # Leaf segment?
                     if i == num_segments:
-                        if b'source' in item and stat.S_ISREG(item[b'mode']):
-                            inode = self._find_inode(item[b'source'], prefix)
+                        if 'source' in item and stat.S_ISREG(item['mode']):
+                            inode = self._find_inode(item['source'], prefix)
                             item = self.cache.get(inode)
-                            item[b'nlink'] = item.get(b'nlink', 1) + 1
+                            item['nlink'] = item.get('nlink', 1) + 1
                             self.items[inode] = item
                         else:
                             inode = self.cache.add(item)
@@ -142,7 +142,7 @@ class FuseOperations(llfuse.Operations):
         size = 0
         dsize = 0
         try:
-            for key, chunksize, _ in item[b'chunks']:
+            for key, chunksize, _ in item['chunks']:
                 size += chunksize
                 if self.accounted_chunks.get(key, inode) == inode:
                     self.accounted_chunks[key] = inode
@@ -154,45 +154,45 @@ class FuseOperations(llfuse.Operations):
         entry.generation = 0
         entry.entry_timeout = 300
         entry.attr_timeout = 300
-        entry.st_mode = item[b'mode']
-        entry.st_nlink = item.get(b'nlink', 1)
-        entry.st_uid = item[b'uid']
-        entry.st_gid = item[b'gid']
-        entry.st_rdev = item.get(b'rdev', 0)
+        entry.st_mode = item['mode']
+        entry.st_nlink = item.get('nlink', 1)
+        entry.st_uid = item['uid']
+        entry.st_gid = item['gid']
+        entry.st_rdev = item.get('rdev', 0)
         entry.st_size = size
         entry.st_blksize = 512
         entry.st_blocks = dsize / 512
         # note: older archives only have mtime (not atime nor ctime)
         if have_fuse_xtime_ns:
-            entry.st_mtime_ns = bigint_to_int(item[b'mtime'])
-            if b'atime' in item:
-                entry.st_atime_ns = bigint_to_int(item[b'atime'])
+            entry.st_mtime_ns = bigint_to_int(item['mtime'])
+            if 'atime' in item:
+                entry.st_atime_ns = bigint_to_int(item['atime'])
             else:
-                entry.st_atime_ns = bigint_to_int(item[b'mtime'])
-            if b'ctime' in item:
-                entry.st_ctime_ns = bigint_to_int(item[b'ctime'])
+                entry.st_atime_ns = bigint_to_int(item['mtime'])
+            if 'ctime' in item:
+                entry.st_ctime_ns = bigint_to_int(item['ctime'])
             else:
-                entry.st_ctime_ns = bigint_to_int(item[b'mtime'])
+                entry.st_ctime_ns = bigint_to_int(item['mtime'])
         else:
-            entry.st_mtime = bigint_to_int(item[b'mtime']) / 1e9
-            if b'atime' in item:
-                entry.st_atime = bigint_to_int(item[b'atime']) / 1e9
+            entry.st_mtime = bigint_to_int(item['mtime']) / 1e9
+            if 'atime' in item:
+                entry.st_atime = bigint_to_int(item['atime']) / 1e9
             else:
-                entry.st_atime = bigint_to_int(item[b'mtime']) / 1e9
-            if b'ctime' in item:
-                entry.st_ctime = bigint_to_int(item[b'ctime']) / 1e9
+                entry.st_atime = bigint_to_int(item['mtime']) / 1e9
+            if 'ctime' in item:
+                entry.st_ctime = bigint_to_int(item['ctime']) / 1e9
             else:
-                entry.st_ctime = bigint_to_int(item[b'mtime']) / 1e9
+                entry.st_ctime = bigint_to_int(item['mtime']) / 1e9
         return entry
 
     def listxattr(self, inode, ctx=None):
         item = self.get_item(inode)
-        return item.get(b'xattrs', {}).keys()
+        return item.get('xattrs', {}).keys()
 
     def getxattr(self, inode, name, ctx=None):
         item = self.get_item(inode)
         try:
-            return item.get(b'xattrs', {})[name]
+            return item.get('xattrs', {})[name]
         except KeyError:
             raise llfuse.FUSEError(errno.ENODATA) from None
 
@@ -224,7 +224,7 @@ class FuseOperations(llfuse.Operations):
     def read(self, fh, offset, size):
         parts = []
         item = self.get_item(fh)
-        for id, s, csize in item[b'chunks']:
+        for id, s, csize in item['chunks']:
             if s < offset:
                 offset -= s
                 continue
@@ -245,7 +245,7 @@ class FuseOperations(llfuse.Operations):
 
     def readlink(self, inode, ctx=None):
         item = self.get_item(inode)
-        return os.fsencode(item[b'source'])
+        return os.fsencode(item['source'])
 
     def mount(self, mountpoint, extra_options, foreground=False):
         options = ['fsname=borgfs', 'ro']

--- a/borg/key.py
+++ b/borg/key.py
@@ -14,6 +14,8 @@ logger = create_logger()
 from .constants import *  # NOQA
 from .crypto import AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks, hmac_sha256
 from .compress import Compressor, COMPR_BUFFER
+
+# NOTE: this is still using msgpack (not msg_pack) for key files to stay compatible with old key files
 import msgpack
 
 PREFIX = b'\0' * 8

--- a/borg/msg_pack.py
+++ b/borg/msg_pack.py
@@ -1,0 +1,77 @@
+# this is a wrapper around msgpack that fixes some bad defaults.
+# - we want bytes -> pack -> unpack -> bytes
+# - we want str -> pack -> unpack -> str (and use utf-8 encoding)
+
+import msgpack
+import msgpack.fallback
+
+msgpack_packb = msgpack.packb
+msgpack_unpackb = msgpack.unpackb
+
+
+def is_slow():
+    return msgpack.Packer is msgpack.fallback.Packer
+
+
+def packb(data, **kw):
+    return msgpack_packb(data, encoding='utf-8', use_bin_type=True, **kw)
+
+
+def unpackb(data, **kw):
+    return msgpack_unpackb(data, encoding='utf-8', **kw)
+
+
+class Packer(msgpack.Packer):
+    def __init__(self,
+                 default=None,
+                 encoding='utf-8',
+                 unicode_errors='strict',
+                 use_single_float=False,
+                 autoreset=1,
+                 use_bin_type=1,  # different from base class
+                 ):
+        super().__init__(
+            default=default,
+            encoding=encoding,
+            unicode_errors=unicode_errors,
+            use_single_float=use_single_float,
+            autoreset=autoreset,
+            use_bin_type=use_bin_type,
+        )
+
+
+class Unpacker(msgpack.Unpacker):
+    def __init__(self,
+                 file_like=None,
+                 read_size=0,
+                 use_list=1,
+                 object_hook=None,
+                 object_pairs_hook=None,
+                 list_hook=None,
+                 encoding='utf-8',  # different from base class
+                 unicode_errors='strict',
+                 max_buffer_size=0,
+                 ext_hook=None,
+                 max_str_len=2147483647,
+                 max_bin_len=2147483647,
+                 max_array_len=2147483647,
+                 max_map_len=2147483647,
+                 max_ext_len=2147483647,
+                 ):
+        super().__init__(
+            file_like=file_like,
+            read_size=read_size,
+            use_list=use_list,
+            object_hook=object_hook,
+            object_pairs_hook=object_pairs_hook,
+            list_hook=list_hook,
+            encoding=encoding,
+            unicode_errors=unicode_errors,
+            max_buffer_size=max_buffer_size,
+            ext_hook=ext_hook,
+            max_str_len=max_str_len,
+            max_bin_len=max_bin_len,
+            max_array_len=max_array_len,
+            max_map_len=max_map_len,
+            max_ext_len=max_ext_len,
+        )

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -13,6 +13,7 @@ from . import __version__
 from .helpers import Error, IntegrityError, get_home_dir, sysinfo
 from .repository import Repository
 
+# NOTE: this is still using msgpack (not msg_pack) for RPC to stay compatible with old remotes
 import msgpack
 
 RPC_PROTOCOL_VERSION = 2

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -1455,8 +1455,8 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         archive, repository = self.open_archive('archive1')
         with repository:
             for item in archive.iter_items():
-                if item[b'path'].endswith('testsuite/archiver.py'):
-                    repository.delete(item[b'chunks'][-1].id)
+                if item['path'].endswith('testsuite/archiver.py'):
+                    repository.delete(item['chunks'][-1].id)
                     break
             repository.commit()
         self.cmd('check', self.repository_location, exit_code=1)
@@ -1466,7 +1466,7 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
     def test_missing_archive_item_chunk(self):
         archive, repository = self.open_archive('archive1')
         with repository:
-            repository.delete(archive.metadata[b'items'][-5])
+            repository.delete(archive.metadata['items'][-5])
             repository.commit()
         self.cmd('check', self.repository_location, exit_code=1)
         self.cmd('check', '--repair', self.repository_location, exit_code=0)

--- a/borg/testsuite/msg_pack.py
+++ b/borg/testsuite/msg_pack.py
@@ -1,3 +1,5 @@
+import pytest
+
 import msgpack
 
 from ..msg_pack import packb, unpackb, is_slow
@@ -15,6 +17,7 @@ def test_is_slow():
 
 
 def test_msg_pack_roundtrip():
+    # this is how the new code works, easily roundtripping bytes and str
     data = b'bytes-ascii\x00'
     assert data == unpackb(packb(data))
     data = b'bytes-arbitrary-\xe4\xf6\xfc\x00'
@@ -23,3 +26,37 @@ def test_msg_pack_roundtrip():
     assert data == unpackb(packb(data))
     data = 'text-unicode-äöü\u0000'
     assert data == unpackb(packb(data))
+
+
+def test_msgpack_roundtrip():
+    # this is how the old code works (directly using msgpack)
+    # str needs addtl. decode to round-trip
+    data = 'text-unicode-äöü\u0000'
+    assert msgpack.unpackb(msgpack.packb(data)).decode('utf-8') == data
+    # bytes do roundtrip without addtl. effort
+    data = b'bytes-arbitrary-\xe4\xf6\xfc\x00'
+    assert msgpack.unpackb(msgpack.packb(data)) == data
+
+
+def test_compat_keys():
+    key_old = b'keyname'  # old code item dict key
+    key_new = 'keyname'  # new code item dict key
+    # old code with old key produces same output as new code with new key
+    assert msgpack.packb(key_old) == packb(key_new)
+
+
+def test_compat_values_str():
+    # old and new code produce same output for str
+    value = 'str-ascii'
+    assert msgpack.packb(value) == packb(value)
+    value = 'str-unicode-äöü\u0000'
+    assert msgpack.packb(value) == packb(value)
+
+
+@pytest.mark.xfail(reason="impossible, bytes must serialize differently now from str to have clean roundtrip")
+def test_compat_values_bytes():
+    # old and new code do NOT produce same output for bytes
+    value = b'bytes-ascii'
+    assert msgpack.packb(value) == packb(value)
+    value = b'bytes-arbitrary-\xe4\xf6\xfc\x00'
+    assert msgpack.packb(value) == packb(value)

--- a/borg/testsuite/msg_pack.py
+++ b/borg/testsuite/msg_pack.py
@@ -1,0 +1,25 @@
+import msgpack
+
+from ..msg_pack import packb, unpackb, is_slow
+
+
+def test_is_slow():
+    saved_packer = msgpack.Packer
+    try:
+        msgpack.Packer = msgpack.fallback.Packer
+        assert is_slow()
+    finally:
+        msgpack.Packer = saved_packer
+    # this assumes that we have fast msgpack on test platform:
+    assert not is_slow()
+
+
+def test_msg_pack_roundtrip():
+    data = b'bytes-ascii\x00'
+    assert data == unpackb(packb(data))
+    data = b'bytes-arbitrary-\xe4\xf6\xfc\x00'
+    assert data == unpackb(packb(data))
+    data = 'text-ascii\u0000'
+    assert data == unpackb(packb(data))
+    data = 'text-unicode-äöü\u0000'
+    assert data == unpackb(packb(data))


### PR DESCRIPTION
note: i am working on a different approach in another PR (refactor item), this PR is not going to be used as is due to compatibility issues. Some parts of it (like msg_pack.py) might be useful in a slightly modified form, though.

msgpack has bad defaults and using them made it necessary to
have ugly b'keyname' and .encode/.decode all over the place.
