### PR TITLE
display README correctly on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Initialize a new backup repository and create a backup archive::
 
 Now doing another backup, just to show off the great deduplication:
 
-.. code-block:: none
+.. code-block::
 
     $ borg create -v --stats /path/to/repo::Saturday2 ~/Documents
     -----------------------------------------------------------------------------
@@ -141,6 +141,8 @@ THIS IS SOFTWARE IN DEVELOPMENT, DECIDE YOURSELF WHETHER IT FITS YOUR NEEDS.
 Security issues should be reported to the `Security contact`_ (or
 see ``docs/suppport.rst`` in the source distribution).
 
+.. start-badges
+
 |doc| |build| |coverage| |bestpractices|
 
 .. |doc| image:: https://readthedocs.org/projects/borgbackup/badge/?version=stable
@@ -162,3 +164,5 @@ see ``docs/suppport.rst`` in the source distribution).
 .. |bestpractices| image:: https://bestpractices.coreinfrastructure.org/projects/271/badge
         :alt: Best Practices Score
         :target: https://bestpractices.coreinfrastructure.org/projects/271
+
+.. end-badges

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,12 @@ if libb2_prefix:
 
 with open('README.rst', 'r') as fd:
     long_description = fd.read()
+    # remove badges
+    long_description = re.compile(r'^\.\. start-badges.*^\.\. end-badges', re.M | re.S).sub('', long_description)
+    # remove |substitutions|
+    long_description = re.compile(r'\|screencast\|').sub('', long_description)
+    # remove unknown directives
+    long_description = re.compile(r'^\.\. highlight:: \w+$', re.M).sub('', long_description)
 
 
 class build_usage(Command):


### PR DESCRIPTION
I have discovered that PyPI is way more sensitive to RST warnings than
other platforms: warnings and errors will make the document not show
up correctly, which is currently the case here:

https://pypi.python.org/pypi/borgbackup/

the suggested changes remove Sphinx-specific markup from the output,
namely the badges and `|replacement|` patterns, but also the
`higlight` directive. this also requires adding tags to the README to
mark the badges to remove and removal of the `none` argument for the
`.. code-block::` element which was not having any significant in
Sphinx anyways.