### PR TITLE
clearify doc for same filesystems

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1373,7 +1373,7 @@ class Archiver:
                                help='write checkpoint every SECONDS seconds (Default: 300)')
         subparser.add_argument('-x', '--one-file-system', dest='one_file_system',
                                action='store_true', default=False,
-                               help='stay in same file system, do not cross mount points')
+                               help='stay in same file system')
         subparser.add_argument('--numeric-owner', dest='numeric_owner',
                                action='store_true', default=False,
                                help='only store numeric user and group identifiers')

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -58,7 +58,7 @@ borg create
       -c SECONDS, --checkpoint-interval SECONDS
                             write checkpoint every SECONDS seconds (Default: 300)
       -x, --one-file-system
-                            stay in same file system, do not cross mount points
+                            stay in same file system
       --numeric-owner       only store numeric user and group identifiers
       --noatime             do not store atime into archive
       --noctime             do not store ctime into archive


### PR DESCRIPTION
Fixes #2141

It's not possible to detect with Posix API submounts of same filesystems. Therefore borg create will traverse mountpoints even with -x, when FS of $MOUNTPOINT == FS of $MOUNTPOINT/.. .