### PR TITLE
fix/optimize initial hash table size for borg check

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -826,7 +826,7 @@ class ArchiveChecker:
         """
         # Explicitly set the initial hash table capacity to avoid performance issues
         # due to hash table "resonance"
-        capacity = int(len(self.repository) * 1.2)
+        capacity = int(len(self.repository) * 1.35 + 1)  # > len * 1.0 / HASH_MAX_LOAD (see _hashindex.c)
         self.chunks = ChunkIndex(capacity)
         marker = None
         while True:


### PR DESCRIPTION
initial size should be so that the hash table does not need resizing -
it must always stay below the MAX_LOAD_FACTOR.


1 / 0.75 == 1.333...  - i took a bit more to make sure.