### PR TITLE
use lz4 compression by default, fixes #2179

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -108,19 +108,23 @@ Are there other known limitations?
   An easy workaround is to create multiple archives with less items each.
   See also the :ref:`archive_limitation` and :issue:`1452`.
 
-Why is my backup bigger than with attic? Why doesn't |project_name| do compression by default?
-----------------------------------------------------------------------------------------------
+Why is my backup bigger than with attic?
+----------------------------------------
 
 Attic was rather unflexible when it comes to compression, it always
 compressed using zlib level 6 (no way to switch compression off or
 adjust the level or algorithm).
 
-|project_name| offers a lot of different compression algorithms and
-levels. Which of them is the best for you pretty much depends on your
-use case, your data, your hardware -- so you need to do an informed
-decision about whether you want to use compression, which algorithm
-and which level you want to use. This is why compression defaults to
-none.
+The default in Borg is lz4, which is fast enough to not use significant CPU time
+in most cases, but can only achieve modest compression. It still compresses
+easily compressed data fairly well.
+
+zlib compression with all levels (1-9) as well as LZMA (1-6) are available
+as well, for cases where they are worth it.
+
+Which choice is the best option depends on a number of factors, like
+bandwidth to the repository, how well the data compresses, available CPU
+power and so on.
 
 If a backup stops mid-way, does the already-backed-up data stay there?
 ----------------------------------------------------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -118,12 +118,12 @@ sudoers(5), or try ``sudo BORG_PASSPHRASE='yourphrase' borg`` syntax.
 Backup compression
 ------------------
 
-Default is no compression, but we support different methods with high speed
-or high compression:
+The default is lz4 (very fast, but low compression ratio), but other methods are
+supported for different situations.
 
-If you have a fast repo storage and you want some compression: ::
+If you have a fast repo storage and you want minimum CPU usage, no compression::
 
-    $ borg create --compression lz4 /path/to/repo::arch ~
+    $ borg create --compression none /path/to/repo::arch ~
 
 If you have a less fast repo storage and you want a bit more compression (N=0..9,
 0 means no compression, 9 means high compression): ::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -70,7 +70,7 @@ Examples
         --exclude 'sh:/home/*/.thumbnails'
 
     # Backup the root filesystem into an archive named "root-YYYY-MM-DD"
-    # use zlib compression (good, but slow) - default is no compression
+    # use zlib compression (good, but slow) - default is lz4 (fast, low compression ratio)
     $ borg create -C zlib,6 /path/to/repo::root-{now:%Y-%m-%d} / --one-file-system
 
     # Backup a remote host locally ("pull" style) using sshfs

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1629,17 +1629,17 @@ class Archiver:
             borg create /path/to/repo::{hostname}-{now:%Y-%m-%d_%H:%M:%S} ...
             borg prune --prefix '{hostname}-' ...\n\n''')
     helptext['compression'] = textwrap.dedent('''
-        Compression is off by default, if you want some, you have to specify what you want.
+        Compression is lz4 by default. If you want something else, you have to specify what you want.
 
         Valid compression specifiers are:
 
         none
 
-            Do not compress. (default)
+            Do not compress.
 
         lz4
 
-            Use lz4 compression. High speed, low compression.
+            Use lz4 compression. High speed, low compression. (default)
 
         zlib[,L]
 
@@ -2276,7 +2276,7 @@ class Archiver:
                                    help='specify the chunker parameters (CHUNK_MIN_EXP, CHUNK_MAX_EXP, '
                                         'HASH_MASK_BITS, HASH_WINDOW_SIZE). default: %d,%d,%d,%d' % CHUNKER_PARAMS)
         archive_group.add_argument('-C', '--compression', dest='compression',
-                                   type=CompressionSpec, default=dict(name='none'), metavar='COMPRESSION',
+                                   type=CompressionSpec, default=dict(name='lz4'), metavar='COMPRESSION',
                                    help='select compression algorithm, see the output of the '
                                         '"borg help compression" command for details.')
         archive_group.add_argument('--compression-from', dest='compression_files',

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -262,7 +262,7 @@ class ArchiverTestCaseBase(BaseTestCase):
         return output
 
     def create_src_archive(self, name):
-        self.cmd('create', self.repository_location + '::' + name, src_dir)
+        self.cmd('create', '--compression=none', self.repository_location + '::' + name, src_dir)
 
     def open_archive(self, name):
         repository = Repository(self.repository_path, exclusive=True)


### PR DESCRIPTION
not for create_src_archive() though as this triggers a bug that has to get fixed outside this PR first.
