### PR TITLE
extract: small bugfix and refactoring for parent dir creation

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -403,8 +403,6 @@ Number of files: {0.stats.nfiles}'''.format(
             if b'source' in item:
                 source = os.path.join(dest, item[b'source'])
                 with backup_io():
-                    if os.path.exists(path):
-                        os.unlink(path)
                     os.link(source, path)
             else:
                 with backup_io():
@@ -438,8 +436,6 @@ Number of files: {0.stats.nfiles}'''.format(
             elif stat.S_ISLNK(mode):
                 make_parent(path)
                 source = item[b'source']
-                if os.path.exists(path):
-                    os.unlink(path)
                 try:
                     os.symlink(source, path)
                 except UnicodeEncodeError:


### PR DESCRIPTION
make_parent(path) helper to reduce code duplication.
also use it for directories although makedirs can also do it.

bugfix: also create parent dir for device files, if needed.

(cherry picked from commit d4e27e2952888d547c54d5b0f4be22892aa9e2f1)

Backported for the bugfix. I kept the small refactor also to keep the code better in sync.
