### PR TITLE
partially remove virtualenv/pip version requirement, fixes #1738

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -31,9 +31,9 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             ;;
     esac
     pyenv rehash
-    python -m pip install --user 'virtualenv<14.0'
+    python -m pip install --user virtualenv
 else
-    pip install 'virtualenv<14.0'
+    pip install virtualenv
     sudo apt-get update
     sudo apt-get install -y liblz4-dev
     sudo apt-get install -y libacl1-dev

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-virtualenv<14.0
+virtualenv
 tox
 pytest
 pytest-cov


### PR DESCRIPTION
Is needed only for python 3.2 support.

For normal development, we expect you have py34+ for borg 1.1.

For vagrant, it is still needed because of older VMs like wheezy (py32).

Not needed for Travis-CI any more, we moved to trusty VMs (py34) there.