### PR TITLE
fix more issues with the PDF

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
-Borg Contributors ("The Borg Collective")
-=========================================
+Borg authors ("The Borg Collective")
+------------------------------------
 
 - Thomas Waldmann <tw@waldmann-edv.de>
 - Antoine Beaupré <anarcat@debian.org>

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,5 +1,8 @@
 .. include:: global.rst.inc
 
+Authors
+=======
+
 .. include:: ../AUTHORS
 
 License

--- a/docs/book.rst
+++ b/docs/book.rst
@@ -6,7 +6,7 @@ Borg documentation
 .. when you add an element here, do not forget to add it to index.rst
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
 
     introduction
     installation

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -521,7 +521,7 @@ Borg intends to be:
   * if major version number changes, it may have incompatible changes
 
 What are the differences between Attic and Borg?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 
 Borg is a fork of `Attic`_ and maintained by "`The Borg collective`_".
 


### PR DESCRIPTION
as agreed on IRC:

```
21:05:45 <ThomasWaldmann> anarcat: about the toc in the pdf:
21:06:04 <ThomasWaldmann> the x.y.z level in usage seems unwanted
21:06:49 <ThomasWaldmann> same for changelog (attic versions)
21:07:03 <anarcat> right, we could stick that to 2 levels
21:07:09 <anarcat> there's also a level error in the FAQ
21:07:57 <ThomasWaldmann> in "borg collective" it seems strange that 2nd and 3rd level only talks about attic
21:08:11 <ThomasWaldmann> so guess there is a borg headline missing
21:08:31 <ThomasWaldmann> also could drop 3rd level
21:08:38 <anarcat> ThomasWaldmann: maybe that should be just "Authors"
21:08:43 <anarcat> or "Credits"
21:09:18 <anarcat> i'll whip up something
21:09:39 <ThomasWaldmann> yes 12 Authors, 12.1 Borg Authors ("The Borg Collective") 12.2 Attic Authors
```