### PR TITLE
WIP Add file authentication

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -239,7 +239,7 @@ class Archiver:
             manager.export(args.path)
         return EXIT_SUCCESS
 
-    @with_repository(lock=False, exclusive=False, manifest=False, cache=False)
+    @with_repository(exclusive=True, manifest=False, cache=False)
     def do_key_import(self, args, repository):
         """Import the repository key from backup"""
         manager = KeyManager(repository)

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -321,6 +321,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                     os.unlink(fn_tmp)
                 else:
                     os.rename(fn_tmp, fn)
+                    os.rename(fn_tmp + '.signature', fn + '.signature')
             return chunk_idx
 
         def lookup_name(archive_id):

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -21,6 +21,7 @@ from .key import PlaintextKey
 from .locking import Lock
 from .platform import SaveFile
 from .remote import cache_if_remote
+from .signature import SignedFile
 
 ChunkListEntry = namedtuple('ChunkListEntry', 'id size csize')
 FileCacheEntry = namedtuple('FileCacheEntry', 'age inode size mtime chunk_ids')
@@ -146,7 +147,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         config.set('cache', 'manifest', '')
         with SaveFile(os.path.join(self.path, 'config')) as fd:
             config.write(fd)
-        ChunkIndex().write(os.path.join(self.path, 'chunks').encode('utf-8'))
+        ChunkIndex().write(self.repository.id, os.path.join(self.path, 'chunks'))
         os.makedirs(os.path.join(self.path, 'chunks.archive.d'))
         with SaveFile(os.path.join(self.path, 'files'), binary=True) as fd:
             pass  # empty file
@@ -170,7 +171,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         self.timestamp = self.config.get('cache', 'timestamp', fallback=None)
         self.key_type = self.config.get('cache', 'key_type', fallback=None)
         self.previous_location = self.config.get('cache', 'previous_location', fallback=None)
-        self.chunks = ChunkIndex.read(os.path.join(self.path, 'chunks').encode('utf-8'))
+        self.chunks = ChunkIndex.read(self.repository.id, os.path.join(self.path, 'chunks'))
         self.files = None
 
     def open(self, lock_wait=None):
@@ -188,7 +189,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         self.files = {}
         self._newest_mtime = 0
         logger.debug('Reading files cache ...')
-        with open(os.path.join(self.path, 'files'), 'rb') as fd:
+        with SignedFile(self.repository.id, os.path.join(self.path, 'files'), write=False) as fd:
             u = msgpack.Unpacker(use_list=True)
             while True:
                 data = fd.read(64 * 1024)
@@ -218,7 +219,8 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
             return
         if self.files is not None:
             ttl = int(os.environ.get('BORG_FILES_CACHE_TTL', 20))
-            with SaveFile(os.path.join(self.path, 'files'), binary=True) as fd:
+            files_path = os.path.join(self.path, 'files')
+            with SignedFile(self.repository.id, files_path, write=True) as fd:
                 for path_hash, item in self.files.items():
                     # Only keep files seen in this backup that are older than newest mtime seen in this backup -
                     # this is to avoid issues with filesystem snapshots and mtime granularity.
@@ -233,7 +235,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         self.config.set('cache', 'previous_location', self.repository._location.canonical_path())
         with SaveFile(os.path.join(self.path, 'config')) as fd:
             self.config.write(fd)
-        self.chunks.write(os.path.join(self.path, 'chunks').encode('utf-8'))
+        self.chunks.write(self.repository.id, os.path.join(self.path, 'chunks'))
         os.rename(os.path.join(self.path, 'txn.active'),
                   os.path.join(self.path, 'txn.tmp'))
         shutil.rmtree(os.path.join(self.path, 'txn.tmp'))
@@ -272,7 +274,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         def mkpath(id, suffix=''):
             id_hex = bin_to_hex(id)
             path = os.path.join(archive_path, id_hex + suffix)
-            return path.encode('utf-8')
+            return path
 
         def cached_archives():
             if self.do_cache:
