### PR TITLE
.gitattributes: Set python diff mode for all *.py files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 borg/_version.py export-subst
+
+*.py diff=python


### PR DESCRIPTION
Some tools like gitk need this for sensible word diffs.