### PR TITLE
create --read-special fix crash on broken symlink

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -610,7 +610,8 @@ Number of files: {0.stats.nfiles}'''.format(
             return 'b'  # block device
 
     def process_symlink(self, path, st):
-        source = os.readlink(path)
+        with backup_io():
+            source = os.readlink(path)
         item = {b'path': make_path_safe(path), b'source': source}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -306,8 +306,13 @@ class Archiver:
                 if not read_special:
                     status = archive.process_symlink(path, st)
                 else:
-                    st_target = os.stat(path)
-                    if is_special(st_target.st_mode):
+                    try:
+                        st_target = os.stat(path)
+                    except OSError:
+                        special = False
+                    else:
+                        special = is_special(st_target.st_mode)
+                    if special:
                         status = archive.process_file(path, st_target, cache)
                     else:
                         status = archive.process_symlink(path, st)

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -901,6 +901,14 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd('create', '-v', '--list', '--filter=AM', self.repository_location + '::test3', 'input')
         self.assert_in('file1', output)
 
+    def test_create_read_special_broken_symlink(self):
+        os.symlink('somewhere doesnt exist', os.path.join(self.input_path, 'link'))
+        self.cmd('init', self.repository_location)
+        archive = self.repository_location + '::test'
+        self.cmd('create', '--read-special', archive, 'input')
+        output = self.cmd('list', archive)
+        assert 'input/link -> somewhere doesnt exist' in output
+
     # def test_cmdline_compatibility(self):
     #    self.create_regular_file('file1', size=1024 * 80)
     #    self.cmd('init', self.repository_location)


### PR DESCRIPTION
also correctly processes broken symlinks. before this regressed to a crash
(5b45385) a broken symlink would've been skipped.

Fixes #1584