### PR TITLE
F/debug remote

### DIFF
--- a/borg/remote.py
+++ b/borg/remote.py
@@ -13,8 +13,11 @@ from . import __version__
 from .helpers import Error, IntegrityError, sysinfo
 from .helpers import replace_placeholders
 from .repository import Repository
+from .logger import create_logger
 
 import msgpack
+
+logger = create_logger(__name__)
 
 RPC_PROTOCOL_VERSION = 2
 
@@ -185,6 +188,7 @@ class RemoteRepository:
             env.pop('LD_LIBRARY_PATH', None)
         env.pop('BORG_PASSPHRASE', None)  # security: do not give secrets to subprocess
         env['BORG_VERSION'] = __version__
+        logger.debug('SSH command line: %s', borg_cmd)
         self.p = Popen(borg_cmd, bufsize=0, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env)
         self.stdin_fd = self.p.stdin.fileno()
         self.stdout_fd = self.p.stdout.fileno()


### PR DESCRIPTION
```
$ borg ...
Got unexpected RPC data format from server:
This account is currently not available.

zsh: exit 2
$ borg ...
Got unexpected RPC data format from server:
b"a[\xe2\xe6\x04\x1c\n\x95\x9ffV1\xbbj\xaf\x87\x1dW\xba4@p\x04U\x85kl\x08^j\xda\x
8ds\x8a\x98\x08a'\x9cvG\xc5\nV\xbc\xb0|\xdd\xa2\x9e\x1fn\x03\n\x12;&\xfd\xa9\xe9\x
04\x16\xc8Q^\xc4\xc8@ Az\x0c\x10\xba\xbb\xd8?d\x96E\x10^\xf3\xbb,\xcc\x97\x97#\x
dd\xbb#\xf3\x941\xb1#\x03d\x83"
zsh: exit 2
```

(The cmd line log format is rather plain, but is also "extremely accurate"; could also do ' '.join(shlex.quote(s) for s in cmdline) but that can be harder to interpret in difficult cases)