### PR TITLE
travis: use latest pythons for OS X based testing

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,12 +21,12 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     case "${TOXENV}" in
         py34)
-            pyenv install 3.4.3
-            pyenv global 3.4.3
+            pyenv install 3.4.5
+            pyenv global 3.4.5
             ;;
         py35)
-            pyenv install 3.5.1
-            pyenv global 3.5.1
+            pyenv install 3.5.2
+            pyenv global 3.5.2
             ;;
         py36)
             pyenv install 3.6.0


### PR DESCRIPTION
we test on old pythons (3.x.0) on Linux, so we can test on 3.x.latest on OS X.