### PR TITLE
PoC lockless fuse mount

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -726,8 +726,8 @@ class Archiver:
             self.print_error('Loading fuse support failed [ImportError: %s]' % str(e))
             return self.exit_code
 
-        if not os.path.isdir(args.mountpoint) or not os.access(args.mountpoint, os.R_OK | os.W_OK | os.X_OK):
-            self.print_error('%s: Mountpoint must be a writable directory' % args.mountpoint)
+        if not os.path.isdir(args.mountpoint):
+            self.print_error('%s: Mountpoint must be a directory' % args.mountpoint)
             return self.exit_code
 
         with cache_if_remote(repository) as cached_repo:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -717,8 +717,7 @@ class Archiver:
             logger.info("Cache deleted.")
         return self.exit_code
 
-    @with_repository()
-    def do_mount(self, args, repository, manifest, key):
+    def do_mount(self, args):
         """Mount archive or an entire repository as a FUSE filesystem"""
         try:
             from .fuse import FuseOperations
@@ -730,18 +729,21 @@ class Archiver:
             self.print_error('%s: Mountpoint must be a directory' % args.mountpoint)
             return self.exit_code
 
-        with cache_if_remote(repository) as cached_repo:
-            if args.location.archive:
-                archive = Archive(repository, key, manifest, args.location.archive)
-            else:
-                archive = None
-            operations = FuseOperations(key, repository, manifest, archive, cached_repo)
-            logger.info("Mounting filesystem")
-            try:
-                operations.mount(args.mountpoint, args.options, args.foreground)
-            except RuntimeError:
-                # Relevant error message already printed to stderr by fuse
-                self.exit_code = EXIT_ERROR
+        # XXX duplication of @with_repository code, but we don't want it
+        # opened all the time.
+        location = args.location  # note: 'location' must be always present in args
+        if location.proto == 'ssh':
+            repository = RemoteRepository(location, args=args)
+        else:
+            repository = Repository(location.path)
+
+        operations = FuseOperations(repository, args.location.archive)
+        logger.info("Mounting filesystem")
+        try:
+            operations.mount(args.mountpoint, args.options, args.foreground)
+        except RuntimeError:
+            # Relevant error message already printed to stderr by fuse
+            self.exit_code = EXIT_ERROR
         return self.exit_code
 
     @with_repository()

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -17,6 +17,9 @@ from .archive import Archive
 from .helpers import daemonize
 from .item import Item
 from .lrucache import LRUCache
+from .helpers import Manifest
+from .remote import cache_if_remote
+
 
 # Does this version of llfuse support ns precision?
 have_fuse_xtime_ns = hasattr(llfuse.EntryAttributes, 'st_mtime_ns')
@@ -50,11 +53,12 @@ class ItemCache:
 class FuseOperations(llfuse.Operations):
     """Export archive as a fuse filesystem
     """
-    def __init__(self, key, repository, manifest, archive, cached_repo):
+    def __init__(self, repository, archive_name):
+      with repository:
+        self.key, self.manifest = Manifest.load(repository)
         super().__init__()
         self._inode_count = 0
-        self.key = key
-        self.repository = cached_repo
+        self.repository = repository
         self.items = {}
         self.parent = {}
         self.contents = defaultdict(dict)
@@ -65,25 +69,28 @@ class FuseOperations(llfuse.Operations):
         data_cache_capacity = int(os.environ.get('BORG_MOUNT_DATA_CACHE_ENTRIES', os.cpu_count() or 1))
         logger.debug('mount data cache capacity: %d chunks', data_cache_capacity)
         self.data_cache = LRUCache(capacity=data_cache_capacity, dispose=lambda _: None)
-        if archive:
+        if archive_name:
+            archive = Archive(repository, self.key, self.manifest, archive_name)
             self.process_archive(archive)
         else:
             # Create root inode
             self.parent[1] = self.allocate_inode()
             self.items[1] = self.default_dir
-            for archive_name in manifest.archives:
+            for archive_name in self.manifest.archives:
                 # Create archive placeholder inode
                 archive_inode = self.allocate_inode()
                 self.items[archive_inode] = self.default_dir
                 self.parent[archive_inode] = 1
                 self.contents[1][os.fsencode(archive_name)] = archive_inode
-                self.pending_archives[archive_inode] = Archive(repository, key, manifest, archive_name)
+                self.pending_archives[archive_inode] = archive_name
 
     def process_archive(self, archive, prefix=[]):
-        """Build fuse inode hierarchy from archive metadata
-        """
+      """Build fuse inode hierarchy from archive metadata
+      """
+      with self.repository:
+       with cache_if_remote(self.repository) as cached_repo:
         unpacker = msgpack.Unpacker()
-        for key, chunk in zip(archive.metadata[b'items'], self.repository.get_many(archive.metadata[b'items'])):
+        for key, chunk in zip(archive.metadata[b'items'], cached_repo.get_many(archive.metadata[b'items'])):
             _, data = self.key.decrypt(key, chunk)
             unpacker.feed(data)
             for item in unpacker:
@@ -196,8 +203,11 @@ class FuseOperations(llfuse.Operations):
             raise llfuse.FUSEError(errno.ENODATA) from None
 
     def _load_pending_archive(self, inode):
+      with self.repository:
+       with cache_if_remote(self.repository) as cached_repo:
         # Check if this is an archive we need to load
-        archive = self.pending_archives.pop(inode, None)
+        archive_name = self.pending_archives.pop(inode, None)
+        archive = Archive(cached_repo, self.key, self.manifest, archive_name)
         if archive:
             self.process_archive(archive, [os.fsencode(archive.name)])
 
@@ -221,6 +231,8 @@ class FuseOperations(llfuse.Operations):
         return inode
 
     def read(self, fh, offset, size):
+      with self.repository:
+       with cache_if_remote(self.repository) as cached_repo:
         parts = []
         item = self.get_item(fh)
         for id, s, csize in item.chunks:
@@ -234,7 +246,7 @@ class FuseOperations(llfuse.Operations):
                     # evict fully read chunk from cache
                     del self.data_cache[id]
             else:
-                _, data = self.key.decrypt(id, self.repository.get(id))
+                _, data = self.key.decrypt(id, cached_repo.get(id))
                 if offset + n < len(data):
                     # chunk was only partially read, cache it
                     self.data_cache[id] = data


### PR DESCRIPTION
This  is a proof of concept of the fuse mount that does not hold repository locked.

I cannot actually get it to work because of issues with tox and llfuse not doing well together, but I wanted to show this idea anyway.
In order to highlight the changes needed (not too big) this is lean and simple, but as the result, has some style problems with indentation.

This would also need some extra "revalidation" logic, so that when we e.g. reopen the repo, we check if it's the same one as last time we opened it and if it's not, blow the cache way and repopulate it on demand again (some optimizations are possible here too, but might not be needed in the end).
