### PR TITLE
new crypto code, blackbox, aead internally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ from distutils.command.clean import clean
 
 compress_source = 'src/borg/compress.pyx'
 crypto_ll_source = 'src/borg/crypto/low_level.pyx'
+crypto_helpers = 'src/borg/crypto/_crypto_helpers.c'
 chunker_source = 'src/borg/chunker.pyx'
 hashindex_source = 'src/borg/hashindex.pyx'
 item_source = 'src/borg/item.pyx'
@@ -730,7 +731,7 @@ ext_modules = []
 if not on_rtd:
     ext_modules += [
     Extension('borg.compress', [compress_source], libraries=['lz4'], include_dirs=include_dirs, library_dirs=library_dirs, define_macros=define_macros),
-    Extension('borg.crypto.low_level', [crypto_ll_source], libraries=crypto_libraries, include_dirs=include_dirs, library_dirs=library_dirs, define_macros=define_macros),
+    Extension('borg.crypto.low_level', [crypto_ll_source, crypto_helpers], libraries=crypto_libraries, include_dirs=include_dirs, library_dirs=library_dirs, define_macros=define_macros),
     Extension('borg.hashindex', [hashindex_source]),
     Extension('borg.item', [item_source]),
     Extension('borg.chunker', [chunker_source]),

--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -1,0 +1,27 @@
+/* add missing HMAC functions, so OpenSSL 1.0.x can be used like 1.1 */
+
+#include <string.h>
+#include <openssl/opensslv.h>
+#include <openssl/hmac.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+HMAC_CTX *HMAC_CTX_new(void)
+{
+   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+   if (ctx != NULL) {
+       memset(ctx, 0, sizeof *ctx);
+       HMAC_CTX_cleanup(ctx);
+   }
+   return ctx;
+}
+
+void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+   if (ctx != NULL) {
+       HMAC_CTX_cleanup(ctx);
+       OPENSSL_free(ctx);
+   }
+}
+
+#endif

--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -1,4 +1,4 @@
-/* add missing HMAC functions, so OpenSSL 1.0.x can be used like 1.1 */
+/* some helpers, so our code also works with OpenSSL 1.0.x */
 
 #include <string.h>
 #include <openssl/opensslv.h>
@@ -22,6 +22,14 @@ void HMAC_CTX_free(HMAC_CTX *ctx)
        HMAC_CTX_cleanup(ctx);
        OPENSSL_free(ctx);
    }
+}
+
+const EVP_CIPHER *EVP_aes_256_ocb(void){  /* dummy, so that code compiles */
+    return NULL;
+}
+
+const EVP_CIPHER *EVP_chacha20_poly1305(void){  /* dummy, so that code compiles */
+    return NULL;
 }
 
 #endif

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -1,0 +1,11 @@
+/* add missing HMAC functions, so OpenSSL 1.0.x can be used like 1.1 */
+
+#include <openssl/opensslv.h>
+#include <openssl/hmac.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+HMAC_CTX *HMAC_CTX_new(void);
+void HMAC_CTX_free(HMAC_CTX *ctx);
+
+#endif

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -1,11 +1,15 @@
-/* add missing HMAC functions, so OpenSSL 1.0.x can be used like 1.1 */
+/* some helpers, so our code also works with OpenSSL 1.0.x */
 
 #include <openssl/opensslv.h>
 #include <openssl/hmac.h>
+#include <openssl/evp.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 HMAC_CTX *HMAC_CTX_new(void);
 void HMAC_CTX_free(HMAC_CTX *ctx);
+
+const EVP_CIPHER *EVP_aes_256_ocb(void);  /* dummy, so that code compiles */
+const EVP_CIPHER *EVP_chacha20_poly1305(void);  /* dummy, so that code compiles */
 
 #endif

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -802,6 +802,10 @@ class AuthenticatedKeyBase(RepoKey):
             raise IntegrityError('Manifest: Invalid encryption envelope')
         return 42
 
+    def init_ciphers(self, manifest_data=None):
+        if manifest_data is not None and manifest_data[0] != self.TYPE:
+            raise IntegrityError('Manifest: Invalid encryption envelope')
+
     def encrypt(self, chunk):
         data = self.compressor.compress(chunk)
         return b''.join([self.TYPE_STR, data])

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -359,14 +359,14 @@ class AESKeyBase(KeyBase):
     def encrypt(self, chunk):
         data = self.compressor.compress(chunk)
         self.nonce_manager.ensure_reservation(num_aes_blocks(len(data)))
-        return self.enc_cipher.encrypt(data, header=self.TYPE_STR, aad_offset=1)
+        return self.cipher.encrypt(data, header=self.TYPE_STR, aad_offset=1)
 
     def decrypt(self, id, data, decompress=True):
         if not (data[0] == self.TYPE or
             data[0] == PassphraseKey.TYPE and isinstance(self, RepoKey)):
             id_str = bin_to_hex(id) if id is not None else '(unknown)'
             raise IntegrityError('Chunk %s: Invalid encryption envelope' % id_str)
-        payload = self.enc_cipher.decrypt(data, header_len=1, aad_offset=1)
+        payload = self.cipher.decrypt(data, header_len=1, aad_offset=1)
         if not decompress:
             return payload
         data = self.decompress(payload)
@@ -392,9 +392,9 @@ class AESKeyBase(KeyBase):
             self.chunk_seed = self.chunk_seed - 0xffffffff - 1
 
     def init_ciphers(self, manifest_nonce=0):
-        self.enc_cipher = CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key,
-                                      iv=manifest_nonce.to_bytes(16, byteorder='big'))
-        self.nonce_manager = NonceManager(self.repository, self.enc_cipher, manifest_nonce)
+        self.cipher = CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key,
+                                  iv=manifest_nonce.to_bytes(16, byteorder='big'))
+        self.nonce_manager = NonceManager(self.repository, self.cipher, manifest_nonce)
 
 
 class Passphrase(str):

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -27,7 +27,7 @@ from ..item import Key, EncryptedKey
 from ..platform import SaveFile
 
 from .nonces import NonceManager
-from .low_level import AES, bytes_to_long, long_to_bytes, bytes_to_int, num_aes_blocks, hmac_sha256, blake2b_256, hkdf_hmac_sha512
+from .low_level import AES, bytes_to_long, long_to_bytes, bytes_to_int, num_cipher_blocks, hmac_sha256, blake2b_256, hkdf_hmac_sha512
 from .low_level import AES256_CTR_HMAC_SHA256 as CIPHERSUITE
 
 
