### PR TITLE
Ignore empty index file.

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -129,7 +129,9 @@ class Repository:
         shutil.rmtree(self.path)
 
     def get_index_transaction_id(self):
-        indices = sorted((int(name[6:]) for name in os.listdir(self.path) if name.startswith('index.') and name[6:].isdigit()))
+        indices = sorted(int(fn[6:])
+                         for fn in os.listdir(self.path)
+                         if fn.startswith('index.') and fn[6:].isdigit() and os.stat(os.path.join(self.path, fn)).st_size != 0)
         if indices:
             return indices[-1]
         else:


### PR DESCRIPTION
Empty index file is most likely a result from an unclean
shutdown in the middle of write, e.g. on ext4 with delayed
allocation enabled (default).
Ignoring such a file would get it recreated by other parts of code,
where as not ignoring it leads to an exception about
not being able to read enough bytes from the index.

Signed-off-by: Oleg Drokin <green@linuxhacker.ru>