### PR TITLE
bugfix: no directory recursion when it is needed

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -929,6 +929,23 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in('x input/file2', output)
         self.assert_in('x input/otherfile', output)
 
+    def test_create_pattern_exclude_parent_and_include_child(self):
+        """test when patterns exclude a parent folder, but include a child"""
+        self.patterns_file_path2 = os.path.join(self.tmpdir, 'patterns2')
+        with open(self.patterns_file_path2, 'wb') as fd:
+            fd.write(b'+ input/x/b\n- input/x*\n')
+
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.create_regular_file('x/a/foo_a', size=1024 * 80)
+        self.create_regular_file('x/b/foo_b', size=1024 * 80)
+        self.create_regular_file('y/foo_y', size=1024 * 80)
+        output = self.cmd('create', '-v', '--list',
+                          '--patterns-from=' + self.patterns_file_path2,
+                          self.repository_location + '::test', 'input')
+        self.assert_in('x input/x/a/foo_a', output)
+        self.assert_in("A input/x/b/foo_b", output)
+        self.assert_in('A input/y/foo_y', output)
+
     def test_extract_pattern_opt(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.create_regular_file('file1', size=1024 * 80)


### PR DESCRIPTION
This is a hack to fix the problem raised by issue #2314.  It isn't ideal
because it ends up needing to fully traverse each root subtree, but this can
be improved by deciding whether to descend into a directory based on whether
there are other entries in the pattern file that refer to children of a given
directory.

The problem occurs when a patterns file excludes a parent directory P later in the
file, and earlier in the file a subdirectory S of P is included.
Because a tree is processed recursively, P is processed before S is, but if P
is excluded, then S used to not even be considered, because we wouldn't
recurse into P.  Now we recurse into P nonetheless, but don't add P (as a
directory entry) to the archive.