### PR TITLE
placeholders: deny access to internals and other unspecified stuff

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1755,6 +1755,10 @@ class Archiver:
 
             The version of borg, only major, minor and patch version, e.g.: 1.0.8
 
+        If literal curly braces need to be used, double them for escaping::
+
+            borg create /path/to/repo::{{literal_text}}
+
         Examples::
 
             borg create /path/to/repo::{hostname}-{user}-{utcnow} ...

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -784,9 +784,10 @@ class DatetimeWrapper:
 
 
 def format_line(format, data):
-    keys = [f[1] for f in Formatter().parse(format)]
-    for key in keys:
-        if '.' in key or '__' in key:
+    for _, key, _, conversion in Formatter().parse(format):
+        if not key:
+            continue
+        if '.' in key or '__' in key or conversion:
             raise InvalidPlaceholder(key, format)
     try:
         return format.format(**data)

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -787,12 +787,10 @@ def format_line(format, data):
     for _, key, _, conversion in Formatter().parse(format):
         if not key:
             continue
-        if '.' in key or '__' in key or conversion:
+        if conversion or key not in data:
             raise InvalidPlaceholder(key, format)
     try:
-        return format.format(**data)
-    except KeyError as ke:
-        raise InvalidPlaceholder(ke.args[0], format)
+        return format.format_map(data)
     except Exception as e:
         raise PlaceholderError(format, data, e.__class__.__name__, str(e))
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -110,6 +110,10 @@ class PlaceholderError(Error):
     """Formatting Error: "{}".format({}): {}({})"""
 
 
+class InvalidPlaceholder(PlaceholderError):
+    """Invalid placeholder "{}" in string: {}"""
+
+
 def check_extension_modules():
     from . import platform, compress, item
     if hashindex.API_VERSION != '1.1_01':
@@ -780,6 +784,10 @@ class DatetimeWrapper:
 
 
 def format_line(format, data):
+    keys = [f[1] for f in Formatter().parse(format)]
+    for key in keys:
+        if '.' in key or '__' in key:
+            raise InvalidPlaceholder(key, format)
     try:
         return format.format(**data)
     except Exception as e:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -790,6 +790,8 @@ def format_line(format, data):
             raise InvalidPlaceholder(key, format)
     try:
         return format.format(**data)
+    except KeyError as ke:
+        raise InvalidPlaceholder(ke.args[0], format)
     except Exception as e:
         raise PlaceholderError(format, data, e.__class__.__name__, str(e))
 

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -1213,6 +1213,10 @@ def test_format_line_erroneous():
         assert format_line('{invalid}', data)
     with pytest.raises(PlaceholderError):
         assert format_line('{}', data)
+    with pytest.raises(PlaceholderError):
+        assert format_line('{now!r}', data)
+    with pytest.raises(PlaceholderError):
+        assert format_line('{now.__class__.__module__.__builtins__}', data)
 
 
 def test_replace_placeholders():


### PR DESCRIPTION
Also better error messages.

`Invalid placeholder "horstname" in string: testrepo::{horstname}-{now}`