### PR TITLE
[docs] improve remote-path description

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1137,7 +1137,7 @@ class Archiver:
         common_parser.add_argument('--umask', dest='umask', type=lambda s: int(s, 8), default=UMASK_DEFAULT, metavar='M',
                                    help='set umask to M (local and remote, default: %(default)04o)')
         common_parser.add_argument('--remote-path', dest='remote_path', metavar='PATH',
-                                   help='set remote path to executable (default: "borg")')
+                                   help='use PATH as borg executable on the remote (default: "borg")')
 
         parser = argparse.ArgumentParser(prog=prog, description='Borg - Deduplicated Backups')
         parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,7 +155,7 @@ General:
         When set, use this command instead of ``ssh``. This can be used to specify ssh options, such as
         a custom identity file ``ssh -i /path/to/private/key``. See ``man ssh`` for other options.
     BORG_REMOTE_PATH
-        When set, use the given path/filename as remote path (default is "borg").
+        When set, use the given path as borg executable on the remote (defaults to "borg" if unset).
         Using ``--remote-path PATH`` commandline option overrides the environment variable.
     BORG_FILES_CACHE_TTL
         When set to a numeric value, this determines the maximum "time to live" for the files cache


### PR DESCRIPTION
As discussed in IRC, this is an improved wording of `remote-path` to not mix it up with borg's repo-path.