### PR TITLE
remove some unneeded test overriding methods

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1929,22 +1929,6 @@ class ArchiverTestCaseBinary(ArchiverTestCase):
     def test_init_interrupt(self):
         pass
 
-    @unittest.skip('patches objects')
-    def test_recreate_rechunkify_interrupt(self):
-        pass
-
-    @unittest.skip('patches objects')
-    def test_recreate_interrupt(self):
-        pass
-
-    @unittest.skip('patches objects')
-    def test_recreate_interrupt2(self):
-        pass
-
-    @unittest.skip('patches objects')
-    def test_recreate_changed_source(self):
-        pass
-
     @unittest.skip('test_basic_functionality seems incompatible with fakeroot and/or the binary.')
     def test_basic_functionality(self):
         pass


### PR DESCRIPTION
they are not there any more in the base class, so there is nothing to override.

@enkore ^^^