### PR TITLE
pytest: only rewrite the testsuite, fixes #1938

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 # needed to get pretty assertion failures in unit tests:
-pytest.register_assert_rewrite('borg')
+pytest.register_assert_rewrite('borg.testsuite')
 
 # This is a hack to fix path problems because "borg" (the package) is in the source root.
 # When importing the conftest an "import borg" can incorrectly import the borg from the


### PR DESCRIPTION
do not rewrite the borg application code, just the test code,
so the bytecode tested is identical / very close to the bytecode used in practice.

@RonnyPfannschmidt ^^

Hopefully it's better now, it was a bit unclear to me what you actually meant by "test helpers".

note: testsuite.helpers are not test helpers, but the tests for borg.helpers.