### PR TITLE
Add dsize and dcsize keys, fixes #2164

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Borg authors ("The Borg Collective")
 - Marian Beermann <public@enkore.de>
 - Daniel Reichelt <hacking@nachtgeist.net>
 - Lauri Niskanen <ape@ape3000.com>
+- Abdel-Rahman A. (Abogical)
 
 Borg is a fork of Attic.
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -19,7 +19,7 @@ import time
 import unicodedata
 import uuid
 from binascii import hexlify
-from collections import namedtuple, deque, abc
+from collections import namedtuple, deque, abc, Counter
 from datetime import datetime, timezone, timedelta
 from fnmatch import translate
 from functools import wraps, partial, lru_cache
@@ -1546,11 +1546,15 @@ class ItemFormatter(BaseFormatter):
 
     def calculate_dsize(self, item):
         chunk_index = self.archive.cache.chunks
-        return sum(c.size for c in item.get('chunks', []) if chunk_index[c.id].refcount == 1)
+        chunks = item.get('chunks', [])
+        chunks_counter = Counter(c.id for c in chunks)
+        return sum(c.size for c in chunks if chunk_index[c.id].refcount == chunks_counter[c.id])
 
     def calculate_dcsize(self, item):
         chunk_index = self.archive.cache.chunks
-        return sum(c.csize for c in item.get('chunks', []) if chunk_index[c.id].refcount == 1)
+        chunks = item.get('chunks', [])
+        chunks_counter = Counter(c.id for c in chunks)
+        return sum(c.csize for c in chunks if chunk_index[c.id].refcount == chunks_counter[c.id])
 
     def hash_item(self, hash_function, item):
         if 'chunks' not in item:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1484,7 +1484,7 @@ class ItemFormatter(BaseFormatter):
             'dsize': partial(self.sum_unique_chunks_metadata, lambda chunk: chunk.size),
             'dcsize': partial(self.sum_unique_chunks_metadata, lambda chunk: chunk.csize),
             'num_chunks': self.calculate_num_chunks,
-            'unique_chunks': self.calculate_unique_chunks,
+            'unique_chunks': partial(self.sum_unique_chunks_metadata, lambda chunk: 1),
             'isomtime': partial(self.format_time, 'mtime'),
             'isoctime': partial(self.format_time, 'ctime'),
             'isoatime': partial(self.format_time, 'atime'),
@@ -1547,10 +1547,6 @@ class ItemFormatter(BaseFormatter):
 
     def calculate_num_chunks(self, item):
         return len(item.get('chunks', []))
-
-    def calculate_unique_chunks(self, item):
-        chunk_index = self.archive.cache.chunks
-        return sum(1 for c in item.get('chunks', []) if chunk_index[c.id].refcount == 1)
 
     def calculate_size(self, item):
         return sum(c.size for c in item.get('chunks', []))

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1298,9 +1298,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', self.repository_location)
         test_archive = self.repository_location + '::test'
         self.cmd('create', '-C', 'lz4', test_archive, 'input')
-        output = self.cmd('list', '--format', '{size} {csize} {path}{NL}', test_archive)
-        size, csize, path = output.split("\n")[1].split(" ")
+        output = self.cmd('list', '--format', '{size} {csize} {dsize} {dcsize} {path}{NL}', test_archive)
+        size, csize, dsize, dcsize, path = output.split("\n")[1].split(" ")
         assert int(csize) < int(size)
+        assert int(dcsize) < int(dsize)
+        assert int(dsize) <= int(size)
+        assert int(dcsize) <= int(csize)
 
     def _get_sizes(self, compression, compressible, size=10000):
         if compressible:


### PR DESCRIPTION
These keys shows the amount of deduplicated size and compressed size of each file in the archive. As suggested in #2164.