### PR TITLE
archived file items: add size metadata

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -777,7 +777,7 @@ Utilization of max. archive size: {csize_max:.0%}
         length = len(item.chunks)
         # the item should only have the *additional* chunks we processed after the last partial item:
         item.chunks = item.chunks[from_chunk:]
-        item.file_size(memorize=True)
+        item.get_size(memorize=True)
         item.path += '.borg_part_%d' % number
         item.part = number
         number += 1
@@ -826,7 +826,7 @@ Utilization of max. archive size: {csize_max:.0%}
         )
         fd = sys.stdin.buffer  # binary
         self.chunk_file(item, cache, self.stats, backup_io_iter(self.chunker.chunkify(fd)))
-        item.file_size(memorize=True)
+        item.get_size(memorize=True)
         self.stats.nfiles += 1
         self.add_item(item)
         return 'i'  # stdin
@@ -887,7 +887,7 @@ Utilization of max. archive size: {csize_max:.0%}
                 cache.memorize_file(path_hash, st, [c.id for c in item.chunks])
             status = status or 'M'  # regular file, modified (if not 'A' already)
         item.update(self.stat_attrs(st, path))
-        item.file_size(memorize=True)
+        item.get_size(memorize=True)
         if is_special_file:
             # we processed a special file like a regular file. reflect that in mode,
             # so it can be extracted / accessed in FUSE mount like a regular file:

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1306,6 +1306,13 @@ class ArchiveChecker:
                 logger.info('{}: Completely healed previously damaged file!'.format(item.path))
                 del item.chunks_healthy
             item.chunks = chunk_list
