### PR TITLE
pytest -n 4 as default (4 parallel workers)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
      -rrequirements.d/development.txt
      -rrequirements.d/attic.txt
      -rrequirements.d/fuse.txt
-commands = py.test -n {env:XDISTN:auto} -rs --cov=borg --cov-config=../.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
+commands = py.test -n {env:XDISTN:4} -rs --cov=borg --cov-config=../.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:
 passenv = *
 


### PR DESCRIPTION
auto does not produce enough load, e.g. on freebsd64 vagrant VM,
cpu is 80-90% idle (1 core == 1 parallel tox worker).
