### PR TITLE
gitignore .coverage.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ borg.build/
 borg.dist/
 borg.exe
 .coverage
+.coverage.*
 .vagrant
 .eggs


### PR DESCRIPTION
These files are generated during the execution of `tox` and are cleaned up if not interrupted with Ctrl+C.