### PR TITLE
skip the O_NOATIME test on GNU Hurd, fixes #1315

### DIFF
--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -362,6 +362,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         # the interesting parts of info_output2 and info_output should be same
         self.assert_equal(filter(info_output), filter(info_output2))
 
+    # Search for O_NOATIME there: https://www.gnu.org/software/hurd/contributing.html - we just
+    # skip the test on Hurd, it is not critical anyway, just testing a performance optimization.
+    @pytest.mark.skipif(sys.platform == 'gnu0', reason="O_NOATIME is strangely broken on GNU Hurd")
     def test_atime(self):
         def has_noatime(some_file):
             atime_before = os.stat(some_file).st_atime_ns


### PR DESCRIPTION
GNU Hurd needs to fix their O_NOATIME, after that we can
re-enable the test on that platform.

They already know, see link in the src.