### PR TITLE
Fix for PR #1971

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -347,7 +347,7 @@ class ArgparsePatternFileAction(argparse.Action):
             self.parse(f, args)
 
     def parse(self, fobj, args):
-        load_pattern_file(fobj, args.roots, args.patterns)
+        load_pattern_file(fobj, args.paths, args.patterns)
 
 
 class ArgparseExcludeFileAction(ArgparsePatternFileAction):

--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -213,6 +213,7 @@ class ArchiverTestCaseBase(BaseTestCase):
         self.keys_path = os.path.join(self.tmpdir, 'keys')
         self.cache_path = os.path.join(self.tmpdir, 'cache')
         self.exclude_file_path = os.path.join(self.tmpdir, 'excludes')
+        self.patterns_file_path = os.path.join(self.tmpdir, 'patterns')
         os.environ['BORG_KEYS_DIR'] = self.keys_path
         os.environ['BORG_CACHE_DIR'] = self.cache_path
         os.mkdir(self.input_path)
@@ -222,6 +223,8 @@ class ArchiverTestCaseBase(BaseTestCase):
         os.mkdir(self.cache_path)
         with open(self.exclude_file_path, 'wb') as fd:
             fd.write(b'input/file2\n# A comment line, then a blank line\n\n')
+        with open(self.patterns_file_path, 'wb') as fd:
+            fd.write(b'+input/file_important\n- input/file*\n# A comment line, then a blank line\n\n')
         self._old_wd = os.getcwd()
         os.chdir(self.tmpdir)
 
@@ -680,9 +683,23 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                           '--pattern=+input/file_important', '--pattern=-input/file*',
                           self.repository_location + '::test', 'input')
         self.assert_in("A input/file_important", output)
+        self.assert_not_in('file1', output)
+        self.assert_not_in('file2', output)
+
+    def test_create_pattern_file(self):
+        """test file patterns during create"""
+        self.cmd('init', self.repository_location)
+        self.create_regular_file('file1', size=1024 * 80)
+        self.create_regular_file('file2', size=1024 * 80)
+        self.create_regular_file('otherfile', size=1024 * 80)
+        self.create_regular_file('file_important', size=1024 * 80)
+        output = self.cmd('create', '-v', '--list',
+                          '--pattern=-input/otherfile', '--patterns-from=' + self.patterns_file_path,
+                          self.repository_location + '::test', 'input')
         self.assert_in("A input/file_important", output)
         self.assert_not_in('file1', output)
         self.assert_not_in('file2', output)
+        self.assert_not_in('otherfile', output)
 
     def test_extract_pattern_opt(self):
         self.cmd('init', self.repository_location)


### PR DESCRIPTION
This is a fix for the already merged #1971.
 --patterns-from was accessing args.roots instead of args.paths
I also added a test case that parses a command containing --patterns-from.
