### PR TITLE
create subcommand: add new --cap-user option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ class build_usage(Command):
         print('generating usage docs')
         # allows us to build docs without the C modules fully loaded during help generation
         from borg.archiver import Archiver
-        parser = Archiver(prog='borg').parser
+        parser = Archiver(prog='borg', include_all_platform_args=True).parser
         choices = {}
         for action in parser._actions:
             if action.choices is not None:
@@ -310,7 +310,7 @@ if not on_rtd:
         ext_modules.append(Extension('borg.platform.posix', [platform_posix_source]))
 
     if sys.platform == 'linux':
-        ext_modules.append(Extension('borg.platform.linux', [platform_linux_source], libraries=['acl']))
+        ext_modules.append(Extension('borg.platform.linux', [platform_linux_source], libraries=['acl', 'cap']))
     elif sys.platform.startswith('freebsd'):
         ext_modules.append(Extension('borg.platform.freebsd', [platform_freebsd_source]))
     elif sys.platform == 'darwin':

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -96,7 +96,7 @@ def check_extension_modules():
         raise ExtensionModuleError
     if crypto.API_VERSION != 3:
         raise ExtensionModuleError
-    if platform.API_VERSION != 3:
+    if platform.API_VERSION != 4:
         raise ExtensionModuleError
 
 
@@ -857,6 +857,12 @@ def archivename_validator():
             raise argparse.ArgumentTypeError('Invalid repository name: "%s"' % text)
         return text
     return validator
+
+
+def validate_capuser(text):
+    if os.geteuid() != 0:
+        raise argparse.ArgumentTypeError('only available when running borg as root')
+    return text
 
 
 def decode_dict(d, keys, encoding='utf-8', errors='surrogateescape'):

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -12,13 +12,17 @@ from .base import SyncFile, sync_dir, fdatasync
 from .base import swidth, API_VERSION
 
 if sys.platform.startswith('linux'):  # pragma: linux only
+    from .posix import switch_to_user
     from .linux import acl_get, acl_set
     from .linux import set_flags, get_flags
+    from .linux import set_capuser
     from .linux import SyncFile
     from .linux import swidth, API_VERSION
 elif sys.platform.startswith('freebsd'):  # pragma: freebsd only
+    from .posix import switch_to_user
     from .freebsd import acl_get, acl_set
     from .freebsd import swidth, API_VERSION
 elif sys.platform == 'darwin':  # pragma: darwin only
+    from .posix import switch_to_user
     from .darwin import acl_get, acl_set
     from .darwin import swidth, API_VERSION

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -12,7 +12,7 @@ platform API: that way platform APIs provided by the platform-specific support m
 are correctly composed into the base functionality.
 """
 
-API_VERSION = 3
+API_VERSION = 4
 
 fdatasync = getattr(os, 'fdatasync', os.fsync)
 
@@ -46,6 +46,10 @@ except ImportError:
 def get_flags(path, st):
     """Return BSD-style file flags for path or stat without following symlinks."""
     return getattr(st, 'st_flags', 0)
+
+
+def set_capuser():
+    raise "cap user is not supported on this platform"
 
 
 def sync_dir(path):

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -4,7 +4,7 @@ from ..helpers import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
 from .posix import swidth
 
-API_VERSION = 3
+API_VERSION = 4
 
 cdef extern from "sys/acl.h":
     ctypedef struct _acl_t:

--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -4,7 +4,7 @@ from ..helpers import posix_acl_use_stored_uid_gid
 from ..helpers import safe_encode, safe_decode
 from .posix import swidth
 
-API_VERSION = 3
+API_VERSION = 4
 
 cdef extern from "errno.h":
     int errno

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -1,3 +1,5 @@
+import os, pwd
+
 cdef extern from "wchar.h":
     cdef int wcswidth(const Py_UNICODE *str, size_t n)
  
@@ -8,3 +10,15 @@ def swidth(s):
         return terminal_width
     else:
         return str_len
+
+def switch_to_user(username):
+    pw = pwd.getpwnam(username)
+    uid = pw.pw_uid
+    gid = pw.pw_gid
+    os.setgroups(())
+    os.setresgid(gid, gid, gid)
+    os.setresuid(uid, uid, uid)
+    os.environ['LOGNAME'] = username
+    os.environ['USER'] = username
+    os.environ['USERNAME'] = username
+    os.environ['HOME'] = pw.pw_dir


### PR DESCRIPTION
The new `--cap-user` option is available when running borg as root (Linux only).

It causes borg to switch to the given user, while retaining the `CAP_DAC_READ_SEARCH` capability, which enables it to read all files. See the `capabilities(7)` manpage on Linux for more information on how this works.

This behaviour is convenient when backup up things like `/etc`, without wanting to run borg with full root privileges.

I've been running a similar setup at home for months now; the difference is that I'm still on attic, which obviously doesn't have this features built in, so I'm currently using a home-grown C++ wrapper that achieves the equivalent.

Note that this introduces a new dependency (on Linux only), namely on [libcap](https://sites.google.com/site/fullycapable/). If this is deemed unacceptable, I could perhaps look into dynamically detecting whether it's installed, thereby making it an optional dependency.

One more thing to note is that this functionality can only be tested by running as root &ndash; fakeroot is not enough. I've therefore added a test which is skipped unless running as non-fake root. I've not taken any steps to automatically run this in the `Vagrantfile` or `.travis/run.sh`, as I wanted to get some feedback first, and I'm also not sufficiently familiar with your Travis setup.

I'm also open to any better ideas for the name of this option; `--cap-user` is admittedly not super-clear.