### PR TITLE
recreate: fix crash if recompress and deduplication beyond autocommit…

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1450,7 +1450,7 @@ class ArchiveRecreater:
                 chunk_id, size, csize = self.cache.add_chunk(chunk_id, chunk, target.stats, overwrite=overwrite)
                 new_chunks.append((chunk_id, size, csize))
                 self.seen_chunks.add(chunk_id)
-                if self.recompress:
+                if self.recompress and self.cache.seen_chunk(chunk_id) == 1:
                     # This tracks how many bytes are uncommitted but compactable, since we are recompressing
                     # existing chunks.
                     target.recreate_uncomitted_bytes += csize


### PR DESCRIPTION
…_threshold

ie. it means that if all the recompressed chunks were already in the repo
no data would be written, so there would be no active txn, so failure
ensues.