### PR TITLE
use immutable data structure for the compression spec, fixes #2331

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -953,7 +953,7 @@ Utilization of max. archive size: {csize_max:.0%}
             item.chunks = chunks
         else:
             compress = self.compression_decider1.decide(path)
-            self.file_compression_logger.debug('%s -> compression %s', path, compress['name'])
+            self.file_compression_logger.debug('%s -> compression %s', path, compress.name)
             with backup_io('open'):
                 fh = Archive._open_rb(path)
             with os.fdopen(fh, 'rb') as fd:
@@ -1651,7 +1651,7 @@ class ArchiveRecreater:
         if self.recompress and not self.always_recompress and chunk_id in self.cache.chunks:
             # Check if this chunk is already compressed the way we want it
             old_chunk = self.key.decrypt(None, self.repository.get(chunk_id), decompress=False)
-            if Compressor.detect(old_chunk.data).name == compression_spec['name']:
+            if Compressor.detect(old_chunk.data).name == compression_spec.name:
                 # Stored chunk has the same compression we wanted
                 overwrite = False
         chunk_entry = self.cache.add_chunk(chunk_id, chunk, target.stats, overwrite=overwrite)

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -37,7 +37,7 @@ from .constants import *  # NOQA
 from .crc32 import crc32
 from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
 from .helpers import Error, NoManifestError, set_ec
-from .helpers import location_validator, archivename_validator, ChunkerParams, CompressionSpec
+from .helpers import location_validator, archivename_validator, ChunkerParams, CompressionSpec, ComprSpec
 from .helpers import PrefixSpec, SortBySpec, HUMAN_SORT_KEYS
 from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter
 from .helpers import format_time, format_timedelta, format_file_size, format_archive
@@ -2394,7 +2394,7 @@ class Archiver:
                                    help='specify the chunker parameters (CHUNK_MIN_EXP, CHUNK_MAX_EXP, '
                                         'HASH_MASK_BITS, HASH_WINDOW_SIZE). default: %d,%d,%d,%d' % CHUNKER_PARAMS)
         archive_group.add_argument('-C', '--compression', dest='compression',
-                                   type=CompressionSpec, default=dict(name='lz4'), metavar='COMPRESSION',
+                                   type=CompressionSpec, default=ComprSpec(name='lz4', spec=None), metavar='COMPRESSION',
                                    help='select compression algorithm, see the output of the '
                                         '"borg help compression" command for details.')
         archive_group.add_argument('--compression-from', dest='compression_files',

--- a/src/borg/key.py
+++ b/src/borg/key.py
@@ -153,7 +153,7 @@ class KeyBase:
 
     def compress(self, chunk):
         compr_args, chunk = self.compression_decider2.decide(chunk)
-        compressor = Compressor(**compr_args)
+        compressor = Compressor(name=compr_args.name, level=compr_args.spec)
         meta, data = chunk
         data = compressor.compress(data)
         return Chunk(data, **meta)


### PR DESCRIPTION
the bug was compr_args.update(compr_spec), helpers.py line 2168 - that mutated the compression
spec dict (and not just some local one, but the compr spec dict parsed from the commandline args.

 so a change that was intended just for 1 chunk changed the desired compression
 level on the archive scope.

 I refactored the stuff to use a namedtuple (which is immutable, so such effects can not happen).
