### PR TITLE
catch errno.ENOSYS for mknod (win 10 lxsys)

### DIFF
--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -311,7 +311,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         except PermissionError:
             have_root = False
         except OSError as e:
-            if e.errno != errno.EINVAL:
+            # Note: ENOSYS "Function not implemented" happens as non-root on Win 10 Linux Subsystem.
+            if e.errno not in (errno.EINVAL, errno.ENOSYS):
                 raise
             have_root = False
         return have_root


### PR DESCRIPTION
mknod raises this when running as non-root under Windows 10's Linux Subsystem.