### PR TITLE
Randomize files cache TTL

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+import random
 import stat
 import shutil
 from binascii import unhexlify
@@ -217,7 +218,8 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                     # Discard cached files with the newest mtime to avoid
                     # issues with filesystem snapshots and mtime precision
                     entry = FileCacheEntry(*msgpack.unpackb(item))
-                    if entry.age < 10 and bigint_to_int(entry.mtime) < self._newest_mtime:
+                    age_limit = random.randint(8, 16)
+                    if entry.age < age_limit and bigint_to_int(entry.mtime) < self._newest_mtime:
                         msgpack.pack((path_hash, entry), fd)
         self.config.set('cache', 'manifest', self.manifest.id_str)
         self.config.set('cache', 'timestamp', self.manifest.timestamp)


### PR DESCRIPTION
This avoids* the "spiking backup time" effect, i.e. every 10th backup
takes much longer typically. This distributes this more evenly beyond
the 8th backup.

The mean TTL is bumped slightly to 12 instead of 10.

\* dampens