### PR TITLE
Add standalone build for android. (using glibc)

### DIFF
--- a/scripts/borg.android.sh
+++ b/scripts/borg.android.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+if [ -z "$1" ] ; then
+    echo "Usage: $0 <path to pyinstaller result>"
+    exit 1
+fi
+
+cd $1
+
+cp -t . \
+    /lib/ld-linux-armhf.so.3 \
+    /lib/arm-linux-gnueabihf/libc.so.6 \
+    /lib/arm-linux-gnueabihf/libm.so.6 \
+    /lib/arm-linux-gnueabihf/libpthread.so.0 \
+    /lib/arm-linux-gnueabihf/librt.so.1 \
+    /lib/arm-linux-gnueabihf/libutil.so.1 \
+    /lib/arm-linux-gnueabihf/libdl.so.2
+
+# keep in mind that this script needs to run with the very minimal
+# support of an standard android build. So no readlink or anything
+# fancy and not even a bash.
+cat > borg <<'EOF'
+#! /system/bin/sh
+
+ORIGDIR="$(pwd)"
+RELPATH="${0%%/borg}"
+if ! [ -d "$RELPATH" ] ; then
+    echo "$0: can't find installation dir. Use absolute path to help."
+    exit 2
+fi
+cd "$RELPATH"
+BORGDIR="$PWD"
+cd "$ORIGDIR"
+
+# jump straigt to pass2 because reexec doesn't work with explicit ld.so invocation.
+export _MEIPASS2="$BORGDIR"
+
+"$BORGDIR/ld-linux-armhf.so.3" --library-path "$BORGDIR" "$BORGDIR/borg.real" "$@"
+EOF
+
+chmod a+x borg
+
+# the bootloader uses the executable name to find it's packaged resources.
+# But it can fallback to the executable name plus .pkg
+cp borg.real ld-linux-armhf.so.3.pkg

--- a/scripts/borg.android.spec
+++ b/scripts/borg.android.spec
@@ -1,0 +1,46 @@
+# -*- mode: python -*-
+# this pyinstaller spec file is used to build borg binaries on posix platforms
+
+import os, sys
+
+#basepath = '/vagrant/borg/borg'
+basepath = '/home/borg/borg/borg'
+
+block_cipher = None
+
+a = Analysis([os.path.join(basepath, 'src/borg/__main__.py'), ],
+             pathex=[basepath, ],
+             binaries=[],
+             datas=[],
+             hiddenimports=['borg.platform.posix'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+
+if sys.platform == 'darwin':
+    # do not bundle the osxfuse libraries, so we do not get a version
+    # mismatch to the installed kernel driver of osxfuse.
+    a.binaries = [b for b in a.binaries if 'libosxfuse' not in b[0]]
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name='borg.real',
+          debug=False,
+          strip=False,
+          upx=False,
+          console=True )
+
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=False,
+               name='borg.android')
+

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -55,7 +55,11 @@ def get_all(path, follow_symlinks=True):
             return {}
 
 
-libc_name = find_library('c')
+libc_name = None
+try:
+    libc_name = find_library('c')
+except:
+    pass  # workaround for systems like android where find_library doesn't work
 if libc_name is None:
     # find_library didn't work, maybe we are on some minimal system that misses essential
     # tools used by find_library, like ldconfig, gcc/cc, objdump.


### PR DESCRIPTION
This build uses pyinstaller in directory mode and ships the libc of the build system.
It currently assumes a debian armhf as build system.

Currently tested on android 4.2.2.

Still needs integration into Vagrant and testing on more modern android versions.

Q: Do we need to explicitly manage the ctypes.find_library workaround or is just ignoring the exceptions ok?
