### PR TITLE
Vagrant, OpenBSD and rsync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,7 +99,8 @@ def packages_openbsd
   return <<-EOF
     . ~/.profile
     mkdir -p /home/vagrant/borg
-    rsync -aH /vagrant/borg/ /home/vagrant/borg/
+    pkg_add rsync
+    /usr/local/bin/rsync -aH /vagrant/borg/ /home/vagrant/borg/
     rm -rf /vagrant/borg
     ln -sf /home/vagrant/borg /vagrant/
     pkg_add bash


### PR DESCRIPTION
This should fix #1695:

OpenBSD does not include rsync in base, as such install it using
pkg_add. Instead of calling rsync use complete path to rsync.

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>