### PR TITLE
mount: allow / in archive names with rules that make sense

### DIFF
--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -60,28 +60,25 @@ Repository / Archive Locations
 Many commands want either a repository (just give the repo URL, see above) or
 an archive location, which is a repo URL followed by ``::archive_name``.
 
-Borg does not assume a particular meaning or structuring of archive names,
-but for use with :ref:`borg_prune` and other commands it makes sense
-to structure names with prefixes (e.g. ``{hostname}-{date}``) for the
-``--prefix`` option.
+Archive names can be almost any string, but Borg places two important restrictions
+on them:
 
-When mounting an entire repository with :ref:`borg_mount` (without the
-'versions' option) the archive names are used as paths in the
-virtual filesystem.
-
-Archive names can contain ``/`` (slash) characters, but may not begin
-nor end with a slash, and may not contain consecutive slashes.
-Further, the usual path constructs involving ``.`` and ``..`` are not permitted;
-for example, these are all invalid archive names: ``/foo``, ``foo/../bar``, ``foo/.``,
-``//foohost/share``. The archive names ``.`` and ``..`` are invalid as well,
-but otherwise there is no restriction on using dots, e.g. ``foo.example.net....myfiles``
-is valid.
-
-This is to ensure a direct mapping to file system paths in :ref:`borg_mount`.
+1. Since archives can only be filtered by ``--prefix`` (for e.g. :ref:`borg_prune`),
+   grouping needs to be prefix based. For example, when backing up multiple hosts
+   into the same repository ``{hostname}-{date}`` makes sense, while ``{date}-{hostname}``
+   will pose issues for pruning.
+2. When mounting (:ref:`borg_mount`) an entire repository, archive names are interpreted
+   as paths. Therefore archives cannot be named ".", "..", cannot start nor end with a slash,
+   and may not contain two or more consecutive slashes.
 
 Otherwise any string can be used, including whitespace, newlines, Unicode
 and so on, however, to cause less confusion and maximize portability it's
-likely a good idea to avoid special characters.
+likely a good idea to avoid special characters. Similarly backslashes are permitted,
+but should not be used to improve portability.
+
+In summary, these are valid archive names: ``foo.example.net..myfiles``,
+``foo.example.net-system@2017-04-01``, whereas these are invalid: ``/foo``,
+``foo/../bar``, ``foo/.``, ``//foohost/share``.
 
 If you have set BORG_REPO (see above) and an archive location is needed, use
 ``::archive_name`` - the repo URL part is then read from BORG_REPO.

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -60,10 +60,28 @@ Repository / Archive Locations
 Many commands want either a repository (just give the repo URL, see above) or
 an archive location, which is a repo URL followed by ``::archive_name``.
 
-Archive names must not contain the ``/`` (slash) character. For simplicity,
-maybe also avoid blanks or other characters that have special meaning on the
-shell or in a filesystem (borg mount will use the archive name as directory
-name).
+Borg does not assume a particular meaning or structuring of archive names,
+but for use with :ref:`borg_prune` and other commands it makes sense
+to structure names with prefixes (e.g. ``{hostname}-{date}``) for the
+``--prefix`` option.
+
+When mounting an entire repository with :ref:`borg_mount` (without the
+'versions' option) the archive names are used as paths in the
+virtual filesystem.
+
+Archive names can contain ``/`` (slash) characters, but may not begin
+nor end with a slash, and may not contain consecutive slashes.
+Further, the usual path constructs involving ``.`` and ``..`` are not permitted;
+for example, these are all invalid archive names: ``/foo``, ``foo/../bar``, ``foo/.``,
+``//foohost/share``. The archive names ``.`` and ``..`` are invalid as well,
+but otherwise there is no restriction on using dots, e.g. ``foo.example.net....myfiles``
+is valid.
+
+This is to ensure a direct mapping to file system paths in :ref:`borg_mount`.
+
+Otherwise any string can be used, including whitespace, newlines, Unicode
+and so on, however, to cause less confusion and maximize portability it's
+likely a good idea to avoid special characters.
 
 If you have set BORG_REPO (see above) and an archive location is needed, use
 ``::archive_name`` - the repo URL part is then read from BORG_REPO.

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -313,6 +313,8 @@ class Archive:
             self.chunker = Chunker(self.key.chunk_seed, *chunker_params)
             if name in manifest.archives:
                 raise self.AlreadyExists(name)
