### PR TITLE
Fix tox/pybuild in 1.0-maint

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import sys
 
 import pytest
@@ -10,12 +11,10 @@ import pytest
 # The workaround is to remove entries pointing there from the path and check whether "borg"
 # is still importable. If it is not, then it has not been installed in the environment
 # and the entries are put back.
-#
-# TODO: After moving the package to src/: remove this.
 
 original_path = list(sys.path)
 for entry in original_path:
-    if entry == '' or entry.endswith('/borg'):
+    if entry == '' or entry == os.path.dirname(__file__):
         sys.path.remove(entry)
 
 try:


### PR DESCRIPTION
Fixes #1801 

Cherry pick of 4f1157c into 1.0-maint due to f3efcdb

TODO removed since we already did that after 1.0-maint, but 1.0-maint
will never receive the change.