### PR TITLE
recreate fixes

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1528,7 +1528,7 @@ class ArchiveRecreater:
             # The target.chunker will read the file contents through ChunkIteratorFileWrapper chunk-by-chunk
             # (does not load the entire file into memory)
             file = ChunkIteratorFileWrapper(chunk_iterator)
-            return target.chunker.chunkify(file)
+            yield from target.chunker.chunkify(file)
         else:
             for chunk in chunk_iterator:
                 yield chunk.data

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1517,9 +1517,9 @@ class ArchiveRecreater:
             if Compressor.detect(old_chunk.data).name == compression_spec['name']:
                 # Stored chunk has the same compression we wanted
                 overwrite = False
-        chunk_id, size, csize = self.cache.add_chunk(chunk_id, chunk, target.stats, overwrite=overwrite)
-        self.seen_chunks.add(chunk_id)
-        return chunk_id, size, csize
+        chunk_entry = self.cache.add_chunk(chunk_id, chunk, target.stats, overwrite=overwrite)
+        self.seen_chunks.add(chunk_entry.id)
+        return chunk_entry
 
     def create_chunk_iterator(self, archive, target, chunks):
         """Return iterator of chunks to store for 'item' from 'archive' in 'target'."""

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1447,7 +1447,7 @@ class ArchiveRecreater:
             return True
         self.process_items(archive, target)
         replace_original = target_name is None
-        return self.save(archive, target, comment, replace_original=replace_original)
+        self.save(archive, target, comment, replace_original=replace_original)
 
     def process_items(self, archive, target):
         matcher = self.matcher

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1102,9 +1102,10 @@ class Archiver:
                     continue
                 print('Processing', name)
                 recreater.recreate(name, args.comment)
-        manifest.write()
-        repository.commit()
-        cache.commit()
+        if not args.dry_run:
+            manifest.write()
+            repository.commit()
+            cache.commit()
         return self.exit_code
 
     @with_repository(manifest=False, exclusive=True)
@@ -2387,8 +2388,8 @@ class Archiver:
 
         When rechunking space usage can be substantial, expect at least the entire
         deduplicated size of the archives using the previous chunker params.
-        When recompressing approximately 1 % of the repository size or 512 MB
-        (whichever is greater) of additional space is used.
+        When recompressing expect approx throughput / checkpoint-interval in space usage,
+        assuming all chunks are recompressed.
         """)
         subparser = subparsers.add_parser('recreate', parents=[common_parser], add_help=False,
                                           description=self.do_recreate.__doc__,

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1101,8 +1101,7 @@ class Archiver:
                 if recreater.is_temporary_archive(name):
                     continue
                 print('Processing', name)
-                if not recreater.recreate(name, args.comment):
-                    break
+                recreater.recreate(name, args.comment)
         manifest.write()
         repository.commit()
         cache.commit()

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2388,7 +2388,7 @@ class Archiver:
 
         When rechunking space usage can be substantial, expect at least the entire
         deduplicated size of the archives using the previous chunker params.
-        When recompressing expect approx throughput / checkpoint-interval in space usage,
+        When recompressing expect approx. (throughput / checkpoint-interval) in space usage,
         assuming all chunks are recompressed.
         """)
         subparser = subparsers.add_parser('recreate', parents=[common_parser], add_help=False,

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2355,6 +2355,8 @@ class Archiver:
         recreate_epilog = textwrap.dedent("""
         Recreate the contents of existing archives.
 
+        This is an *experimental* feature. Do *not* use this on your only backup.
+
         --exclude, --exclude-from and PATH have the exact same semantics
         as in "borg create". If PATHs are specified the resulting archive
         will only contain files from these PATHs.
@@ -2370,15 +2372,6 @@ class Archiver:
         --chunker-params will re-chunk all files in the archive, this can be
         used to have upgraded Borg 0.xx or Attic archives deduplicate with
         Borg 1.x archives.
-
-        borg recreate is signal safe. Send either SIGINT (Ctrl-C on most terminals) or
-        SIGTERM to request termination.
-
-        Use the *exact same* command line to resume the operation later - changing excludes
-        or paths will lead to inconsistencies (changed excludes will only apply to newly
-        processed files/dirs). Changing compression leads to incorrect size information
-        (which does not cause any data loss, but can be misleading).
-        Changing chunker params between invocations might lead to data loss.
 
         USE WITH CAUTION.
         Depending on the PATHs and patterns given, recreate can be used to permanently

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1823,6 +1823,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('recreate', self.repository_location, '--chunker-params', 'default')
         self.check_cache()
         # test1 and test2 do deduplicate after recreate
+        assert int(self.cmd('list', self.repository_location + '::test1', 'input/large_file', '--format={size}'))
         assert not int(self.cmd('list', self.repository_location + '::test1', 'input/large_file',
                                 '--format', '{unique_chunks}'))
 


### PR DESCRIPTION
Fixes #1920 #1919 #1913

#1920 was introduced in 93b03ea2310. Previously the function always returned an iterator (a3ee9d2c). In 93b03ea I rewrote it to *be* the iterator, without also modifying the second code path to conform. This was not noticed because the test for this code path was broken, and because I did not take a closer look at the resulting archives during manual testing. Just using `recreate ... --stats` would have already shown that something was amiss.

#1919 was overlooked when removing the signal processing stuff. Archiver.do_recreate used the return value to exit should a signal be received; these returns where removed, but the if in do_recreate was not updated.