### PR TITLE
info: show utilization of maximum archive size

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -350,10 +350,13 @@ Archive fingerprint: {0.fpr}
 Time (start): {start}
 Time (end):   {end}
 Duration: {0.duration}
-Number of files: {0.stats.nfiles}'''.format(
+Number of files: {0.stats.nfiles}
+Utilization of max. archive size: {csize_max:.0%}
+'''.format(
             self,
             start=format_time(to_localtime(self.start.replace(tzinfo=timezone.utc))),
-            end=format_time(to_localtime(self.end.replace(tzinfo=timezone.utc))))
+            end=format_time(to_localtime(self.end.replace(tzinfo=timezone.utc))),
+            csize_max=self.cache.chunks[self.id].csize / MAX_DATA_SIZE)
 
     def __repr__(self):
         return 'Archive(%r)' % self.name

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -987,6 +987,7 @@ class Archiver:
             print('Duration: %s' % archive.duration_from_meta)
             print('Number of files: %d' % stats.nfiles)
             print('Command line: %s' % format_cmdline(archive.metadata.cmdline))
+            print('Utilization of max. archive size: %d%%' % (100 * cache.chunks[archive.id].csize / MAX_DATA_SIZE))
             print(DASHES)
             print(STATS_HEADER)
             print(str(stats))

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -27,6 +27,8 @@ CACHE_TAG_CONTENTS = b'Signature: 8a477f597d28d172789f06886806bc55'
 # bytes. That's why it's 500 MiB instead of 512 MiB.
 DEFAULT_MAX_SEGMENT_SIZE = 500 * 1024 * 1024
 
+MAX_DATA_SIZE = 20 * 1024 * 1024
+
 # A few hundred files per directory to go easy on filesystems which don't like too many files per dir (NTFS)
 DEFAULT_SEGMENTS_PER_DIR = 500
 

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -27,7 +27,9 @@ CACHE_TAG_CONTENTS = b'Signature: 8a477f597d28d172789f06886806bc55'
 # bytes. That's why it's 500 MiB instead of 512 MiB.
 DEFAULT_MAX_SEGMENT_SIZE = 500 * 1024 * 1024
 
-MAX_DATA_SIZE = 20 * 1024 * 1024
+# 20 MiB minus 41 bytes for a Repository header (because the "size" field in the Repository includes
+# the header, and the total size was set to 20 MiB).
+MAX_DATA_SIZE = 20971479
 
 # A few hundred files per directory to go easy on filesystems which don't like too many files per dir (NTFS)
 DEFAULT_SEGMENTS_PER_DIR = 500

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1203,7 +1203,7 @@ class LoggedIO:
         return self.segment - 1  # close_segment() increments it
 
 
-# MAX_OBJECT_SIZE = 20 MiB (MAX_DATA_SIZE) + 41 bytes for a Repository PUT header, which consists of
+# MAX_OBJECT_SIZE = <20 MiB (MAX_DATA_SIZE) + 41 bytes for a Repository PUT header, which consists of
 # a 1 byte tag ID, 4 byte CRC, 4 byte size and 32 bytes for the ID.
 MAX_OBJECT_SIZE = MAX_DATA_SIZE + LoggedIO.put_header_fmt.size
-assert MAX_OBJECT_SIZE == 20971561
+assert MAX_OBJECT_SIZE == 20971520 == 20 * 1024 * 1024

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -26,7 +26,6 @@ from .crc32 import crc32
 
 logger = create_logger(__name__)
 
-MAX_OBJECT_SIZE = 20 * 1024 * 1024
 MAGIC = b'BORG_SEG'
 MAGIC_LEN = len(MAGIC)
 TAG_PUT = 0
@@ -1204,4 +1203,7 @@ class LoggedIO:
         return self.segment - 1  # close_segment() increments it
 
 
-MAX_DATA_SIZE = MAX_OBJECT_SIZE - LoggedIO.put_header_fmt.size
+# MAX_OBJECT_SIZE = 20 MiB (MAX_DATA_SIZE) + 41 bytes for a Repository PUT header, which consists of
+# a 1 byte tag ID, 4 byte CRC, 4 byte size and 32 bytes for the ID.
+MAX_OBJECT_SIZE = MAX_DATA_SIZE + LoggedIO.put_header_fmt.size
+assert MAX_OBJECT_SIZE == 20971561


### PR DESCRIPTION
See #1452

"This is 100 % accurate."

Also increases maximum data size by ~41 bytes. Not 100 % side-effect free;
if you manage to exactly land in that area then older Borg would not read
it. OTOH it gives us a nice round number there. No hard opinion here.