### PR TITLE
move security verification to support section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,22 +113,6 @@ Now doing another backup, just to show off the great deduplication:
 
 For a graphical frontend refer to our complementary project `BorgWeb <https://borgweb.readthedocs.io/>`_.
 
-Checking Release Authenticity and Security Contact
---------------------------------------------------
-
-`Releases <https://github.com/borgbackup/borg/releases>`_ are signed with this GPG key,
-please use GPG to verify their authenticity.
-
-In case you discover a security issue, please use this contact for reporting it privately
-and please, if possible, use encrypted E-Mail:
-
-Thomas Waldmann <tw@waldmann-edv.de>
-
-GPG Key Fingerprint: 6D5B EF9A DD20 7580 5747  B70F 9F88 FB52 FAF7 B393
-
-The public key can be fetched from any GPG keyserver, but be careful: you must
-use the **full fingerprint** to check that you got the correct key.
-
 Links
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ Links
 * `Web-Chat (IRC) <http://webchat.freenode.net/?randomnick=1&channels=%23borgbackup&uio=MTY9dHJ1ZSY5PXRydWUa8>`_ and
   `Mailing List <https://mail.python.org/mailman/listinfo/borgbackup>`_
 * `License <https://borgbackup.readthedocs.org/en/stable/authors.html#license>`_
+* `Security contact <https://borgbackup.readthedocs.org/en/stable/support.html#security-contact>`_
 
 Compatibility notes
 -------------------
@@ -137,7 +138,7 @@ NOT RELEASED DEVELOPMENT VERSIONS HAVE UNKNOWN COMPATIBILITY PROPERTIES.
 
 THIS IS SOFTWARE IN DEVELOPMENT, DECIDE YOURSELF WHETHER IT FITS YOUR NEEDS.
 
-Security issues should be reported to the :ref:`security-contact` (or
+Security issues should be reported to the `Security contact`_ (or
 see ``docs/suppport.rst`` in the source distribution).
 
 |doc| |build| |coverage| |bestpractices|

--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,9 @@ NOT RELEASED DEVELOPMENT VERSIONS HAVE UNKNOWN COMPATIBILITY PROPERTIES.
 
 THIS IS SOFTWARE IN DEVELOPMENT, DECIDE YOURSELF WHETHER IT FITS YOUR NEEDS.
 
+Security issues should be reported to the :ref:`security-contact` (or
+see ``docs/suppport.rst`` in the source distribution).
+
 |doc| |build| |coverage| |bestpractices|
 
 .. |doc| image:: https://readthedocs.org/projects/borgbackup/badge/?version=stable

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -203,6 +203,13 @@ Thus:
 - have media at another place
 - have a relatively recent backup on your media
 
+How do I report security issue with |project_name|?
+---------------------------------------------------
+
+Send a private email to the :ref:`security-contact` if you think you
+have discovered a security issue. Please disclose security issues
+responsibly.
+
 Why do I get "connection closed by remote" after a while?
 ---------------------------------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -64,6 +64,9 @@ and compare that to our latest release and review the :doc:`changes`.
 Standalone Binary
 -----------------
 
+.. note:: Releases are signed with an OpenPGP key, see
+          :ref:`security-contact` for more instructions.
+
 |project_name| binaries (generated with `pyinstaller`_) are available
 on the releases_ page for the following platforms:
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -56,3 +56,21 @@ As a developer, you can become a Bounty Hunter and win bounties (earn money) by
 contributing to |project_name|, a free and open source software project.
 
 We might also use BountySource to fund raise for some bigger goals.
+
+.. _security-contact:
+
+Security
+--------
+
+In case you discover a security issue, please use this contact for reporting it privately
+and please, if possible, use encrypted E-Mail:
+
+Thomas Waldmann <tw@waldmann-edv.de>
+
+GPG Key Fingerprint: 6D5B EF9A DD20 7580 5747  B70F 9F88 FB52 FAF7 B393
+
+The public key can be fetched from any GPG keyserver, but be careful: you must
+use the **full fingerprint** to check that you got the correct key.
+
+`Releases <https://github.com/borgbackup/borg/releases>`_ are signed with this GPG key,
+please use GPG to verify their authenticity.


### PR DESCRIPTION
the rationale is to simplify the README file to the bare
minimum. security researchers will be able to find the contact
information if they look minimally and people installing the software
will find a link where relevant (in binary releases only, since all
the others have other trust paths)

reroll of #1798 against 1.0-maint