### PR TITLE
RemoteRepository: Fix busy wait in call_many, fixes #940

### DIFF
--- a/borg/remote.py
+++ b/borg/remote.py
@@ -20,6 +20,8 @@ RPC_PROTOCOL_VERSION = 2
 
 BUFSIZE = 10 * 1024 * 1024
 
+MAX_INFLIGHT = 100
+
 
 class ConnectionClosed(Error):
     """Connection closed by remote host"""
@@ -316,7 +318,6 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
 
         calls = list(calls)
         waiting_for = []
-        w_fds = [self.stdin_fd]
         while wait or calls:
             while waiting_for:
                 try:
@@ -330,6 +331,10 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                             return
                 except KeyError:
                     break
+            if self.to_send or ((calls or self.preload_ids) and len(waiting_for) < MAX_INFLIGHT):
+                w_fds = [self.stdin_fd]
+            else:
+                w_fds = []
             r, w, x = select.select(self.r_fds, w_fds, self.x_fds, 1)
             if x:
                 raise Exception('FD exception occurred')
@@ -362,7 +367,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                         else:
                             sys.stderr.write("Remote: " + line)
             if w:
-                while not self.to_send and (calls or self.preload_ids) and len(waiting_for) < 100:
+                while not self.to_send and (calls or self.preload_ids) and len(waiting_for) < MAX_INFLIGHT:
                     if calls:
                         if is_preloaded:
                             if calls[0] in self.cache:
@@ -389,8 +394,6 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                         # that the fd should be writable
                         if e.errno != errno.EAGAIN:
                             raise
-                if not self.to_send and not (calls or self.preload_ids):
-                    w_fds = []
         self.ignore_responses |= set(waiting_for)
 
     def check(self, repair=False, save_space=False):


### PR DESCRIPTION
Cherry-pick commit 731f6241faa254c379a9bc25dd21133d3604d32a from master to fix issue #940 in 1.0-maint.