### PR TITLE
Improve extract progress display, for #1721

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -547,6 +547,7 @@ class Archiver:
             if pattern.match_count == 0:
                 self.print_warning("Include pattern '%s' never matched.", pattern)
         if pi:
+            # clear progress output
             pi.finish()
         return self.exit_code
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -501,7 +501,7 @@ class Archiver:
 
         filter = self.build_filter(matcher, peek_and_store_hardlink_masters, strip_components)
         if progress:
-            pi = ProgressIndicatorPercent(msg='Extracting files %5.1f%%', step=0.1)
+            pi = ProgressIndicatorPercent(msg='%5.1f%% Extracting: %s', step=0.1)
             pi.output('Calculating size')
             extracted_size = sum(item.file_size(hardlink_masters) for item in archive.iter_items(filter))
             pi.total = extracted_size
@@ -546,6 +546,8 @@ class Archiver:
         for pattern in include_patterns:
             if pattern.match_count == 0:
                 self.print_warning("Include pattern '%s' never matched.", pattern)
+        if pi:
+            pi.finish()
         return self.exit_code
 
     @with_repository()

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1200,6 +1200,8 @@ def ellipsis_truncate(msg, space):
     from .platform import swidth
     ellipsis_width = swidth('...')
     msg_width = swidth(msg)
