### PR TITLE
Fix 1159

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -595,8 +595,8 @@ ITEM_KEYS = frozenset([b'path', b'source', b'rdev', b'chunks',
 REQUIRED_ITEM_KEYS = frozenset([b'path', b'mtime', ])
 
 
-def valid_msgpacked_item(d, item_keys_serialized):
-    """check if the data <d> looks like a msgpacked item metadata dict"""
+def valid_msgpacked_dict(d, keys_serialized):
+    """check if the data <d> looks like a msgpacked dict"""
     d_len = len(d)
     if d_len == 0:
         return False
@@ -606,7 +606,7 @@ def valid_msgpacked_item(d, item_keys_serialized):
         offs = 3
     else:
         # object is not a map (dict)
-        # note: we must not have item dicts with > 2^16-1 elements
+        # note: we must not have dicts with > 2^16-1 elements
         return False
     if d_len <= offs:
         return False
@@ -620,7 +620,7 @@ def valid_msgpacked_item(d, item_keys_serialized):
         return False
     # is the bytestring any of the expected key names?
     key_serialized = d[offs:]
-    return any(key_serialized.startswith(pattern) for pattern in item_keys_serialized)
+    return any(key_serialized.startswith(pattern) for pattern in keys_serialized)
 
 
 class RobustUnpacker:
@@ -654,7 +654,7 @@ class RobustUnpacker:
                 if not data:
                     raise StopIteration
                 # Abort early if the data does not look like a serialized item dict
-                if not valid_msgpacked_item(data, self.item_keys):
+                if not valid_msgpacked_dict(data, self.item_keys):
                     data = data[1:]
                     continue
                 self._unpacker = msgpack.Unpacker(object_hook=StableDict)

--- a/borg/testsuite/archive.py
+++ b/borg/testsuite/archive.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import msgpack
 import pytest
 
-from ..archive import Archive, CacheChunkBuffer, RobustUnpacker, valid_msgpacked_item, ITEM_KEYS
+from ..archive import Archive, CacheChunkBuffer, RobustUnpacker, valid_msgpacked_dict, ITEM_KEYS
 from ..key import PlaintextKey
 from ..helpers import Manifest
 from . import BaseTestCase
@@ -127,7 +127,7 @@ def item_keys_serialized():
         [42, 23.42, True, b'foobar', {b'foo': b'bar'}, [b'foo', b'bar'], (b'foo', b'bar')]
     )])
 def test_invalid_msgpacked_item(packed, item_keys_serialized):
-    assert not valid_msgpacked_item(packed, item_keys_serialized)
+    assert not valid_msgpacked_dict(packed, item_keys_serialized)
 
 
 @pytest.mark.parametrize('packed',
@@ -137,11 +137,11 @@ def test_invalid_msgpacked_item(packed, item_keys_serialized):
         dict((k, b'x' * 1000) for k in ITEM_KEYS),  # as big (key count and volume) as it gets
     ]])
 def test_valid_msgpacked_items(packed, item_keys_serialized):
-    assert valid_msgpacked_item(packed, item_keys_serialized)
+    assert valid_msgpacked_dict(packed, item_keys_serialized)
 
 
 def test_key_length_msgpacked_items():
     key = b'x' * 32  # 31 bytes is the limit for fixstr msgpack type
     data = {key: b''}
     item_keys_serialized = [msgpack.packb(key), ]
-    assert valid_msgpacked_item(msgpack.packb(data), item_keys_serialized)
+    assert valid_msgpacked_dict(msgpack.packb(data), item_keys_serialized)


### PR DESCRIPTION
these changes for archive metadata dicts are somehow almost the same as what has been already done for the item metadata dicts.

note: we are really lucky that neither the item metadata nor the archive metadata dict had grown beyond 15 items.