### PR TITLE
setup.py: Fix build_usage to always process all commands.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ class build_usage(Command):
             print('generating help for %s' % command)
 
             if self.generate_level(command + " ", parser, Archiver):
-                return
+                break
 
             with open('docs/usage/%s.rst.inc' % command.replace(" ", "_"), 'w') as doc:
                 doc.write(".. IMPORTANT: this file is auto-generated from borg's built-in help, do not edit!\n\n")


### PR DESCRIPTION
The original code meant to skip processing commands with subcommands as notmal commands. But instead it also skipped all other commands with the same parent. As the order of commands is not static this build a different subset of documentation includes each time.