### PR TITLE
development.rst: Add sphinx_rtd_theme to the sphinx install command

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -147,7 +147,7 @@ The documentation (in reStructuredText format, .rst) is in docs/.
 
 To build the html version of it, you need to have sphinx installed::
 
-  pip3 install sphinx  # important: this will install sphinx with Python 3
+  pip3 install sphinx sphinx_rtd_theme  # important: this will install sphinx with Python 3
 
 Now run::
 


### PR DESCRIPTION
It’s used by default, so install it as well.