### PR TITLE
use patched LDLP-preserving pyinstaller

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -248,10 +248,13 @@ def install_pyinstaller_bootloader(boxname)
     . borg-env/bin/activate
     git clone https://github.com/pyinstaller/pyinstaller.git
     cd pyinstaller
-    git checkout v3.1.1
+    # develop branch, merge commit of ThomasWaldmann/do-not-overwrite-LD_LP
+    git checkout 639fcec992d753db2058314b843bccc37b815265
     # build bootloader, if it is not included
     cd bootloader
-    python ./waf all
+    # XXX temporarily use --no-lsb as we have no LSB environment
+    # XXX https://github.com/borgbackup/borg/issues/1506
+    python ./waf --no-lsb all
     cd ..
     pip install -e .
   EOF
@@ -392,7 +395,8 @@ Vagrant.configure(2) do |config|
     b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("wheezy32")
     b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("wheezy32")
     b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("wheezy32")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller("wheezy32")
+    # XXX https://github.com/borgbackup/borg/issues/1506
+    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller_bootloader("wheezy32")
     b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("wheezy32")
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("wheezy32")
   end
@@ -405,7 +409,8 @@ Vagrant.configure(2) do |config|
     b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("wheezy64")
     b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("wheezy64")
     b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("wheezy64")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller("wheezy64")
+    # XXX https://github.com/borgbackup/borg/issues/1506
+    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller_bootloader("wheezy64")
     b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("wheezy64")
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("wheezy64")
   end


### PR DESCRIPTION
fixes #1416, see also: https://github.com/pyinstaller/pyinstaller/pull/2148

also: use waf --no-lsb (the bootloader does not build without it on our wheezy vagrant VM)

This fixes the fakeroot issues, when fakeroot can't find its libs.
Also it fixes a lot of tests that get disturbed by the stderr message fakeroot emits due to that.