### PR TITLE
Added --export-file flag to the info command 

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -373,10 +373,9 @@ Number of files: {0.stats.nfiles}'''.format(
         del self.manifest.archives[self.checkpoint_name]
         self.cache.chunk_decref(self.id, self.stats)
 
-
     def get_summary(self):
-        summary = namedtuple('Summary', ['name','fingerprint', 'comment',
-        'hostname','username','time_start','time_end','duration','command_line'])
+        summary = namedtuple('Summary', ['name', 'fingerprint', 'comment',
+        'hostname', 'username', 'time_start', 'time_end', 'duration', 'command_line'])
         return summary(*self.summarize())._asdict()
 
     def summarize(self):

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -4,6 +4,7 @@ import socket
 import stat
 import sys
 import time
+from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from functools import partial
@@ -60,6 +61,13 @@ class Statistics:
             self.usize += csize
 
     summary = "{label:15} {stats.osize_fmt:>20s} {stats.csize_fmt:>20s} {stats.usize_fmt:>20s}"
+
+    def get_summary(self):
+        summary = namedtuple('Summary', ['original_size', 'compressed_size', 'unique_size', 'number_files'])
+        return summary(*self.summarize())._asdict()
+
+    def summarize(self):
+        return self.osize, self.csize, self.usize, self.nfiles
 
     def __str__(self):
         return self.summary.format(stats=self, label='This archive:')
@@ -364,6 +372,17 @@ Number of files: {0.stats.nfiles}'''.format(
         self.save(self.checkpoint_name)
         del self.manifest.archives[self.checkpoint_name]
         self.cache.chunk_decref(self.id, self.stats)
+
+
+    def get_summary(self):
+        summary = namedtuple('Summary', ['name','fingerprint', 'comment',
+        'hostname','username','time_start','time_end','duration','command_line'])
+        return summary(*self.summarize())._asdict()
+
+    def summarize(self):
+        return [self.name, self.fpr, self.metadata.get('comment', ''),
+        self.metadata.hostname, self.metadata.username, format_time(to_localtime(self.ts)),
+        format_time(to_localtime(self.ts_end)), self.duration_from_meta, self.metadata.cmdline]
 
     def save(self, name=None, comment=None, timestamp=None, additional_metadata=None):
         name = name or self.name

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -928,7 +928,7 @@ class Archiver:
         else:
             return self._info_repository(repository, key, cache, args.export_file)
 
-    def _info_archives(self, args, repository, manifest, key, cache, export_file = None):
+    def _info_archives(self, args, repository, manifest, key, cache, export_file=None):
         def format_cmdline(cmdline):
             return remove_surrogates(' '.join(shlex.quote(x) for x in cmdline))
 
@@ -951,9 +951,9 @@ class Archiver:
 
             if export_file:
                 archive_info = {
-                    'metadata' : archiveSummary,
-                    'stats' : statsSummary,
-                    'cache' : cacheSummary,
+                    'metadata': archiveSummary,
+                    'stats': statsSummary,
+                    'cache': cacheSummary,
                 }
                 archives.append(archive_info)
             print('Archive name: %s' % archiveSummary['name'])
@@ -979,7 +979,7 @@ class Archiver:
             export_data(archives, export_file)
         return self.exit_code
 
-    def _info_repository(self, repository, key, cache, export_file = None):
+    def _info_repository(self, repository, key, cache, export_file=None):
         print('Repository ID: %s' % bin_to_hex(repository.id))
         if key.NAME == 'plaintext':
             encrypted = 'No'
@@ -996,14 +996,14 @@ class Archiver:
         print(str(cache))
 
         if export_file:
-            repository_info ={
-                'encripted' : encrypted,
-                'key_file' : key.find_key(),
-                'security_dir' : cache.security_manager.dir,
-                'cache_dir' : cache.path,
-                'cache_info' : cache.get_summary()
+            repository_info = {
+                'encripted': encrypted,
+                'key_file': key.find_key(),
+                'security_dir': cache.security_manager.dir,
+                'cache_dir': cache.path,
+                'cache_info': cache.get_summary()
             }
-            export_data(repository_info,export_file)
+            export_data(repository_info, export_file)
 
         return self.exit_code
 

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -219,6 +219,10 @@ All archives:   {0.total_size:>20s} {0.total_csize:>20s} {0.unique_csize:>20s}
 Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         return fmt.format(self.format_tuple())
 
+    def get_summary(self):
+        Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks', 'total_chunks'])
+        return Summary(*self.chunks.summarize())._asdict()
+
     def format_tuple(self):
         # XXX: this should really be moved down to `hashindex.pyx`
         Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks', 'total_chunks'])

--- a/src/borg/exporter.py
+++ b/src/borg/exporter.py
@@ -1,0 +1,7 @@
+import json
+
+def export_data(data, path):
+    """ Method to export data to a specific path
+    """
+    with open(path, 'w') as output:
+        json.dump(data,output)

--- a/src/borg/exporter.py
+++ b/src/borg/exporter.py
@@ -1,7 +1,8 @@
 import json
 
+
 def export_data(data, path):
     """ Method to export data to a specific path
     """
     with open(path, 'w') as output:
-        json.dump(data,output)
+        json.dump(data, output)


### PR DESCRIPTION
#1812 
Added `--export-file` flag to the `borg info` command in order to export repository or archive information encoded as a json file. 

The exporter.py file was added to separate concepts, making it easly in the future to add some new export formats and related stuff, but let me know what you guys think about that. 