### PR TITLE
add pip and setuptools to requirements file, fixes #2030

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,3 +1,5 @@
+setuptools
+pip
 virtualenv<14.0
 tox
 pytest


### PR DESCRIPTION
sometimes the system pip/setuptools is rather old and causes
warnings or malfunctions in the primary virtual env.