### PR TITLE
Clarify prune behavior for different archive contents

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1536,6 +1536,8 @@ class Archiver:
         considered for deletion and only those archives count towards the totals
         specified by the rules.
         Otherwise, *all* archives in the repository are candidates for deletion!
+        There is no automatic distinction between archives representing different
+        contents. These need to be distinguished by specifying matching prefixes.
         """)
         subparser = subparsers.add_parser('prune', parents=[common_parser],
                                           description=self.do_prune.__doc__,


### PR DESCRIPTION
In the online help, explain that archives with different contents need to be
separated via the prefix when pruning to achieve a desired retention policy per
archive set.

Relates to #1824.