### PR TITLE
clearify doc for same filesystems

### DIFF
--- a/docs/man/borg-create.1
+++ b/docs/man/borg-create.1
@@ -109,7 +109,7 @@ keep tag objects (i.e.: arguments to \-\-exclude\-if\-present) in otherwise     
 .INDENT 0.0
 .TP
 .B \-x\fP,\fB  \-\-one\-file\-system
-stay in same file system, do not cross mount points
+stay in same file system
 .TP
 .B \-\-numeric\-owner
 only store numeric user and group identifiers

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -43,7 +43,7 @@ Exclusion options
 
 Filesystem options
     ``-x``, ``--one-file-system``
-        | stay in same file system, do not cross mount points
+        | stay in same file system
     ``--numeric-owner``
         | only store numeric user and group identifiers
     ``--noatime``

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2072,7 +2072,7 @@ class Archiver:
         fs_group = subparser.add_argument_group('Filesystem options')
         fs_group.add_argument('-x', '--one-file-system', dest='one_file_system',
                               action='store_true', default=False,
-                              help='stay in same file system, do not cross mount points')
+                              help='stay in same file system')
         fs_group.add_argument('--numeric-owner', dest='numeric_owner',
                               action='store_true', default=False,
                               help='only store numeric user and group identifiers')


### PR DESCRIPTION
Fixes #2141 

It's not possible to detect with Posix API submounts of same filesystems. Therefore `borg create` will traverse mountpoints even with `-x`, when `FS of $MOUNTPOINT` == `FS of $MOUNTPOINT/..` .