### PR TITLE
check: catch two kinds of different repos

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -833,6 +833,9 @@ class ArchiveChecker:
         self.repair = repair
         self.repository = repository
         self.init_chunks()
+        if not self.chunks:
+            logger.error('Repository contains no apparent data at all, cannot continue check/repair.')
+            return False
         self.key = self.identify_key(repository)
         if Manifest.MANIFEST_ID not in self.chunks:
             logger.error("Repository manifest not found!")

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -438,6 +438,9 @@ class Repository:
             transaction_id = self.get_index_transaction_id()
         if transaction_id is None:
             transaction_id = self.io.get_latest_segment()
+        if transaction_id is None:
+            report_error('This repository contains no valid data.')
+            return False
         if repair:
             self.io.cleanup(transaction_id)
         segments_transaction_id = self.io.get_segments_transaction_id()

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -1444,6 +1444,13 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         self.cmd('check', self.repository_location, exit_code=0)
         self.cmd('extract', '--dry-run', self.repository_location + '::archive1', exit_code=0)
 
+    def test_empty_repository(self):
+        with Repository(self.repository_location, exclusive=True) as repository:
+            for id_ in repository.list():
+                repository.delete(id_)
+            repository.commit()
+        self.cmd('check', self.repository_location, exit_code=1)
+
 
 @pytest.mark.skipif(sys.platform == 'cygwin', reason='remote is broken on cygwin and hangs')
 class RemoteArchiverTestCase(ArchiverTestCase):


### PR DESCRIPTION
64a3fa8: no segments, no index. (or no committed segments and no index, if we'd have no committed segments but an index we can usually recover, the stick-a-commit-on-it technique).

2261709: no objects

Fixes #1815