### PR TITLE
WIP just a suspicion about #2225

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -558,7 +558,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         count, size, csize = self.chunks.decref(id)
         if count == 0:
             del self.chunks[id]
-            self.repository.delete(id, wait=False)
+            self.repository.delete(id, wait=False) # wait=False responsible for #2225?
             stats.update(-size, -csize, True)
         else:
             stats.update(-size, -csize, False)


### PR DESCRIPTION
currently, I can't reproduce the problem any more.

but here it happened again: https://travis-ci.org/borgbackup/borg/jobs/207708189

if the remote borg serve tries to delete and does not find the object any more,
it will raise ObjectNotFound.

but if we did not wait for it, does just some of the next repo rpc calls issued
get the exception?