### PR TITLE
Fix incorrect propagation of OSErrors in create code

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -29,7 +29,7 @@ from .upgrader import AtticRepositoryUpgrader, BorgRepositoryUpgrader
 from .repository import Repository
 from .cache import Cache
 from .key import key_creator, RepoKey, PassphraseKey
-from .archive import Archive, ArchiveChecker, CHUNKER_PARAMS
+from .archive import input_io, InputOSError, Archive, ArchiveChecker, CHUNKER_PARAMS
 from .remote import RepositoryServer, RemoteRepository, cache_if_remote
 
 has_lchflags = hasattr(os, 'lchflags')
@@ -198,7 +198,7 @@ class Archiver:
                     if not dry_run:
                         try:
                             status = archive.process_stdin(path, cache)
-                        except OSError as e:
+                        except InputOSError as e:
                             status = 'E'
                             self.print_warning('%s: %s', path, e)
                     else:
@@ -273,7 +273,7 @@ class Archiver:
             if not dry_run:
                 try:
                     status = archive.process_file(path, st, cache, self.ignore_inode)
-                except OSError as e:
+                except InputOSError as e:
                     status = 'E'
                     self.print_warning('%s: %s', path, e)
         elif stat.S_ISDIR(st.st_mode):

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -241,6 +241,24 @@ class RemoteRepository:
                 del self.cache[args]
             return msgid
 
+        def handle_error(error, res):
+            if error == b'DoesNotExist':
+                raise Repository.DoesNotExist(self.location.orig)
+            elif error == b'AlreadyExists':
+                raise Repository.AlreadyExists(self.location.orig)
+            elif error == b'CheckNeeded':
+                raise Repository.CheckNeeded(self.location.orig)
+            elif error == b'IntegrityError':
+                raise IntegrityError(res)
+            elif error == b'PathNotAllowed':
+                raise PathNotAllowed(*res)
+            elif error == b'ObjectNotFound':
+                raise Repository.ObjectNotFound(res[0], self.location.orig)
+            elif error == b'InvalidRPCMethod':
+                raise InvalidRPCMethod(*res)
+            else:
+                raise self.RPCError(res.decode('utf-8'))
+
         calls = list(calls)
         waiting_for = []
         w_fds = [self.stdin_fd]
@@ -250,22 +268,7 @@ class RemoteRepository:
                     error, res = self.responses.pop(waiting_for[0])
                     waiting_for.pop(0)
                     if error:
-                        if error == b'DoesNotExist':
-                            raise Repository.DoesNotExist(self.location.orig)
-                        elif error == b'AlreadyExists':
-                            raise Repository.AlreadyExists(self.location.orig)
-                        elif error == b'CheckNeeded':
-                            raise Repository.CheckNeeded(self.location.orig)
-                        elif error == b'IntegrityError':
-                            raise IntegrityError(res)
-                        elif error == b'PathNotAllowed':
-                            raise PathNotAllowed(*res)
-                        elif error == b'ObjectNotFound':
-                            raise Repository.ObjectNotFound(res[0], self.location.orig)
-                        elif error == b'InvalidRPCMethod':
-                            raise InvalidRPCMethod(*res)
-                        else:
-                            raise self.RPCError(res.decode('utf-8'))
+                        handle_error(error, res)
                     else:
                         yield res
                         if not waiting_for and not calls:
@@ -287,6 +290,8 @@ class RemoteRepository:
                         type, msgid, error, res = unpacked
                         if msgid in self.ignore_responses:
                             self.ignore_responses.remove(msgid)
+                            if error:
+                                handle_error(error, res)
                         else:
                             self.responses[msgid] = error, res
                 elif fd is self.stderr_fd:


### PR DESCRIPTION
Pulling a thumbdrive during a backup now produces the correct result:

```
Traceback (most recent call last):
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 81, in wrapper
    return method(self, args, repository=repository, **kwargs)
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 247, in do_create
    create_inner(archive, cache)
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 219, in create_inner
    read_special=args.read_special, dry_run=dry_run)
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 275, in _process
    status = archive.process_file(path, st, cache, self.ignore_inode)
  File "/home/mabe/Projekte/_oss/borg/borg/archive.py", line 594, in process_file
    chunks.append(cache.add_chunk(self.key.id_hash(chunk), chunk, self.stats))
  File "/home/mabe/Projekte/_oss/borg/borg/cache.py", line 365, in add_chunk
    self.repository.put(id, data, wait=False)
  File "/home/mabe/Projekte/_oss/borg/borg/repository.py", line 467, in put
    segment, offset = self.io.write_put(id, data)
  File "/home/mabe/Projekte/_oss/borg/borg/repository.py", line 706, in write_put
    fd = self.get_write_fd(raise_full=raise_full)
  File "/home/mabe/Projekte/_oss/borg/borg/repository.py", line 600, in get_write_fd
    self._write_fd = open(self.segment_filename(self.segment), 'ab')
OSError: [Errno 5] Input/output error: '/run/media/mabe/00B524275BF67732/repo/data/0/9'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 1569, in main
    exit_code = archiver.run(args)
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 1506, in run
    return args.func(args)
  File "/home/mabe/Projekte/_oss/borg/borg/archiver.py", line 81, in wrapper
    return method(self, args, repository=repository, **kwargs)
  File "/home/mabe/Projekte/_oss/borg/borg/repository.py", line 86, in __exit__
    self.close()
  File "/home/mabe/Projekte/_oss/borg/borg/repository.py", line 181, in close
    self.lock.release()
  File "/home/mabe/Projekte/_oss/borg/borg/locking.py", line 291, in release
    self._roster.modify(EXCLUSIVE, REMOVE)
  File "/home/mabe/Projekte/_oss/borg/borg/locking.py", line 203, in modify
    roster = self.load()
  File "/home/mabe/Projekte/_oss/borg/borg/locking.py", line 182, in load
    data = json.load(f)
  File "/home/mabe/.pyenv/versions/3.5.1/lib/python3.5/json/__init__.py", line 265, in load
    return loads(fp.read(),
OSError: [Errno 5] Input/output error

Platform: Linux tiger 4.5.7-1-ck #1 SMP PREEMPT Wed Jun 8 08:42:43 EDT 2016 x86_64 
Linux: arch  
Borg: 1.0.4.dev46+ngbc0a838.d20160627  Python: CPython 3.5.1
PID: 27050  CWD: /home/mabe/Projekte/_oss/borg/issue1138
sys.argv: ['/home/mabe/.pyenv/versions/3.5.1/bin/borg', 'create', '/run/media/mabe/00B524275BF67732/repo::testbreaking', '...............', '-svp']
SSH_ORIGINAL_COMMAND: None

zsh: exit 2     borg create /run/media/mabe/00B524275BF67732/repo::testbreaking  -svp
```

Tried it a few times, logic seems solid. I don't think I missed a spot, but that's what we do code reviews for, isn't it? ;)

_Rather curious_: ntfs-3g journaling doesn't seem to be very reliable. After a few pulls with no repository corruption I get an EIO on open(2) on a data file and a rather ugly ntfs-3g message:

> Jun 27 20:59:35 tiger ntfs-3g[27314]: Trying to read non-allocated mft records (83 > 82): Nicht erlaubter Seek (_seek not permissible_)
> Jun 27 20:59:35 tiger ntfs-3g[27314]: Trying to read non-allocated mft records (83 > 82): Nicht erlaubter Seek

Even root can't touch that inode anymore, not even rm the dirent. I'll see whether Windows chkdsk can fix that, or whether I have to reformat my thumb drive?!