### PR TITLE
Securely erase config file, fixes #2257

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -2256,3 +2256,13 @@ def json_dump(obj):
 
 def json_print(obj):
     print(json_dump(obj))
+
+
+def secure_erase(path):
+    """Attempt to securely erase a file by writing random data over it before deleting it."""
+    with open(path, 'r+b') as fd:
+        length = os.stat(fd.fileno()).st_size
+        fd.write(os.urandom(length))
+        fd.flush()
+        os.fsync(fd.fileno())
+    os.unlink(path)


### PR DESCRIPTION
The SaveFile code, while ensuring atomicity, did not allow for secure
erasure of the config file (containing the old encrypted key). Now it
creates a hardlink to the file, lets SaveFile do its thing, and writes
random data over the old file (via the hardlink). A secure erase is
needed because the config file can contain the old key after changing
one's password.
