### PR TITLE
extract: warning RC for unextracted big extended attributes, followup

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -26,7 +26,7 @@ from .constants import *  # NOQA
 from .hashindex import ChunkIndex, ChunkIndexEntry
 from .helpers import Manifest
 from .helpers import Chunk, ChunkIteratorFileWrapper, open_item
-from .helpers import Error, IntegrityError
+from .helpers import Error, IntegrityError, set_ec
 from .helpers import uid2user, user2uid, gid2group, group2gid
 from .helpers import parse_timestamp, to_localtime
 from .helpers import format_time, format_timedelta, format_file_size, file_status, FileSize
@@ -691,6 +691,7 @@ Utilization of max. archive size: {csize_max:.0%}
                 if e.errno == errno.E2BIG:
                     logger.warning('%s: Value or key of extended attribute %s is too big for this filesystem' %
                                    (path, k.decode()))
+                    set_ec(EXIT_WARNING)
                 elif e.errno not in (errno.ENOTSUP, errno.EACCES):
                     # only raise if the errno is not on our ignore list:
                     # ENOTSUP == xattrs not supported here

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1049,18 +1049,35 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     @pytest.mark.skipif(not xattr.XATTR_FAKEROOT, reason='xattr not supported on this system or on this version of'
                                                          'fakeroot')
-    def test_extract_big_xattrs(self):
-        def patched_setxattr(*args, **kwargs):
+    def test_extract_xattrs_errors(self):
+        def patched_setxattr_E2BIG(*args, **kwargs):
             raise OSError(errno.E2BIG, 'E2BIG')
+
+        def patched_setxattr_ENOTSUP(*args, **kwargs):
+            raise OSError(errno.ENOTSUP, 'ENOTSUP')
+
+        def patched_setxattr_EACCES(*args, **kwargs):
+            raise OSError(errno.EACCES, 'EACCES')
+
         self.create_regular_file('file')
         xattr.setxattr('input/file', 'attribute', 'value')
         self.cmd('init', self.repository_location, '-e' 'none')
         self.cmd('create', self.repository_location + '::test', 'input')
         with changedir('output'):
-            with patch.object(xattr, 'setxattr', patched_setxattr):
+            input_abspath = os.path.abspath('input/file')
+            with patch.object(xattr, 'setxattr', patched_setxattr_E2BIG):
                 out = self.cmd('extract', self.repository_location + '::test', exit_code=EXIT_WARNING)
-                assert out == (os.path.abspath('input/file') + ': Value or key of extended attribute attribute is too big'
-                                                               'for this filesystem\n')
+                assert out == (input_abspath + ': Value or key of extended attribute attribute is too big for this '
+                                               'filesystem\n')
+            os.remove(input_abspath)
+            with patch.object(xattr, 'setxattr', patched_setxattr_ENOTSUP):
+                out = self.cmd('extract', self.repository_location + '::test', exit_code=EXIT_WARNING)
+                assert out == (input_abspath + ': Extended attributes are not supported on this filesystem\n')
+            os.remove(input_abspath)
+            with patch.object(xattr, 'setxattr', patched_setxattr_EACCES):
+                out = self.cmd('extract', self.repository_location + '::test', exit_code=EXIT_WARNING)
+                assert out == (input_abspath + ': Permission denied when setting extended attribute attribute\n')
+            assert os.path.isfile(input_abspath)
 
     def test_path_normalization(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
Previous PR: #2198
This sets a warning exit code whenever an xattr is too big.

Was waiting for #2199 to be merged.