### PR TITLE
Fix upgrade --tam, change-passphrase crashes if not encrypted

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -182,6 +182,9 @@ class Archiver:
             return EXIT_ERROR
         key.change_passphrase()
         logger.info('Key updated')
+        if hasattr(key, 'find_key'):
+            # print key location to make backing it up easier
+            logger.info('Key location: %s', key.find_key())
         return EXIT_SUCCESS
 
     @with_repository(lock=False, exclusive=False, manifest=False, cache=False)

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -177,6 +177,9 @@ class Archiver:
     @with_repository()
     def do_change_passphrase(self, args, repository, manifest, key):
         """Change repository key file passphrase"""
+        if not hasattr(key, 'change_passphrase'):
+            print('This repository is not encrypted, cannot change the passphrase.')
+            return EXIT_ERROR
         key.change_passphrase()
         logger.info('Key updated')
         return EXIT_SUCCESS

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -730,6 +730,10 @@ class Archiver:
         if args.tam:
             manifest, key = Manifest.load(repository, force_tam_not_required=args.force)
 
+            if not hasattr(key, 'change_passphrase'):
+                print('This repository is not encrypted, cannot enable TAM.')
+                return EXIT_ERROR
+
             if not manifest.tam_verified or not manifest.config.get(b'tam_required', False):
                 # The standard archive listing doesn't include the archive ID like in borg 1.1.x
                 print('Manifest contents:')

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -133,6 +133,8 @@ Bug fixes:
 
 - Avoid triggering an ObjectiveFS bug in xattr retrieval, #1992
 - When running out of buffer memory when reading xattrs, only skip the current file, #1993
+- Fixed "borg upgrade --tam" crashing with unencrypted repositories. Since :ref:`the issue <tam_vuln>` is
+  not relevant for unencrypted repositories, it now does nothing and prints an error, #1981.
 
 Version 1.0.9 (2016-12-20)
 --------------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -135,6 +135,7 @@ Bug fixes:
 - When running out of buffer memory when reading xattrs, only skip the current file, #1993
 - Fixed "borg upgrade --tam" crashing with unencrypted repositories. Since :ref:`the issue <tam_vuln>` is
   not relevant for unencrypted repositories, it now does nothing and prints an error, #1981.
+- Fixed change-passphrase crashing with unencrypted repositories, #1978
 
 Version 1.0.9 (2016-12-20)
 --------------------------


### PR DESCRIPTION
Fixes #1981 #1978