### PR TITLE
flake8: ignore F405, fixes #1185

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -559,7 +559,7 @@ def format_line(format, data):
     except (KeyError, ValueError) as e:
         # this should catch format errors
         print('Error in lineformat: "{}" - reason "{}"'.format(format, str(e)))
-    except:
+    except Exception as e:
         # something unexpected, print error and raise exception
         print('Error in lineformat: "{}" - reason "{}"'.format(format, str(e)))
         raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ python_files = testsuite/*.py
 # please note that the values are adjusted so that they do not cause failures
 # with existing code. if you want to change them, you should first fix all
 # flake8 failures that appear with your change.
-ignore = E122,E123,E125,E126,E127,E128,E226,E402,F401,F811
+ignore = E122,E123,E125,E126,E127,E128,E226,E402,F401,F405,F811
 # line length long term target: 120
 max-line-length = 255
 exclude = build,dist,.git,.idea,.cache,.tox,docs/conf.py


### PR DESCRIPTION
We know that star imports have their issues and we only have one of them,
for good reasons. Thus, we switch off that new F405 test/message.