### PR TITLE
Add --remote-ratelimit

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1322,6 +1322,8 @@ class Archiver:
                                   help='set umask to M (local and remote, default: %(default)04o)')
         common_group.add_argument('--remote-path', dest='remote_path', metavar='PATH',
                                   help='set remote path to executable (default: "borg")')
+        common_group.add_argument('--remote-ratelimit', dest='remote_ratelimit', type=int, metavar='rate',
+                                  help='set remote network upload rate limit in kiByte/s (default: 0=unlimited)')
         common_group.add_argument('--consider-part-files', dest='consider_part_files',
                                   action='store_true', default=False,
                                   help='treat part files like normal files (e.g. to list/extract them)')

--- a/src/borg/testsuite/remote.py
+++ b/src/borg/testsuite/remote.py
@@ -1,0 +1,60 @@
+import os
+import time
+
+import pytest
+
+from ..remote import SleepingBandwidthLimiter
+
+
+class TestSleepingBandwidthLimiter:
+    def expect_write(self, fd, data):
+        self.expected_fd = fd
+        self.expected_data = data
+
+    def check_write(self, fd, data):
+        assert fd == self.expected_fd
+        assert data == self.expected_data
+        return len(data)
+
+    def test_write_unlimited(self, monkeypatch):
+        monkeypatch.setattr(os, "write", self.check_write)
+
+        it = SleepingBandwidthLimiter(0)
+        self.expect_write(5, b"test")
+        it.write(5, b"test")
+
+    def test_write(self, monkeypatch):
+        monkeypatch.setattr(os, "write", self.check_write)
+        monkeypatch.setattr(time, "monotonic", lambda: now)
+        monkeypatch.setattr(time, "sleep", lambda x: None)
+
+        now = 100
+
+        it = SleepingBandwidthLimiter(100)
+
+        # all fits
+        self.expect_write(5, b"test")
+        it.write(5, b"test")
+
+        # only partial write
+        self.expect_write(5, b"123456")
+        it.write(5, b"1234567890")
+
+        # sleeps
+        self.expect_write(5, b"123456")
+        it.write(5, b"123456")
+
+        # long time interval between writes
+        now += 10
+        self.expect_write(5, b"1")
+        it.write(5, b"1")
+
+        # long time interval between writes, filling up quota
+        now += 10
+        self.expect_write(5, b"1")
+        it.write(5, b"1")
+
+        # long time interval between writes, filling up quota to clip to maximum
+        now += 10
+        self.expect_write(5, b"1")
+        it.write(5, b"1")


### PR DESCRIPTION
The --remote-ratelimit option adds a very simple rate limit for the
sending data to the remote.

Currently implemented by sleeping if the transmission speed is greater
than the limit.