### PR TITLE
Travis workers hate him: improve testing speed with one simple trick

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -96,9 +96,10 @@ def with_archive(method):
 
 class Archiver:
 
-    def __init__(self, lock_wait=None):
+    def __init__(self, lock_wait=None, prog=None):
         self.exit_code = EXIT_SUCCESS
         self.lock_wait = lock_wait
+        self.parser = self.build_parser(prog)
 
     def print_error(self, msg, *args):
         msg = args and msg % args or msg
@@ -1118,7 +1119,7 @@ class Archiver:
                     self.print_warning(warning)
         return args
 
-    def build_parser(self, args=None, prog=None):
+    def build_parser(self, prog=None):
         common_parser = argparse.ArgumentParser(add_help=False, prog=prog)
 
         common_group = common_parser.add_argument_group('Common options')
@@ -2062,8 +2063,7 @@ class Archiver:
         # We can't use argparse for "serve" since we don't want it to show up in "Available commands"
         if args:
             args = self.preprocess_args(args)
-        parser = self.build_parser(args)
-        args = parser.parse_args(args or ['-h'])
+        args = self.parser.parse_args(args or ['-h'])
         update_excludes(args)
         return args
 

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,12 @@ setup_logging()
 
 from borg.testsuite import has_lchflags, no_lchlfags_because, has_llfuse
 from borg.testsuite.platform import fakeroot_detected
-from borg import xattr
+from borg import xattr, constants
+
+
+def pytest_configure(config):
+    # no fixture-based monkey-patching since star-imports are used for the constants module
+    constants.PBKDF2_ITERATIONS = 1
 
 
 def pytest_report_header(config, startdir):

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ class build_usage(Command):
         print('generating usage docs')
         # allows us to build docs without the C modules fully loaded during help generation
         from borg.archiver import Archiver
-        parser = Archiver().build_parser(prog='borg')
+        parser = Archiver(prog='borg').parser
         choices = {}
         for action in parser._actions:
             if action.choices is not None:


### PR DESCRIPTION
Actually two, but the second one by far eclipses the first :)

With "-k 'not remote'" (<-- a bit overeager matching) it runs in 26 seconds vs. 73 seconds for me. Without any -k (but still with --benchmark-skip) I get 200 seconds vs. 290 seconds. (All numbers without xdist).

(xdist: without benchmark, without remote, they run in ~8 seconds @ 9 processes - and still have good coverage)

While *overall* it doesn't make a large difference for Travis (since a lot of time is spent on installing and compiling stuff):

```
#1818: ============= 532 passed, 142 skipped, 2 xpassed in 382.75 seconds =============
#1820: ============= 532 passed, 142 skipped, 2 xpassed in 298.44 seconds =============
```