### PR TITLE
remove openssl RAND_bytes from crypto.pyx

### DIFF
--- a/borg/crypto.pyx
+++ b/borg/crypto.pyx
@@ -1,15 +1,9 @@
-"""A thin OpenSSL wrapper
+"""A thin OpenSSL wrapper"""
 
-This could be replaced by PyCrypto maybe?
-"""
 from libc.stdlib cimport malloc, free
 from cpython.buffer cimport PyBUF_SIMPLE, PyObject_GetBuffer, PyBuffer_Release
 
 API_VERSION = 3
-
-
-cdef extern from "openssl/rand.h":
-    int  RAND_bytes(unsigned char *buf, int num)
 
 
 cdef extern from "openssl/evp.h":


### PR DESCRIPTION
was forgotten there and not used any more since a while.

also removed the hint about PyCrypto being an alternative to crypto.pyx,
it was not updated since 2014, looks pretty stale.