### PR TITLE
posix: use fully-qualified hostname + node ID

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -48,7 +48,7 @@ from .helpers import ProgressIndicatorPercent
 from .item import Item
 from .key import key_creator, tam_required_file, tam_required, RepoKey, PassphraseKey
 from .keymanager import KeyManager
-from .platform import get_flags, umount
+from .platform import get_flags, umount, get_process_id
 from .remote import RepositoryServer, RemoteRepository, cache_if_remote
 from .repository import Repository
 from .selftest import selftest
@@ -1194,6 +1194,7 @@ class Archiver:
 
         # Additional debug information
         print('CRC implementation:', crc32.__name__)
+        print('Process ID:', get_process_id())
         return EXIT_SUCCESS
 
     @with_repository()

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -1,11 +1,13 @@
 import errno
 import os
+import uuid
 import socket
 import subprocess
 
 
 cdef extern from "wchar.h":
     cdef int wcswidth(const Py_UNICODE *str, size_t n)
+
 
 def swidth(s):
     str_len = len(s)
@@ -21,7 +23,7 @@ def swidth(s):
 # the lock made by the parent, so it needs to use the same PID for that.
 _pid = os.getpid()
 # XXX this sometimes requires live internet access for issuing a DNS query in the background.
-_hostname = socket.gethostname()
+_hostname = '%s@%s' % (socket.getfqdn(), uuid.getnode())
 
 
 def get_process_id():
@@ -75,5 +77,3 @@ def local_pid_alive(pid):
 # most POSIX platforms (but not Linux)
 def umount(mountpoint):
     return subprocess.call(['umount', mountpoint])
-
-


### PR DESCRIPTION
The node ID is usually the 48 bit MAC of the primary network
interface.

This pretty much kills off any possibility of colliding hostnames unless one is bent on doing that (same hostnames, spoofing MAC etc.).