### PR TITLE
fuse: fix st_blocks to be an integer (not float) value

### DIFF
--- a/borg/fuse.py
+++ b/borg/fuse.py
@@ -214,7 +214,7 @@ class FuseOperations(llfuse.Operations):
         entry.st_rdev = item.get(b'rdev', 0)
         entry.st_size = size
         entry.st_blksize = 512
-        entry.st_blocks = dsize / 512
+        entry.st_blocks = (dsize + entry.st_blksize - 1) // entry.st_blksize
         # note: older archives only have mtime (not atime nor ctime)
         if have_fuse_xtime_ns:
             entry.st_mtime_ns = bigint_to_int(item[b'mtime'])


### PR DESCRIPTION
it's basically ceil(dsize / blocksize) now (without doing floating point ops).

(fallout from #2157)

st_blocks is not expected to be a floating point value.
also: reduces execution time and keeps fuse code better in sync with (future) master.