### PR TITLE
fuse_mount contextmanager: accept any options

### DIFF
--- a/borg/testsuite/__init__.py
+++ b/borg/testsuite/__init__.py
@@ -94,11 +94,9 @@ class BaseTestCase(unittest.TestCase):
             self._assert_dirs_equal_cmp(sub_diff)
 
     @contextmanager
-    def fuse_mount(self, location, mountpoint, mount_options=None):
+    def fuse_mount(self, location, mountpoint, *options):
         os.mkdir(mountpoint)
-        args = ['mount', location, mountpoint]
-        if mount_options:
-            args += '-o', mount_options
+        args = ['mount', location, mountpoint] + list(options)
         self.cmd(*args, fork=True)
         self.wait_for_mount(mountpoint)
         yield

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -1119,7 +1119,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             with pytest.raises(OSError) as excinfo:
                 open(os.path.join(mountpoint, path))
             assert excinfo.value.errno == errno.EIO
-        with self.fuse_mount(self.repository_location + '::archive', mountpoint, 'allow_damaged_files'):
+        with self.fuse_mount(self.repository_location + '::archive', mountpoint, '-o', 'allow_damaged_files'):
             open(os.path.join(mountpoint, path)).close()
 
     def verify_aes_counter_uniqueness(self, method):


### PR DESCRIPTION
not just the -o mount_options, but any options borg mount would take.
simpler, more flexible.

Applying against 1.0-maint to keep the tests better in sync.