### PR TITLE
Test multiple filesystems with Vagrant

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Borg Contributors ("The Borg Collective")
 - Marian Beermann <public@enkore.de>
 - Daniel Reichelt <hacking@nachtgeist.net>
 - Lauri Niskanen <ape@ape3000.com>
+- Lee Bousfield <ljbousfield@gmail.com>
 
 Borg is a fork of Attic.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,8 @@ def packages_debianoid
     apt-get install -y python3-dev python3-setuptools
     # for building python:
     apt-get install -y zlib1g-dev libbz2-dev libncurses5-dev libreadline-dev liblzma-dev libsqlite3-dev
+    # filesystem drivers
+    apt-get install -y ntfs-3g openssh-server sshfs xfsprogs samba cifs-utils
     # this way it works on older dists (like ubuntu 12.04) also:
     # for python 3.2 on ubuntu 12.04 we need pip<8 and virtualenv<14 as
     # newer versions are not compatible with py 3.2 any more.
@@ -50,6 +52,8 @@ def packages_redhatted
     yum install -y gcc-c++
     # for building python:
     yum install -y zlib-devel bzip2-devel ncurses-devel readline-devel xz xz-devel sqlite-devel
+    # filesystem drivers
+    yum install -y ntfs-3g openssh fuse-sshfs xfsprogs samba cifs-utils ntfsprogs
     #yum install -y python-pip
     #pip install virtualenv
     touch ~vagrant/.bash_profile ; chown vagrant ~vagrant/.bash_profile
@@ -86,6 +90,8 @@ def packages_freebsd
     pkg install -y fakeroot git bash
     # for building python:
     pkg install -y sqlite3
+    # filesystem drivers
+    pkg install -y openssh sshfs samba ntfs-3g
     # make bash default / work:
     chsh -s bash vagrant
     mount -t fdescfs fdesc /dev/fd
@@ -141,6 +147,7 @@ def packages_netbsd
     pkg_add pkg-config  # avoids some "pkg-config missing" error msg, even without fuse
     # pkg_add fuse  # llfuse supports netbsd, but is still buggy.
     # https://bitbucket.org/nikratio/python-llfuse/issues/70/perfuse_open-setsockopt-no-buffer-space
+    pkg_add samba
     pkg_add python34 py34-setuptools
     ln -s /usr/pkg/bin/python3.4 /usr/pkg/bin/python
     ln -s /usr/pkg/bin/python3.4 /usr/pkg/bin/python3
@@ -270,23 +277,7 @@ def build_binary_with_pyinstaller(boxname)
 end
 
 def run_tests(boxname)
-  return <<-EOF
-    . ~/.bash_profile
-    cd /vagrant/borg/borg
-    . ../borg-env/bin/activate
-    if which pyenv > /dev/null; then
-      # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.4.0 3.5.0
-    fi
-    # otherwise: just use the system python
-    if which fakeroot > /dev/null; then
-      echo "Running tox WITH fakeroot -u"
-      fakeroot -u tox --skip-missing-interpreters
-    else
-      echo "Running tox WITHOUT fakeroot -u"
-      tox --skip-missing-interpreters
-    fi
-  EOF
+  return "source /vagrant/borg/borg/vagrant-tools/run-tests.sh"
 end
 
 def fix_perms
@@ -309,7 +300,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   # fix permissions on synced folder
-  config.vm.provision "fix perms", :type => :shell, :inline => fix_perms
+  config.vm.provision "fix perms",                  :type => :shell, :privileged => true,  :inline => fix_perms
 
   config.vm.provider :virtualbox do |v|
     #v.gui = true
