### PR TITLE
hashindex: bump api_version

### DIFF
--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -8,7 +8,7 @@ from libc.stdint cimport uint32_t, UINT32_MAX, uint64_t
 from libc.errno cimport errno
 from cpython.exc cimport PyErr_SetFromErrnoWithFilename
 
-API_VERSION = 3
+API_VERSION = 4
 
 
 cdef extern from "_hashindex.c":

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -85,7 +85,7 @@ class PlaceholderError(Error):
 
 def check_extension_modules():
     from . import platform, compress
-    if hashindex.API_VERSION != 3:
+    if hashindex.API_VERSION != 4:
         raise ExtensionModuleError
     if chunker.API_VERSION != 2:
         raise ExtensionModuleError


### PR DESCRIPTION
note:
merging the respective changeset from 1.0-maint was not effective
as we already had version 3, so there was no increase.