@@ -314,7 +316,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                 fn = mkpath(archive_id)
                 fn_tmp = mkpath(archive_id, suffix='.tmp')
                 try:
-                    chunk_idx.write(fn_tmp)
+                    chunk_idx.write(self.repository.id, fn_tmp, filename=fn)
                 except Exception:
                     os.unlink(fn_tmp)
                 else:
@@ -343,7 +345,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                     if archive_id in cached_ids:
                         archive_chunk_idx_path = mkpath(archive_id)
                         logger.info("Reading cached archive chunk index for %s ..." % archive_name)
-                        archive_chunk_idx = ChunkIndex.read(archive_chunk_idx_path)
+                        archive_chunk_idx = ChunkIndex.read(self.repository.id, archive_chunk_idx_path)
                     else:
                         logger.info('Fetching and building archive index for %s ...' % archive_name)
                         archive_chunk_idx = fetch_and_build_idx(archive_id, repository, self.key)

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -178,7 +178,11 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         if not os.path.isdir(self.path):
             raise Exception('%s Does not look like a Borg cache' % self.path)
         self.lock = Lock(os.path.join(self.path, 'lock'), exclusive=True, timeout=lock_wait).acquire()
-        self.rollback()
+        try:
+            self.rollback()
+        except:
+            self.lock.release()
+            raise
 
     def close(self):
         if self.lock is not None:

--- a/src/borg/crypto.pyx
+++ b/src/borg/crypto.pyx
@@ -1,9 +1,13 @@
 """A thin OpenSSL wrapper"""
 
+import hashlib
+import hmac
+import io
+
 from libc.stdlib cimport malloc, free
 from cpython.buffer cimport PyBUF_SIMPLE, PyObject_GetBuffer, PyBuffer_Release
 
-API_VERSION = 3
+API_VERSION = 4
 
 
 cdef extern from "openssl/evp.h":
@@ -201,3 +205,94 @@ def hmac_sha256(key, data):
     finally:
         PyBuffer_Release(&data_buf)
     return md
+
+
+class FileLikeWrapper:
+    def __enter__(self):
+        self.fd.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.fd.__exit__(exc_type, exc_val, exc_tb)
+
+    def tell(self):
+        return self.fd.tell()
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        return self.fd.seek(offset, whence)
+
+    def write(self, data):
+        self.fd.write(data)
+
+    def read(self, n=None):
+        return self.fd.read(n)
+
+
+class StreamSigner(FileLikeWrapper):
+    """
+    Wrapper for file-like objects that computes a signature or digest.
+
+    WARNING: Seeks should only be used to query the size of the file, not
+    to skip data, because skipped data isn't read and not signed.
+
+    Note: When used as a context manager read/write operations outside the enclosed scope
+    are illegal.
+    """
+
+    def __init__(self, key, backing_fd, write):
+        self.fd = backing_fd
+        self.writing = write
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.sign_length()
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def write(self, data):
+        """
+        Write *data* to backing file and update internal state.
+        """
+        self.fd.write(data)
+        self.update(data)
+
+    def read(self, n=None):
+        """
+        Read *data* from backing file (*n* has the usual meaning) and update internal state.
+        """
+        data = self.fd.read(n)
+        self.update(data)
+        return data
+
+    def signature(self):
+        """
+        Return current signature bytestring.
+
+        Note: this can be called multiple times.
+        """
+        raise NotImplementedError
+
+    def update(self, data):
+        """
+        Update internal state with *data*.
+        """
+        raise NotImplementedError
+
+    def sign_length(self, seek_to_end=False):
+        if seek_to_end:
+            # Sign length of file as well to avoid problems if only a prefix is read.
+            self.seek(0, io.SEEK_END)
+        self.update(str(self.tell()).encode())
+
+
+class StreamSigner_HMAC_SHA512(StreamSigner):
+    NAME = 'HMAC_SHA_512'
+
+    def __init__(self, key, backing_fd, write):
+        super().__init__(key, backing_fd, write)
+        self.hmac = hmac.new(key, digestmod=hashlib.sha512)
+
+    def update(self, data):
+        self.hmac.update(data)
+
+    def signature(self):
+        return self.hmac.digest()

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -36,7 +36,6 @@ logger = create_logger()
 from . import __version__ as borg_version
 from . import chunker
 from . import crypto
