### PR TITLE
detect mingw byte order

### DIFF
--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -13,10 +13,12 @@
 #endif
 
 #if (defined(BYTE_ORDER)&&(BYTE_ORDER == BIG_ENDIAN)) ||  \
+    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \
     (defined(_BIG_ENDIAN)&&defined(__SVR4)&&defined(__sun))
 #define _le32toh(x) __builtin_bswap32(x)
 #define _htole32(x) __builtin_bswap32(x)
 #elif (defined(BYTE_ORDER)&&(BYTE_ORDER == LITTLE_ENDIAN)) || \
+      (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || \
       (defined(_LITTLE_ENDIAN)&&defined(__SVR4)&&defined(__sun))
 #define _le32toh(x) (x)
 #define _htole32(x) (x)

--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -12,18 +12,24 @@
 #include <sys/isa_defs.h>
 #endif
 
-#if (defined(BYTE_ORDER)&&(BYTE_ORDER == BIG_ENDIAN)) ||  \
+#if (defined(BYTE_ORDER) && (BYTE_ORDER == BIG_ENDIAN)) ||  \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || \
-    (defined(_BIG_ENDIAN)&&defined(__SVR4)&&defined(__sun))
-#define _le32toh(x) __builtin_bswap32(x)
-#define _htole32(x) __builtin_bswap32(x)
-#elif (defined(BYTE_ORDER)&&(BYTE_ORDER == LITTLE_ENDIAN)) || \
+    (defined(_BIG_ENDIAN) && defined(__SVR4)&&defined(__sun))
+#define BORG_BIG_ENDIAN 1
+#elif (defined(BYTE_ORDER) && (BYTE_ORDER == LITTLE_ENDIAN)) || \
       (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) || \
-      (defined(_LITTLE_ENDIAN)&&defined(__SVR4)&&defined(__sun))
-#define _le32toh(x) (x)
-#define _htole32(x) (x)
+      (defined(_LITTLE_ENDIAN) && defined(__SVR4)&&defined(__sun))
+#define BORG_BIG_ENDIAN 0
 #else
 #error Unknown byte order
+#endif
+
+#if BORG_BIG_ENDIAN
+#define _le32toh(x) __builtin_bswap32(x)
+#define _htole32(x) __builtin_bswap32(x)
+#else
+#define _le32toh(x) (x)
+#define _htole32(x) (x)
 #endif
 
 #define MAGIC "BORG_IDX"


### PR DESCRIPTION
Fixes #2073

@oroppas feel free to check if this actually fixes it (although I have little doubt)

657ecfd aimed at master (crc, hashindex dedup).