@@ -322,22 +313,22 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "install system packages", :type => :shell, :inline => packages_redhatted
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("centos7_64")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("centos7_64")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("centos7_64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("centos7_64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("centos7_64")
+    b.vm.provision "install system packages",       :type => :shell, :privileged => true, :inline => packages_redhatted
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("centos7_64")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("centos7_64")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("centos7_64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("centos7_64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("centos7_64")
   end
 
   config.vm.define "centos6_32" do |b|
     b.vm.box = "centos6-32"
-    b.vm.provision "install system packages", :type => :shell, :inline => packages_redhatted
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("centos6_32")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("centos6_32")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("centos6_32")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg_no_fuse("centos6_32")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("centos6_32")
+    b.vm.provision "install system packages",       :type => :shell, :privileged => true, :inline => packages_redhatted
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("centos6_32")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("centos6_32")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("centos6_32")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg_no_fuse("centos6_32")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("centos6_32")
   end
 
   config.vm.define "centos6_64" do |b|
@@ -345,12 +336,12 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "install system packages", :type => :shell, :inline => packages_redhatted
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("centos6_64")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("centos6_64")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("centos6_64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg_no_fuse("centos6_64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("centos6_64")
+    b.vm.provision "install system packages",       :type => :shell, :privileged => true, :inline => packages_redhatted
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("centos6_64")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("centos6_64")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("centos6_64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg_no_fuse("centos6_64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("centos6_64")
   end
 
   config.vm.define "xenial64" do |b|
@@ -358,10 +349,10 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_sys_venv("xenial64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("xenial64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("xenial64")
+    b.vm.provision "packages debianoid",            :type => :shell, :privileged => true, :inline => packages_debianoid
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_sys_venv("xenial64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("xenial64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("xenial64")
   end
 
   config.vm.define "trusty64" do |b|
@@ -369,10 +360,10 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_sys_venv("trusty64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("trusty64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("trusty64")
+    b.vm.provision "packages debianoid",            :type => :shell, :privileged => true, :inline => packages_debianoid
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_sys_venv("trusty64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("trusty64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("trusty64")
   end
 
   config.vm.define "jessie64" do |b|
@@ -380,50 +371,51 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_sys_venv("jessie64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("jessie64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("jessie64")
+    b.vm.provision "packages debianoid",            :type => :shell, :privileged => true, :inline => packages_debianoid
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_sys_venv("jessie64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("jessie64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("jessie64")
   end
 
   config.vm.define "wheezy32" do |b|
     b.vm.box = "boxcutter/debian79-i386"
-    b.vm.provision "packages prepare wheezy", :type => :shell, :inline => packages_prepare_wheezy
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("wheezy32")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("wheezy32")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("wheezy32")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("wheezy32")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller("wheezy32")
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("wheezy32")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("wheezy32")
+    b.vm.provision "packages prepare wheezy",       :type => :shell, :privileged => true, :inline => packages_prepare_wheezy
+    b.vm.provision "packages debianoid",            :type => :shell, :privileged => true, :inline => packages_debianoid
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("wheezy32")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("wheezy32")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("wheezy32")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("wheezy32")
+    # XXX https://github.com/borgbackup/borg/issues/1506
+    b.vm.provision "install pyinstaller",           :type => :shell, :privileged => true, :inline => install_pyinstaller("wheezy32")
+    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => true, :inline => build_binary_with_pyinstaller("wheezy32")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("wheezy32")
   end
 
   config.vm.define "wheezy64" do |b|
     b.vm.box = "boxcutter/debian79"
-    b.vm.provision "packages prepare wheezy", :type => :shell, :inline => packages_prepare_wheezy
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("wheezy64")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("wheezy64")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("wheezy64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("wheezy64")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller("wheezy64")
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("wheezy64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("wheezy64")
+    b.vm.provision "packages prepare wheezy",       :type => :shell, :privileged => true, :inline => packages_prepare_wheezy
+    b.vm.provision "packages debianoid",            :type => :shell, :privileged => true, :inline => packages_debianoid
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("wheezy64")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("wheezy64")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("wheezy64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("wheezy64")
+    b.vm.provision "install pyinstaller",           :type => :shell, :privileged => true, :inline => install_pyinstaller("wheezy64")
+    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => true, :inline => build_binary_with_pyinstaller("wheezy64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("wheezy64")
   end
 
   # OS X
   config.vm.define "darwin64" do |b|
     b.vm.box = "jhcook/yosemite-clitools"
-    b.vm.provision "packages darwin", :type => :shell, :privileged => false, :inline => packages_darwin
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("darwin64")
-    b.vm.provision "fix pyenv", :type => :shell, :privileged => false, :inline => fix_pyenv_darwin("darwin64")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("darwin64")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("darwin64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("darwin64")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller("darwin64")
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("darwin64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("darwin64")
+    b.vm.provision "packages darwin",               :type => :shell, :privileged => true, :inline => packages_darwin
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("darwin64")
+    b.vm.provision "fix pyenv",                     :type => :shell, :privileged => true, :inline => fix_pyenv_darwin("darwin64")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("darwin64")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("darwin64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("darwin64")
+    b.vm.provision "install pyinstaller",           :type => :shell, :privileged => true, :inline => install_pyinstaller("darwin64")
+    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => true, :inline => build_binary_with_pyinstaller("darwin64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("darwin64")
   end
 
   # BSD
@@ -432,14 +424,14 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "install system packages", :type => :shell, :inline => packages_freebsd
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("freebsd")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("freebsd")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("freebsd")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("freebsd")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller_bootloader("freebsd")
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("freebsd")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("freebsd")
+    b.vm.provision "install system packages",       :type => :shell, :privileged => true, :inline => packages_freebsd
+    b.vm.provision "install pyenv",                 :type => :shell, :privileged => true, :inline => install_pyenv("freebsd")
+    b.vm.provision "install pythons",               :type => :shell, :privileged => true, :inline => install_pythons("freebsd")
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_pyenv_venv("freebsd")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg("freebsd")
+    b.vm.provision "install pyinstaller",           :type => :shell, :privileged => true, :inline => install_pyinstaller_bootloader("freebsd")
+    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => true, :inline => build_binary_with_pyinstaller("freebsd")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("freebsd")
   end
 
   config.vm.define "openbsd64" do |b|
@@ -447,10 +439,10 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "packages openbsd", :type => :shell, :inline => packages_openbsd
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_sys_venv("openbsd64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg_no_fuse("openbsd64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("openbsd64")
+    b.vm.provision "packages openbsd",              :type => :shell, :privileged => true, :inline => packages_openbsd
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_sys_venv("openbsd64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg_no_fuse("openbsd64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("openbsd64")
   end
 
   config.vm.define "netbsd64" do |b|
@@ -458,9 +450,9 @@ Vagrant.configure(2) do |config|
     b.vm.provider :virtualbox do |v|
       v.memory = 768
     end
-    b.vm.provision "packages netbsd", :type => :shell, :inline => packages_netbsd
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_sys_venv("netbsd64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg_no_fuse("netbsd64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("netbsd64")
+    b.vm.provision "packages netbsd",               :type => :shell, :privileged => true, :inline => packages_netbsd
+    b.vm.provision "build env",                     :type => :shell, :privileged => true, :inline => build_sys_venv("netbsd64")
+    b.vm.provision "install borg",                  :type => :shell, :privileged => true, :inline => install_borg_no_fuse("netbsd64")
+    b.vm.provision "run tests",                     :type => :shell, :privileged => true, :inline => run_tests("netbsd64")
   end
 end

--- a/vagrant-tools/run-tests.sh
+++ b/vagrant-tools/run-tests.sh
@@ -1,0 +1,169 @@
+. ~/.bash_profile
+cd /vagrant/borg/borg
+. ../borg-env/bin/activate
+if which pyenv > /dev/null; then
+  # for testing, use the earliest point releases of the supported python versions:
+  pyenv global 3.4.0 3.5.0
+fi
+# otherwise: just use the system python
+
+bold_out=$(tput bold)
+blue_out=$(tput setaf 4)
+red_out=$(tput setaf 1)
+normal_out=$(tput sgr0)
+
+testing_partition_size=64M
+root_testing_dir="/var/tmp/borg-tests" # Also hardcoded in server configs in this directory
+mkdir -p "$root_testing_dir/rootfs"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  mount_base="/Volumes/borg-tests"
+else
+  mount_base="/mnt/borg-tests"
+fi
+mkdir -p "$mount_base"
+
+# The directories variable is a bit odd
+# In addition to directories, is specifies env variables to be set to "true"
+# The environment variables are equal sign seperated, and cannot begin with /
+# The directory must start with / and come last, because of that it can have equal signs
+# If we had guarenteed Bash 4 support, we could use associative arrays
+# However, it isn't on OS X and probably won't come due to licensing issues
+directories=("$root_testing_dir/rootfs")
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # No /proc, very limited FS support (pretty much just the root, /tmp, and fuse)
+  directories+=("$TMPDIR")
+  filesystems="fuse"
+else
+  test_mount_point="$(df -P "$root_testing_dir" | awk 'END{print $NF}')" # /var could be mounted to a different FS type
+  root_fs="$(grep -oP '^[^ ]* '"$test_mount_point"' \K[^ ]*' /proc/mounts | tail -n 1)"
+
+  # /proc/filesystems specifies which filesystems *are* loaded
+  # Directories in /lib/modules/$(uname -r)/kernel/fs specify which filesystems *can* be loaded
+  # We want both
+  filesystems="$((cut -d'	' -f2 /proc/filesystems; find "/lib/modules/$(uname -r)/kernel/fs/" -mindepth 1 -maxdepth 1 -type d -printf "%f\n") | sort -u)"
+fi
+
+if id "vagrant" >/dev/null 2>&1; then
+  ssh_user="vagrant"
+elif id "ubuntu" >/dev/null 2>&1; then
+  ssh_user="ubuntu"
+elif [[ "$SUDO_USER" ]] && [[ "$SUDO_USER" != root ]]; then
+  ssh_user="$SUDO_USER"
+  >&2 echo "${bold_out}${blue_out}It looks like this is a host dev environment not a Vagrant environment"
+  >&2 echo "Using user $ssh_user for SSH${normal_out}"
+else
+  ssh_user="root"
+  >&2 echo "${bold_out}${red_out}Warning: no suitable SSH user found, using root{normal_out}"
+  exit 1
+fi
+
+function cleanup() {
+  # We use a loop because umount short-circuits on a failure
+  for dir in "$mount_base"/*; do
+    [[ -d "$dir" ]] && umount "$dir"
+  done
+  # kill after umount in cases of networked servers
+  kill $(cat "$root_testing_dir"/*.pid 2> /dev/null) 2> /dev/null # Only outputs errors if no PID files found
+  rm -r "$mount_base"
+  rm -r "$root_testing_dir"
+}
+
+function error() {
+  >&2 echo "${bold_out}${red_out}Error while preparing filesystem type $1, aborting${normal_out}"
+  cleanup
+  exit 1
+}
+
+while read filesystem; do
+  [[ "$filesystem" == "$root_fs" ]] && continue
+  case "$filesystem" in
+    tmpfs)
+      mkdir "$mount_base/tmpfs"
+      mount -t tmpfs tmpfs "$mount_base/tmpfs" -o "size=$testing_partition_size" || error tmpfs
+      directories+=("$mount_base/tmpfs")
+      ;;
+    ext4 | xfs)
+      truncate -s "$testing_partition_size" "$root_testing_dir/$filesystem"
+      force_option="-F"
+      if [[ "$filesystem" == "xfs" ]]; then
+        force_option="-f"
+      fi
+      "mkfs.$filesystem" "$force_option" "$root_testing_dir/$filesystem" || error "$filesystem"
+      mkdir "$mount_base/$filesystem"
+      mount -t "$filesystem" "$root_testing_dir/$filesystem" "$mount_base/$filesystem" || error "$filesystem"
+      directories+=("$mount_base/$filesystem")
+      ;;
+    cifs)
+      continue # Breaks py.test (I think). Reenable if working.
+      mkdir "$root_testing_dir/cifs"
+      chown nobody "$root_testing_dir/cifs" # guest == nobody user
+      smbd -D -s vagrant-tools/smb.conf
+      mkdir "$mount_base/cifs"
+      # smbd exits before startup
+      if which nc > /dev/null && [[ "$(readlink "$(which nc)")" != "ncat" ]]; then
+        while ! nc -z localhost 10445; do
+          sleep 0.5
+        done
+      else
+        while ! bash -c 'cat < /dev/null > /dev/tcp/localhost/10445' 2> /dev/null; do
+          sleep 0.5
+        done
+      fi
+      mount -t cifs //localhost/share "$mount_base/cifs" -o "port=10445,credentials=$PWD/vagrant-tools/smbcredentials" || error CIFS
+      directories+=("$mount_base/cifs")
+      ;;
+    fuse)
+      fuse_supported=true
+      ;;
+  esac
+done <<< "$filesystems"
+
+if [[ "$fuse_supported" ]]; then
+  if which sshfs > /dev/null; then
+    mkdir "$root_testing_dir/sshfs"
+    chown "$ssh_user" "$root_testing_dir/sshfs"
+    ssh-keygen -t rsa -b 2048 -C 'borgbackup@github.com' -N '' -f "$root_testing_dir/ssh_key"
+    "$(which sshd)" -f vagrant-tools/sshd_config
+    mkdir "$mount_base/sshfs"
+    sshfs "$ssh_user@localhost:$root_testing_dir/sshfs" "$mount_base/sshfs" \
+      -p 10022 \
+      -o "IdentityFile=$root_testing_dir/ssh_key" \
+      -o "StrictHostKeyChecking=no" \
+      || error SSHFS
+    directories+=("$mount_base/sshfs")
+  fi
+  if which ntfs-3g > /dev/null; then
+    truncate -s 128M "$root_testing_dir/ntfs" # NTFS requires a larger partition size than most filesystems
+    mkfs.ntfs -F "$root_testing_dir/ntfs" || error NTFS
+    mkdir "$mount_base/ntfs"
+    ntfs-3g "$root_testing_dir/ntfs" "$mount_base/ntfs" || error NTFS
+    directories+=("BORG_TESTS_IGNORE_MODES=$mount_base/ntfs")
+  fi
+fi
+
+for directory in "${directories[@]}"; do
+  env=()
+  while true; do
+    if [[ "$directory" == /* ]]; then # That's not a filesystem glob (just checks if it starts with /)
+      break
+    fi
+    index="$(expr index "$directory" =)"
+    if [[ "$index" -eq 0 ]]; then
+      >&2 echo "${bold_out}${red_out}Warning: malformed directory in test driver${normal_out}"
+      break
+    fi
+    env+=("${directory:0:$(($index-1))}=true")
+    directory="${directory:$index}"
+  done
+  echo "${bold_out}${blue_out}Running tests in $directory${normal_out}"
+  env+=("TMPDIR=$directory")
+  if ! env -- "${env[@]}" tox --skip-missing-interpreters; then
+    >&2 echo "${bold_out}${red_out}Tests failed in $directory, aborting${normal_out}"
+    cleanup
+    exit 1
+  fi
+done
+
+cleanup
+exit 0

--- a/vagrant-tools/smb.conf
+++ b/vagrant-tools/smb.conf
@@ -1,0 +1,22 @@
+[global]
+smb ports = 10445
+hosts allow = 127.0.0.1 ::1
+pid directory = /var/tmp/borg-tests
+security = user
+map to guest = Bad User
+
+# Who thought it was a good idea
+# to put printing in a file sharing protocol?
+load printers = no
+printing = bsd
+printcap name = /dev/null
+disable spoolss = yes
+
+[share]
+path = /var/tmp/borg-tests/cifs
+
+guest ok = yes
+guest only = yes
+writable = yes
+public = yes
+null passwords = yes

--- a/vagrant-tools/smbcredentials
+++ b/vagrant-tools/smbcredentials
@@ -1,0 +1,3 @@
+username=nobody
+password=
+domain=WORKGROUP

--- a/vagrant-tools/sshd_config
+++ b/vagrant-tools/sshd_config
@@ -1,0 +1,25 @@
+Port 10022
+AddressFamily any
+ListenAddress 127.0.0.1
+ListenAddress ::1
+PidFile /var/tmp/borg-tests/sshd.pid
+
+# Try to keep this setup secure
+# This might be run in a chroot/docker instead of a VM
+# In which case root can escape the container
+
+AuthorizedKeysFile /var/tmp/borg-tests/ssh_key.pub
+ChallengeResponseAuthentication no
+PasswordAuthentication no
+PermitRootLogin no
+
+# TODO get ChrootDirectory working
+
+# For some reason, sshd checks /var/tmp's permissions.
+# Of course, those are loose.
+# The actual key is output by ssh-keygen with proper permissions.
+StrictModes no
+
+# sshfs uses sftp
+Subsystem sftp /usr/lib/ssh/sftp-server
+ForceCommand internal-sftp


### PR DESCRIPTION
Fixes #1289 

Both kernel module and FUSE filesystems are supported.

TODO:
- Filesystems requiring a device
  - [x] ext4
  - [x] XFS
  - [x] NTFS
- Filesystems requiring a server
  - [x] CIFS
  - [x] SSHFS
- Filesystems requiring neither
  - [x] tmpfs
- Fix FS specific test issues
  - [x] #1361 - test_non_ascii_acl only failed outside of Vagrant due to übel user missing
  - [x] #1362 - tests failing on SSHFS (fixed with #1373)
  - [x] #1363 - tests failing on ntfs-3g (fixed with #1373 + #1383)
- Platform specific Vagrant testing
  - Linux
    - [x] centos7_64
    - [ ] centos6_32
    - [ ] centos6_64
    - [x] xenial64
    - [x] trusty64
    - [ ] jessie64
    - [ ] wheezy32
    - [ ] wheezy64
  - OS X
    - [x] darwin64
  - BSD
    - [ ] freebsd64
    - [ ] openbsd64
    - [ ] netbsd64