-from . import hashindex
 from . import shellpattern
 from .constants import *  # NOQA
 
@@ -84,7 +83,7 @@ class PlaceholderError(Error):
 
 
 def check_extension_modules():
-    from . import platform, compress
+    from . import platform, compress, hashindex
     if hashindex.API_VERSION != 4:
         raise ExtensionModuleError
     if chunker.API_VERSION != 2:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -91,7 +91,7 @@ def check_extension_modules():
         raise ExtensionModuleError
     if compress.API_VERSION != 2:
         raise ExtensionModuleError
-    if crypto.API_VERSION != 3:
+    if crypto.API_VERSION != 4:
         raise ExtensionModuleError
     if platform.API_VERSION != 3:
         raise ExtensionModuleError

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -315,6 +315,9 @@ class Repository:
 
     def prepare_txn(self, transaction_id, do_cleanup=True):
         self._active_txn = True
+        if not self.lock:
+            logger.warning('Locking repository to recover')
+            self.lock = Lock(os.path.join(self.path, 'lock'), exclusive=True, timeout=self.lock_wait).acquire()
         if not self.lock.got_exclusive_lock():
             if self.exclusive is not None:
                 # self.exclusive is either True or False, thus a new client is active here.

--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -30,7 +30,7 @@ SELFTEST_CASES = [
     ChunkerTestCase,
 ]
 
-SELFTEST_COUNT = 29
+SELFTEST_COUNT = 31
 
 
 class SelfTestResult(TestResult):

--- a/src/borg/signature.py
+++ b/src/borg/signature.py
@@ -1,0 +1,84 @@
+
+import json
+import os
+from hmac import compare_digest
+
+from .crypto import StreamSigner_HMAC_SHA512, FileLikeWrapper
+from .helpers import bin_to_hex
+from .helpers import Error
+from .logger import create_logger
+logger = create_logger()
+
+
+class SignatureError(Error):
+    """Invalid signature for {}."""
+
+
+class SignedFile(FileLikeWrapper):
+    # generic enough that it can be used without a KeyBase
+    def __init__(self, key, path, write):
+        self.path = path
+        self.writing = write
+        mode = 'wb' if write else 'rb'
+        self.file_fd = open(path, mode)
+        self.signer = StreamSigner_HMAC_SHA512(key, self.file_fd, write)
+        self.fd = self.signer  # for FileLikeWrapper
+        self.sign_filename()
+        if write:
+            self.signatures = {}
+        else:
+            self.signatures = self.read_signatures(path, self.signer)
+
+    def sign_filename(self):
+        # Sign the name of the file as well, but only the basename, ie. not the path. In Borg
+        # the name itself encodes the context (eg. index.N, cache, files), while the path doesn't matter,
+        # and moving eg. a repository or cache directory is supported.
+        # Changing the name however imbues a change of context that is not permissible.
+        filename = os.path.basename(self.path)
+        self.signer.update(str(len(filename)).encode())
+        self.signer.update(filename.encode())
+
+    @staticmethod
+    def signature_path(path):
+        return path + '.signature'
+
+    @classmethod
+    def read_signatures(cls, path, signer):
+        try:
+            with open(cls.signature_path(path), 'r') as fd:
+                signature = json.load(fd)
+                # Provisions for agility now, implementation later, but make sure the on-disk joint is oiled.
+                algorithm = signature['algorithm']
+                if algorithm != signer.NAME:
+                    logger.info('Cannot verify signature for %s: Unknown algorithm %r', path, algorithm)
+                    return
+                signatures = signature['signatures']
+                # Require at least presence of the final signature
+                signatures['final']
+                return signatures
+        except FileNotFoundError:
+            logger.info('No signature found for %s', path)
+        except (OSError, ValueError, TypeError, KeyError) as e:
+            logger.warning('Could not read signature for %s: %s', path, e)
+            raise SignatureError(path)
+
+    def sign_part(self, partname, is_final=False):
+        self.signer.update(partname.encode())
+        self.signer.sign_length(seek_to_end=is_final)
+        signature = bin_to_hex(self.signer.signature())
+        if self.writing:
+            self.signatures[partname] = signature
+        elif self.signatures and not compare_digest(self.signatures.get(partname, ''), signature):
+            raise SignatureError(self.path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        no_exception = exc_type is None
+        if no_exception:
+            self.sign_part('final', is_final=True)
+        self.signer.__exit__(exc_type, exc_val, exc_tb)
+        if no_exception and self.writing:
+            with open(self.signature_path(self.path), 'w') as fd:
+                json.dump({
+                    'algorithm': self.signer.NAME,
+                    'signatures': self.signatures,
+                }, fd)

--- a/src/borg/signature.py
+++ b/src/borg/signature.py
@@ -83,5 +83,5 @@ class SignedFile(FileLikeWrapper):
                     'algorithm': self.signer.NAME,
                     'signatures': self.signatures,
                 }, fd)
