### PR TITLE
pytest: use [pytest] section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 python_files = testsuite/*.py
 
 [flake8]


### PR DESCRIPTION
[tool:pytest] only works for pytest >= 3.0.

fixes issue #2112.