### PR TITLE
WIP: posix platform module: only build / import on non-win32 platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,7 @@ if not on_rtd:
     Extension('borg.item', [item_source]),
     Extension('borg.crc32', [crc32_source]),
 ]
-    if sys.platform.startswith(('linux', 'freebsd', 'darwin')):
+    if not sys.platform.startswith(('win32', )):
         ext_modules.append(Extension('borg.platform.posix', [platform_posix_source]))
 
     if sys.platform == 'linux':

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -10,10 +10,13 @@ from .base import acl_get, acl_set
 from .base import set_flags, get_flags
 from .base import SaveFile, SyncFile, sync_dir, fdatasync
 from .base import swidth, umount, API_VERSION
-from .posix import process_alive, get_process_id, local_pid_alive
-
+from .base import process_alive, get_process_id, local_pid_alive
 
 OS_API_VERSION = API_VERSION
+
+if not sys.platform.startswith(('win32', )):
+    from .posix import process_alive, get_process_id, local_pid_alive
+
 if sys.platform.startswith('linux'):  # pragma: linux only
     from .linux import API_VERSION as OS_API_VERSION
     from .linux import acl_get, acl_set

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -162,3 +162,23 @@ def swidth(s):
 def umount(mountpoint):
     """un-mount the FUSE filesystem mounted at <mountpoint>"""
     return 0  # dummy, see also posix module
+
+
+def get_process_id():
+    """
+    Return identification tuple (hostname, pid, thread_id) for 'us'. If this is a FUSE process, then the PID will be
+    that of the parent, not the forked FUSE child.
+    """
+    raise NotImplementedError
+
+
+def process_alive(host, pid, thread):
+    """
+    Check if the (host, pid, thread_id) combination corresponds to a potentially alive process.
+    """
+    raise NotImplementedError
+
+
+def local_pid_alive(pid):
+    """Return whether *pid* is alive."""
+    raise NotImplementedError


### PR DESCRIPTION
fixes #2041

rather use a inverted check like "not windows".
also: add a base implementation for this stuff, just raising NotImplementedError
