### PR TITLE
SyncFile: open with O_EXCL (or equivalent)

### DIFF
--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -75,7 +75,7 @@ class SyncFile:
     """
 
     def __init__(self, path):
-        self.fd = open(path, 'wb')
+        self.fd = open(path, 'xb')
         self.fileno = self.fd.fileno()
 
     def __enter__(self):


### PR DESCRIPTION
This doesn't avoid "any and all issues", but can limit the damage.

A "backport" (the SyncFile abstraction is new, cherry-picking does not apply) to 1.0-maint makes sense.

Works with sshfs. Linux manpage says it shouldn't work with NFSv3.