### PR TITLE
docs: fix the highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 |screencast|
 
+.. highlight:: bash
+
 What is BorgBackup?
 ===================
 
@@ -87,7 +89,10 @@ Initialize a new backup repository and create a backup archive::
     $ borg init /path/to/repo
     $ borg create /path/to/repo::Saturday1 ~/Documents
 
-Now doing another backup, just to show off the great deduplication::
+Now doing another backup, just to show off the great deduplication:
+
+.. code-block:: none
+   :emphasize-lines: 11
 
     $ borg create -v --stats /path/to/repo::Saturday2 ~/Documents
     -----------------------------------------------------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,4 @@
+.. highlight:: python
 
 API Documentation
 =================

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: none
 .. _deployment:
 
 Deployment

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: bash
 .. _development:
 
 Development

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,5 +1,6 @@
-.. _faq:
 .. include:: global.rst.inc
+.. highlight:: none
+.. _faq:
 
 Frequently asked questions
 ==========================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: bash
 .. _installation:
 
 Installation

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: none
 .. _internals:
 
 Internals

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: bash
 .. _quickstart:
 
 Quick Start

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,4 +1,5 @@
 .. include:: global.rst.inc
+.. highlight:: none
 .. _detailed_usage:
 
 Usage


### PR DESCRIPTION
default is "python", that's why some help fragments and bash scripts looked strange.