### PR TITLE
check: fail if single archive does not exist

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -1100,8 +1100,12 @@ class ArchiveChecker:
                                    key=lambda name_info: name_info[1][b'time'])
             if prefix is not None:
                 archive_items = [item for item in archive_items if item[0].startswith(prefix)]
+                if not archive_items:
+                    logger.warning('--prefix %s does not match any archives', prefix)
             num_archives = len(archive_items)
             end = None if last is None else min(num_archives, last)
+            if last is not None and end < last:
+                logger.warning('--last %d archives: only found %d archives', last, end)
         else:
             # we only want one specific archive
             archive_items = [item for item in self.manifest.archives.items() if item[0] == archive]

--- a/borg/archive.py
+++ b/borg/archive.py
@@ -1107,6 +1107,10 @@ class ArchiveChecker:
             archive_items = [item for item in self.manifest.archives.items() if item[0] == archive]
             num_archives = 1
             end = 1
+            if not archive_items:
+                logger.error('Archive %s does not exist', archive)
+                self.error_found = True
+                return
 
         with cache_if_remote(self.repository) as repository:
             for i, (name, info) in enumerate(archive_items[:end]):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -136,6 +136,7 @@ Bug fixes:
 - Fixed "borg upgrade --tam" crashing with unencrypted repositories. Since :ref:`the issue <tam_vuln>` is
   not relevant for unencrypted repositories, it now does nothing and prints an error, #1981.
 - Fixed change-passphrase crashing with unencrypted repositories, #1978
+- Fixed "borg check repo::archive" indicating success if "archive" does not exist, #1997
 
 Version 1.0.9 (2016-12-20)
 --------------------------


### PR DESCRIPTION
Fixes #1997 

I didn't change the other branch to issue a warning/error if --prefix doesn't match anything or if there are not >=N archives with --last N because this might actually break scripts.

Edit: Made the described cases print a warning but nothing else (esp. not an exit code).