### PR TITLE
docs: FAQ by categories as proposed by @anarcat in #1802

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -96,7 +96,7 @@ Which file types, attributes, etc. are *not* preserved?
       backed up as (deduplicated and compressed) runs of zero bytes.
       Archive extraction has optional support to extract all-zero chunks as
       holes in a sparse file.
-    * filesystem specific attributes, like ext4 immutable bit, see :issue:`618`.
+    * Some filesystem specific attributes, like btrfs NOCOW, see :ref:`platforms`.
 
 Are there other known limitations?
 ----------------------------------


### PR DESCRIPTION
docs: FAQ by categories as proposed by @anarcat in #1802

Usage & Limitations
Security
Common issues
Miscellaneous (only three items, two fork-related)

I immediately noticed that this makes it *much* easier to find FAQ items -- the list is just too long without any kind of hierarchy / order.

Note: This does not change/invalidate any links to FAQ items.