### PR TITLE
obtain ioctl from sys/ioctl.h as per manpage

### DIFF
--- a/borg/platform_linux.pyx
+++ b/borg/platform_linux.pyx
@@ -47,7 +47,7 @@ cdef extern from "linux/fs.h":
     int FS_APPEND_FL
     int FS_COMPR_FL
 
-cdef extern from "stropts.h":
+cdef extern from "sys/ioctl.h":
     int ioctl(int fildes, int request, ...)
 
 cdef extern from "string.h":


### PR DESCRIPTION
fixed build failure on fedora