### PR TITLE
Travis using ubuntu trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,24 @@ cache:
     directories:
         - $HOME/.cache/pip
 
+# note: use py 3.5.2, it has lzma support. 3.5(.0) on travis.org/trusty does not.
 matrix:
     include:
         - python: 3.4
           os: linux
+          dist: trusty
           env: TOXENV=py34
-        - python: 3.5
+        - python: 3.5.2
           os: linux
+          dist: trusty
           env: TOXENV=py35
         - python: nightly
           os: linux
+          dist: trusty
           env: TOXENV=py36
-        - python: 3.5
+        - python: 3.4
           os: linux
+          dist: trusty
           env: TOXENV=flake8
         - language: generic
           os: osx

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -32,8 +32,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     python -m pip install --user 'virtualenv<14.0'
 else
     pip install 'virtualenv<14.0'
-    sudo add-apt-repository -y ppa:gezakovacs/lz4
-    sudo apt-get update
     sudo apt-get install -y liblz4-dev
     sudo apt-get install -y libacl1-dev
 fi


### PR DESCRIPTION
this is based on PR #1073.

note: uses python 3.5.2 as python 3.5(.0) has no lzma support (on the NON-container ubuntu trusty travis-ci.org infrastructure)