### PR TITLE
crc: openbsd has no Intel intrinsics

### DIFF
--- a/src/borg/_crc32/crc32.c
+++ b/src/borg/_crc32/crc32.c
@@ -8,6 +8,11 @@
  * target attributes or the options stack. So we disable this faster code path for clang.
  */
 #ifndef __clang__
+/*
+ * While OpenBSD uses GCC, they don't have Intel intrinsics, so we can't compile this code
+ * on OpenBSD.
+ */
+#ifndef __OpenBSD__
 #if __x86_64__
 /*
  * Because we don't want a configure script we need compiler-dependent pre-defined macros for detecting this,
@@ -59,6 +64,7 @@
 #endif
 
 #endif /* if __x86_64__ */
+#endif /* ifndef __OpenBSD__ */
 #endif /* ifndef __clang__ */
 #endif /* ifdef __GNUC__ */
 


### PR DESCRIPTION
Fixes #2043 

Fixes OpenBSD build, when #2045 is applied as well. `700 passed, 176 skipped, 2 xfailed, 1 pytest-warnings in 269.22 seconds`