### PR TITLE
JSON output for major commands

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -28,7 +28,7 @@ from .helpers import Chunk, ChunkIteratorFileWrapper, open_item
 from .helpers import Error, IntegrityError
 from .helpers import uid2user, user2uid, gid2group, group2gid
 from .helpers import parse_timestamp, to_localtime
-from .helpers import format_time, format_timedelta, format_file_size, file_status
+from .helpers import format_time, format_timedelta, format_file_size, file_status, FileSize
 from .helpers import safe_encode, safe_decode, make_path_safe, remove_surrogates
 from .helpers import StableDict
 from .helpers import bin_to_hex
@@ -70,9 +70,9 @@ class Statistics:
 
     def as_dict(self):
         return {
-            'original_size': self.osize,
-            'compressed_size': self.csize,
-            'deduplicated_size': self.usize,
+            'original_size': FileSize(self.osize),
+            'compressed_size': FileSize(self.csize),
+            'deduplicated_size': FileSize(self.usize),
             'nfiles': self.nfiles,
         }
 
@@ -379,6 +379,7 @@ class Archive:
                 'command_line': self.metadata.cmdline,
                 'hostname': self.metadata.hostname,
                 'username': self.metadata.username,
+                'comment': self.metadata.get('comment', ''),
             })
         return info
 

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -68,6 +68,14 @@ class Statistics:
         return "<{cls} object at {hash:#x} ({self.osize}, {self.csize}, {self.usize})>".format(
             cls=type(self).__name__, hash=id(self), self=self)
 
+    def as_dict(self):
+        return {
+            'original_size': self.osize,
+            'compressed_size': self.csize,
+            'deduplicated_size': self.usize,
+            'nfiles': self.nfiles,
+        }
+
     @property
     def osize_fmt(self):
         return format_file_size(self.osize)
@@ -342,6 +350,19 @@ class Archive:
     @property
     def duration_from_meta(self):
         return format_timedelta(self.ts_end - self.ts)
