### PR TITLE
Handle BrokenPipeError for list, info and diff commands

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2168,6 +2168,13 @@ def main():  # pragma: no cover
     except RemoteRepository.RPCError as e:
         msg = '%s\n%s' % (str(e), sysinfo())
         exit_code = EXIT_ERROR
+    except BrokenPipeError:
+        if args.func.__name__ in ['do_info', 'do_list', 'do_diff']:
+            sys.stderr.close()
+            sys.exit(0)
+        else:
+            msg = '\n%s\n%s' % (traceback.format_exc(), sysinfo())
+            exit_code = EXIT_ERROR
     except Exception:
         msg = 'Local Exception.\n%s\n%s' % (traceback.format_exc(), sysinfo())
         exit_code = EXIT_ERROR


### PR DESCRIPTION
Considering conversations on #1116, #805 and #790, BrokenPipeError message is not desirable in certain cases. As far as I know, cases involving list, info and diff commands seem to be the most important ones when their outputs are piped to filter/count utilities. Thus, this commit takes care of those cases only.