### PR TITLE
add transaction_id assertion

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -248,6 +248,7 @@ class Repository:
                  b'segments': self.segments,
                  b'compact': list(self.compact)}
         transaction_id = self.io.get_segments_transaction_id()
+        assert transaction_id is not None
         hints_file = os.path.join(self.path, 'hints.%d' % transaction_id)
         with open(hints_file + '.tmp', 'wb') as fd:
             msgpack.pack(hints, fd)


### PR DESCRIPTION
an acd_cli (amazon cloud drive fuse filesystem) user had "borg init" crash in the line below.

by adding the assertion we tell that we do not expect the transaction_id to be None there,
so it is easier to differentiate from a random coding error.