+
+    def info(self):
+        return {
+            'name': self.name,
+            'id': self.fpr,
+            'start': format_time(to_localtime(self.start.replace(tzinfo=timezone.utc))),
+            'end': format_time(to_localtime(self.end.replace(tzinfo=timezone.utc))),
+            'duration': (self.end - self.start).total_seconds(),
+            'nfiles': self.stats.nfiles,
+            'limits': {
+                'max_archive_size': self.cache.chunks[self.id].csize / MAX_DATA_SIZE,
+            },
+        }
 
     def __str__(self):
         return '''\

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -977,8 +977,19 @@ class Archiver:
             format = "{archive:<36} {time} [{id}]{NL}"
         formatter = ArchiveFormatter(format)
 
+        output_data = []
+
         for archive_info in manifest.archives.list_considering(args):
-            write(safe_encode(formatter.format_item(archive_info)))
+            if args.json:
+                output_data.append(formatter.get_item_data(archive_info))
+            else:
+                write(safe_encode(formatter.format_item(archive_info)))
+
+        if args.json:
+            print_as_json({
+                'repository': manifest.repository,
+                'archives': output_data,
+            })
 
         return self.exit_code
 
@@ -2492,6 +2503,8 @@ class Archiver:
         subparser.add_argument('--format', '--list-format', dest='format', type=str,
                                help="""specify format for file listing
                                 (default: "{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NL}")""")
+        subparser.add_argument('--json', action='store_true',
+                               help='format output as JSON')
         subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',
                                type=location_validator(),
                                help='repository/archive to list contents of')

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -369,13 +369,20 @@ class Archiver:
                 if args.progress:
                     archive.stats.show_progress(final=True)
                 if args.stats:
-                    log_multi(DASHES,
-                              str(archive),
-                              DASHES,
-                              STATS_HEADER,
-                              str(archive.stats),
-                              str(cache),
-                              DASHES, logger=logging.getLogger('borg.output.stats'))
+                    if args.json:
+                        print_as_json({
+                            'cache_stats': cache.stats(),
+                            'stats': archive.stats.as_dict(),
+                            'archive': archive.info(),
+                        })
+                    else:
+                        log_multi(DASHES,
+                                  str(archive),
+                                  DASHES,
+                                  STATS_HEADER,
+                                  str(archive.stats),
+                                  str(cache),
+                                  DASHES, logger=logging.getLogger('borg.output.stats'))
 
         self.output_filter = args.output_filter
         self.output_list = args.output_list
@@ -1027,7 +1034,7 @@ class Archiver:
         }
 
         if args.json:
-            info['cache-stats'] = cache.stats()
+            info['cache_stats'] = cache.stats()
             print_as_json(info)
         else:
             print(textwrap.dedent("""
@@ -2174,6 +2181,8 @@ class Archiver:
                                help='output verbose list of items (files, dirs, ...)')
         subparser.add_argument('--filter', dest='output_filter', metavar='STATUSCHARS',
                                help='only display items with the given status characters')
+        subparser.add_argument('--json', action='store_true',
+                               help='output stats as JSON')
 
         exclude_group = subparser.add_argument_group('Exclusion options')
         exclude_group.add_argument('-e', '--exclude', dest='patterns',

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -962,10 +962,12 @@ class Archiver:
                 format = "{path}{NL}"
             else:
                 format = "{mode} {user:6} {group:6} {size:8} {isomtime} {path}{extra}{NL}"
-            formatter = ItemFormatter(archive, format)
 
+            formatter = ItemFormatter(archive, format, json=args.json)
+            write(safe_encode(formatter.begin()))
             for item in archive.iter_items(lambda item: matcher.match(item.path)):
                 write(safe_encode(formatter.format_item(item)))
+            write(safe_encode(formatter.end()))
         return self.exit_code
 
     def _list_repository(self, args, manifest, write):
@@ -2504,7 +2506,9 @@ class Archiver:
                                help="""specify format for file listing
                                 (default: "{mode} {user:6} {group:6} {size:8d} {isomtime} {path}{extra}{NL}")""")
         subparser.add_argument('--json', action='store_true',
-                               help='format output as JSON')
+                               help='format output as JSON. The form of --format is ignored, but keys used in it '
+                                    'are added to the JSON output. Some keys are always present. Note: JSON can only '
+                                    'represent text. A "bpath" key is therefore not available.')
         subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',
                                type=location_validator(),
                                help='repository/archive to list contents of')

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -219,18 +219,22 @@ All archives:   {0.total_size:>20s} {0.total_csize:>20s} {0.unique_csize:>20s}
 Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         return fmt.format(self.format_tuple())
 
-    def format_tuple(self):
+    Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks',
+                                     'total_chunks'])
+
+    def stats(self):
         # XXX: this should really be moved down to `hashindex.pyx`
-        Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks', 'total_chunks'])
-        stats = Summary(*self.chunks.summarize())._asdict()
+        stats = self.Summary(*self.chunks.summarize())._asdict()
+        return stats
+
+    def format_tuple(self):
+        stats = self.stats()
         for field in ['total_size', 'total_csize', 'unique_csize']:
             stats[field] = format_file_size(stats[field])
-        return Summary(**stats)
+        return self.Summary(**stats)
 
     def chunks_stored_size(self):
-        Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks', 'total_chunks'])
-        stats = Summary(*self.chunks.summarize())
-        return stats.unique_csize
+        return self.stats()['unique_csize']
 
     def create(self):
         """Create a new empty cache at `self.path`

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -831,6 +831,11 @@ def format_file_size(v, precision=2, sign=False):
     return sizeof_fmt_decimal(v, suffix='B', sep=' ', precision=precision, sign=sign)
 
 
+class FileSize(int):
+    def __format__(self, format_spec):
+        return format_file_size(int(self)).__format__(format_spec)
+
+
 def parse_file_size(s):
     """Return int from file size (1234, 55G, 1.7T)."""
     if not s:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1558,6 +1558,7 @@ class ArchiveFormatter(BaseFormatter):
 
     def get_item_data(self, archive):
         return {
+            'name': remove_surrogates(archive.name),
             'barchive': archive.name,
             'archive': remove_surrogates(archive.name),
             'id': bin_to_hex(archive.id),
@@ -1566,7 +1567,7 @@ class ArchiveFormatter(BaseFormatter):
 
     @staticmethod
     def keys_help():
-        return " - archive: archive name interpreted as text (might be missing non-text characters, see barchive)\n" \
+        return " - archive, name: archive name interpreted as text (might be missing non-text characters, see barchive)\n" \
                " - barchive: verbatim archive name, can contain any character except NUL\n" \
                " - time: time of creation of the archive\n" \
                " - id: internal ID of the archive"

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1112,6 +1112,16 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         info_archive = self.cmd('info', '--first', '1', self.repository_location)
         assert 'Archive name: test\n' in info_archive
 
+    def test_info_json(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        info_repo = json.loads(self.cmd('info', '--json', self.repository_location))
+        assert len(info_repo['id']) == 64
+        assert info_repo['encryption']['mode'] == 'repokey'
+        assert 'keyfile' not in info_repo['encryption']
+        assert 'cache-stats' in info_repo
+
     def test_comment(self):
         self.create_regular_file('file1', size=1024 * 80)
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
Fixes #2200 

This is the data output, going out over stdout. JSON logging as proposed in #2024 would go out over stderr as usual, so no conflicts there.

There is some overlap between info (with --last/--first/--prefix) and list which is more obvious in the JSON output. The difference is that "info" reports more stuff, and takes longer for that, while "list" is fast (only looks at the manifest).