### PR TITLE
Fix check incorrectly reporting attic 0.13 and earlier archives as corrupt

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -1020,6 +1020,9 @@ class ArchiveChecker:
             def valid_item(obj):
                 if not isinstance(obj, StableDict):
                     return False
+                # A bug in Attic up to and including release 0.13 added a (meaningless) b'acl' key to every item.
+                # We ignore it here, should it exist. See test_attic013_acl_bug for details.
+                obj.pop(b'acl', None)
                 keys = set(obj)
                 return REQUIRED_ITEM_KEYS.issubset(keys) and keys.issubset(item_keys)
 

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -1017,14 +1017,21 @@ class ArchiveChecker:
                 self.error_found = True
                 logger.error(msg)
 
+            def list_keys_safe(keys):
+                return ', '.join((k.decode() if isinstance(k, bytes) else str(k) for k in keys))
+
             def valid_item(obj):
                 if not isinstance(obj, StableDict):
-                    return False
+                    return False, 'not a dictionary'
                 # A bug in Attic up to and including release 0.13 added a (meaningless) b'acl' key to every item.
                 # We ignore it here, should it exist. See test_attic013_acl_bug for details.
                 obj.pop(b'acl', None)
                 keys = set(obj)
-                return REQUIRED_ITEM_KEYS.issubset(keys) and keys.issubset(item_keys)
+                if not REQUIRED_ITEM_KEYS.issubset(keys):
+                    return False, 'missing required keys: ' + list_keys_safe(REQUIRED_ITEM_KEYS - keys)
+                if not keys.issubset(item_keys):
+                    return False, 'invalid keys: ' + list_keys_safe(keys - item_keys)
+                return True, ''
 
             i = 0
             for state, items in groupby(archive[b'items'], missing_chunk_detector):
@@ -1040,10 +1047,11 @@ class ArchiveChecker:
                     unpacker.feed(self.key.decrypt(chunk_id, cdata))
                     try:
                         for item in unpacker:
-                            if valid_item(item):
+                            valid, reason = valid_item(item)
+                            if valid:
                                 yield item
                             else:
-                                report('Did not get expected metadata dict when unpacking item metadata', chunk_id, i)
+                                report('Did not get expected metadata dict when unpacking item metadata (%s)' % reason, chunk_id, i)
                     except RobustUnpacker.UnpackerCrashed as err:
                         report('Unpacker crashed while unpacking item metadata, trying to resync...', chunk_id, i)
                         unpacker.resync()


### PR DESCRIPTION
Fixes #1837 for 1.0-maint