### PR TITLE
Adds uuid to archive format tags

### DIFF
--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -79,7 +79,7 @@ The archive name needs to be unique. It must not end in '.checkpoint' or
 checkpoints and treated in special ways.
 
 In the archive name, you may use the following format tags:
-{now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}
+{now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid}
 
 To speed up pulling backups over sshfs and similar network file systems which do
 not provide correct inode information the --ignore-inode flag can be used. This

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -79,7 +79,7 @@ The archive name needs to be unique. It must not end in '.checkpoint' or
 checkpoints and treated in special ways.
 
 In the archive name, you may use the following format tags:
-{now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid}
+{now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid4}
 
 To speed up pulling backups over sshfs and similar network file systems which do
 not provide correct inode information the --ignore-inode flag can be used. This

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1362,7 +1362,7 @@ class Archiver:
         checkpoints and treated in special ways.
 
         In the archive name, you may use the following format tags:
-        {now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}
+        {now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid}
 
         To speed up pulling backups over sshfs and similar network file systems which do
         not provide correct inode information the --ignore-inode flag can be used. This

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1362,7 +1362,7 @@ class Archiver:
         checkpoints and treated in special ways.
 
         In the archive name, you may use the following format tags:
-        {now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid}
+        {now}, {utcnow}, {fqdn}, {hostname}, {user}, {pid}, {uuid4}
 
         To speed up pulling backups over sshfs and similar network file systems which do
         not provide correct inode information the --ignore-inode flag can be used. This

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -13,6 +13,7 @@ import stat
 import textwrap
 import time
 import unicodedata
+import uuid
 from binascii import hexlify
 from collections import namedtuple, deque
 from datetime import datetime, timezone, timedelta
@@ -740,7 +741,8 @@ class Location:
             'hostname': socket.gethostname(),
             'now': current_time.now(),
             'utcnow': current_time.utcnow(),
-            'user': uid2user(os.getuid(), os.getuid())
+            'user': uid2user(os.getuid(), os.getuid()),
+            'uuid': str(uuid.uuid4())
             }
         return format_line(text, data)
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -742,7 +742,7 @@ class Location:
             'now': current_time.now(),
             'utcnow': current_time.utcnow(),
             'user': uid2user(os.getuid(), os.getuid()),
-            'uuid': str(uuid.uuid4())
+            'uuid4': str(uuid.uuid4())
             }
         return format_line(text, data)
 


### PR DESCRIPTION
Create time is already stored as meta data. Hence, it often makes more sense to use random names that are potentially globally unique. Other names could lead to confusion if different backup systems exist in parallel etc.