-        else:
+        elif self.signatures:
             logger.debug('Verified signature of %s', self.path)

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -3,7 +3,7 @@ from binascii import hexlify, unhexlify
 
 from ..crypto import AES, bytes_to_long, bytes_to_int, long_to_bytes, hmac_sha256
 from ..crypto import increment_iv, bytes16_to_int, int_to_bytes16
-from ..crypto import StreamSigner_HMAC_SHA512
+from ..crypto import StreamSigner_HMAC_SHA512_REPOID
 
 from . import BaseTestCase
 
@@ -83,21 +83,21 @@ class CryptoTestCase(BaseTestCase):
                          '85f0faa3e578f8077a2e3ff46729665b')
         assert hmac_sha256(key, data) == hmac
 
-    def test_StreamSigner_HMAC_SHA512_write(self):
+    def test_StreamSigner_HMAC_SHA512_REPOID_write(self):
         # Standard test vectors don't apply, since we add the length of the data into the MAC
         fd = io.BytesIO()
         key = b'\x0b' * 20
-        ss = StreamSigner_HMAC_SHA512(key, fd, write=True)
+        ss = StreamSigner_HMAC_SHA512_REPOID(key, fd, write=True)
         with ss:
             ss.write(unhexlify('12345678'))
         assert ss.signature() == unhexlify('760c9a20dfccc132d30ec838ba19b3989f2a41201236623f07bf923c67aeccc1'
                                            'e3245709f2508455cddea55f168b84b90563d5016065830793b31f9deb8e4687')
 
-    def test_StreamSigner_HMAC_SHA512_read(self):
+    def test_StreamSigner_HMAC_SHA512_REPOID_read(self):
         data = unhexlify('12345678')
         fd = io.BytesIO(data)
         key = b'\x0b' * 20
