### PR TITLE
FUSE on OpenBSD

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,7 +106,6 @@ def packages_openbsd
     chsh -s /usr/local/bin/bash vagrant
     pkg_add openssl
     pkg_add lz4
-    # pkg_add fuse  # does not install, sdl dependency missing
     pkg_add git  # no fakeroot
     pkg_add python-3.4.2
     pkg_add py3-setuptools


### PR DESCRIPTION
Concerning #1696:

OpenBSD offers in kernel support for FUSE 2.6. Borg relies on llfuse,
which relies on FUSE >2.9. There is no FUSE package.

I'm not aware of plans to bring FUSE on OpenBSD to a more recent
version.

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>