### PR TITLE
point XDG_*_HOME to temp dirs for tests, fixes #1714

### DIFF
--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -605,44 +605,29 @@ class TestParseTimestamp(BaseTestCase):
         self.assert_equal(parse_timestamp('2015-04-19T20:25:00'), datetime(2015, 4, 19, 20, 25, 0, 0, timezone.utc))
 
 
-def test_get_cache_dir():
+def test_get_cache_dir(monkeypatch):
     """test that get_cache_dir respects environment"""
-    # reset BORG_CACHE_DIR in order to test default
-    old_env = None
-    if os.environ.get('BORG_CACHE_DIR'):
-        old_env = os.environ['BORG_CACHE_DIR']
-        del(os.environ['BORG_CACHE_DIR'])
+    monkeypatch.delenv('XDG_CACHE_HOME', raising=False)
     assert get_cache_dir() == os.path.join(os.path.expanduser('~'), '.cache', 'borg')
-    os.environ['XDG_CACHE_HOME'] = '/var/tmp/.cache'
+    monkeypatch.setenv('XDG_CACHE_HOME', '/var/tmp/.cache')
     assert get_cache_dir() == os.path.join('/var/tmp/.cache', 'borg')
-    os.environ['BORG_CACHE_DIR'] = '/var/tmp'
+    monkeypatch.setenv('BORG_CACHE_DIR', '/var/tmp')
     assert get_cache_dir() == '/var/tmp'
-    # reset old env
-    if old_env is not None:
-        os.environ['BORG_CACHE_DIR'] = old_env
 
 
-def test_get_keys_dir():
+def test_get_keys_dir(monkeypatch):
     """test that get_keys_dir respects environment"""
-    # reset BORG_KEYS_DIR in order to test default
-    old_env = None
-    if os.environ.get('BORG_KEYS_DIR'):
-        old_env = os.environ['BORG_KEYS_DIR']
-        del(os.environ['BORG_KEYS_DIR'])
+    monkeypatch.delenv('XDG_CONFIG_HOME', raising=False)
     assert get_keys_dir() == os.path.join(os.path.expanduser('~'), '.config', 'borg', 'keys')
-    os.environ['XDG_CONFIG_HOME'] = '/var/tmp/.config'
+    monkeypatch.setenv('XDG_CONFIG_HOME', '/var/tmp/.config')
     assert get_keys_dir() == os.path.join('/var/tmp/.config', 'borg', 'keys')
-    os.environ['BORG_KEYS_DIR'] = '/var/tmp'
+    monkeypatch.setenv('BORG_KEYS_DIR', '/var/tmp')
     assert get_keys_dir() == '/var/tmp'
-    # reset old env
-    if old_env is not None:
-        os.environ['BORG_KEYS_DIR'] = old_env
 
 
 def test_get_nonces_dir(monkeypatch):
     """test that get_nonces_dir respects environment"""
     monkeypatch.delenv('XDG_CONFIG_HOME', raising=False)
-    monkeypatch.delenv('BORG_NONCES_DIR', raising=False)
     assert get_nonces_dir() == os.path.join(os.path.expanduser('~'), '.config', 'borg', 'key-nonces')
     monkeypatch.setenv('XDG_CONFIG_HOME', '/var/tmp/.config')
     assert get_nonces_dir() == os.path.join('/var/tmp/.config', 'borg', 'key-nonces')

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -14,17 +14,6 @@ from ..helpers import get_nonces_dir
 from ..key import PlaintextKey, PassphraseKey, KeyfileKey, Passphrase, PasswordRetriesExceeded, bin_to_hex
 
 
-@pytest.fixture(autouse=True)
-def clean_env(monkeypatch):
-    # Workaround for some tests (testsuite/archiver) polluting the environment
-    monkeypatch.delenv('BORG_PASSPHRASE', False)
-
-
-@pytest.fixture(autouse=True)
-def nonce_dir(tmpdir_factory, monkeypatch):
-    monkeypatch.setenv('XDG_CONFIG_HOME', tmpdir_factory.mktemp('xdg-config-home'))
-
-
 class TestKey:
     class MockArgs:
         location = Location(tempfile.mkstemp()[1])

--- a/src/borg/testsuite/nonces.py
+++ b/src/borg/testsuite/nonces.py
@@ -10,17 +10,6 @@ from ..remote import InvalidRPCMethod
 from .. import nonces  # for monkey patching NONCE_SPACE_RESERVATION
 
 
-@pytest.fixture(autouse=True)
-def clean_env(monkeypatch):
-    # Workaround for some tests (testsuite/archiver) polluting the environment
-    monkeypatch.delenv('BORG_PASSPHRASE', False)
-
-
-@pytest.fixture(autouse=True)
-def nonce_dir(tmpdir_factory, monkeypatch):
-    monkeypatch.setenv('XDG_CONFIG_HOME', tmpdir_factory.mktemp('xdg-config-home'))
-
-
 class TestNonceManager:
 
     class MockRepository:


### PR DESCRIPTION
otherwise it spoils the user's nonces and cache dirs with lots of files.

also: remove all BORG_* env vars from the outer environment

TODO: check whether some of this should be applied to 1.0-maint first.