@@ -514,7 +514,7 @@ class PassphraseKey(ID_HMAC_SHA_256, AESKeyBase):
             key.init(repository, passphrase)
             try:
                 key.decrypt(None, manifest_data)
-                num_blocks = num_aes_blocks(len(manifest_data) - 41)
+                num_blocks = num_cipher_blocks(len(manifest_data) - 41)
                 key.init_ciphers(key.extract_nonce(manifest_data) + num_blocks)
                 key._passphrase = passphrase
                 return key
@@ -554,7 +554,7 @@ class KeyfileKeyBase(AESKeyBase):
         else:
             if not key.load(target, passphrase):
                 raise PassphraseWrong
-        num_blocks = num_aes_blocks(len(manifest_data) - 41)
+        num_blocks = num_cipher_blocks(len(manifest_data) - 41)
         key.init_ciphers(key.extract_nonce(manifest_data) + num_blocks)
         key._passphrase = passphrase
         return key

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -590,7 +590,7 @@ class KeyfileKeyBase(AESKeyBase):
         assert enc_key.version == 1
         assert enc_key.algorithm == 'sha256'
         key = passphrase.kdf(enc_key.salt, enc_key.iterations, 32)
-        data = AES(is_encrypt=False, key=key).decrypt(enc_key.data)
+        data = AES(key, b'\0'*16).decrypt(enc_key.data)
         if hmac_sha256(key, data) == enc_key.hash:
             return data
 
@@ -599,7 +599,7 @@ class KeyfileKeyBase(AESKeyBase):
         iterations = PBKDF2_ITERATIONS
         key = passphrase.kdf(salt, iterations, 32)
         hash = hmac_sha256(key, data)
-        cdata = AES(is_encrypt=True, key=key).encrypt(data)
+        cdata = AES(key, b'\0'*16).encrypt(data)
         enc_key = EncryptedKey(
             version=1,
             salt=salt,

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -791,17 +791,6 @@ class AuthenticatedKeyBase(RepoKey):
         super().save(target, passphrase)
         self.logically_encrypted = False
 
-    def extract_nonce(self, payload):
-        # This is called during set-up of the AES ciphers we're not actually using for this
-        # key. Therefore the return value of this method doesn't matter; it's just around
-        # to not have it crash should key identification be run against a very small chunk
-        # by "borg check" when the manifest is lost. (The manifest is always large enough
-        # to have the original method read some garbage from bytes 33-41). (Also, the return
-        # value must be larger than the 41 byte bloat of the original format).
-        if payload[0] != self.TYPE:
-            raise IntegrityError('Manifest: Invalid encryption envelope')
-        return 42
-
     def init_ciphers(self, manifest_data=None):
         if manifest_data is not None and manifest_data[0] != self.TYPE:
             raise IntegrityError('Manifest: Invalid encryption envelope')

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -358,10 +358,9 @@ class AESKeyBase(KeyBase):
 
     def encrypt(self, chunk):
         data = self.compressor.compress(chunk)
-        next_nonce = int.from_bytes(self.cipher.next_iv(), byteorder='big')
-        next_nonce = self.nonce_manager.ensure_reservation(next_nonce, self.cipher.block_count(len(data)))
-        iv = next_nonce.to_bytes(self.cipher.iv_len, byteorder='big')
-        return self.cipher.encrypt(data, header=self.TYPE_STR, iv=iv)
+        next_iv = self.nonce_manager.ensure_reservation(self.cipher.next_iv(),
+                                                        self.cipher.block_count(len(data)))
+        return self.cipher.encrypt(data, header=self.TYPE_STR, iv=next_iv)
 
     def decrypt(self, id, data, decompress=True):
         if not (data[0] == self.TYPE or
@@ -402,7 +401,7 @@ class AESKeyBase(KeyBase):
             # be a bit too high, but that does not matter.
             manifest_blocks = num_cipher_blocks(len(manifest_data))
             nonce = self.cipher.extract_iv(manifest_data) + manifest_blocks
-        self.cipher.set_iv(nonce.to_bytes(16, byteorder='big'))
+        self.cipher.set_iv(nonce)
         self.nonce_manager = NonceManager(self.repository, nonce)
 
 

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -358,7 +358,7 @@ class AESKeyBase(KeyBase):
 
     def encrypt(self, chunk):
         data = self.compressor.compress(chunk)
-        self.nonce_manager.ensure_reservation(num_aes_blocks(len(data)))
+        self.nonce_manager.ensure_reservation(self.cipher.block_count(len(data)))
         return self.cipher.encrypt(data, header=self.TYPE_STR, aad_offset=1)
 
     def decrypt(self, id, data, decompress=True):

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -28,7 +28,7 @@ from ..platform import SaveFile
 
 from .nonces import NonceManager
 from .low_level import AES, bytes_to_long, long_to_bytes, bytes_to_int, num_cipher_blocks, hmac_sha256, blake2b_256, hkdf_hmac_sha512
-from .low_level import AES256_CTR_HMAC_SHA256 as CIPHERSUITE
+from .low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b
 
 
 class PassphraseWrong(Error):
@@ -352,7 +352,7 @@ class AESKeyBase(KeyBase):
 
     PAYLOAD_OVERHEAD = 1 + 32 + 8  # TYPE + HMAC + NONCE
 
-    MAC = hmac_sha256  # TODO: not used yet
+    CIPHERSUITE = AES256_CTR_HMAC_SHA256
 
     logically_encrypted = True
 
@@ -389,7 +389,7 @@ class AESKeyBase(KeyBase):
             self.chunk_seed = self.chunk_seed - 0xffffffff - 1
 
     def init_ciphers(self, manifest_data=None):
-        self.cipher = CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key, header_len=1, aad_offset=1)
+        self.cipher = self.CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key, header_len=1, aad_offset=1)
         if manifest_data is None:
             nonce = 0
         else:
@@ -764,7 +764,7 @@ class Blake2KeyfileKey(ID_BLAKE2b_256, KeyfileKey):
     STORAGE = KeyBlobStorage.KEYFILE
 
     FILE_ID = 'BORG_KEY'
-    MAC = blake2b_256  # TODO: not used yet
+    CIPHERSUITE = AES256_CTR_BLAKE2b
 
 
 class Blake2RepoKey(ID_BLAKE2b_256, RepoKey):
