### PR TITLE
vagrant: no chown when rsyncing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -301,7 +301,7 @@ end
 
 Vagrant.configure(2) do |config|
   # use rsync to copy content to the folder
-  config.vm.synced_folder ".", "/vagrant/borg/borg", :type => "rsync", :rsync__args => ["--verbose", "--archive", "--delete", "-z"]
+  config.vm.synced_folder ".", "/vagrant/borg/borg", :type => "rsync", :rsync__args => ["--verbose", "--archive", "--delete", "-z"], :rsync__chown => false
   # do not let the VM access . on the host machine via the default shared folder!
   config.vm.synced_folder ".", "/vagrant", disabled: true
 


### PR DESCRIPTION
it tries to do chown -R vagrant.vagrant, but some boxes do not
have a vagrant group and break there. also, we do our own chown
in the provisioning scripts.