### PR TITLE
ProgressIndicatorPercent / extract minor cosmetic enhancement

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -459,10 +459,10 @@ class Archiver:
 
         filter = self.build_filter(matcher, peek_and_store_hardlink_masters, strip_components)
         if progress:
-            progress_logger = logging.getLogger(ProgressIndicatorPercent.LOGGER)
-            progress_logger.info('Calculating size')
+            pi = ProgressIndicatorPercent(msg='Extracting files %5.1f%%', step=0.1)
+            pi.output('Calculating size')
             extracted_size = sum(item.file_size(hardlink_masters) for item in archive.iter_items(filter))
-            pi = ProgressIndicatorPercent(total=extracted_size, msg='Extracting files %5.1f%%', step=0.1)
+            pi.total = extracted_size
         else:
             pi = None
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1107,7 +1107,7 @@ def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
 class ProgressIndicatorPercent:
     LOGGER = 'borg.output.progress'
 
-    def __init__(self, total, step=5, start=0, msg="%3.0f%%"):
+    def __init__(self, total=0, step=5, start=0, msg="%3.0f%%"):
         """
         Percentage-based progress indicator
 
@@ -1121,6 +1121,7 @@ class ProgressIndicatorPercent:
         self.trigger_at = start  # output next percentage value when reaching (at least) this
         self.step = step
         self.msg = msg
+        self.output_len = len(self.msg % 100.0)
         self.handler = None
         self.logger = logging.getLogger(self.LOGGER)
 
@@ -1154,13 +1155,15 @@ class ProgressIndicatorPercent:
     def show(self, current=None, increase=1):
         pct = self.progress(current, increase)
         if pct is not None:
-            return self.output(pct)
+            return self.output(self.msg % pct)
 
-    def output(self, percent):
-        self.logger.info(self.msg % percent)
+    def output(self, message):
+        self.output_len = max(len(message), self.output_len)
+        message = message.ljust(self.output_len)
+        self.logger.info(message)
 
     def finish(self):
-        self.logger.info(" " * len(self.msg % 100.0))
+        self.output('')
 
 
 class ProgressIndicatorEndless:


### PR DESCRIPTION
Instead of

```
Calculating Size
Extracting files xx %
```

now

(short) `Calculating Size`, then `Extracting files xx %` in the same line, if no other output was requested, then after successful completion the output collapses completely ie.

```
$ borg extract ...
$
```