### PR TITLE
traceback-less messaging for OSErrors

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2422,6 +2422,17 @@ def main():  # pragma: no cover
         tb_log_level = logging.ERROR if important else logging.DEBUG
         tb = sysinfo()
         exit_code = EXIT_ERROR
+    except OSError as e:
+        at_frame = traceback.extract_tb(e.__traceback__, limit=-1)[0]
+        msg = textwrap.dedent("""
+        I/O error: {error}
+
+        At: {frame.filename}:{frame.lineno} ({frame.name})
+        {sysinfo}
+        """).strip().format(error=e, frame=at_frame, sysinfo=sysinfo(short=True))
+        tb_log_level = logging.DEBUG
+        tb = '%s\n%s' % (traceback.format_exc(), sysinfo())
+        exit_code = EXIT_ERROR
     except Exception:
         msg = 'Local Exception'
         tb_log_level = logging.ERROR

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1197,12 +1197,14 @@ class ProgressIndicatorEndless:
         print(file=self.file)
 
 
-def sysinfo():
+def sysinfo(short=False):
     info = []
     info.append('Platform: %s' % (' '.join(platform.uname()), ))
     if sys.platform.startswith('linux'):
         info.append('Linux: %s %s %s' % platform.linux_distribution())
     info.append('Borg: %s  Python: %s %s' % (borg_version, platform.python_implementation(), platform.python_version()))
+    if short:
+        return info[-1]
     info.append('PID: %d  CWD: %s' % (os.getpid(), os.getcwd()))
     info.append('sys.argv: %r' % sys.argv)
     info.append('SSH_ORIGINAL_COMMAND: %r' % os.environ.get('SSH_ORIGINAL_COMMAND'))


### PR DESCRIPTION
- still has the last line of the TB which is un-scary but also the most
  important one
- error line much more prominently (1st line)
- reduced sysinfo() output (borg + python version)

new output would look like this:

```
$ borg list testrepo
I/O error: [Errno 2] No such file or directory: 'doesntexist'

Location:
  File "/home/mabe/Projekte/_oss/borg/src/borg/helpers.py", line 175, in __init__
    open('doesntexist', 'rb')

Borg: 1.0.8.dev445+ng4d214e2 Python: CPython 3.5.2
```

discuss!
