### PR TITLE
Docs: one link per distro in the installation page

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,10 +42,10 @@ package which can be installed with the package manager.
 Distribution Source                                        Command
 ============ ============================================= =======
 Arch Linux   `[community]`_                                ``pacman -S borg``
-Debian       `jessie-backports`_, `stretch`_, `sid`_       ``apt install borgbackup``
+Debian       `Debian packages`_                            ``apt install borgbackup``
 Gentoo       `ebuild`_                                     ``emerge borgbackup``
 GNU Guix     `GNU Guix`_                                   ``guix package --install borg``
-Fedora/RHEL  `Fedora official repository`_, `EPEL`_        ``dnf install borgbackup``
+Fedora/RHEL  `Fedora official repository`_                 ``dnf install borgbackup``
 FreeBSD      `FreeBSD ports`_                              ``cd /usr/ports/archivers/py-borgbackup && make install clean``
 Mageia       `cauldron`_                                   ``urpmi borgbackup``
 NetBSD       `pkgsrc`_                                     ``pkg_add py-borgbackup``
@@ -55,15 +55,12 @@ OpenIndiana  `OpenIndiana hipster repository`_             ``pkg install borg``
 openSUSE     `openSUSE official repository`_               ``zypper in python3-borgbackup``
 OS X         `Brew cask`_                                  ``brew cask install borgbackup``
 Raspbian     `Raspbian testing`_                           ``apt install borgbackup``
-Ubuntu       `16.04`_, backports (PPA): `15.10`_, `14.04`_ ``apt install borgbackup``
+Ubuntu       `Ubuntu packages`_, `Ubuntu PPA`_             ``apt install borgbackup``
 ============ ============================================= =======
 
 .. _[community]: https://www.archlinux.org/packages/?name=borg
-.. _jessie-backports: https://packages.debian.org/jessie-backports/borgbackup
-.. _stretch: https://packages.debian.org/stretch/borgbackup
-.. _sid: https://packages.debian.org/sid/borgbackup
+.. _Debian packages: https://packages.debian.org/search?keywords=borgbackup&searchon=names&exact=1&suite=all&section=all
 .. _Fedora official repository: https://apps.fedoraproject.org/packages/borgbackup
-.. _EPEL: https://admin.fedoraproject.org/pkgdb/package/rpms/borgbackup/
 .. _FreeBSD ports: http://www.freshports.org/archivers/py-borgbackup/
 .. _ebuild: https://packages.gentoo.org/packages/app-backup/borgbackup
 .. _GNU Guix: https://www.gnu.org/software/guix/package-list.html#borg
@@ -75,9 +72,8 @@ Ubuntu       `16.04`_, backports (PPA): `15.10`_, `14.04`_ ``apt install borgbac
 .. _openSUSE official repository: http://software.opensuse.org/package/borgbackup
 .. _Brew cask: http://caskroom.io/
 .. _Raspbian testing: http://archive.raspbian.org/raspbian/pool/main/b/borgbackup/
-.. _16.04: https://launchpad.net/ubuntu/xenial/+source/borgbackup
-.. _15.10: https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
-.. _14.04: https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
+.. _Ubuntu packages: http://packages.ubuntu.com/xenial/borgbackup
+.. _Ubuntu PPA: https://launchpad.net/~costamagnagianfranco/+archive/ubuntu/borgbackup
 
 Please ask package maintainers to build a package or, if you can package /
 submit it yourself, please help us with that! See :issue:`105` on


### PR DESCRIPTION
BorgBackup 1.0.10 is only available in the experimental distribution for the moment.
Works perfectly for me. So I suggest to add this distribution as well.

http://metadata.ftp-master.debian.org/changelogs/main/b/borgbackup/borgbackup_1.0.10-2_changelog