### PR TITLE
docs: use 'restrict' for authorized_keys

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -69,8 +69,7 @@ forced command and restrictions applied as shown below:
 
   command="cd /home/backup/repos/<client fqdn>;
            borg serve --restrict-to-path /home/backup/repos/<client fqdn>",
-           no-port-forwarding,no-X11-forwarding,no-pty,
-           no-agent-forwarding,no-user-rc <keytype> <key> <host>
+           restrict <keytype> <key> <host>
 
 .. note:: The text shown above needs to be written on a single line!
 
@@ -148,7 +147,7 @@ package manager to install and keep borg up-to-date.
     - file: path="{{ pool }}" owner="{{ user }}" group="{{ group }}" mode=0700 state=directory
     - authorized_key: user="{{ user }}"
                       key="{{ item.key }}"
-                      key_options='command="cd {{ pool }}/{{ item.host }};borg serve --restrict-to-path {{ pool }}/{{ item.host }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'
+                      key_options='command="cd {{ pool }}/{{ item.host }};borg serve --restrict-to-path {{ pool }}/{{ item.host }}",restrict'
       with_items: "{{ auth_users }}"
     - file: path="{{ home }}/.ssh/authorized_keys" owner="{{ user }}" group="{{ group }}" mode=0600 state=file
     - file: path="{{ pool }}/{{ item.host }}" owner="{{ user }}" group="{{ group }}" mode=0700 state=directory

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -254,7 +254,7 @@ use of the SSH keypair by prepending a forced command to the SSH public key in
 the remote server's `authorized_keys` file. This example will start |project_name|
 in server mode and limit it to a specific filesystem path::
 
-  command="borg serve --restrict-to-path /path/to/repo",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc ssh-rsa AAAAB3[...]
+  command="borg serve --restrict-to-path /path/to/repo",restrict ssh-rsa AAAAB3[...]
 
 If it is not possible to install |project_name| on the remote host,
 it is still possible to use the remote host to store a repository by

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -669,7 +669,7 @@ forced command. That way, other options given by the client (like ``--info`` or
     # Use key options to disable unneeded and potentially dangerous SSH functionality.
     # This will help to secure an automated remote backup system.
     $ cat ~/.ssh/authorized_keys
-    command="borg serve --restrict-to-path /path/to/repo",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc ssh-rsa AAAAB3[...]
+    command="borg serve --restrict-to-path /path/to/repo",restrict ssh-rsa AAAAB3[...]
 
 
 .. include:: usage/upgrade.rst.inc


### PR DESCRIPTION
'restrict' enables all restriction (even future ones), so it is safest.

Thanks to Michael Reed for the patch.