### PR TITLE
Fix inconsistency in FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -399,7 +399,7 @@ Create a wrapper script:  /usr/local/bin/pv-wrapper  ::
 
 Add BORG_RSH environment variable to use pipeviewer wrapper script with ssh. ::
 
-    export BORG_RSH='/usr/local/bin/pv-wrapper.sh ssh'
+    export BORG_RSH='/usr/local/bin/pv-wrapper ssh'
 
 Now |project_name| will be bandwidth limited. Nice thing about pv is that you can change rate-limit on the fly: ::
 


### PR DESCRIPTION
The script in the FAQ is named pv-wrapper. But in the variable export pv-wrapper.sh was used.