### PR TITLE
fixes for flake 3.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ def detect_libb2(prefixes):
                 if 'blake2b_init' in fd.read():
                     return prefix
 
+
 include_dirs = []
 library_dirs = []
 define_macros = []

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -672,6 +672,7 @@ def replace_placeholders(text):
     }
     return format_line(text, data)
 
+
 PrefixSpec = replace_placeholders
 
 
@@ -1668,6 +1669,7 @@ def scandir_generic(path='.'):
     """Like os.listdir(), but yield DirEntry objects instead of returning a list of names."""
     for name in sorted(os.listdir(path)):
         yield GenericDirEntry(path, name)
+
 
 try:
     from os import scandir

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -34,6 +34,7 @@ def acl_set(path, item, numeric_owner=False):
     of the user/group names
     """
 
+
 try:
     from os import lchflags
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ passenv = *
 [testenv:flake8]
 changedir =
 deps = flake8
-commands = flake8
+commands = flake8 src scripts conftest.py


### PR DESCRIPTION
our setup.py seems to trigger a false positive in flake8, so apart from applying one fix I also excluded it for now.

```
setup.py:143:1: E305 expected 2 blank lines after class or function definition, found 0

    138 
    139 
    140 include_dirs = []
    141 library_dirs = []
    142 define_macros = []
    143 crypto_libraries = ['crypto']
    144 
    145 possible_openssl_prefixes = ['/usr', '/usr/local', '/usr/local/opt/openssl', '/usr/local/ssl', '/usr/local/openssl',
    146                              '/usr/local/borg', '/opt/local', '/opt/pkg', ]
```