### PR TITLE
Repository: avoid reading large segments for commit state check

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -735,8 +735,8 @@ class LoggedIO:
         return self.segment
 
     def write_commit(self):
-        fd = self.get_write_fd(no_new=True)
-        fd.sync()
+        self.close_segment()
+        fd = self.get_write_fd()
         header = self.header_no_crc_fmt.pack(self.header_fmt.size, TAG_COMMIT)
         crc = self.crc_fmt.pack(crc32(header) & 0xffffffff)
         fd.write(b''.join((crc, header)))

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -927,7 +927,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in('borgbackup version', output)  # implied output even without --info given
         self.assert_not_in('Starting repository check', output)  # --info not given for root logger
 
-        name = sorted(os.listdir(os.path.join(self.tmpdir, 'repository', 'data', '0')), reverse=True)[0]
+        name = sorted(os.listdir(os.path.join(self.tmpdir, 'repository', 'data', '0')), reverse=True)[1]
         with open(os.path.join(self.tmpdir, 'repository', 'data', '0', name), 'r+b') as fd:
             fd.seek(100)
             fd.write(b'XXXX')


### PR DESCRIPTION
Forces commit tags into their own micro-segment, which can be checked
quickly by is_committed_segment

Follow-up to #1052 for master.