+            if 'size' in item:
+                item_size = item.size
+                item_chunks_size = item.get_size(compressed=False, from_chunks=True)
+                if item_size != item_chunks_size:
+                    # just warn, but keep the inconsistency, so that borg extract can warn about it.
+                    logger.warning('{}: size inconsistency detected: size {}, chunks size {}'.format(
+                                   item.path, item_size, item_chunks_size))
 
         def robust_iterator(archive):
             """Iterates through all archive items

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -777,7 +777,7 @@ Utilization of max. archive size: {csize_max:.0%}
         length = len(item.chunks)
         # the item should only have the *additional* chunks we processed after the last partial item:
         item.chunks = item.chunks[from_chunk:]
-        item.size = sum(chunk.size for chunk in item.chunks)
+        item.file_size(memorize=True)
         item.path += '.borg_part_%d' % number
         item.part = number
         number += 1
@@ -826,7 +826,7 @@ Utilization of max. archive size: {csize_max:.0%}
         )
         fd = sys.stdin.buffer  # binary
         self.chunk_file(item, cache, self.stats, backup_io_iter(self.chunker.chunkify(fd)))
-        item.size = sum(chunk.size for chunk in item.chunks)
+        item.file_size(memorize=True)
         self.stats.nfiles += 1
         self.add_item(item)
         return 'i'  # stdin
@@ -887,7 +887,7 @@ Utilization of max. archive size: {csize_max:.0%}
                 cache.memorize_file(path_hash, st, [c.id for c in item.chunks])
             status = status or 'M'  # regular file, modified (if not 'A' already)
         item.update(self.stat_attrs(st, path))
-        item.size = sum(chunk.size for chunk in item.chunks)
+        item.file_size(memorize=True)
         if is_special_file:
             # we processed a special file like a regular file. reflect that in mode,
             # so it can be extracted / accessed in FUSE mount like a regular file:

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -777,6 +777,7 @@ Utilization of max. archive size: {csize_max:.0%}
         length = len(item.chunks)
         # the item should only have the *additional* chunks we processed after the last partial item:
         item.chunks = item.chunks[from_chunk:]
+        item.size = sum(chunk.size for chunk in item.chunks)
         item.path += '.borg_part_%d' % number
         item.part = number
         number += 1
@@ -825,6 +826,7 @@ Utilization of max. archive size: {csize_max:.0%}
         )
         fd = sys.stdin.buffer  # binary
         self.chunk_file(item, cache, self.stats, backup_io_iter(self.chunker.chunkify(fd)))
+        item.size = sum(chunk.size for chunk in item.chunks)
         self.stats.nfiles += 1
         self.add_item(item)
         return 'i'  # stdin
@@ -885,6 +887,7 @@ Utilization of max. archive size: {csize_max:.0%}
                 cache.memorize_file(path_hash, st, [c.id for c in item.chunks])
             status = status or 'M'  # regular file, modified (if not 'A' already)
         item.update(self.stat_attrs(st, path))
+        item.size = sum(chunk.size for chunk in item.chunks)
         if is_special_file:
             # we processed a special file like a regular file. reflect that in mode,
             # so it can be extracted / accessed in FUSE mount like a regular file:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -600,10 +600,15 @@ class Archiver:
 
         def sum_chunk_size(item, consider_ids=None):
             if item.get('deleted'):
-                return None
+                size = None
             else:
-                return sum(c.size for c in item.chunks
-                           if consider_ids is None or c.id in consider_ids)
+                if consider_ids is not None:  # consider only specific chunks
+                    size = sum(chunk.size for chunk in item.chunks if chunk.id in consider_ids)
+                else:  # consider all chunks
+                    size = item.get('size')
+                    if size is None:
+                        size = sum(chunk.size for chunk in item.chunks)
+            return size
 
         def get_owner(item):
             if args.numeric_owner:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -605,9 +605,7 @@ class Archiver:
                 if consider_ids is not None:  # consider only specific chunks
                     size = sum(chunk.size for chunk in item.chunks if chunk.id in consider_ids)
                 else:  # consider all chunks
-                    size = item.get('size')
-                    if size is None:
-                        size = sum(chunk.size for chunk in item.chunks)
+                    size = item.file_size()
             return size
 
         def get_owner(item):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -541,7 +541,7 @@ class Archiver:
         if progress:
             pi = ProgressIndicatorPercent(msg='%5.1f%% Extracting: %s', step=0.1)
             pi.output('Calculating size')
-            extracted_size = sum(item.file_size(hardlink_masters) for item in archive.iter_items(filter))
+            extracted_size = sum(item.get_size(hardlink_masters) for item in archive.iter_items(filter))
             pi.total = extracted_size
         else:
             pi = None
@@ -605,7 +605,7 @@ class Archiver:
                 if consider_ids is not None:  # consider only specific chunks
                     size = sum(chunk.size for chunk in item.chunks if chunk.id in consider_ids)
                 else:  # consider all chunks
-                    size = item.file_size()
+                    size = item.get_size()
             return size
 
         def get_owner(item):

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -20,13 +20,12 @@ from .helpers import format_file_size
 from .helpers import yes
 from .helpers import remove_surrogates
 from .helpers import ProgressIndicatorPercent, ProgressIndicatorMessage
-from .item import Item, ArchiveItem
+from .item import Item, ArchiveItem, ChunkListEntry
 from .key import PlaintextKey
 from .locking import Lock
 from .platform import SaveFile
 from .remote import cache_if_remote
 
-ChunkListEntry = namedtuple('ChunkListEntry', 'id size csize')
 FileCacheEntry = namedtuple('FileCacheEntry', 'age inode size mtime chunk_ids')
 
 

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -1,6 +1,6 @@
 # this set must be kept complete, otherwise the RobustUnpacker might malfunction:
 ITEM_KEYS = frozenset(['path', 'source', 'rdev', 'chunks', 'chunks_healthy', 'hardlink_master',
-                       'mode', 'user', 'group', 'uid', 'gid', 'mtime', 'atime', 'ctime',
+                       'mode', 'user', 'group', 'uid', 'gid', 'mtime', 'atime', 'ctime', 'size',
                        'xattrs', 'bsdflags', 'acl_nfs4', 'acl_access', 'acl_default', 'acl_extended',
                        'part'])
 

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -266,7 +266,7 @@ class FuseOperations(llfuse.Operations):
         entry.st_uid = item.uid
         entry.st_gid = item.gid
         entry.st_rdev = item.get('rdev', 0)
-        entry.st_size = item.file_size()
+        entry.st_size = item.get_size()
         entry.st_blksize = 512
         entry.st_blocks = (entry.st_size + entry.st_blksize - 1) // entry.st_blksize
         # note: older archives only have mtime (not atime nor ctime)

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -260,6 +260,7 @@ class FuseOperations(llfuse.Operations):
         size = 0
         dsize = 0
         if 'chunks' in item:
+            # if we would not need to compute dsize, we could get size quickly from item.size, if present.
             for key, chunksize, _ in item.chunks:
                 size += chunksize
                 if self.accounted_chunks.get(key, inode) == inode:

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -256,10 +256,6 @@ class FuseOperations(llfuse.Operations):
 
     def getattr(self, inode, ctx=None):
         item = self.get_item(inode)
-        size = 0
-        if 'chunks' in item:
-            for key, chunksize, _ in item.chunks:
-                size += chunksize
         entry = llfuse.EntryAttributes()
         entry.st_ino = inode
         entry.generation = 0
@@ -270,9 +266,9 @@ class FuseOperations(llfuse.Operations):
         entry.st_uid = item.uid
         entry.st_gid = item.gid
         entry.st_rdev = item.get('rdev', 0)
-        entry.st_size = size
+        entry.st_size = item.file_size()
         entry.st_blksize = 512
-        entry.st_blocks = (size + entry.st_blksize - 1) // entry.st_blksize
+        entry.st_blocks = (entry.st_size + entry.st_blksize - 1) // entry.st_blksize
         # note: older archives only have mtime (not atime nor ctime)
         mtime_ns = item.mtime
         if have_fuse_xtime_ns:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1702,11 +1702,11 @@ class ItemFormatter(BaseFormatter):
 
     def calculate_size(self, item):
         # note: does not support hardlink slaves, they will be size 0
-        return item.file_size(compressed=False)
+        return item.get_size(compressed=False)
 
     def calculate_csize(self, item):
         # note: does not support hardlink slaves, they will be csize 0
-        return item.file_size(compressed=True)
+        return item.get_size(compressed=True)
 
     def hash_item(self, hash_function, item):
         if 'chunks' not in item:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1701,10 +1701,12 @@ class ItemFormatter(BaseFormatter):
         return len(item.get('chunks', []))
 
     def calculate_size(self, item):
-        return item.file_size()
+        # note: does not support hardlink slaves, they will be size 0
+        return item.file_size(compressed=False)
 
     def calculate_csize(self, item):
-        return sum(c.csize for c in item.get('chunks', []))
+        # note: does not support hardlink slaves, they will be csize 0
+        return item.file_size(compressed=True)
 
     def hash_item(self, hash_function, item):
         if 'chunks' not in item:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1701,10 +1701,7 @@ class ItemFormatter(BaseFormatter):
         return len(item.get('chunks', []))
 
     def calculate_size(self, item):
-        size = item.get('size')
-        if size is not None:
-            return size
-        return sum(c.size for c in item.get('chunks', []))
+        return item.file_size()
 
     def calculate_csize(self, item):
         return sum(c.csize for c in item.get('chunks', []))

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -104,7 +104,7 @@ def check_extension_modules():
         raise ExtensionModuleError
     if platform.API_VERSION != platform.OS_API_VERSION != '1.1_01':
         raise ExtensionModuleError
-    if item.API_VERSION != '1.1_01':
+    if item.API_VERSION != '1.1_02':
         raise ExtensionModuleError
 
 
@@ -1701,6 +1701,9 @@ class ItemFormatter(BaseFormatter):
         return len(item.get('chunks', []))
 
     def calculate_size(self, item):
+        size = item.get('size')
+        if size is not None:
+            return size
         return sum(c.size for c in item.get('chunks', []))
 
     def calculate_csize(self, item):

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -176,8 +176,15 @@ class Item(PropDict):
 
     part = PropDict._make_property('part', int)
 
-    def file_size(self, hardlink_masters=None, memorize=False, compressed=False):
-        """determine the (uncompressed or compressed) size of this item"""
+    def get_size(self, hardlink_masters=None, memorize=False, compressed=False):
+        """
+        Determine the (uncompressed or compressed) size of this item.
+
+        For hardlink slaves, the size is computed via the hardlink master's
+        chunk list, if available (otherwise size will be returned as 0).
+
+        If memorize is True, the computed size value will be stored into the item.
+        """
         attr = 'csize' if compressed else 'size'
         try:
             size = getattr(self, attr)

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -2,7 +2,7 @@ from .constants import ITEM_KEYS
 from .helpers import safe_encode, safe_decode
 from .helpers import StableDict
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 
 class PropDict:
@@ -156,6 +156,10 @@ class Item(PropDict):
     ctime = PropDict._make_property('ctime', int)
     mtime = PropDict._make_property('mtime', int)
 
+    # size is only present for items with a chunk list and then it is sum(chunk_sizes)
+    # compatibility note: this is a new feature, in old archives size will be missing.
+    size = PropDict._make_property('size', int)
+
     hardlink_master = PropDict._make_property('hardlink_master', bool)
 
     chunks = PropDict._make_property('chunks', (list, type(None)), 'list or None')
@@ -169,6 +173,9 @@ class Item(PropDict):
     part = PropDict._make_property('part', int)
 
     def file_size(self, hardlink_masters=None):
+        size = self.get('size')
+        if size is not None:
+            return size
         hardlink_masters = hardlink_masters or {}
         chunks, _ = hardlink_masters.get(self.get('source'), (None, None))
         chunks = self.get('chunks', chunks)

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -176,7 +176,7 @@ class Item(PropDict):
 
     part = PropDict._make_property('part', int)
 
-    def get_size(self, hardlink_masters=None, memorize=False, compressed=False):
+    def get_size(self, hardlink_masters=None, memorize=False, compressed=False, from_chunks=False):
         """
         Determine the (uncompressed or compressed) size of this item.
 
