### PR TITLE
yes(): abort on wrong answers, saying so

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -141,7 +141,8 @@ class Archiver:
             msg = ("'check --repair' is an experimental feature that might result in data loss." +
                    "\n" +
                    "Type 'YES' if you understand this and want to continue: ")
-            if not yes(msg, false_msg="Aborting.", truish=('YES', ),
+            if not yes(msg, false_msg="Aborting.", invalid_msg="Invalid answer, aborting.",
+                       truish=('YES', ), retry=False,
                        env_var_override='BORG_CHECK_I_KNOW_WHAT_I_AM_DOING'):
                 return EXIT_ERROR
         if not args.archives_only:
@@ -466,8 +467,8 @@ class Archiver:
                         msg.append(format_archive(archive_info))
                 msg.append("Type 'YES' if you understand this and want to continue: ")
                 msg = '\n'.join(msg)
-                if not yes(msg, false_msg="Aborting.", truish=('YES', ),
-                           env_var_override='BORG_DELETE_I_KNOW_WHAT_I_AM_DOING'):
+                if not yes(msg, false_msg="Aborting.", invalid_msg='Invalid answer, aborting.', truish=('YES', ),
+                           retry=False, env_var_override='BORG_DELETE_I_KNOW_WHAT_I_AM_DOING'):
                     self.exit_code = EXIT_ERROR
                     return self.exit_code
                 repository.destroy()

--- a/borg/cache.py
+++ b/borg/cache.py
@@ -63,7 +63,8 @@ class Cache:
                 msg = ("Warning: Attempting to access a previously unknown unencrypted repository!" +
                        "\n" +
                        "Do you want to continue? [yN] ")
-                if not yes(msg, false_msg="Aborting.", env_var_override='BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK'):
+                if not yes(msg, false_msg="Aborting.", invalid_msg="Invalid answer, aborting.",
+                           retry=False, env_var_override='BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK'):
                     raise self.CacheInitAbortedError()
             self.create()
         self.open(lock_wait=lock_wait)
@@ -73,7 +74,8 @@ class Cache:
                 msg = ("Warning: The repository at location {} was previously located at {}".format(repository._location.canonical_path(), self.previous_location) +
                        "\n" +
                        "Do you want to continue? [yN] ")
-                if not yes(msg, false_msg="Aborting.", env_var_override='BORG_RELOCATED_REPO_ACCESS_IS_OK'):
+                if not yes(msg, false_msg="Aborting.", invalid_msg="Invalid answer, aborting.",
+                           retry=False, env_var_override='BORG_RELOCATED_REPO_ACCESS_IS_OK'):
                     raise self.RepositoryAccessAborted()
 
             if sync and self.manifest.id != self.manifest_id:

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -959,9 +959,8 @@ def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
         default=False, retry=True, env_var_override=None, ofile=None, input=input):
     """Output <msg> (usually a question) and let user input an answer.
     Qualifies the answer according to falsish, truish and defaultish as True, False or <default>.
-    If it didn't qualify and retry_msg is None (no retries wanted),
-    return the default [which defaults to False]. Otherwise let user retry
-    answering until answer is qualified.
+    If it didn't qualify and retry is False (no retries wanted), return the default [which
+    defaults to False]. If retry is True let user retry answering until answer is qualified.
 
     If env_var_override is given and this var is present in the environment, do not ask
     the user, but just use the env var contents as answer as if it was typed in.

--- a/borg/key.py
+++ b/borg/key.py
@@ -190,8 +190,9 @@ class Passphrase(str):
 
     @classmethod
     def verification(cls, passphrase):
-        if yes('Do you want your passphrase to be displayed for verification? [yN]: ',
-               env_var_override='BORG_DISPLAY_PASSPHRASE'):
+        msg = 'Do you want your passphrase to be displayed for verification? [yN]: '
+        if yes(msg, retry_msg=msg, invalid_msg='Invalid answer, try again.',
+               retry=True, env_var_override='BORG_DISPLAY_PASSPHRASE'):
             print('Your passphrase (between double-quotes): "%s"' % passphrase,
                   file=sys.stderr)
             print('Make sure the passphrase displayed above is exactly what you wanted.',


### PR DESCRIPTION
except for the passphrase display as we can only display it as long as we have it in memory,
here: retry, telling the user if he entered something invalid and needs to enter again.