### PR TITLE
creating a new segment: use "xb" mode, fixes #2099

### DIFF
--- a/borg/repository.py
+++ b/borg/repository.py
@@ -670,7 +670,8 @@ class LoggedIO:
                 if not os.path.exists(dirname):
                     os.mkdir(dirname)
                     sync_dir(os.path.join(self.path, 'data'))
-            self._write_fd = open(self.segment_filename(self.segment), 'ab')
+            # play safe: fail if file exists (do not overwrite existing contents, do not append)
+            self._write_fd = open(self.segment_filename(self.segment), 'xb')
             self._write_fd.write(MAGIC)
             self.offset = MAGIC_LEN
         return self._write_fd


### PR DESCRIPTION
"ab" seems to make no sense here (if there is already a (crap, but non-empty) segment file,
we would write a MAGIC right into the middle of the resulting file) and cause #2099.

WIP, it is not sure yet that this is the right fix. It would naturally fix the magic being written into the middle of the file, but also kill previous file content. If that content was only from some (uncommitted) crap segment (of an aborted transaction), that might be valid. If not, maybe not - needs more code review.

The unit tests worked (before and after this change).