### PR TITLE
borg serve throws exception while trying to close when it gets eof at start

### DIFF
--- a/borg/remote.py
+++ b/borg/remote.py
@@ -89,6 +89,9 @@ class RepositoryServer:  # pragma: no cover
                 if not data:
                     if self.repository is not None:
                         self.repository.close()
+                    else:
+                        os.write(stderr_fd, "Borg {}: Got connection close before repository was opened.\n"
+                                 .format(__version__).encode())
                     return
                 unpacker.feed(data)
                 for unpacked in unpacker:

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -37,6 +37,14 @@ class InvalidRPCMethod(Error):
     """RPC method {} is not valid"""
 
 
+class UnexpectedRPCDataFormatFromClient(Error):
+    """Borg {}: Got unexpected RPC data format from client."""
+
+
+class UnexpectedRPCDataFormatFromServer(Error):
+    """Got unexpected RPC data format from server."""
+
+
 class RepositoryServer:  # pragma: no cover
     rpc_methods = (
         '__len__',
@@ -87,7 +95,7 @@ class RepositoryServer:  # pragma: no cover
                     if not (isinstance(unpacked, tuple) and len(unpacked) == 4):
                         if self.repository is not None:
                             self.repository.close()
-                        raise Exception("Unexpected RPC data format.")
+                        raise UnexpectedRPCDataFormatFromClient(__version__)
                     type, msgid, method, args = unpacked
                     method = method.decode('ascii')
                     try:
@@ -328,7 +336,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                     self.unpacker.feed(data)
                     for unpacked in self.unpacker:
                         if not (isinstance(unpacked, tuple) and len(unpacked) == 4):
-                            raise Exception("Unexpected RPC data format.")
+                            raise UnexpectedRPCDataFormatFromServer()
                         type, msgid, error, res = unpacked
                         if msgid in self.ignore_responses:
                             self.ignore_responses.remove(msgid)

--- a/borg/remote.py
+++ b/borg/remote.py
@@ -79,12 +79,14 @@ class RepositoryServer:  # pragma: no cover
             if r:
                 data = os.read(stdin_fd, BUFSIZE)
                 if not data:
-                    self.repository.close()
+                    if self.repository is not None:
+                        self.repository.close()
                     return
                 unpacker.feed(data)
                 for unpacked in unpacker:
                     if not (isinstance(unpacked, tuple) and len(unpacked) == 4):
-                        self.repository.close()
+                        if self.repository is not None:
+                            self.repository.close()
                         raise Exception("Unexpected RPC data format.")
                     type, msgid, method, args = unpacked
                     method = method.decode('ascii')


### PR DESCRIPTION
While checking if my ssh forced command worked i started an ssh session to the backup server manually and got the following stacktrace:
```
$ echo -n | borg serve
$LOG ERROR borg.archiver Remote: Local Exception.
Traceback (most recent call last):
  File "/home/martin/sw-dev/borg/src/borg/archiver.py", line 2395, in main
    exit_code = archiver.run(args)
  File "/home/martin/sw-dev/borg/src/borg/archiver.py", line 2328, in run
    return args.func(args)
  File "/home/martin/sw-dev/borg/src/borg/archiver.py", line 175, in do_serve
    return RepositoryServer(restrict_to_paths=args.restrict_to_paths, append_only=args.append_only).serve()
  File "/home/martin/sw-dev/borg/src/borg/remote.py", line 91, in serve
    self.repository.close()
AttributeError: 'NoneType' object has no attribute 'close'

Platform: Linux eclipse.s 4.4.1 #1 SMP PREEMPT Mon Feb 1 19:14:30 CET 2016 x86_64 
Linux: debian 8.4 
Borg: 1.0.8.dev442+ng81dd381  Python: CPython 3.4.2
PID: 4544  CWD: /home/martin/sw-dev/borg
sys.argv: ['/home/martin/sw-dev/borg/borg-env/bin/borg', 'serve']
SSH_ORIGINAL_COMMAND: None
```

This PR fixes this to be more friendly:

    $ echo -n | borg serve
    Borg 1.0.8.dev8+nga7c370b: Got connection close before repository was opened

or 

    $ echo something | borg serve
    $LOG ERROR Remote: Borg 1.0.8.dev8+nga7c370b: Got unexpected RPC data format from client.