### PR TITLE
fuse: getxattr fail must use errno.ENOATTR, fixes #1126

### DIFF
--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -194,7 +194,7 @@ class FuseOperations(llfuse.Operations):
         try:
             return item.get(b'xattrs', {})[name]
         except KeyError:
-            raise llfuse.FUSEError(errno.ENODATA) from None
+            raise llfuse.FUSEError(errno.ENOATTR) from None
 
     def _load_pending_archive(self, inode):
         # Check if this is an archive we need to load


### PR DESCRIPTION
The problem was that OS X Finder queried some OS X specific xattrs
and if they were not present, the wrong errno (ENODATA) was included
in the raised FUSEError exception. According to the llfuse docs, the
errno must be ENOATTR for this case.

Obviously, Finder didn't handle this well and denied access to the
file. Also, file size was displayed as "zero bytes" although we
return the correct value.