@@ -773,7 +773,7 @@ class Blake2RepoKey(ID_BLAKE2b_256, RepoKey):
     ARG_NAME = 'repokey-blake2'
     STORAGE = KeyBlobStorage.REPO
 
-    MAC = blake2b_256  # TODO: not used yet
+    CIPHERSUITE = AES256_CTR_BLAKE2b
 
 
 class AuthenticatedKeyBase(RepoKey):

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -405,6 +405,9 @@ cdef class AES256_CTR_HMAC_SHA256:
         return bytes_to_long(envelope[offset:offset+self.iv_len_short])
 
 
+AES256_CTR_BLAKE2b = AES256_CTR_HMAC_SHA256  # TODO this is a dummy
+
+
 ctypedef const EVP_CIPHER * (* CIPHER)()
 
 

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -373,9 +373,9 @@ cdef class AES256_CTR_BASE:
         if isinstance(iv, int):
             iv = iv.to_bytes(self.iv_len, byteorder='big')
         assert isinstance(iv, bytes) and len(iv) == self.iv_len
-        self.blocks = 0  # how many AES blocks got encrypted with this IV?
         for i in range(self.iv_len):
             self.iv[i] = iv[i]
+        self.blocks = 0  # how many AES blocks got encrypted with this IV?
 
     def next_iv(self):
         # call this after encrypt() to get the next iv (int) for the next encrypt() call
@@ -645,9 +645,9 @@ cdef class _AEAD_BASE:
         if isinstance(iv, int):
             iv = iv.to_bytes(self.iv_len, byteorder='big')
         assert isinstance(iv, bytes) and len(iv) == self.iv_len
-        self.blocks = 0  # number of cipher blocks encrypted with this IV
         for i in range(self.iv_len):
             self.iv[i] = iv[i]
+        self.blocks = 0  # number of cipher blocks encrypted with this IV
 
     def next_iv(self):
         # call this after encrypt() to get the next iv (int) for the next encrypt() call
@@ -809,9 +809,9 @@ cdef class AES:
         if isinstance(iv, int):
             iv = iv.to_bytes(self.iv_len, byteorder='big')
         assert isinstance(iv, bytes) and len(iv) == self.iv_len
-        self.blocks = 0  # number of cipher blocks encrypted with this IV
         for i in range(self.iv_len):
             self.iv[i] = iv[i]
+        self.blocks = 0  # number of cipher blocks encrypted with this IV
 
     def next_iv(self):
         # call this after encrypt() to get the next iv (int) for the next encrypt() call

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -209,7 +209,6 @@ cdef class AES256_CTR_HMAC_SHA256:
         self.iv_len = 16
         self.iv_len_short = 8
         self.mac_len = 32
-        assert iv is None or isinstance(iv, bytes) and len(iv) == self.iv_len
         self.mac_key = mac_key
         self.enc_key = enc_key
         if iv is not None:
@@ -326,6 +325,7 @@ cdef class AES256_CTR_HMAC_SHA256:
         return (length + self.cipher_blk_len - 1) // self.cipher_blk_len
 
     def set_iv(self, iv):
+        assert isinstance(iv, bytes) and len(iv) == self.iv_len
         self.blocks = 0  # how many AES blocks got encrypted with this IV?
         for i in range(self.iv_len):
             self.iv[i] = iv[i]
@@ -364,7 +364,6 @@ cdef class _AEAD_BASE:
         assert isinstance(enc_key, bytes) and len(enc_key) == 32
         self.iv_len = 12
         self.mac_len = 16
-        assert iv is None or isinstance(iv, bytes) and len(iv) == self.iv_len
         self.enc_key = enc_key
         if iv is not None:
             self.set_iv(iv)
@@ -484,6 +483,7 @@ cdef class _AEAD_BASE:
         return (length + self.cipher_blk_len - 1) // self.cipher_blk_len
 
     def set_iv(self, iv):
+        assert isinstance(iv, bytes) and len(iv) == self.iv_len
         self.blocks = 0  # number of cipher blocks encrypted with this IV
         for i in range(self.iv_len):
             self.iv[i] = iv[i]

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -508,15 +508,15 @@ cdef class _AEAD_BASE:
 
 
 cdef class _AES_BASE(_AEAD_BASE):
-    def __init__(self, mac_key, enc_key, iv=None):
+    def __init__(self, *args, **kwargs):
         self.cipher_blk_len = 16
-        super().__init__(mac_key, enc_key, iv=iv)
+        super().__init__(*args, **kwargs)
 
 
 cdef class _CHACHA_BASE(_AEAD_BASE):
-    def __init__(self, mac_key, enc_key, iv=None):
+    def __init__(self, *args, **kwargs):
         self.cipher_blk_len = 64
-        super().__init__(mac_key, enc_key, iv=iv)
+        super().__init__(*args, **kwargs)
 
 
 cdef class AES256_GCM(_AES_BASE):

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -199,14 +199,14 @@ cdef class AES256_CTR_HMAC_SHA256:
     cdef int cipher_blk_len
     cdef int iv_len, iv_len_short
     cdef int mac_len
-    cdef unsigned char iv[16]  # XXX use self.iv_len or some MAX_IV_LEN?
+    cdef unsigned char iv[16]
     cdef long long blocks
 
     def __init__(self, mac_key, enc_key, iv=None):
         assert isinstance(mac_key, bytes) and len(mac_key) == 32
         assert isinstance(enc_key, bytes) and len(enc_key) == 32
         self.cipher_blk_len = 16
-        self.iv_len = 16
+        self.iv_len = sizeof(self.iv)
         self.iv_len_short = 8
         self.mac_len = 32
         self.mac_key = mac_key
@@ -286,7 +286,8 @@ cdef class AES256_CTR_HMAC_SHA256:
             raise MemoryError
         cdef int olen
         cdef int offset
-        cdef unsigned char hmac_buf[32]  # XXX use self.mac_len or some MAX_HMAC_LEN?
+        cdef unsigned char hmac_buf[32]
+        assert sizeof(hmac_buf) == self.mac_len
         cdef Py_buffer idata = ro_buffer(envelope)
         try:
             if not HMAC_Init_ex(self.hmac_ctx, self.mac_key, self.mac_len, EVP_sha256(), NULL):
@@ -356,13 +357,13 @@ cdef class _AEAD_BASE:
     cdef int cipher_blk_len
     cdef int iv_len
     cdef int mac_len