-        ss = StreamSigner_HMAC_SHA512(key, fd, write=True)
+        ss = StreamSigner_HMAC_SHA512_REPOID(key, fd, write=False)
         with ss:
             assert ss.read() == data
         assert ss.signature() == unhexlify('760c9a20dfccc132d30ec838ba19b3989f2a41201236623f07bf923c67aeccc1'

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -507,7 +507,7 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
         return sorted(int(n) for n in os.listdir(os.path.join(self.tmppath, 'repository', 'data', '0')) if n.isdigit())[-1]
 
     def open_index(self):
-        return NSIndex.read(os.path.join(self.tmppath, 'repository', 'index.{}'.format(self.get_head())))
+        return NSIndex.read(self.repository.id, os.path.join(self.tmppath, 'repository', 'index.{}'.format(self.get_head())))
 
     def corrupt_object(self, id_):
         idx = self.open_index()
@@ -578,9 +578,9 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
         self.assert_raises(Repository.CheckNeeded, lambda: self.get_objects(4))
         self.check(status=False)
         self.check(status=False)
-        self.assert_equal(self.list_indices(), ['index.1'])
+        self.assert_equal(self.list_indices(), ['index.1.signature', 'index.1'])
         self.check(repair=True, status=True)
-        self.assert_equal(self.list_indices(), ['index.3'])
+        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
         self.check(status=True)
         self.get_objects(3)
         self.assert_equal(set([1, 2, 3]), self.list_objects())
@@ -594,10 +594,10 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
 
     def test_repair_index_too_new(self):
         self.add_objects([[1, 2, 3], [4, 5, 6]])
-        self.assert_equal(self.list_indices(), ['index.3'])
+        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
         self.rename_index('index.100')
         self.check(status=True)
-        self.assert_equal(self.list_indices(), ['index.3'])
+        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
         self.get_objects(4)
         self.assert_equal(set([1, 2, 3, 4, 5, 6]), self.list_objects())
 

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -486,7 +486,7 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
 class RepositoryCheckTestCase(RepositoryTestCaseBase):
 
     def list_indices(self):
-        return [name for name in os.listdir(os.path.join(self.tmppath, 'repository')) if name.startswith('index.')]
+        return [name for name in os.listdir(os.path.join(self.tmppath, 'repository')) if name.startswith('index.') and not name.endswith('.signature')]
 
     def check(self, repair=False, status=True):
         self.assert_equal(self.repository.check(repair=repair), status)
@@ -578,9 +578,9 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
         self.assert_raises(Repository.CheckNeeded, lambda: self.get_objects(4))
         self.check(status=False)
         self.check(status=False)
-        self.assert_equal(self.list_indices(), ['index.1.signature', 'index.1'])
+        self.assert_equal(self.list_indices(), ['index.1'])
         self.check(repair=True, status=True)
-        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
+        self.assert_equal(self.list_indices(), ['index.3'])
         self.check(status=True)
         self.get_objects(3)
         self.assert_equal(set([1, 2, 3]), self.list_objects())
@@ -594,10 +594,10 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
 
     def test_repair_index_too_new(self):
         self.add_objects([[1, 2, 3], [4, 5, 6]])
-        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
+        self.assert_equal(self.list_indices(), ['index.3'])
         self.rename_index('index.100')
         self.check(status=True)
-        self.assert_equal(self.list_indices(), ['index.3.signature', 'index.3'])
+        self.assert_equal(self.list_indices(), ['index.3'])
         self.get_objects(4)
         self.assert_equal(set([1, 2, 3, 4, 5, 6]), self.list_objects())
 

--- a/src/borg/testsuite/signature.py
+++ b/src/borg/testsuite/signature.py
@@ -1,0 +1,163 @@
+
+import pytest
+
+from ..signature import SignedFile, SignatureError
+
+
+class TestReadSignatures:
+    def test_no_signature(self, tmpdir):
+        protected_file = tmpdir.join('file')
+        protected_file.write('1234')
+        assert not SignedFile.read_signatures(str(protected_file), None)
+
+    def test_truncated_signature(self, tmpdir):
+        protected_file = tmpdir.join('file')
+        protected_file.write('1234')
+        tmpdir.join('file.signature').write('')
+        with pytest.raises(SignatureError):
+            SignedFile.read_signatures(str(protected_file), None)
+
+    def test_unknown_algorithm(self, tmpdir):
+        class SomeSigner:
+            NAME = 'HMAC_FOOHASH9000'
+        protected_file = tmpdir.join('file')
+        protected_file.write('1234')
+        tmpdir.join('file.signature').write('{"algorithm": "HMAC_SERIOUSHASH", "signature": "1234"}')
+        assert not SignedFile.read_signatures(str(protected_file), SomeSigner())
+
+    @pytest.mark.parametrize('json', (
+        '{"ALGORITHM": "HMAC_SERIOUSHASH", "signature": "1234"}',
+        '[]',
+        '1234.5',
+        '"A string"',
+        'Invalid JSON',
+    ))
+    def test_malformed(self, tmpdir, json):
+        protected_file = tmpdir.join('file')
+        protected_file.write('1234')
+        tmpdir.join('file.signature').write(json)
+        with pytest.raises(SignatureError):
+            SignedFile.read_signatures(str(protected_file), None)
+
+    def test_valid(self, tmpdir):
+        class SomeSigner:
+            NAME = 'HMAC_FOO1'
+
+        protected_file = tmpdir.join('file')
+        protected_file.write('1234')
+        tmpdir.join('file.signature').write('{"algorithm": "HMAC_FOO1", "signatures": {"final": "1234"}}')
+        assert SignedFile.read_signatures(str(protected_file), SomeSigner()) == {'final': '1234'}
+
+
+class TestSignedFile:
+    @pytest.fixture
+    def key(self):
+        return bytes(1234)
+
+    @pytest.fixture
+    def signed_path(self, tmpdir, key):
+        path = str(tmpdir.join('file'))
+        with SignedFile(key, path, write=True) as fd:
+            fd.write(b'foo and bar')
+        return path
+
+    def test_simple(self, tmpdir, signed_path, key):
+        assert tmpdir.join('file').check(file=True)
+        assert tmpdir.join('file.signature').check(file=True)
+        with SignedFile(key, signed_path, write=False) as fd:
+            assert fd.read() == b'foo and bar'
+
+    def test_corrupted_file(self, signed_path, key):
+        with open(signed_path, 'ab') as fd:
+            fd.write(b' extra data')
+        with pytest.raises(SignatureError):
+            with SignedFile(key, signed_path, write=False) as fd:
+                assert fd.read() == b'foo and bar extra data'
+
+    def test_corrupted_file_partial_read(self, signed_path, key):
+        with open(signed_path, 'ab') as fd:
+            fd.write(b' extra data')
+        with pytest.raises(SignatureError):
+            with SignedFile(key, signed_path, write=False) as fd:
+                data = b'foo and bar'
+                assert fd.read(len(data)) == data
+
+    @pytest.mark.parametrize('new_name', (
+        'different_file',
+        'different_file.different_ext',
+    ))
+    def test_renamed_file(self, tmpdir, signed_path, key, new_name):
+        new_path = tmpdir.join(new_name)
+        tmpdir.join('file').move(new_path)
+        tmpdir.join('file.signature').move(new_path + '.signature')
+        with pytest.raises(SignatureError):
+            with SignedFile(key, str(new_path), write=False) as fd:
+                assert fd.read() == b'foo and bar'
+
+    def test_moved_file(self, tmpdir, signed_path, key):
+        new_dir = tmpdir.mkdir('another_directory')
+        tmpdir.join('file').move(new_dir.join('file'))
+        tmpdir.join('file.signature').move(new_dir.join('file.signature'))
+        new_path = str(new_dir.join('file'))
+        with SignedFile(key, new_path, write=False) as fd:
+            assert fd.read() == b'foo and bar'
+
+    def test_wrong_key(self, signed_path, key):
+        with pytest.raises(SignatureError):
+            with SignedFile(key + b'abba', signed_path, write=False) as fd:
+                assert fd.read() == b'foo and bar'
+
+    def test_no_signature(self, tmpdir, signed_path, key):
+        tmpdir.join('file.signature').remove()
+        with SignedFile(key + b'abba', signed_path, write=False) as fd:
+            assert fd.read() == b'foo and bar'
+
+
+class TestSignedFileParts:
+    @pytest.fixture
+    def key(self):
+        return bytes(1234)
+
+    @pytest.fixture
+    def signed_path(self, tmpdir, key):
+        path = str(tmpdir.join('file'))
+        with SignedFile(key, path, write=True) as fd:
+            fd.write(b'foo and bar')
+            fd.sign_part('foopart')
+            fd.write(b' other data')
+        return path
+
+    def test_simple(self, tmpdir, signed_path, key):
+        with SignedFile(key, signed_path, write=False) as fd:
+            data1 = b'foo and bar'
+            assert fd.read(len(data1)) == data1
+            fd.sign_part('foopart')
+            assert fd.read() == b' other data'
+
+    def test_wrong_part_name(self, signed_path, key):
+        with pytest.raises(SignatureError):
+            # Because some sign_part failed, the final signing will fail as well - again - even if we catch
+            # the failing sign_part. This is intentional: (1) it makes the code simpler (2) it's a good fail-safe
+            # against overly broad exception handling.
+            with SignedFile(key, signed_path, write=False) as fd:
+                data1 = b'foo and bar'
+                assert fd.read(len(data1)) == data1
+                with pytest.raises(SignatureError):
+                    # This specific bit raises it directly
+                    fd.sign_part('barpart')
+
+    @pytest.mark.parametrize('partial_read', (False, True))
+    def test_part_independence(self, signed_path, key, partial_read):
+        with open(signed_path, 'ab') as fd:
+            fd.write(b'some extra stuff that does not belong')
+        with pytest.raises(SignatureError):
+            with SignedFile(key, signed_path, write=False) as fd:
+                data1 = b'foo and bar'
+                try:
+                    assert fd.read(len(data1)) == data1
+                    fd.sign_part('foopart')
+                except:
+                    assert False, 'This part must not raise, since this part is still valid.'
+                if not partial_read:
+                    fd.read()
+                # But overall it explodes with the final signature. Neat, eh?

--- a/src/borg/testsuite/signature.py
+++ b/src/borg/testsuite/signature.py
@@ -52,7 +52,7 @@ class TestReadSignatures:
 class TestSignedFile:
     @pytest.fixture
     def key(self):
-        return bytes(1234)
+        return bytes(64)
 
     @pytest.fixture
     def signed_path(self, tmpdir, key):
@@ -116,7 +116,7 @@ class TestSignedFile:
 class TestSignedFileParts:
     @pytest.fixture
     def key(self):
-        return bytes(1234)
+        return bytes(64)
 
     @pytest.fixture
     def signed_path(self, tmpdir, key):


### PR DESCRIPTION
Fixes #1101 

First the implementation only; I'll have another idea or two here to make it safer in the ways we'll be using it, especially in the hashindex (C) code. Then I'll integrate it in the various spots that need it:
- [x] Hashindex (this could be a bit awkward talking a lot to Python from C, but well, let's do it -- at least we get better error handling now than PRINTF_ERROR; RETURN ABORT)
- [x] Cache
  - [x] chunks cache
  - [x] archive caches
  - [x] files cache
- [x] Repository (index, hints... config?)
- [x] ~~Signing key generation for the cache (this will change the key to store the newly generated key; log message saying so)~~
- [x] Work out test issue (good news: no bug in the signing code)
- [x] optimize: SignedFile in read mode doesn't need to do anything if there's no signature attached
- [ ] check/review/refactor nested context wrappers

Gist:
- Create an accompanying .bsi (_b_org _si_gnature, didn't want to use .sig due to PGP use). Contains signature algo + value in JSON.
- When reading, signature state is continuously updated. When done, signatures are compared and appropiate errors are raised.
  
  This has the advantage that the file doesn't have to be read twice and has no races that would be associated with reading twice.
  
  ~~The disadvantage is that invalid data may be processed (_but I have an idea about that_).~~ [1]
- When writing, the same thing happens
- Both the file name (but not the path) and the file length are encoded into the signature

Implementation is HMAC-SHA512 for now. Since most of these places we'll use it (indices, caches) will be rather large objects I didn't bother to add low-level OpenSSL wrappers for now.

[1] d46f3be solves this. By allowing us to sign parts of a file independently as we go (header and data in hashindex for example) this allows us to sanitize-by-signing parts of the file we need to work with later parts of the file.

If eg. the header were corrupted and says we got a gazillion entries, we can detect this now immediately, because the header can be signed independently and thus verified immediately.
