### PR TITLE
extract: When doing a partial restore don't leak prefetched chunks.

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -161,11 +161,11 @@ class DownloadPipeline:
         for _, data in self.fetch_many(ids):
             unpacker.feed(data)
             items = [Item(internal_dict=item) for item in unpacker]
-            if filter:
-                items = [item for item in items if filter(item)]
             for item in items:
                 if 'chunks' in item:
                     item.chunks = [ChunkListEntry(*e) for e in item.chunks]
+            if filter:
+                items = [item for item in items if filter(item)]
             if preload:
                 for item in items:
                     if 'chunks' in item:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -417,7 +417,7 @@ class Archiver:
         self.print_file_status(status, path)
 
     @staticmethod
-    def build_filter(matcher, peek_and_store_hardlink_masters, strip_components=0):
+    def build_filter(matcher, peek_and_store_hardlink_masters, strip_components):
         if strip_components:
             def item_filter(item):
                 peek_and_store_hardlink_masters(item)

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -459,7 +459,7 @@ class Archiver:
         if progress:
             progress_logger = logging.getLogger(ProgressIndicatorPercent.LOGGER)
             progress_logger.info('Calculating size')
-            extracted_size = sum(item.file_size() for item in archive.iter_items(filter))
+            extracted_size = sum(item.file_size(hardlink_masters) for item in archive.iter_items(filter))
             pi = ProgressIndicatorPercent(total=extracted_size, msg='Extracting files %5.1f%%', step=0.1)
         else:
             pi = None

--- a/src/borg/item.py
+++ b/src/borg/item.py
@@ -157,10 +157,13 @@ class Item(PropDict):
 
     part = PropDict._make_property('part', int)
 
-    def file_size(self):
-        if 'chunks' not in self:
+    def file_size(self, hardlink_masters=None):
+        hardlink_masters = hardlink_masters or {}
+        chunks, _ = hardlink_masters.get(self.get('source'), (None, None))
+        chunks = self.get('chunks', chunks)
+        if chunks is None:
             return 0
-        return sum(chunk.size for chunk in self.chunks)
+        return sum(chunk.size for chunk in chunks)
 
 
 class EncryptedKey(PropDict):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2204,25 +2204,25 @@ def test_compare_chunk_contents():
 
 class TestBuildFilter:
     @staticmethod
-    def item_is_hardlink_master(item):
+    def peek_and_store_hardlink_masters(item):
         return False
 
     def test_basic(self):
         matcher = PatternMatcher()
         matcher.add([parse_pattern('included')], True)
-        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master, 0)
+        filter = Archiver.build_filter(matcher, self.peek_and_store_hardlink_masters, 0)
         assert filter(Item(path='included'))
         assert filter(Item(path='included/file'))
         assert not filter(Item(path='something else'))
 
     def test_empty(self):
         matcher = PatternMatcher(fallback=True)
-        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master, 0)
+        filter = Archiver.build_filter(matcher, self.peek_and_store_hardlink_masters, 0)
         assert filter(Item(path='anything'))
 
     def test_strip_components(self):
         matcher = PatternMatcher(fallback=True)
-        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master, strip_components=1)
+        filter = Archiver.build_filter(matcher, self.peek_and_store_hardlink_masters, strip_components=1)
         assert not filter(Item(path='shallow'))
         assert not filter(Item(path='shallow/'))  # can this even happen? paths are normalized...
         assert filter(Item(path='deep enough/file'))

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2204,8 +2204,8 @@ def test_compare_chunk_contents():
 
 class TestBuildFilter:
     @staticmethod
-    def peek_and_store_hardlink_masters(item):
-        return False
+    def peek_and_store_hardlink_masters(item, matched):
+        pass
 
     def test_basic(self):
         matcher = PatternMatcher()

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2210,14 +2210,14 @@ class TestBuildFilter:
     def test_basic(self):
         matcher = PatternMatcher()
         matcher.add([parse_pattern('included')], True)
-        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master)
+        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master, 0)
         assert filter(Item(path='included'))
         assert filter(Item(path='included/file'))
         assert not filter(Item(path='something else'))
 
     def test_empty(self):
         matcher = PatternMatcher(fallback=True)
-        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master)
+        filter = Archiver.build_filter(matcher, self.item_is_hardlink_master, 0)
         assert filter(Item(path='anything'))
 
     def test_strip_components(self):


### PR DESCRIPTION
  extract: When doing a partial restore don't leak prefetched chunks.
    
  The filter function passed to iter_items (with preload=True) may never return True for items that
    are not really extracted later because that would leak prefetched items.
    
  For restoring hard linked files the item containing the actual chunks might not be matched
    or implicitly removed from the restore by strip_components. For this reason the chunk list or all
    items that can potentially be used as hardlink target needs to be stored.
    
  To achive both requirements at the same time the filter function needs to store the needed information
    for the hardlinks while not returning True just because it could be a hardlink target.
    
Also contains fixes by encore to fix miscalculation of progress wrt hardlinks and reduces memory usage  by storing hardlink masters only when the file is not going to be extracted.