@@ -187,6 +187,8 @@ class Item(PropDict):
         """
         attr = 'csize' if compressed else 'size'
         try:
+            if from_chunks:
+                raise AttributeError
             size = getattr(self, attr)
         except AttributeError:
             # no precomputed (c)size value available, compute it:

--- a/src/borg/testsuite/item.py
+++ b/src/borg/testsuite/item.py
@@ -142,9 +142,9 @@ def test_item_file_size():
         ChunkListEntry(csize=1, size=1000, id=None),
         ChunkListEntry(csize=1, size=2000, id=None),
     ])
-    assert item.file_size() == 3000
+    assert item.get_size() == 3000
 
 
 def test_item_file_size_no_chunks():
     item = Item()
-    assert item.file_size() == 0
+    assert item.get_size() == 0


### PR DESCRIPTION
if an item has a chunk list, pre-compute the total size and store it into "size" metadata entry.

this speeds up access to item size (e.g. for regular files) and could also be used to verify the validity of the chunks list.

note about hardlinks: size is only stored for hardlink masters (only they have an own chunk list)


- [x] add a size entry to metadata IF item has a chunks list
- [x] keep sum-of-chunk-sizes as fallback for old archives
- [x] optimize borg list archive to directly use metadata file size
- [x] optimize size-related FUSE code
- [ ] do similar pre-computation / optimization for csize as for size? -> No, don't.
- [x] add borg check code that checks metadata file size vs. sum of chunk sizes
- [x] add borg extract code that checks metadata file size vs. sum of chunk sizes (or extracted file size)