### PR TITLE
Windows ssh

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -28,3 +28,4 @@ elif sys.platform == 'win32':  # pragma: windows only
     from .windows import sync_dir
     from .windows import get_owner, set_owner
     from .windows import get_ads
+    from .windows import select


### PR DESCRIPTION
Fix ssh not working on windows.
Use putty link (plink) as ssh client if openssh cant be found.

Interactive authenticating does not work so you need to use shh keys