+    if space < 8:
+        return '...' + ' ' * (space - ellipsis_width)
     if space < ellipsis_width + msg_width:
         return '%s...%s' % (swidth_slice(msg, space // 2 - ellipsis_width),
                             swidth_slice(msg, -space // 2))
@@ -1262,10 +1264,7 @@ class ProgressIndicatorPercent:
                 terminal_space = get_terminal_size(fallback=(-1, -1))[0]
                 if terminal_space != -1:
                     space = terminal_space - len(self.msg % tuple([pct] + info[:-1] + ['']))
-                    if space < 8:
-                        info[-1] = ' ' * space
-                    else:
-                        info[-1] = ellipsis_truncate(info[-1], space)
+                    info[-1] = ellipsis_truncate(info[-1], space)
                 return self.output(self.msg % tuple([pct] + info), justify=False)
 
             return self.output(self.msg % pct)

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1193,11 +1193,11 @@ def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
 
 
 def ellipsis_truncate(msg, space):
-    from .platform import swidth
     """
     shorten a long string by adding ellipsis between it and return it, example:
     this_is_a_very_long_string -------> this_is..._string
     """
+    from .platform import swidth
     ellipsis_width = swidth('...')
     msg_width = swidth(msg)
     if space < ellipsis_width + msg_width:
@@ -1253,11 +1253,11 @@ class ProgressIndicatorPercent:
             self.trigger_at += self.step
             return pct
 
-    def show(self, current=None, increase=1, info=[]):
+    def show(self, current=None, increase=1, info=None):
         pct = self.progress(current, increase)
         if pct is not None:
-            # truncate the last argument, if space is available
-            if info != []:
+            # truncate the last argument, if no space is available
+            if info is not None:
                 msg = self.msg % tuple([pct] + info[:-1] + [''])
                 space = get_terminal_size()[0] - len(msg)
                 if space < 8:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1258,18 +1258,24 @@ class ProgressIndicatorPercent:
         if pct is not None:
             # truncate the last argument, if no space is available
             if info is not None:
-                msg = self.msg % tuple([pct] + info[:-1] + [''])
-                space = get_terminal_size()[0] - len(msg)
-                if space < 8:
-                    info[-1] = ''
-                else:
-                    info[-1] = ellipsis_truncate(info[-1], space)
-                return self.output(self.msg % tuple([pct] + info))
+                # no need to truncate if we're not outputing to a terminal
+                terminal_space = get_terminal_size(fallback=(-1, -1))[0]
+                if terminal_space != -1:
+                    space = terminal_space - len(self.msg % tuple([pct] + info[:-1] + ['']))
+                    if space < 8:
+                        info[-1] = ' ' * space
+                    else:
+                        info[-1] = ellipsis_truncate(info[-1], space)
+                return self.output(self.msg % tuple([pct] + info), justify=False)
 
             return self.output(self.msg % pct)
 
-    def output(self, message):
-        message = message.ljust(get_terminal_size(fallback=(4, 1))[0])
+    def output(self, message, justify=True):
+        if justify:
+            terminal_space = get_terminal_size(fallback=(-1, -1))[0]
+            # no need to ljust if we're not outputing to a terminal
+            if terminal_space != -1:
+                message = message.ljust(terminal_space)
         self.logger.info(message)
 
     def finish(self):

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1258,13 +1258,13 @@ class ProgressIndicatorPercent:
         if pct is not None:
             # truncate the last argument, if space is available
             if info != []:
-                msg = self.msg % (pct, *info[:-1], '')
+                msg = self.msg % tuple([pct] + info[:-1] + [''])
                 space = get_terminal_size()[0] - len(msg)
                 if space < 8:
                     info[-1] = ''
                 else:
                     info[-1] = ellipsis_truncate(info[-1], space)
-                return self.output(self.msg % (pct, *info))
+                return self.output(self.msg % tuple([pct] + info))
 
             return self.output(self.msg % pct)
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1201,6 +1201,7 @@ def ellipsis_truncate(msg, space):
     ellipsis_width = swidth('...')
     msg_width = swidth(msg)
     if space < 8:
+        # if there is very little space, just show ...
         return '...' + ' ' * (space - ellipsis_width)
     if space < ellipsis_width + msg_width:
         return '%s...%s' % (swidth_slice(msg, space // 2 - ellipsis_width),
@@ -1256,6 +1257,13 @@ class ProgressIndicatorPercent:
             return pct
 
     def show(self, current=None, increase=1, info=None):
+        """
+        Show and output the progress message
+
+        :param current: set the current percentage [None]
+        :param increase: increase the current percentage [None]
+        :param info: array of strings to be formatted with msg [None]
+        """
         pct = self.progress(current, increase)
         if pct is not None:
             # truncate the last argument, if no space is available

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -774,7 +774,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
         with changedir('output'):
             output = self.cmd('extract', self.repository_location + '::test', '--progress')
-            assert 'Extracting files' in output
+            assert 'Extracting:' in output
 
     def _create_test_caches(self):
         self.cmd('init', self.repository_location)

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -903,9 +903,10 @@ def test_yes_env_output(capfd, monkeypatch):
     assert 'yes' in err
 
 
-def test_progress_percentage_sameline(capfd):
-    os.environ['COLUMNS'] = '4'
-    os.environ['LINES'] = '1'
+def test_progress_percentage_sameline(capfd, monkeypatch):
+    # run the test as if it was in a 4x1 terminal
+    monkeypatch.setenv('COLUMNS', '4')
+    monkeypatch.setenv('LINES', '1')
     pi = ProgressIndicatorPercent(1000, step=5, start=0, msg="%3.0f%%")
     pi.logger.setLevel('INFO')
     pi.show(0)
@@ -923,7 +924,10 @@ def test_progress_percentage_sameline(capfd):
     assert err == ' ' * 4 + '\r'
 
 
-def test_progress_percentage_step(capfd):
+def test_progress_percentage_step(capfd, monkeypatch):
+    # run the test as if it was in a 4x1 terminal
+    monkeypatch.setenv('COLUMNS', '4')
+    monkeypatch.setenv('LINES', '1')
     pi = ProgressIndicatorPercent(100, step=2, start=0, msg="%3.0f%%")
     pi.logger.setLevel('INFO')
     pi.show()

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -904,6 +904,8 @@ def test_yes_env_output(capfd, monkeypatch):
 
 
 def test_progress_percentage_sameline(capfd):
+    os.environ['COLUMNS'] = '4'
+    os.environ['LINES'] = '1'
     pi = ProgressIndicatorPercent(1000, step=5, start=0, msg="%3.0f%%")
     pi.logger.setLevel('INFO')
     pi.show(0)


### PR DESCRIPTION
This changes the extract progress output to include the current file being extracted.
```bash
$ borg extract rep::archive -p
 42.0% Extracting: /answer/to/life/...verse/and/everything
```
This is made possible by making `ProgressIndicator` more flexible, it can take as many arguments for it's message format.

As suggested in #1721.