### PR TITLE
move fork differences to FAQ

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ Main features
 
 **Free and Open Source Software**
   * security and functionality can be audited independently
-  * licensed under the BSD (3-clause) license
-
+  * licensed under the BSD (3-clause) license, see `License`_ for the
+    complete license
 
 Easy to use
 -----------
@@ -143,37 +143,8 @@ Links
   `Mailing List <https://mail.python.org/mailman/listinfo/borgbackup>`_
 * `License <https://borgbackup.readthedocs.org/en/stable/authors.html#license>`_
 
-Notes
------
-
-Borg is a fork of `Attic`_ and maintained by "`The Borg collective`_".
-
-.. _Attic: https://github.com/jborg/attic
-.. _The Borg collective: https://borgbackup.readthedocs.org/en/latest/authors.html
-
-Differences between Attic and Borg
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Here's a (incomplete) list of some major changes:
-
-* more open, faster paced development (see `issue #1 <https://github.com/borgbackup/borg/issues/1>`_)
-* lots of attic issues fixed (see `issue #5 <https://github.com/borgbackup/borg/issues/5>`_)
-* less chunk management overhead (less memory and disk usage for chunks index)
-* faster remote cache resync (useful when backing up multiple machines into same repo)
-* compression: no, lz4, zlib or lzma compression, adjustable compression levels
-* repokey replaces problematic passphrase mode (you can't change the passphrase nor the pbkdf2 iteration count in "passphrase" mode)
-* simple sparse file support, great for virtual machine disk files
-* can read special files (e.g. block devices) or from stdin, write to stdout
-* mkdir-based locking is more compatible than attic's posix locking
-* uses fadvise to not spoil / blow up the fs cache
-* better error messages / exception handling
-* better logging, screen output, progress indication
-* tested on misc. Linux systems, 32 and 64bit, FreeBSD, OpenBSD, NetBSD, Mac OS X
-
-Please read the `ChangeLog`_ (or ``docs/changes.rst`` in the source distribution) for more
-information.
-
-BORG IS NOT COMPATIBLE WITH ORIGINAL ATTIC (but there is a one-way conversion).
+Compatibility notes
+===================
 
 EXPECT THAT WE WILL BREAK COMPATIBILITY REPEATEDLY WHEN MAJOR RELEASE NUMBER
 CHANGES (like when going from 0.x.y to 1.0.0 or from 1.x.y to 2.0.0).
@@ -181,8 +152,6 @@ CHANGES (like when going from 0.x.y to 1.0.0 or from 1.x.y to 2.0.0).
 NOT RELEASED DEVELOPMENT VERSIONS HAVE UNKNOWN COMPATIBILITY PROPERTIES.
 
 THIS IS SOFTWARE IN DEVELOPMENT, DECIDE YOURSELF WHETHER IT FITS YOUR NEEDS.
-
-Borg is distributed under a 3-clause BSD license, see `License`_ for the complete license.
 
 |doc| |build| |coverage| |bestpractices|
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -512,3 +512,32 @@ Borg intends to be:
   * do not break compatibility accidentally, without a good reason
     or without warning. allow compatibility breaking for other cases.
   * if major version number changes, it may have incompatible changes
+
+What are the differences between Attic and Borg?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Borg is a fork of `Attic`_ and maintained by "`The Borg collective`_".
+
+.. _Attic: https://github.com/jborg/attic
+.. _The Borg collective: https://borgbackup.readthedocs.org/en/latest/authors.html
+
+Here's a (incomplete) list of some major changes:
+
+* more open, faster paced development (see `issue #1 <https://github.com/borgbackup/borg/issues/1>`_)
+* lots of attic issues fixed (see `issue #5 <https://github.com/borgbackup/borg/issues/5>`_)
+* less chunk management overhead (less memory and disk usage for chunks index)
+* faster remote cache resync (useful when backing up multiple machines into same repo)
+* compression: no, lz4, zlib or lzma compression, adjustable compression levels
+* repokey replaces problematic passphrase mode (you can't change the passphrase nor the pbkdf2 iteration count in "passphrase" mode)
+* simple sparse file support, great for virtual machine disk files
+* can read special files (e.g. block devices) or from stdin, write to stdout
+* mkdir-based locking is more compatible than attic's posix locking
+* uses fadvise to not spoil / blow up the fs cache
+* better error messages / exception handling
+* better logging, screen output, progress indication
+* tested on misc. Linux systems, 32 and 64bit, FreeBSD, OpenBSD, NetBSD, Mac OS X
+
+Please read the `ChangeLog`_ (or ``docs/changes.rst`` in the source distribution) for more
+information.
+
+Borg is not compatible with original attic (but there is a one-way conversion).

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -128,7 +128,19 @@ borg help placeholders
 
  {borgversion}
 
-     The version of borg.
+     The version of borg, e.g.: 1.0.8rc1
+
+ {borgmajor}
+
+     The version of borg, only the major version, e.g.: 1
+
+ {borgminor}
+
+     The version of borg, only major and minor version, e.g.: 1.0
+
+ {borgpatch}
+
+     The version of borg, only major, minor and patch version, e.g.: 1.0.8
 
 Examples::
 


### PR DESCRIPTION
it seems now that the fork is more of historical value than a current
thing. people interested in the differences between borg and attic can
look in the FAQ, but I do not see why this is present in the README.

a new section regarding compatibility is created to keep that warning
in place.