### PR TITLE
Print active env var override by default

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -912,7 +912,7 @@ DEFAULTISH = ('Default', 'DEFAULT', 'default', 'D', 'd', '', )
 
 
 def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
-        retry_msg=None, invalid_msg=None, env_msg=None,
+        retry_msg=None, invalid_msg=None, env_msg='{} (from {})',
         falsish=FALSISH, truish=TRUISH, defaultish=DEFAULTISH,
         default=False, retry=True, env_var_override=None, ofile=None, input=input):
     """Output <msg> (usually a question) and let user input an answer.
@@ -933,8 +933,8 @@ def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
     :param true_msg: message to output before returning True [None]
     :param default_msg: message to output before returning a <default> [None]
     :param invalid_msg: message to output after a invalid answer was given [None]
-    :param env_msg: message to output when using input from env_var_override [None],
-           needs to have 2 placeholders for answer and env var name, e.g.: "{} (from {})"
+    :param env_msg: message to output when using input from env_var_override ['{} (from {})'],
+           needs to have 2 placeholders for answer and env var name
     :param falsish: sequence of answers qualifying as False
     :param truish: sequence of answers qualifying as True
     :param defaultish: sequence of answers qualifying as <default>

--- a/borg/testsuite/helpers.py
+++ b/borg/testsuite/helpers.py
@@ -805,6 +805,16 @@ def test_yes_output(capfd):
     assert 'false-msg' in err
 
 
+def test_yes_env_output(capfd, monkeypatch):
+    env_var = 'OVERRIDE_SOMETHING'
+    monkeypatch.setenv(env_var, 'yes')
+    assert yes(env_var_override=env_var)
+    out, err = capfd.readouterr()
+    assert out == ''
+    assert env_var in err
+    assert 'yes' in err
+
+
 def test_progress_percentage_multiline(capfd):
     pi = ProgressIndicatorPercent(1000, step=5, start=0, same_line=False, msg="%3.0f%%", file=sys.stderr)
     pi.show(0)


### PR DESCRIPTION
Fixes #1467 

Warning: The repository at location /... was previously located at /somewherelese
Do you want to continue? [yN] yes (from BORG_RELOCATED_REPO_ACCESS_IS_OK)

Previously:

Warning: The repository at location /... was previously located at /somewherelese
Do you want to continue? [yN]

*(is that doing something?)*