-    cdef unsigned char iv[12]  # XXX use self.iv_len or some MAX_IV_LEN?
+    cdef unsigned char iv[12]
     cdef long long blocks
 
     def __init__(self, mac_key, enc_key, iv=None):
         assert mac_key is None
         assert isinstance(enc_key, bytes) and len(enc_key) == 32
-        self.iv_len = 12
+        self.iv_len = sizeof(self.iv)
         self.mac_len = 16
         self.enc_key = enc_key
         if iv is not None:

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -134,23 +134,10 @@ import struct
 
 _int = struct.Struct('>I')
 _long = struct.Struct('>Q')
-_2long = struct.Struct('>QQ')
 
 bytes_to_int = lambda x, offset=0: _int.unpack_from(x, offset)[0]
 bytes_to_long = lambda x, offset=0: _long.unpack_from(x, offset)[0]
 long_to_bytes = lambda x: _long.pack(x)
-
-
-def bytes16_to_int(b, offset=0):
-    h, l = _2long.unpack_from(b, offset)
-    return (h << 64) + l
-
-
-def int_to_bytes16(i):
-    max_uint64 = 0xffffffffffffffff
-    l = i & max_uint64
-    h = (i >> 64) & max_uint64
-    return _2long.pack(h, l)
 
 
 def num_cipher_blocks(length, blocksize=16):

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -123,6 +123,14 @@ cdef extern from "openssl/hmac.h":
                     const unsigned char *data, int data_len,
                     unsigned char *md, unsigned int *md_len) nogil
 
+cdef extern from "_crypto_helpers.h":
+    ctypedef struct HMAC_CTX:
+        pass
+
+    HMAC_CTX *HMAC_CTX_new()
+    void HMAC_CTX_free(HMAC_CTX *a)
+
+
 import struct
 
 _int = struct.Struct('>I')

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -476,11 +476,12 @@ cdef class _AEAD_BASE:
             self.iv[i] = iv[i]
 
     def next_iv(self):
+        # AES-GCM, AES-OCB, CHACHA20 ciphers all add a internal 32bit counter to the 96bit
+        # (12 byte) IV we provide, thus we only need to increment the IV by 1 (and we must
+        # not encrypt more than 2^32 cipher blocks with same IV):
         assert self.blocks < 2**32
         # we need 16 bytes for increment_iv:
         last_iv = b'\0' * (16 - self.iv_len) + self.iv[:self.iv_len]
-        # gcm mode is special: it appends a internal 32bit counter to the 96bit (12 byte) we provide, thus we only
-        # need to increment the 96bit counter by 1 (and we must not encrypt more than 2^32 AES blocks with same IV):
         next_iv = increment_iv(last_iv, 1)
         return next_iv[-self.iv_len:]
 

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -224,12 +224,14 @@ cdef class AES256_CTR_HMAC_SHA256:
         EVP_CIPHER_CTX_free(self.ctx)
         HMAC_CTX_free(self.hmac_ctx)
 
-    def encrypt(self, data, header=b'', aad_offset=0):
+    def encrypt(self, data, header=b'', aad_offset=0, iv=None):
         """
         encrypt data, compute mac over aad + iv + cdata, prepend header.
         aad_offset is the offset into the header where aad starts.
         """
-        assert self.blocks == 0, 'set_iv needs to be called before encrypt'
+        if iv is not None:
+            self.set_iv(iv)
+        assert self.blocks == 0, 'iv needs to be set before encrypt is called'
         cdef int ilen = len(data)
         cdef int hlen = len(header)
         cdef int aoffset = aad_offset
@@ -382,12 +384,14 @@ cdef class _AEAD_BASE:
     def __dealloc__(self):
         EVP_CIPHER_CTX_free(self.ctx)
 
-    def encrypt(self, data, header=b'', aad_offset=0):
+    def encrypt(self, data, header=b'', aad_offset=0, iv=None):
         """
         encrypt data, compute mac over aad + iv + cdata, prepend header.
         aad_offset is the offset into the header where aad starts.
         """
