### PR TITLE
IntegrityError: add placeholder for message, fixes #1572

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -64,7 +64,7 @@ class ErrorWithTraceback(Error):
 
 
 class IntegrityError(ErrorWithTraceback):
-    """Data integrity error"""
+    """Data integrity error: {}"""
 
 
 class ExtensionModuleError(Error):


### PR DESCRIPTION
So that the message we give appears not only in the traceback, but also in the (short) error message.