### PR TITLE
pyinstaller: use a spec file to build borg.exe binary

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -263,7 +263,7 @@ def build_binary_with_pyinstaller(boxname)
     cd /vagrant/borg
     . borg-env/bin/activate
     cd borg
-    pyinstaller -F -n borg.exe --distpath=/vagrant/borg --clean borg/__main__.py
+    pyinstaller --clean --distpath=/vagrant/borg scripts/borg.exe.spec
   EOF
 end
 

--- a/scripts/borg.exe.spec
+++ b/scripts/borg.exe.spec
@@ -1,0 +1,38 @@
+# -*- mode: python -*-
+# this pyinstaller spec file is used to build borg binaries on posix platforms
+
+import os, sys
+
+basepath = '/vagrant/borg/borg'
+
+block_cipher = None
+
+a = Analysis([os.path.join(basepath, 'borg/__main__.py'), ],
+             pathex=[basepath, ],
+             binaries=[],
+             datas=[],
+             hiddenimports=['borg.platform.posix'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+
+if sys.platform == 'darwin':
+    # do not bundle the osxfuse libraries, so we do not get a version
+    # mismatch to the installed kernel driver of osxfuse.
+    a.binaries = [b for b in a.binaries if 'libosxfuse' not in b[0]]
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='borg.exe',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )


### PR DESCRIPTION
also: exclude osxfuse dylib on Mac OS X