### PR TITLE
Clarify extract is relative to current directory

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -88,7 +88,7 @@ A step by step example
     -rw-r--r-- user   group       7961 Mon, 2016-02-15 18:22:30 home/user/Documents/Important.doc
     ...
 
-6. Restore the *Monday* archive::
+6. Restore the *Monday* archive by extracting the files relative to the current directory::
 
     $ borg extract /path/to/repo::Monday
 


### PR DESCRIPTION
I'm still hoping that a destination switch can be added (requested long ago in https://github.com/jborg/attic/issues/195), but in the meantime this may help. I'm guessing this clobbers any existing files.