### PR TITLE
Add 'debug dump-manifest' and 'debug dump-archive' commands.

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3,6 +3,7 @@ from configparser import ConfigParser
 import errno
 import os
 import inspect
+import json
 from datetime import datetime
 from datetime import timedelta
 from io import StringIO
@@ -2019,6 +2020,35 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
  1: 616263 646566 676869 6a6b6c 6d6e6f 707172 - 6d
  2: 737475 - 88
 """
+
+    def test_debug_dump_manifest(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        dump_file = self.output_path + '/dump'
+        output = self.cmd('debug', 'dump-manifest', self.repository_location, dump_file)
+        assert output == ""
+        with open(dump_file, "r") as f:
+            result = json.load(f)
+        assert 'archives' in result
+        assert 'config' in result
+        assert 'item_keys' in result
+        assert 'timestamp' in result
+        assert 'version' in result
+
+    def test_debug_dump_archive(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        dump_file = self.output_path + '/dump'
+        output = self.cmd('debug', 'dump-archive', self.repository_location + "::test", dump_file)
+        assert output == ""
+        with open(dump_file, "r") as f:
+            result = json.load(f)
+        assert '_name' in result
+        assert '_manifest_entry' in result
+        assert '_meta' in result
+        assert '_items' in result
 
 
 @unittest.skipUnless('binary' in BORG_EXES, 'no borg.exe available')


### PR DESCRIPTION
This adds two new commands for low level debugging and maybe analysis. These are debug commands without stability guarantees.

The output is the decrypted contents of the manifest translated from msgpack to json for manifest and similar for archive. For archive the json has a synthetic top level object that combines the metadata from the manifest about the archive with the archive msgpack item and the items stream.

I don‘t think this will duplicate #1946 / #1812 as those are meant to be a nice and higher level interface while this is a debugging and development aid.

```
# borg debug dump-manifest /tmp/borg-repo /dev/stdout
{
    "item_keys": [
        "acl_access",
        "acl_default",
        "acl_extended",
        "acl_nfs4",
        "atime",
        "bsdflags",
        "chunks",
        "chunks_healthy",
        "ctime",
        "gid",
        "group",
        "hardlink_master",
        "mode",
        "mtime",
        "part",
        "path",
        "rdev",
        "source",
        "uid",
        "user",
        "xattrs"
    ],
    "archives": {
        "test1": {
            "time": "2017-01-29T16:36:23.687059",
            "id": "\u007fea93c330cd9782770f0c02c9799e408a8a3b8a182a834fbb34bc4eeecf470466"
        }
    },
    "tam": {
        "type": "HKDF_HMAC_SHA512",
        "hmac": "\u007f8874645345ee77804b78e833a23c91c98086d3f2381036e44c5d7e94947637446cd8166605da454144ad507f8e2b8ea7e4b64e598da3958e67215e62f06fa6d8",
        "salt": "\u007f4ae27b21b7b209664e413ce84c83a772132effd0a7d68fedf77f69dc52b4457e08e91b8aba38494bd9f0921698f92ac5dde8db2a843b6ea4d40747de078e2adf"
    },
    "version": 1,
    "config": {},
    "timestamp": "2017-01-29T16:36:23.728885"
}
```

and

```
# borg debug dump-archive /tmp/borg-repo::test1 /dev/stdout
{
    "id": "\u007fea93c330cd9782770f0c02c9799e408a8a3b8a182a834fbb34bc4eeecf470466",
    "time": "2017-01-29T16:36:23.687059",
    "_name": "test1",
    "_meta": {
        "username": "martin",
        "version": 1,
        "name": "test1",
        "time": "2017-01-29T16:36:23.687059",
        "items": [
            "\u007f8b57530fda213ee55c4ffb7d6ee661977987aa80e0069264efb6e8297a123006"
        ],
        "cmdline": [
            "/home/martin/git/borg/borg-env/bin/borg",
            "create",
            "/tmp/borg-repo::test1",
            "tox.ini"
        ],
        "hostname": "martin",
        "time_end": "2017-01-29T16:36:23.728687",
        "comment": "",
        "chunker_params": [
            19,
            23,
            21,
            4095
        ],
        "tam": {
            "type": "HKDF_HMAC_SHA512",
            "hmac": "\u007fc56cf2a15b44cf6ae410de60a22653597ab2c122dd571039a0955bb518bfc492314ce7dffe69864a374690e77ee97e0db9d585d13a8da3ac1c0b39563c2a8bd4",
            "salt": "\u007fdb57ccdb2acd3a6221e65e13a82f8e6c2c2d4c7dbb3db0fba719898d59381bd8b787d685828bc921228ee22bf6ddfe34eba1646da668357b33354036a9927097"
        }
    },
    "_items": [
        {
            "user": "martin",
            "hardlink_master": false,
            "gid": 1000,
            "atime": 1485706267000000000,
            "uid": 1000,
            "mtime": 1485706177000000000,
            "group": "martin",
            "ctime": 1485706177000000000,
            "path": "tox.ini",
            "chunks": [
                [
                    "\u007f4a4d98a6d4e6e0667af3084190a18823d93e8013d19b11b9c8f352182f15735a",
                    517,
                    520
                ]
            ],
            "mode": 33188
        }
    ]
}
```