### PR TITLE
vagrant: fix fuse test for darwin, fixes #1546

### DIFF
--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -211,6 +211,7 @@ class ArchiverTestCaseBase(BaseTestCase):
         os.environ['BORG_KEYS_DIR'] = self.keys_path
         os.environ['BORG_CACHE_DIR'] = self.cache_path
         os.mkdir(self.input_path)
+        os.chmod(self.input_path, 0o777)  # avoid troubles with fakeroot / FUSE
         os.mkdir(self.output_path)
         os.mkdir(self.keys_path)
         os.mkdir(self.cache_path)


### PR DESCRIPTION
otherwise the "input" dir is root.wheel -rwx------ and gives a PermissionError when trying to access it.