### PR TITLE
API_VERSION: use numberspaces, fixes #2023

### DIFF
--- a/borg/chunker.pyx
+++ b/borg/chunker.pyx
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-API_VERSION = 2
+API_VERSION = '1.0_01'
 
 from libc.stdlib cimport free
 

--- a/borg/crypto.pyx
+++ b/borg/crypto.pyx
@@ -8,7 +8,7 @@ from math import ceil
 
 from libc.stdlib cimport malloc, free
 
-API_VERSION = 3
+API_VERSION = '1.0_01'
 
 cdef extern from "openssl/rand.h":
     int  RAND_bytes(unsigned char *buf, int num)

--- a/borg/hashindex.pyx
+++ b/borg/hashindex.pyx
@@ -4,7 +4,7 @@ import os
 cimport cython
 from libc.stdint cimport uint32_t, UINT32_MAX, uint64_t
 
-API_VERSION = 3
+API_VERSION = '1.0_01'
 
 
 cdef extern from "_hashindex.c":

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -88,13 +88,13 @@ class PlaceholderError(Error):
 
 def check_extension_modules():
     from . import platform
-    if hashindex.API_VERSION != 3:
+    if hashindex.API_VERSION != '1.0_01':
         raise ExtensionModuleError
-    if chunker.API_VERSION != 2:
+    if chunker.API_VERSION != '1.0_01':
         raise ExtensionModuleError
-    if crypto.API_VERSION != 3:
+    if crypto.API_VERSION != '1.0_01':
         raise ExtensionModuleError
-    if platform.API_VERSION != 3:
+    if platform.API_VERSION != '1.0_01':
         raise ExtensionModuleError
 
 

--- a/borg/platform.py
+++ b/borg/platform.py
@@ -30,7 +30,7 @@ elif sys.platform.startswith('freebsd'):  # pragma: freebsd only
 elif sys.platform == 'darwin':  # pragma: darwin only
     from .platform_darwin import acl_get, acl_set, API_VERSION
 else:  # pragma: unknown platform only
-    API_VERSION = 3
+    API_VERSION = '1.0_01'
 
     def acl_get(path, item, st, numeric_owner=False):
         pass

--- a/borg/platform_darwin.pyx
+++ b/borg/platform_darwin.pyx
@@ -1,7 +1,7 @@
 import os
 from .helpers import user2uid, group2gid, safe_decode, safe_encode
 
-API_VERSION = 3
+API_VERSION = '1.0_01'
 
 cdef extern from "sys/acl.h":
     ctypedef struct _acl_t:

--- a/borg/platform_freebsd.pyx
+++ b/borg/platform_freebsd.pyx
@@ -1,7 +1,7 @@
 import os
 from .helpers import posix_acl_use_stored_uid_gid, safe_encode, safe_decode
 
-API_VERSION = 3
+API_VERSION = '1.0_01'
 
 cdef extern from "errno.h":
     int errno

--- a/borg/platform_linux.pyx
+++ b/borg/platform_linux.pyx
@@ -4,7 +4,7 @@ import subprocess
 from stat import S_ISLNK
 from .helpers import posix_acl_use_stored_uid_gid, user2uid, group2gid, safe_decode, safe_encode
 
-API_VERSION = 3
+API_VERSION = '1.0_01'
 
 cdef extern from "sys/types.h":
     int ACL_TYPE_ACCESS


### PR DESCRIPTION
like '<numberspace>_<version>', e.g. '1.0_01' for version 01 (used in 1.0 maintenance branch).

this avoids overlap and accidental collisions between different release branches.