### PR TITLE
Windows: alternate data steams

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -51,6 +51,7 @@ from .upgrader import AtticRepositoryUpgrader, BorgRepositoryUpgrader
 
 if sys.platform == 'win32':
     import posixpath
+    from .platform import get_ads
 
 
 def argument(args, str_or_bool):
@@ -409,6 +410,13 @@ class Archiver:
             else:
                 status = '-'  # dry run, item was not backed up
         self.print_file_status(status, path)
+        if sys.platform == 'win32':
+            if ':' not in os.path.basename(path):
+                for stream in get_ads(path):
+                    if stream != '::$DATA':
+                        self._process(archive, cache, matcher, exclude_caches, exclude_if_present,
+                            keep_tag_files, skip_inodes, path + stream[:-6], restrict_dev,
+                            read_special, dry_run, st)
 
     @with_repository()
     @with_archive

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -27,3 +27,4 @@ elif sys.platform == 'win32':  # pragma: windows only
     from .windows import API_VERSION
     from .windows import sync_dir
     from .windows import get_owner, set_owner
+    from .windows import get_ads

--- a/src/borg/platform/windows.pyx
+++ b/src/borg/platform/windows.pyx
@@ -77,6 +77,7 @@ cdef extern from 'windows.h':
     cdef extern int ERROR_INSUFFICIENT_BUFFER
     cdef extern int ERROR_INVALID_SID
     cdef extern int ERROR_NONE_MAPPED
+    cdef extern int ERROR_HANDLE_EOF
 
     cdef extern int OWNER_SECURITY_INFORMATION
     cdef extern int GROUP_SECURITY_INFORMATION
@@ -359,6 +360,7 @@ def sync_dir(path):
     # TODO
     pass
 
+
 def get_ads(path):
     ret = []
     cdef _WIN32_FIND_STREAM_DATA data
@@ -371,7 +373,7 @@ def get_ads(path):
     while FindNextStreamW(searchHandle, <void*>&data) != 0:
         ret.append(PyUnicode_FromWideChar(data.cStreamName, -1))
     errno = GetLastError()
-    if errno != 38:
+    if errno != ERROR_HANDLE_EOF:
         raise_error('FindNextStreamW', path)
 
     FindClose(searchHandle)

--- a/src/borg/platform/windows.pyx
+++ b/src/borg/platform/windows.pyx
@@ -372,7 +372,7 @@ def get_ads(path):
         ret.append(PyUnicode_FromWideChar(data.cStreamName, -1))
     errno = GetLastError()
     if errno != 38:
-        print(errno)
+        raise_error('FindNextStreamW', path)
 
     FindClose(searchHandle)
     PyMem_Free(cstrPath)


### PR DESCRIPTION
Backup and extract Windows alternate data steams (#1342 #983 )
ADS are saved as separate items and extracted as such on non-windows.
