### PR TITLE
allow excluding parent and including child, fixes #2314

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -36,7 +36,7 @@ from .helpers import StableDict
 from .helpers import bin_to_hex
 from .helpers import safe_ns
 from .helpers import ellipsis_truncate, ProgressIndicatorPercent, log_multi
-from .helpers import PathPrefixPattern, FnmatchPattern
+from .helpers import PathPrefixPattern, FnmatchPattern, IECommand
 from .item import Item, ArchiveItem
 from .key import key_factory
 from .platform import acl_get, acl_set, set_flags, get_flags, swidth
@@ -1721,10 +1721,10 @@ class ArchiveRecreater:
         """Add excludes to the matcher created by exclude_cache and exclude_if_present."""
         def exclude(dir, tag_item):
             if self.keep_exclude_tags:
-                tag_files.append(PathPrefixPattern(tag_item.path))
-                tagged_dirs.append(FnmatchPattern(dir + '/'))
+                tag_files.append(PathPrefixPattern(tag_item.path, recurse_dir=False))
+                tagged_dirs.append(FnmatchPattern(dir + '/', recurse_dir=False))
             else:
-                tagged_dirs.append(PathPrefixPattern(dir))
+                tagged_dirs.append(PathPrefixPattern(dir, recurse_dir=False))
 
         matcher = self.matcher
         tag_files = []
@@ -1747,8 +1747,8 @@ class ArchiveRecreater:
                         file = open_item(archive, cachedir_masters[item.source])
                     if file.read(len(CACHE_TAG_CONTENTS)).startswith(CACHE_TAG_CONTENTS):
                         exclude(dir, item)
-        matcher.add(tag_files, True)
-        matcher.add(tagged_dirs, False)
+        matcher.add(tag_files, IECommand.Include)
+        matcher.add(tagged_dirs, IECommand.ExcludeNoRecurse)
 
     def create_target(self, archive, target_name=None):
         """Create target archive."""

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -557,12 +557,12 @@ def test_switch_patterns_style():
     roots, patterns = [], []
     load_pattern_file(pattern_file, roots, patterns)
     assert len(patterns) == 6
-    assert isinstance(patterns[0].pattern, ShellPattern)
-    assert isinstance(patterns[1].pattern, FnmatchPattern)
-    assert isinstance(patterns[2].pattern, RegexPattern)
-    assert isinstance(patterns[3].pattern, RegexPattern)
-    assert isinstance(patterns[4].pattern, PathPrefixPattern)
-    assert isinstance(patterns[5].pattern, ShellPattern)
+    assert isinstance(patterns[0].val, ShellPattern)
+    assert isinstance(patterns[1].val, FnmatchPattern)
+    assert isinstance(patterns[2].val, RegexPattern)
+    assert isinstance(patterns[3].val, RegexPattern)
+    assert isinstance(patterns[4].val, PathPrefixPattern)
+    assert isinstance(patterns[5].val, ShellPattern)
 
 
 @pytest.mark.parametrize("lines", [
@@ -681,6 +681,10 @@ def test_pattern_matcher():
 
     for i in ["", "foo", "bar"]:
         assert pm.match(i) is None
+
+    # add extra entries to aid in testing
+    for target in ["A", "B", "Empty", "FileNotFound"]:
+        pm.is_include_cmd[target] = target
 
     pm.add([RegexPattern("^a")], "A")
     pm.add([RegexPattern("^b"), RegexPattern("^z")], "B")


### PR DESCRIPTION
This fixes the problem raised by issue #2314 by requiring that each root subtree
be fully traversed.

The problem occurs when a patterns file excludes a parent directory P later in
the file, and earlier in the file a subdirectory S of P is included.  Because a
tree is processed recursively, P is processed before S is, but if P is
excluded, then S used to not even be considered, because we wouldn't recurse
into P.  With this fix, we now recurse into P nonetheless, but don't add P (as
a directory entry) to the archive.