### PR TITLE
Add warning about running build_usage on Python >3.4 (fixes #2123)

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -297,7 +297,10 @@ Checklist:
 - update ``CHANGES.rst``, based on ``git log $PREVIOUS_RELEASE..``
 - check version number of upcoming release in ``CHANGES.rst``
 - verify that ``MANIFEST.in`` and ``setup.py`` are complete
-- ``python setup.py build_api ; python setup.py build_usage ; python setup.py build_man`` and commit
+- ``python setup.py build_api ; python setup.py build_usage ; python
+  setup.py build_man`` and commit (be sure to build with Python 3.4 as
+  Python 3.6 added `more guaranteed hashing algorithms
+  <https://github.com/borgbackup/borg/issues/2123>`_)
 - tag the release::
 
     git tag -s -m "tagged/signed release X.Y.Z" X.Y.Z


### PR DESCRIPTION
Python 3.6 added some new guaranteed hashing algorithms that will show up as available in the docs when they are built with >=3.6 even though the baseline for support is currently Python 3.4. We don't want to include hashing algorithms that might not exist on certain builds of borg in the docs, and running build_usage with Python 3.4 instead will fix this.

I wasn't sure where the diff attached to #2123 came from (which command? API docs?), but I'm pretty sure these changes will suffice.

It might be better to have the link point to the part of the Python 3.6 changelog where it tells about the new guaranteed algorithms instead of to the issue...