+            if '/' in name:
+                logger.warning('Note: Slashes in archive names result in a directory hierarchy when the repository is mounted.')
             self.last_checkpoint = time.monotonic()
             i = 0
             while True:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2651,6 +2651,10 @@ class Archiver:
         option is given the command will run in the background until the filesystem
         is ``umounted``.
 
+        When mounting an entire repository (without the 'versions' option), archive names
+        are used as paths from the root of the mountpoint. Names containing slashes thus
+        form a directory hierarchy.
+
         The command ``borgfs`` provides a wrapper for ``borg mount``. This can also be
         used in fstab entries:
         ``/path/to/repo /mnt/point fuse.borgfs defaults,noauto 0 0``

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -9,6 +9,7 @@ import json
 import os
 import os.path
 import platform
+import posixpath
 import pwd
 import re
 import signal
@@ -29,7 +30,6 @@ from itertools import islice
 from operator import attrgetter
 from string import Formatter
 from shutil import get_terminal_size
-from posixpath import normpath
 
 import msgpack
 import msgpack.fallback
@@ -1088,13 +1088,11 @@ class Location:
         (?P<path>(/([^:]|(:(?!:)))+))                       # start with /, then any chars, but no "::"
         """
 
-    # optional ::archive_name at the end, archive name must not contain "/".
-    # borg mount's FUSE filesystem creates one level of directories from
-    # the archive names and of course "/" is not valid in a directory name.
+    # optional ::archive_name at the end.
     optional_archive_re = r"""
         (?:
             ::                                              # "::" as separator
-            (?P<archive>[^/]{1}.*)
+            (?P<archive>[^/].*)
         )?$"""                                              # must match until the end
 
     # regexes for misc. kinds of supported location specifiers:
@@ -1181,7 +1179,7 @@ class Location:
 
     @staticmethod
     def archive_valid(archive):
-        return not archive or (archive == normpath(archive) and archive not in ('..', '.') and '::' not in archive)
+        return not archive or (archive == posixpath.normpath(archive) and archive not in ('..', '.') and '::' not in archive)
 
     def __str__(self):
         items = [

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1134,7 +1134,7 @@ class Location:
         text = replace_placeholders(text)
         valid = self._parse(text)
         if valid:
-            return self._archive_valid()
+            return self.archive_valid(self.archive)
         m = self.env_re.match(text)
         if not m:
             return False
@@ -1145,7 +1145,7 @@ class Location:
         if not valid:
             return False
         self.archive = m.group('archive')
-        return self._archive_valid()
+        return self.archive_valid(self.archive)
 
     def _parse(self, text):
         def normpath_special(p):
@@ -1179,8 +1179,9 @@ class Location:
             return True
         return False
 
-    def _archive_valid(self):
-        return not self.archive or (self.archive == normpath(self.archive) and self.archive not in ('..', '.'))
+    @staticmethod
+    def archive_valid(archive):
+        return not archive or (archive == normpath(archive) and archive not in ('..', '.') and '::' not in archive)
 
     def __str__(self):
         items = [
@@ -1234,8 +1235,8 @@ def location_validator(archive=None):
 
 def archivename_validator():
     def validator(text):
-        if '/' in text or '::' in text or not text:
-            raise argparse.ArgumentTypeError('Invalid repository name: "%s"' % text)
+        if not Location.archive_valid(text):
+            raise argparse.ArgumentTypeError('Invalid archive name: "%s"' % text)
         return text
     return validator
 


### PR DESCRIPTION
- POSIX_normalization(archive name) == archive name

  So foo/bar is valid,  foo/bar/, foo/./bar/, foo/../bar/ are not.

- May not begin with any number of slashes (i.e. not an absolute
  path)

- Archives may not be named "." or ".."

  This is a new restriction and previously broke borg-mount
  (it didn't crash, you just got EIO when reading the mountpoint dir)

  With this change borg-mount just ignores existing archives with
  these names.

- borg-mount is very reasonable. You can have an archive foo/bar,
  and an archive foo, if you mount the repository, you'll find
  foo/bar with the archive but also the contents of foo under
  foo/ (makes sense).

  I don't think this should be restricted. If someone does not
  want that behaviour, just don't name your archives like that.
  I think it can be even quite useful.

  Another question might be, "if I have an archive foo, that
  has a directory bar, but also an archive foo/bar, which one
  will I get?". Answer: --sort-by decides, first come first served.

  Again, this is something that doesn't need restricting. Don't
  want that behaviour (which again can be quite useful) -> don't
  name your archives that way.

Fixes #2263