### PR TITLE
Address SSH batch mode in docs (fixes #2202)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -991,7 +991,6 @@ SSH batch mode
 ~~~~~~~~~~~~~~
 
 When running |project_name| using an automated script, ``ssh`` might still ask for a password,
-even if there is an SSH key for the target server. To make scripts more robust, set the
-``BORG_RSH`` environment variable in your script with ``-oBatchMode=yes``::
+even if there is an SSH key for the target server. Use this to make scripts more robust::
 
     export BORG_RSH='ssh -oBatchMode=yes'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -986,3 +986,12 @@ for e.g. regular pruning.
 Further protections can be implemented, but are outside of Borgs scope. For example,
 file system snapshots or wrapping ``borg serve`` to set special permissions or ACLs on
 new data files.
+
+SSH batch mode
+~~~~~~~~~~~~~~
+
+When running |project_name| using an automated script, ``ssh`` might still ask for a password,
+even if there is an SSH key for the target server. To make scripts more robust, set the
+``BORG_RSH`` environment variable in your script with ``-oBatchMode=yes``::
+
+    export BORG_RSH='ssh -oBatchMode=yes'


### PR DESCRIPTION
This adds a snippet in the `Additional notes` section of the docs about why to use the `-oBatchMode=yes` flag in automated backup scripts calling `ssh`.