### PR TITLE
Addjust border color

### DIFF
--- a/docs/borg_theme/css/borg.css
+++ b/docs/borg_theme/css/borg.css
@@ -9,6 +9,11 @@
     background-color: #000000 !important;
 }
 
+.wy-side-nav-search input[type="text"] {
+        border-color: #000000;
+}
+
+
 .wy-side-nav-search > a {
     color: rgba(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
This changes the border-color of the search to match with the background-color.

![borg-border-color](https://cloud.githubusercontent.com/assets/358860/17891737/f431c0da-693d-11e6-8197-c3ae6ee53218.png)
