### PR TITLE
Fix confused I/O Error reporting/handling, fixes #1138

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -67,8 +67,13 @@ class Repository:
 
     def __del__(self):
         if self.lock:
-            self.close()
-            assert False, "cleanup happened in Repository.__del__"
+            try:
+                self.close()
+            except Exception:
+                self.rollback()
+                return
+            else:
+                assert False, "cleanup happened in Repository.__del__"
 
     def __repr__(self):
         return '<%s %s>' % (self.__class__.__name__, self.path)


### PR DESCRIPTION
For the other case whereby the processed file is probably not accessible, `e.errno != errno.EIO`. For instance, I manually created a test-case by moving some of the content of the backup source while archive creation was running. For that, `[Errno 2] No such file or directory` equivalent to `errno.ENOENT` occurred. Thus, the warning is still intact.