### PR TITLE
Docs: language clarification - VM backup FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,7 +13,7 @@ Yes, the `deduplication`_ technique used by
 Also, we have optional simple sparse file support for extract.
 
 If you use non-snapshotting backup tools like Borg to back up virtual machines,
-then these should be turned off for doing so. Backing up live VMs this way can (and will)
+then the VMs should be turned off for the duration of the backup. Backing up live VMs can (and will)
 result in corrupted or inconsistent backup contents: a VM image is just a regular file to
 Borg with the same issues as regular files when it comes to concurrent reading and writing from
 the same file.


### PR DESCRIPTION
Patch speaks for itself.  Just a very minor cleanup of some language I tripped on while reading the FAQ.  The for/before replacement being the most important part.
