### PR TITLE
Archives filters

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2616,9 +2616,9 @@ class Archiver:
 
         group = filters_group.add_mutually_exclusive_group()
         group.add_argument('--first', dest='first', metavar='N', default=0, type=int,
-                           help='consider first N archives after other filter args were applied')
+                           help='consider first N archives after other filters were applied')
         group.add_argument('--last', dest='last', metavar='N', default=0, type=int,
-                           help='consider last N archives after other filter args were applied')
+                           help='consider last N archives after other filters were applied')
 
     def get_args(self, argv, cmd):
         """usually, just returns argv, except if we deal with a ssh forced command for borg serve."""
@@ -2687,10 +2687,6 @@ class Archiver:
             raise Error('The options --first, --last and --prefix can only be used on repository targets.')
 
         archives = manifest.archives.list(prefix=args.prefix)
-        if not archives:
-            logger.critical('There are no archives.')
-            self.exit_code = self.exit_code or EXIT_WARNING
-            return []
 
         for sortkey in reversed(args.sort_by.split(',')):
             archives.sort(key=attrgetter(sortkey))

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -30,7 +30,7 @@ from .constants import *  # NOQA
 from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
 from .helpers import Error, NoManifestError
 from .helpers import location_validator, archivename_validator, ChunkerParams, CompressionSpec
-from .helpers import prefix_spec, sort_by_spec, HUMAN_SORT_KEYS
+from .helpers import PrefixSpec, SortBySpec, HUMAN_SORT_KEYS
 from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter, format_time, format_file_size, format_archive
 from .helpers import safe_encode, remove_surrogates, bin_to_hex
 from .helpers import prune_within, prune_split
@@ -1656,7 +1656,7 @@ class Archiver:
         subparser.add_argument('--last', dest='last',
                                type=int, default=None, metavar='N',
                                help='only check last N archives (Default: all)')
-        subparser.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec,
+        subparser.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('-p', '--progress', dest='progress',
                                action='store_true', default=False,
@@ -2213,7 +2213,7 @@ class Archiver:
                                help='number of monthly archives to keep')
         subparser.add_argument('-y', '--keep-yearly', dest='yearly', type=int, default=0,
                                help='number of yearly archives to keep')
-        subparser.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec,
+        subparser.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('--save-space', dest='save_space', action='store_true',
                                default=False,
@@ -2606,19 +2606,19 @@ class Archiver:
     @staticmethod
     def add_archives_filters_args(subparser):
         filters_group = subparser.add_argument_group('filters', 'Archive filters can be applied to repository targets.')
-        filters_group.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec, default='',
+        filters_group.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec, default='',
                                    help='only consider archive names starting with this prefix')
 
         sort_by_default = 'timestamp'
-        filters_group.add_argument('--sort-by', dest='sort_by', type=sort_by_spec, default=sort_by_default,
-                               help='Comma-separated list of sorting keys; valid keys are: {}; default is: {}'
-                               .format(', '.join(HUMAN_SORT_KEYS), sort_by_default))
+        filters_group.add_argument('--sort-by', dest='sort_by', type=SortBySpec, default=sort_by_default,
+                                   help='Comma-separated list of sorting keys; valid keys are: {}; default is: {}'
+                                   .format(', '.join(HUMAN_SORT_KEYS), sort_by_default))
 
         group = filters_group.add_mutually_exclusive_group()
         group.add_argument('--first', dest='first', metavar='N', default=0, type=int,
-                           help='select first N archives')
+                           help='consider first N archives after other filter args were applied')
         group.add_argument('--last', dest='last', metavar='N', default=0, type=int,
-                           help='delete last N archives')
+                           help='consider last N archives after other filter args were applied')
 
     def get_args(self, argv, cmd):
         """usually, just returns argv, except if we deal with a ssh forced command for borg serve."""

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -30,7 +30,7 @@ from .constants import *  # NOQA
 from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
 from .helpers import Error, NoManifestError
 from .helpers import location_validator, archivename_validator, ChunkerParams, CompressionSpec
