### PR TITLE
WIP: repo.scan - list keys in disk-order

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1045,8 +1045,12 @@ class ArchiveChecker:
         errors = 0
         defect_chunks = []
         pi = ProgressIndicatorPercent(total=count, msg="Verifying data %6.2f%%", step=0.01)
-        for chunk_infos in chunkit(self.chunks.iteritems(), 100):
-            chunk_ids = [chunk_id for chunk_id, _ in chunk_infos]
+        marker = None
+        while True:
+            chunk_ids = self.repository.scan(limit=100, marker=marker)
+            if not chunk_ids:
+                break
+            marker = chunk_ids[-1]
             chunk_data_iter = self.repository.get_many(chunk_ids)
             chunk_ids_revd = list(reversed(chunk_ids))
             while chunk_ids_revd:

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -62,6 +62,7 @@ class RepositoryServer:  # pragma: no cover
         'destroy',
         'get',
         'list',
+        'scan',
         'negotiate',
         'open',
         'put',
@@ -466,6 +467,9 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
 
     def list(self, limit=None, marker=None):
         return self.call('list', limit, marker)
+
+    def scan(self, limit=None, marker=None):
+        return self.call('scan', limit, marker)
 
     def get(self, id_):
         for resp in self.get_many([id_]):

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -133,6 +133,7 @@ class RepositoryTestCase(RepositoryTestCaseBase):
     def test_list(self):
         for x in range(100):
             self.repository.put(H(x), b'SOMEDATA')
+        self.repository.commit()
         all = self.repository.list()
         self.assert_equal(len(all), 100)
         first_half = self.repository.list(limit=50)
@@ -142,6 +143,23 @@ class RepositoryTestCase(RepositoryTestCaseBase):
         self.assert_equal(len(second_half), 50)
         self.assert_equal(second_half, all[50:])
         self.assert_equal(len(self.repository.list(limit=50)), 50)
+
+    def test_scan(self):
+        for x in range(100):
+            self.repository.put(H(x), b'SOMEDATA')
+        self.repository.commit()
+        all = self.repository.scan()
+        assert len(all) == 100
+        first_half = self.repository.scan(limit=50)
+        assert len(first_half) == 50
+        assert first_half == all[:50]
+        second_half = self.repository.scan(marker=first_half[-1])
+        assert len(second_half) == 50
+        assert second_half == all[50:]
+        assert len(self.repository.scan(limit=50)) == 50
+        # check result order == on-disk order (which is hash order)
+        for x in range(100):
+            assert all[x] == H(x)
 
     def test_max_data_size(self):
         max_data = b'x' * MAX_DATA_SIZE


### PR DESCRIPTION
Issue #1610.

I kept repo.list as is and just added a new method repo.scan.