### PR TITLE
Hashindex api version bump

### DIFF
--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -4,7 +4,7 @@ import os
 cimport cython
 from libc.stdint cimport uint32_t, UINT32_MAX, uint64_t
 
-API_VERSION = 2
+API_VERSION = 3
 
 
 cdef extern from "_hashindex.c":

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -80,7 +80,7 @@ class PlaceholderError(Error):
 
 def check_extension_modules():
     from . import platform
-    if hashindex.API_VERSION != 2:
+    if hashindex.API_VERSION != 3:
         raise ExtensionModuleError
     if chunker.API_VERSION != 2:
         raise ExtensionModuleError


### PR DESCRIPTION
API_VERSION is used to check whether the compiled binaries are up-to-date.
the tests for the recent iterator fixes of course need updated (fixed) binaries,
so we bump api_version, so not-up-to-date binaries will get identified.