-        assert self.blocks == 0, 'set_iv needs to be called before encrypt'
+        if iv is not None:
+            self.set_iv(iv)
+        assert self.blocks == 0, 'iv needs to be set before encrypt is called'
         cdef int ilen = len(data)
         cdef int hlen = len(header)
         cdef int aoffset = aad_offset

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -34,20 +34,11 @@ IV handling:
     (repeat)
 """
 
-# TODO: get rid of small malloc
-# as @enkore mentioned on github:
-# "Since we do many small-object allocations here it is probably better to use
-# PyMem_Alloc/Free instead of malloc/free (PyMem has many optimizations for
-# small allocs)."
-#
-# Small mallocs currently happen if the total input file length is small, so
-# the 1 chunk's size is less than what the chunker would produce for big files.
-
 import hashlib
 import hmac
 from math import ceil
 
-from libc.stdlib cimport malloc, free
+from cpython cimport PyMem_Malloc, PyMem_Free
 from cpython.buffer cimport PyBUF_SIMPLE, PyObject_GetBuffer, PyBuffer_Release
 from cpython.bytes cimport PyBytes_FromStringAndSize
 
@@ -234,7 +225,7 @@ cdef class AES256_CTR_HMAC_SHA256:
         cdef int hlen = len(header)
         cdef int aoffset = aad_offset
         cdef int alen = hlen - aoffset
-        cdef unsigned char *odata = <unsigned char *>malloc(hlen + 32 + 8 + ilen + 16)
+        cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(hlen + 32 + 8 + ilen + 16)
         if not odata:
             raise MemoryError
         cdef int olen
@@ -271,7 +262,7 @@ cdef class AES256_CTR_HMAC_SHA256:
             self.blocks += num_aes_blocks(ilen)
             return odata[:offset]
         finally:
-            free(odata)
+            PyMem_Free(odata)
             PyBuffer_Release(&hdata)
             PyBuffer_Release(&idata)
 
@@ -283,7 +274,7 @@ cdef class AES256_CTR_HMAC_SHA256:
         cdef int hlen = header_len
         cdef int aoffset = aad_offset
         cdef int alen = hlen - aoffset
-        cdef unsigned char *odata = <unsigned char *>malloc(ilen + 16)
+        cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(ilen + 16)
         if not odata:
             raise MemoryError
         cdef int olen
@@ -317,7 +308,7 @@ cdef class AES256_CTR_HMAC_SHA256:
             self.blocks += num_aes_blocks(offset)
             return odata[:offset]
         finally:
-            free(odata)
+            PyMem_Free(odata)
             PyBuffer_Release(&idata)
 
     def set_iv(self, iv):
@@ -374,7 +365,7 @@ cdef class _AEAD_BASE:
         cdef int hlen = len(header)
         cdef int aoffset = aad_offset
         cdef int alen = hlen - aoffset
-        cdef unsigned char *odata = <unsigned char *>malloc(hlen + 16 + 12 + ilen + 16)
+        cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(hlen + 16 + 12 + ilen + 16)
         if not odata:
             raise MemoryError
         cdef int olen
@@ -415,7 +406,7 @@ cdef class _AEAD_BASE:
             self.blocks += num_aes_blocks(ilen)
             return odata[:offset]
         finally:
-            free(odata)
+            PyMem_Free(odata)
             PyBuffer_Release(&hdata)
             PyBuffer_Release(&idata)
 
@@ -427,7 +418,7 @@ cdef class _AEAD_BASE:
         cdef int hlen = header_len
         cdef int aoffset = aad_offset
         cdef int alen = hlen - aoffset
-        cdef unsigned char *odata = <unsigned char *>malloc(ilen + 16)
+        cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(ilen + 16)
         if not odata:
             raise MemoryError
         cdef int olen
@@ -462,7 +453,7 @@ cdef class _AEAD_BASE:
             self.blocks += num_aes_blocks(offset)
             return odata[:offset]
         finally:
-            free(odata)
+            PyMem_Free(odata)
             PyBuffer_Release(&idata)
 
     def set_iv(self, iv):

--- a/src/borg/crypto/nonces.py
+++ b/src/borg/crypto/nonces.py
@@ -14,9 +14,8 @@ NONCE_SPACE_RESERVATION = 2**28  # This in units of AES blocksize (16 bytes)
 
 
 class NonceManager:
-    def __init__(self, repository, cipher, manifest_nonce):
+    def __init__(self, repository, manifest_nonce):
         self.repository = repository
-        self.cipher = cipher
         self.end_of_nonce_reservation = None
         self.manifest_nonce = manifest_nonce
         self.nonce_file = os.path.join(get_security_dir(self.repository.id_str), 'nonce')
@@ -47,7 +46,15 @@ class NonceManager:
     def commit_repo_nonce_reservation(self, next_unreserved, start_nonce):
         self.repository.commit_nonce_reservation(next_unreserved, start_nonce)
 
-    def ensure_reservation(self, nonce_space_needed):
+    def ensure_reservation(self, nonce, nonce_space_needed):
+        """
+        Call this before doing encryption, give current, yet unused, integer IV as <nonce>
+        and the amount of subsequent (counter-like) IVs needed as <nonce_space_needed>.
+        Return value is the IV (counter) integer you shall use for encryption.
+
+        Note: this method may return the <nonce> you gave, if a reservation for it exists or
+              can be established, so make sure you give a unused nonce.
+        """
         # Nonces may never repeat, even if a transaction aborts or the system crashes.
         # Therefore a part of the nonce space is reserved before any nonce is used for encryption.
         # As these reservations are committed to permanent storage before any nonce is used, this protects
@@ -64,20 +71,17 @@ class NonceManager:
 
         if self.end_of_nonce_reservation:
             # we already got a reservation, if nonce_space_needed still fits everything is ok
-            next_nonce_bytes = self.cipher.next_iv()
-            next_nonce = int.from_bytes(next_nonce_bytes, byteorder='big')
+            next_nonce = nonce
             assert next_nonce <= self.end_of_nonce_reservation
             if next_nonce + nonce_space_needed <= self.end_of_nonce_reservation:
-                self.cipher.set_iv(next_nonce_bytes)
-                return
+                return next_nonce
 
         repo_free_nonce = self.get_repo_free_nonce()
         local_free_nonce = self.get_local_free_nonce()
         free_nonce_space = max(x for x in (repo_free_nonce, local_free_nonce, self.manifest_nonce, self.end_of_nonce_reservation) if x is not None)
         reservation_end = free_nonce_space + nonce_space_needed + NONCE_SPACE_RESERVATION
         assert reservation_end < MAX_REPRESENTABLE_NONCE
-        next_nonce_bytes = free_nonce_space.to_bytes(16, byteorder='big')
-        self.cipher.set_iv(next_nonce_bytes)
         self.commit_repo_nonce_reservation(reservation_end, repo_free_nonce)
         self.commit_local_nonce_reservation(reservation_end, local_free_nonce)
         self.end_of_nonce_reservation = reservation_end
+        return free_nonce_space

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -91,7 +91,7 @@ class ErrorWithTraceback(Error):
     traceback = True
 
 
-class IntegrityError(ErrorWithTraceback):
+class IntegrityError(ErrorWithTraceback, borg.crypto.low_level.IntegrityError):
     """Data integrity error: {}"""
 
 

--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -30,7 +30,7 @@ SELFTEST_CASES = [
     ChunkerTestCase,
 ]
 
-SELFTEST_COUNT = 35
+SELFTEST_COUNT = 38
 
 
 class SelfTestResult(TestResult):

--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -30,7 +30,7 @@ SELFTEST_CASES = [
     ChunkerTestCase,
 ]
 
-SELFTEST_COUNT = 38
+SELFTEST_COUNT = 37
 
 
 class SelfTestResult(TestResult):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -36,7 +36,7 @@ from ..archive import Archive, ChunkBuffer, flags_noatime, flags_normal
 from ..archiver import Archiver, parse_storage_quota
 from ..cache import Cache, LocalCache
 from ..constants import *  # NOQA
-from ..crypto.low_level import bytes_to_long, num_aes_blocks
+from ..crypto.low_level import bytes_to_long, num_cipher_blocks
 from ..crypto.key import KeyfileKeyBase, RepoKey, KeyfileKey, Passphrase, TAMRequiredError
 from ..crypto.keymanager import RepoIdMismatch, NotABorgKeyFile
 from ..crypto.file_integrity import FileIntegrityError
@@ -2169,7 +2169,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                     hash = sha256(data).digest()
                     if hash not in seen:
                         seen.add(hash)
-                        num_blocks = num_aes_blocks(len(data) - 41)
+                        num_blocks = num_cipher_blocks(len(data) - 41)
                         nonce = bytes_to_long(data[33:41])
                         for counter in range(nonce, nonce + num_blocks):
                             self.assert_not_in(counter, used)

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -1,6 +1,6 @@
 from binascii import hexlify, unhexlify
 
-from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_GCM, AES256_OCB, CHACHA20_POLY1305, \
+from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_GCM, AES256_OCB, CHACHA20_POLY1305, UNENCRYPTED, \
                      IntegrityError, hmac_sha256, blake2b_256, openssl10
 from ..crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes, bytes16_to_int, int_to_bytes16, increment_iv
 from ..crypto.low_level import hkdf_hmac_sha512
@@ -40,6 +40,16 @@ class CryptoTestCase(BaseTestCase):
         self.assert_equal(increment_iv(iva, 1), ivb)
         self.assert_equal(increment_iv(iva, 2), ivc)
         self.assert_equal(increment_iv(iv0, 2**64), ivb)
+
+    def test_UNENCRYPTED(self):
+        iv = b''  # any IV is ok, it just must be set and not None
+        data = b'data'
+        header = b'header'
+        cs = UNENCRYPTED(None, None, iv)
+        envelope = cs.encrypt(data, header=header)
+        self.assert_equal(envelope, header + data)
+        got_data = cs.decrypt(envelope, header_len=len(header))
+        self.assert_equal(got_data, data)
 
     def test_AES256_CTR_HMAC_SHA256(self):
         # this tests the layout as in attic / borg < 1.2 (1 type byte, no aad)

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -2,7 +2,7 @@ from binascii import hexlify, unhexlify
 
 from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_GCM, AES256_OCB, CHACHA20_POLY1305, UNENCRYPTED, \
                                IntegrityError, blake2b_256, hmac_sha256, openssl10
-from ..crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes, bytes16_to_int, int_to_bytes16
+from ..crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes
 from ..crypto.low_level import hkdf_hmac_sha512
 
 from . import BaseTestCase
@@ -19,12 +19,6 @@ class CryptoTestCase(BaseTestCase):
     def test_bytes_to_long(self):
         self.assert_equal(bytes_to_long(b'\0\0\0\0\0\0\0\1'), 1)
         self.assert_equal(long_to_bytes(1), b'\0\0\0\0\0\0\0\1')
-
-    def test_bytes16_to_int(self):
-        self.assert_equal(bytes16_to_int(b'\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1'), 1)
-        self.assert_equal(int_to_bytes16(1), b'\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1')
-        self.assert_equal(bytes16_to_int(b'\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0'), 2 ** 64)
-        self.assert_equal(int_to_bytes16(2 ** 64), b'\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0')
 
     def test_UNENCRYPTED(self):
         iv = b''  # any IV is ok, it just must be set and not None

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -13,7 +13,7 @@ from ..crypto.key import PlaintextKey, PassphraseKey, AuthenticatedKey, RepoKey,
 from ..crypto.key import ID_HMAC_SHA_256, ID_BLAKE2b_256
 from ..crypto.key import TAMRequiredError, TAMInvalid, TAMUnsupportedSuiteError, UnsupportedManifestError
 from ..crypto.key import identify_key
-from ..crypto.low_level import bytes_to_long, num_aes_blocks
+from ..crypto.low_level import bytes_to_long
 from ..crypto.low_level import IntegrityError as IntegrityErrorBase
 from ..helpers import IntegrityError
 from ..helpers import Location
@@ -126,7 +126,7 @@ class TestKey:
         assert key.extract_nonce(manifest2) == 1
         iv = key.extract_nonce(manifest)
         key2 = KeyfileKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.cipher.next_iv(), 8) >= iv + num_aes_blocks(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
+        assert bytes_to_long(key2.cipher.next_iv(), 8) >= iv + key2.cipher.block_count(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
         # Key data sanity check
         assert len({key2.id_key, key2.enc_key, key2.enc_hmac_key}) == 3
         assert key2.chunk_seed != 0
@@ -199,7 +199,7 @@ class TestKey:
         assert key.extract_nonce(manifest2) == 1
         iv = key.extract_nonce(manifest)
         key2 = PassphraseKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + num_aes_blocks(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD)
+        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + key2.cipher.block_count(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD)
         assert key.id_key == key2.id_key
         assert key.enc_hmac_key == key2.enc_hmac_key
         assert key.enc_key == key2.enc_key

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -117,7 +117,7 @@ class TestKey:
     def test_keyfile(self, monkeypatch, keys_dir):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
         key = KeyfileKey.create(self.MockRepository(), self.MockArgs())
-        assert bytes_to_long(key.cipher.next_iv(), 8) == 0
+        assert key.cipher.next_iv() == 0
         manifest = key.encrypt(b'ABC')
         assert key.cipher.extract_iv(manifest) == 0
         manifest2 = key.encrypt(b'ABC')
@@ -126,7 +126,7 @@ class TestKey:
         assert key.cipher.extract_iv(manifest2) == 1
         iv = key.cipher.extract_iv(manifest)
         key2 = KeyfileKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.cipher.next_iv(), 8) >= iv + key2.cipher.block_count(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
+        assert key2.cipher.next_iv() >= iv + key2.cipher.block_count(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
         # Key data sanity check
         assert len({key2.id_key, key2.enc_key, key2.enc_hmac_key}) == 3
         assert key2.chunk_seed != 0
@@ -186,7 +186,7 @@ class TestKey:
     def test_passphrase(self, keys_dir, monkeypatch):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
         key = PassphraseKey.create(self.MockRepository(), None)
-        assert bytes_to_long(key.cipher.next_iv(), 8) == 0
+        assert key.cipher.next_iv() == 0
         assert hexlify(key.id_key) == b'793b0717f9d8fb01c751a487e9b827897ceea62409870600013fbc6b4d8d7ca6'
         assert hexlify(key.enc_hmac_key) == b'b885a05d329a086627412a6142aaeb9f6c54ab7950f996dd65587251f6bc0901'
         assert hexlify(key.enc_key) == b'2ff3654c6daf7381dbbe718d2b20b4f1ea1e34caa6cc65f6bb3ac376b93fed2a'
@@ -199,7 +199,7 @@ class TestKey:
         assert key.cipher.extract_iv(manifest2) == 1
         iv = key.cipher.extract_iv(manifest)
         key2 = PassphraseKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + key2.cipher.block_count(len(manifest))
+        assert key2.cipher.next_iv() == iv + key2.cipher.block_count(len(manifest))
         assert key.id_key == key2.id_key
         assert key.enc_hmac_key == key2.enc_hmac_key
         assert key.enc_key == key2.enc_key

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -119,12 +119,12 @@ class TestKey:
         key = KeyfileKey.create(self.MockRepository(), self.MockArgs())
         assert bytes_to_long(key.cipher.next_iv(), 8) == 0
         manifest = key.encrypt(b'ABC')
-        assert key.extract_nonce(manifest) == 0
+        assert key.cipher.extract_iv(manifest) == 0
         manifest2 = key.encrypt(b'ABC')
         assert manifest != manifest2
         assert key.decrypt(None, manifest) == key.decrypt(None, manifest2)
-        assert key.extract_nonce(manifest2) == 1
-        iv = key.extract_nonce(manifest)
+        assert key.cipher.extract_iv(manifest2) == 1
+        iv = key.cipher.extract_iv(manifest)
         key2 = KeyfileKey.detect(self.MockRepository(), manifest)
         assert bytes_to_long(key2.cipher.next_iv(), 8) >= iv + key2.cipher.block_count(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
         # Key data sanity check
@@ -140,7 +140,7 @@ class TestKey:
             fd.write("0000000000002000")
         key = KeyfileKey.create(repository, self.MockArgs())
         data = key.encrypt(b'ABC')
-        assert key.extract_nonce(data) == 0x2000
+        assert key.cipher.extract_iv(data) == 0x2000
         assert key.decrypt(None, data) == b'ABC'
 
     def test_keyfile_kfenv(self, tmpdir, monkeypatch):
@@ -192,14 +192,14 @@ class TestKey:
         assert hexlify(key.enc_key) == b'2ff3654c6daf7381dbbe718d2b20b4f1ea1e34caa6cc65f6bb3ac376b93fed2a'
         assert key.chunk_seed == -775740477
         manifest = key.encrypt(b'ABC')
-        assert key.extract_nonce(manifest) == 0
+        assert key.cipher.extract_iv(manifest) == 0
         manifest2 = key.encrypt(b'ABC')
         assert manifest != manifest2
         assert key.decrypt(None, manifest) == key.decrypt(None, manifest2)
-        assert key.extract_nonce(manifest2) == 1
-        iv = key.extract_nonce(manifest)
+        assert key.cipher.extract_iv(manifest2) == 1
+        iv = key.cipher.extract_iv(manifest)
         key2 = PassphraseKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + key2.cipher.block_count(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD)
+        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + key2.cipher.block_count(len(manifest))
         assert key.id_key == key2.id_key
         assert key.enc_hmac_key == key2.enc_hmac_key
         assert key.enc_key == key2.enc_key

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -76,6 +76,7 @@ class TestKey:
         AuthenticatedKey,
         KeyfileKey,
         RepoKey,
+        AuthenticatedKey,
         # TODO temporarily disabled for branch merging XXX
         #Blake2KeyfileKey,
         #Blake2RepoKey,
@@ -258,7 +259,6 @@ class TestKey:
         with pytest.raises(IntegrityError):
             key.assert_id(id, plaintext_changed)
 
-    @pytest.mark.skip("temporarily disabled for branch merge")  # TODO
     def test_authenticated_encrypt(self, monkeypatch):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
         key = AuthenticatedKey.create(self.MockRepository(), self.MockArgs())

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -77,10 +77,9 @@ class TestKey:
         KeyfileKey,
         RepoKey,
         AuthenticatedKey,
-        # TODO temporarily disabled for branch merging XXX
-        #Blake2KeyfileKey,
-        #Blake2RepoKey,
-        #Blake2AuthenticatedKey,
+        Blake2KeyfileKey,
+        Blake2RepoKey,
+        Blake2AuthenticatedKey,
     ))
     def key(self, request, monkeypatch):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
@@ -176,7 +175,6 @@ class TestKey:
         key = KeyfileKey.detect(self.MockRepository(), self.keyfile2_cdata)
         assert key.decrypt(self.keyfile2_id, self.keyfile2_cdata) == b'payload'
 
-    @pytest.mark.skip("temporarily disabled for branch merge")  # TODO
     def test_keyfile_blake2(self, monkeypatch, keys_dir):
         with keys_dir.join('keyfile').open('w') as fd:
             fd.write(self.keyfile_blake2_key_file)

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -117,7 +117,7 @@ class TestKey:
     def test_keyfile(self, monkeypatch, keys_dir):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
         key = KeyfileKey.create(self.MockRepository(), self.MockArgs())
-        assert bytes_to_long(key.enc_cipher.next_iv(), 8) == 0
+        assert bytes_to_long(key.cipher.next_iv(), 8) == 0
         manifest = key.encrypt(b'ABC')
         assert key.extract_nonce(manifest) == 0
         manifest2 = key.encrypt(b'ABC')
@@ -126,7 +126,7 @@ class TestKey:
         assert key.extract_nonce(manifest2) == 1
         iv = key.extract_nonce(manifest)
         key2 = KeyfileKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.enc_cipher.next_iv(), 8) >= iv + num_aes_blocks(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
+        assert bytes_to_long(key2.cipher.next_iv(), 8) >= iv + num_aes_blocks(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD)
         # Key data sanity check
         assert len({key2.id_key, key2.enc_key, key2.enc_hmac_key}) == 3
         assert key2.chunk_seed != 0
@@ -186,7 +186,7 @@ class TestKey:
     def test_passphrase(self, keys_dir, monkeypatch):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
         key = PassphraseKey.create(self.MockRepository(), None)
-        assert bytes_to_long(key.enc_cipher.next_iv(), 8) == 0
+        assert bytes_to_long(key.cipher.next_iv(), 8) == 0
         assert hexlify(key.id_key) == b'793b0717f9d8fb01c751a487e9b827897ceea62409870600013fbc6b4d8d7ca6'
         assert hexlify(key.enc_hmac_key) == b'b885a05d329a086627412a6142aaeb9f6c54ab7950f996dd65587251f6bc0901'
         assert hexlify(key.enc_key) == b'2ff3654c6daf7381dbbe718d2b20b4f1ea1e34caa6cc65f6bb3ac376b93fed2a'
@@ -199,7 +199,7 @@ class TestKey:
         assert key.extract_nonce(manifest2) == 1
         iv = key.extract_nonce(manifest)
         key2 = PassphraseKey.detect(self.MockRepository(), manifest)
-        assert bytes_to_long(key2.enc_cipher.next_iv(), 8) == iv + num_aes_blocks(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD)
+        assert bytes_to_long(key2.cipher.next_iv(), 8) == iv + num_aes_blocks(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD)
         assert key.id_key == key2.id_key
         assert key.enc_hmac_key == key2.enc_hmac_key
         assert key.enc_key == key2.enc_key

--- a/src/borg/testsuite/nonces.py
+++ b/src/borg/testsuite/nonces.py
@@ -33,26 +33,6 @@ class TestNonceManager:
         def commit_nonce_reservation(self, next_unreserved, start_nonce):
             pytest.fail("commit_nonce_reservation should never be called on an old repository")
 
-    class MockCipher:
-        def __init__(self, iv):
-            self.iv_set = False  # placeholder, this is never a valid iv
-            self.iv = iv
-
-        def set_iv(self, iv):
-            assert iv is not False
-            self.iv_set = iv
-            self.iv = iv
-
-        def next_iv(self):
-            return self.iv
-
-        def expect_iv_and_advance(self, expected_iv, advance):
-            expected_iv = expected_iv.to_bytes(16, byteorder='big')
-            iv_set = self.iv_set
-            assert iv_set == expected_iv
-            self.iv_set = False
-            self.iv = advance.to_bytes(16, byteorder='big')
-
     def setUp(self):
         self.repository = None
 
@@ -67,74 +47,70 @@ class TestNonceManager:
     def test_empty_cache_and_old_server(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockOldRepository()
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2013)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
 
     def test_empty_cache(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockRepository()
         self.repository.next_free = 0x2000
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2013)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
 
     def test_empty_nonce(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockRepository()
         self.repository.next_free = None
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
 
         # enough space in reservation
-        manager.ensure_reservation(13)
-        cipher.expect_iv_and_advance(0x2013, 0x2000 + 19 + 13)
+        next_nonce = manager.ensure_reservation(0x2013, 13)
+        assert next_nonce == 0x2013
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
 
         # just barely enough space in reservation
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2020, 0x2000 + 19 + 13 + 19)
+        next_nonce = manager.ensure_reservation(0x2020, 19)
+        assert next_nonce == 0x2020
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
 
         # no space in reservation
-        manager.ensure_reservation(16)
-        cipher.expect_iv_and_advance(0x2033, 0x2000 + 19 + 13 + 19 + 16)
+        next_nonce = manager.ensure_reservation(0x2033, 16)
+        assert next_nonce == 0x2033
         assert self.cache_nonce() == "0000000000002063"
         assert self.repository.next_free == 0x2063
 
         # spans reservation boundary
-        manager.ensure_reservation(64)
-        cipher.expect_iv_and_advance(0x2063, 0x2000 + 19 + 13 + 19 + 16 + 64)
+        next_nonce = manager.ensure_reservation(0x2043, 64)
+        assert next_nonce == 0x2063
         assert self.cache_nonce() == "00000000000020c3"
         assert self.repository.next_free == 0x20c3
 
     def test_sync_nonce(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockRepository()
         self.repository.next_free = 0x2000
         self.set_cache_nonce("0000000000002000")
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
@@ -142,14 +118,13 @@ class TestNonceManager:
     def test_server_just_upgraded(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockRepository()
         self.repository.next_free = None
         self.set_cache_nonce("0000000000002000")
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
@@ -157,13 +132,12 @@ class TestNonceManager:
     def test_transaction_abort_no_cache(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x1000)
         self.repository = self.MockRepository()
         self.repository.next_free = 0x2000
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x1000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
@@ -171,27 +145,25 @@ class TestNonceManager:
     def test_transaction_abort_old_server(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x1000)
         self.repository = self.MockOldRepository()
         self.set_cache_nonce("0000000000002000")
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x1000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
 
     def test_transaction_abort_on_other_client(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x1000)
         self.repository = self.MockRepository()
         self.repository.next_free = 0x2000
         self.set_cache_nonce("0000000000001000")
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x1000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
@@ -199,14 +171,13 @@ class TestNonceManager:
     def test_interleaved(self, monkeypatch):
         monkeypatch.setattr(nonces, 'NONCE_SPACE_RESERVATION', 0x20)
 
-        cipher = self.MockCipher(0x2000)
         self.repository = self.MockRepository()
         self.repository.next_free = 0x2000
         self.set_cache_nonce("0000000000002000")
 
-        manager = NonceManager(self.repository, cipher, 0x2000)
-        manager.ensure_reservation(19)
-        cipher.expect_iv_and_advance(0x2000, 0x2000 + 19)
+        manager = NonceManager(self.repository, 0x2000)
+        next_nonce = manager.ensure_reservation(0x2000, 19)
+        assert next_nonce == 0x2000
 
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x2033
@@ -215,13 +186,13 @@ class TestNonceManager:
         self.repository.next_free = 0x4000
 
         # enough space in reservation
-        manager.ensure_reservation(12)
-        cipher.expect_iv_and_advance(0x2013, 0x2000 + 19 + 12)
+        next_nonce = manager.ensure_reservation(0x2013, 12)
+        assert next_nonce == 0x2013
         assert self.cache_nonce() == "0000000000002033"
         assert self.repository.next_free == 0x4000
 
         # spans reservation boundary
-        manager.ensure_reservation(21)
-        cipher.expect_iv_and_advance(0x4000, 0x4000 + 21)
+        next_nonce = manager.ensure_reservation(0x201f, 21)
+        assert next_nonce == 0x4000
         assert self.cache_nonce() == "0000000000004035"
         assert self.repository.next_free == 0x4035


### PR DESCRIPTION
crypto.pyx now implements a AEAD style API:
- encrypt-then-mac inside encrypt(), optionally mac-ing additional data
- auth-then-decrypt inside decrypt(), optionally auth-ing additional data

Implements:
- aes-ctr-hmac-sha256, aes-gcm
- aes-ocb, chacha20-poly1305 (openssl 1.1)
- simple AES, still needed by the keyfile code
- unencrypted/unauthenticated (so we do not need to specialcase that)

Note about iv/nonce/counter handling:

cipher.encrypt() and .decrypt() always do a full openssl context init, thus it is required for encrypt to set a IV before the call (or give iv as encrypt() param). there is no IV state kept inside the openssl ctx which is used for next encrypt() call.

set_iv sets the iv to use for next encrypt() call, it also resets the blocks counter that is used to reflect how many cipher blocks were encrypted with the last encrypt() call. using that, next_iv() computes the IV you shall use for the next encrypt() call.

this simulates the internal openssl IV state, which is in the opaque ctx since 1.1.

TODO:
- [ ] rename to cipher_key, mac_key and id_key?
- [ ] collapse some fixups

Anything else?
