### PR TITLE
remote call to logger that were uninitialized

### DIFF
--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -68,7 +68,7 @@ if libc_name is None:
         libc_name = 'libc.dylib'
     else:
         msg = "Can't find C library. No fallback known. Try installing ldconfig, gcc/cc or objdump."
-        print(msg,file=sys.stderr)  # logger isn't initialized at this stage
+        print(msg, file=sys.stderr)  # logger isn't initialized at this stage
         raise Exception(msg)
 
 # If we are running with fakeroot on Linux, then use the xattr functions of fakeroot. This is needed by

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -68,7 +68,7 @@ if libc_name is None:
         libc_name = 'libc.dylib'
     else:
         msg = "Can't find C library. No fallback known. Try installing ldconfig, gcc/cc or objdump."
-        logger.error(msg)
+        print(msg,file=sys.stderr)  # logger isn't initialized at this stage
         raise Exception(msg)
 
 # If we are running with fakeroot on Linux, then use the xattr functions of fakeroot. This is needed by


### PR DESCRIPTION
replace it with a print() call.