-from .helpers import PrefixSpec, sort_by_spec, HUMAN_SORT_KEYS
+from .helpers import prefix_spec, sort_by_spec, HUMAN_SORT_KEYS
 from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter, format_time, format_file_size, format_archive
 from .helpers import safe_encode, remove_surrogates, bin_to_hex
 from .helpers import prune_within, prune_split
@@ -1605,7 +1605,7 @@ class Archiver:
         subparser.add_argument('--last', dest='last',
                                type=int, default=None, metavar='N',
                                help='only check last N archives (Default: all)')
-        subparser.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec,
+        subparser.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('-p', '--progress', dest='progress',
                                action='store_true', default=False,
@@ -1995,7 +1995,7 @@ class Archiver:
         subparser.add_argument('--format', '--list-format', dest='format', type=str,
                                help="""specify format for file listing
                                 (default: "{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NL}")""")
-        subparser.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec,
+        subparser.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('-e', '--exclude', dest='excludes',
                                type=parse_pattern, action='append',
@@ -2161,7 +2161,7 @@ class Archiver:
                                help='number of monthly archives to keep')
         subparser.add_argument('-y', '--keep-yearly', dest='yearly', type=int, default=0,
                                help='number of yearly archives to keep')
-        subparser.add_argument('-P', '--prefix', dest='prefix', type=PrefixSpec,
+        subparser.add_argument('-P', '--prefix', dest='prefix', type=prefix_spec,
                                help='only consider archive names starting with this prefix')
         subparser.add_argument('--save-space', dest='save_space', action='store_true',
                                default=False,
@@ -2634,7 +2634,7 @@ class Archiver:
         if args.location.archive:
             raise Error('The options --first, --last and --prefix can only be used on repository targets.')
 
-        archives = manifest.archives.list()
+        archives = manifest.archives.list(prefix=args.prefix)
         if not archives:
             logger.critical('There are no archives.')
             self.exit_code = self.exit_code or EXIT_WARNING
@@ -2645,7 +2645,7 @@ class Archiver:
         if args.last:
             archives.reverse()
 
-        n = args.first or args.last
+        n = args.first or args.last or len(archives)
 
         return archives[:n]
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -142,11 +142,11 @@ class Archives(abc.MutableMapping):
         name = safe_encode(name)
         del self._archives[name]
 
-    def list(self, sort_by=None, reverse=False):
+    def list(self, sort_by=None, reverse=False, prefix=''):
         """ Inexpensive Archive.list_archives replacement if we just need .name, .id, .ts
             Returns list of borg.helpers.ArchiveInfo instances
         """
-        archives = list(self.values())  # [self[name] for name in self]
+        archives = [x for x in self.values() if x.name.startswith(prefix)]
         if sort_by is not None:
             archives = sorted(archives, key=attrgetter(sort_by))
         if reverse:
@@ -572,10 +572,6 @@ def CompressionSpec(s):
     raise ValueError
 
 
-def PrefixSpec(s):
-    return replace_placeholders(s)
-
-
 def dir_is_cachedir(path):
     """Determines whether the specified path is a cache directory (and
     therefore should potentially be excluded from the backup) according to
@@ -658,9 +654,12 @@ def replace_placeholders(text):
     }
     return format_line(text, data)
 
+prefix_spec = replace_placeholders
+
 
 HUMAN_SORT_KEYS = ['timestamp'] + list(ArchiveInfo._fields)
 HUMAN_SORT_KEYS.remove('ts')
+
 
 def sort_by_spec(text):
     for token in text.split(','):

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -654,14 +654,14 @@ def replace_placeholders(text):
     }
     return format_line(text, data)
 
-prefix_spec = replace_placeholders
+PrefixSpec = replace_placeholders
 
 
 HUMAN_SORT_KEYS = ['timestamp'] + list(ArchiveInfo._fields)
 HUMAN_SORT_KEYS.remove('ts')
 
 
-def sort_by_spec(text):
+def SortBySpec(text):
     for token in text.split(','):
         if token not in HUMAN_SORT_KEYS:
             raise ValueError('Invalid sort key: %s' % token)

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -143,8 +143,9 @@ class Archives(abc.MutableMapping):
         del self._archives[name]
 
     def list(self, sort_by=None, reverse=False, prefix=''):
-        """ Inexpensive Archive.list_archives replacement if we just need .name, .id, .ts
-            Returns list of borg.helpers.ArchiveInfo instances
+        """
+        Inexpensive Archive.list_archives replacement if we just need .name, .id, .ts
+        Returns list of borg.helpers.ArchiveInfo instances
         """
         archives = [x for x in self.values() if x.name.startswith(prefix)]
         if sort_by is not None:

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -964,6 +964,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         assert 'All archives:' in info_repo
         info_archive = self.cmd('info', self.repository_location + '::test')
         assert 'Archive name: test\n' in info_archive
+        info_archive = self.cmd('info', '--first', '1', self.repository_location)
+        assert 'Archive name: test\n' in info_archive
 
     def test_comment(self):
         self.create_regular_file('file1', size=1024 * 80)

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1826,7 +1826,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('create', self.repository_location + '::test', 'input')
         self.cmd('delete', '--first', '1', '--last', '1', self.repository_location, fork=True, exit_code=2)
 
-
     def test_key_export_keyfile(self):
         export_file = self.output_path + '/exported'
         self.cmd('init', self.repository_location, '--encryption', 'keyfile')

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -59,6 +59,9 @@ def exec_cmd(*args, archiver=None, fork=False, exe=None, **kw):
         except subprocess.CalledProcessError as e:
             output = e.output
             ret = e.returncode
+        except SystemExit as e:  # possibly raised by argparse
+            output = ''
+            ret = e.code
         return ret, os.fsdecode(output)
     else:
         stdin, stdout, stderr = sys.stdin, sys.stdout, sys.stderr
@@ -987,8 +990,13 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', self.repository_location)
         self.cmd('create', self.repository_location + '::test', 'input')
         self.cmd('create', self.repository_location + '::test.2', 'input')
+        self.cmd('create', self.repository_location + '::test.3', 'input')
+        self.cmd('create', self.repository_location + '::another_test.1', 'input')
+        self.cmd('create', self.repository_location + '::another_test.2', 'input')
         self.cmd('extract', '--dry-run', self.repository_location + '::test')
         self.cmd('extract', '--dry-run', self.repository_location + '::test.2')
+        self.cmd('delete', '--prefix', 'another_', self.repository_location)
+        self.cmd('delete', '--last', '1', self.repository_location)
         self.cmd('delete', self.repository_location + '::test')
         self.cmd('extract', '--dry-run', self.repository_location + '::test.2')
         output = self.cmd('delete', '--stats', self.repository_location + '::test.2')
@@ -1810,6 +1818,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd('recreate', '--info', self.repository_location + '::test', '-e', 'input/file5')
         self.assert_not_in("input/file1", output)
         self.assert_not_in("x input/file5", output)
+
+    def test_bad_filters(self):
+        self.cmd('init', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        self.cmd('delete', '--first', '1', '--last', '1', self.repository_location, fork=True, exit_code=2)
+
 
     def test_key_export_keyfile(self):
         export_file = self.output_path + '/exported'


### PR DESCRIPTION
follow-up of #1369

this adds the arguments `--first`, `--last` and `--sort-by`, and groups them with `--prefix` as archives filters that can be applied on repository targets.

usable with `check`, `delete`, `info` and `list`.

use-case in a script:

```bash
while used_space_exceeds_pcent; do
    log 'Used space exceeds ${MAX_DISK_USAGE}%, deleting oldest backup archive.'
    borg delete --first 1 --force $BORG_REPOSITORY & wait
done
```