### PR TITLE
Change {utcnow} and {now} to ISO-8601 format

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1233,11 +1233,13 @@ class Archiver:
 
         {now}
 
-            The current local date and time.
+            The current local date and time, by default in ISO-8601 format.
+            You can also supply your own `format string <https://docs.python.org/3.4/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
 
         {utcnow}
 
-            The current UTC date and time.
+            The current UTC date and time, by default in ISO-8601 format.
+            You can also supply your own `format string <https://docs.python.org/3.4/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
 
         {user}
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -622,6 +622,16 @@ def partial_format(format, mapping):
     return format
 
 
+class DatetimeWrapper:
+    def __init__(self, dt):
+        self.dt = dt
+
+    def __format__(self, format_spec):
+        if format_spec == '':
+            format_spec = '%Y-%m-%dT%H:%M:%S'
+        return self.dt.__format__(format_spec)
+
+
 def format_line(format, data):
     try:
         return format.format(**data)
@@ -636,8 +646,8 @@ def replace_placeholders(text):
         'pid': os.getpid(),
         'fqdn': socket.getfqdn(),
         'hostname': socket.gethostname(),
-        'now': current_time.now(),
-        'utcnow': current_time.utcnow(),
+        'now': DatetimeWrapper(current_time.now()),
+        'utcnow': DatetimeWrapper(current_time.utcnow()),
         'user': uid2user(os.getuid(), os.getuid()),
         'uuid4': str(uuid.uuid4()),
         'borgversion': borg_version,

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -11,7 +11,7 @@ import msgpack.fallback
 
 from ..helpers import Location
 from ..helpers import Buffer
-from ..helpers import partial_format, format_file_size, parse_file_size, format_timedelta, format_line, PlaceholderError
+from ..helpers import partial_format, format_file_size, parse_file_size, format_timedelta, format_line, PlaceholderError, replace_placeholders
 from ..helpers import make_path_safe, clean_lines
 from ..helpers import prune_within, prune_split
 from ..helpers import get_cache_dir, get_keys_dir, get_nonces_dir
@@ -1035,3 +1035,9 @@ def test_format_line_erroneous():
         assert format_line('{invalid}', data)
     with pytest.raises(PlaceholderError):
         assert format_line('{}', data)
+
+
+def test_replace_placeholders():
+    now = datetime.now()
+    assert " " not in replace_placeholders('{now}')
+    assert int(replace_placeholders('{now:%Y}')) == now.year


### PR DESCRIPTION
This changes both `{now}` and `utcnow` to use the ISO-8601 format with the default `T` separator.

Example:

    2016-09-22T11:11:43

Closes #1606