### PR TITLE
fix symlink item fs size computation

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1748,6 +1748,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 out_fn = os.path.join(mountpoint, 'input', 'link1')
                 sti = os.stat(in_fn, follow_symlinks=False)
                 sto = os.stat(out_fn, follow_symlinks=False)
+                assert sti.st_size == len('somewhere')
+                assert sto.st_size == len('somewhere')
                 assert stat.S_ISLNK(sti.st_mode)
                 assert stat.S_ISLNK(sto.st_mode)
                 assert os.readlink(in_fn) == os.readlink(out_fn)

--- a/src/borg/testsuite/item.py
+++ b/src/borg/testsuite/item.py
@@ -149,7 +149,7 @@ def test_unknown_property():
 
 
 def test_item_file_size():
-    item = Item(chunks=[
+    item = Item(mode=0o100666, chunks=[
         ChunkListEntry(csize=1, size=1000, id=None),
         ChunkListEntry(csize=1, size=2000, id=None),
     ])
@@ -157,5 +157,5 @@ def test_item_file_size():
 
 
 def test_item_file_size_no_chunks():
-    item = Item()
+    item = Item(mode=0o100666)
     assert item.get_size() == 0


### PR DESCRIPTION
a symlink has a 'source' attribute, so it was confused with a hardlink
slave here. see also issue #2343.

also, a symlink's fs size is defined as the length of the target path.
