### PR TITLE
Fix tox

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,24 @@
+import sys
+
+# This is a hack to fix path problems because "borg" (the package) is in the source root.
+# When importing the conftest an "import borg" can incorrectly import the borg from the
+# source root instead of the one installed in the environment.
+# The workaround is to remove entries pointing there from the path and check whether "borg"
+# is still importable. If it is not, then it has not been installed in the environment
+# and the entries are put back.
+#
+# TODO: After moving the package to src/: remove this.
+
+original_path = list(sys.path)
+for entry in original_path:
+    if entry == '' or entry.endswith('/borg'):
+        sys.path.remove(entry)
+
+try:
+    import borg
+except ImportError:
+    sys.path = original_path
+
 from borg.logger import setup_logging
 
 # Ensure that the loggers exist for all tests


### PR DESCRIPTION
- [x] works with "py.test borg" from root dir
- [x] works with tox py34 (with py35 in the surrounding env)

Fixes #1055