### PR TITLE
borg info <repo>: print general repo information

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -920,7 +920,7 @@ class Archiver:
         if any((args.location.archive, args.first, args.last, args.prefix)):
             return self._info_archives(args, repository, manifest, key, cache)
         else:
-            return self._info_repository(cache)
+            return self._info_repository(repository, key, cache)
 
     def _info_archives(self, args, repository, manifest, key, cache):
         def format_cmdline(cmdline):
@@ -957,7 +957,17 @@ class Archiver:
                 print()
         return self.exit_code
 
-    def _info_repository(self, cache):
+    def _info_repository(self, repository, key, cache):
+        print('Repository ID: %s' % bin_to_hex(repository.id))
+        if key.NAME == 'plaintext':
+            encrypted = 'No'
+        else:
+            encrypted = 'Yes (%s)' % key.NAME
+        print('Encrypted: %s' % encrypted)
+        if key.NAME == 'key file':
+            print('Key file: %s' % key.find_key())
+        print('Cache: %s' % cache.path)
+        print(DASHES)
         print(STATS_HEADER)
         print(str(cache))
         return self.exit_code

--- a/src/borg/key.py
+++ b/src/borg/key.py
@@ -118,6 +118,7 @@ class KeyBase:
 
 class PlaintextKey(KeyBase):
     TYPE = 0x02
+    NAME = 'plaintext'
 
     chunk_seed = 0
 
@@ -281,6 +282,7 @@ class PassphraseKey(AESKeyBase):
     # - --encryption=passphrase is an invalid argument now
     # This class is kept for a while to support migration from passphrase to repokey mode.
     TYPE = 0x01
+    NAME = 'passphrase'
     iterations = 100000  # must not be changed ever!
 
     @classmethod
@@ -432,6 +434,7 @@ class KeyfileKeyBase(AESKeyBase):
 
 class KeyfileKey(KeyfileKeyBase):
     TYPE = 0x00
+    NAME = 'key file'
     FILE_ID = 'BORG_KEY'
 
     def sanity_check(self, filename, id):
@@ -491,6 +494,7 @@ class KeyfileKey(KeyfileKeyBase):
 
 class RepoKey(KeyfileKeyBase):
     TYPE = 0x03
+    NAME = 'repokey'
 
     def find_key(self):
         loc = self.repository._location.canonical_path()


### PR DESCRIPTION
```
Repository ID: 6cb322e51621ca7a805692788869fb0cf1556cc250d73b4274cd1dd96fb973ad
Encrypted: Yes (key file)
Key file: /home/mabe/.config/borg/keys/tr_keyfile
Cache: /home/mabe/.cache/borg/6cb322e51621ca7a805692788869fb0cf1556cc250d73b4274cd1dd96fb973ad
------------------------------------------------------------------------------
                       Original size      Compressed size    Deduplicated size
All archives:                    0 B                  0 B                  0 B

                       Unique chunks         Total chunks
Chunk index:                       0                    0
```

I think this covers the most important questions:

- What's the repo ID
- Where is that cache
- Where is the key file I need to back up
- Is this stuff even encrypted?

Another interesting question would be "how large is the cache", but with this it can be answered with relative ease. Could still be added later, though.

Fixes #1679

~~PS: Fix for remote repos coming right up.~~ Removed repository path output as a fix; it's literally in the command line, unless the env var is used, so it'll be usually redundant anyway.