### PR TITLE
FAQ to explain warning when running --repair

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -496,33 +496,22 @@ issue in the |project_name| issue tracker about that.
 Why does running 'borgbackup check --repair' warn about data loss?
 ------------------------------------------------------------------
 
-Due to the nature of backup, and especially deduplicated backups as used
-by |project_name|, some repair operations may require a roll-back to an
-earlier version of the repository. Some errors, especially where data
-corruption is involved, may require purging corrupted data to bring the
-repository back to a known good state.
-
-Also, we can't predict every possible corruption vector for a repository.
-Some forms of corruption may be undetected, and some attempts to repair
-corruption could break other parts of the repository.
-
-Repair is considered a destructive operation in that it will modify the
-repository in order to automatically repair some known methods of corruption.
+Repair usually works for recovering data in a corrupted archive. However,
+it's impossible to predict all modes of corruption. In some very rare
+instances, such as malfunctioning storage hardware, additional repo
+corruption may occur. If you can't afford to lose the repo, it's strongly
+recommended that you perform repair on a copy of the repo.
 
 In other words, the warning is there to emphasize that |project_name| will:
   - Perform automated routines that will modify your backup repository
   - May not actually fix the problem you are experiencing
   - May further corrupt your repository
-  - May cause other problems which may not be noticable
-  - May cause contents of backed up data to become corrupted or changed
 
-Aside from this, if you find yourself in a position where you believe your
-repository is corrupt, this operation may result in recovering at least
-some of your backup data. You are **STRONGLY ENCOURAGED** to attempt the
-repair on a copy of the repo in case the repository becomes more unusable
-after the repair.
-
-If you are still unsure, seek :ref:`support`!
+In the case of malfunctioning hardware, such as a drive or USB hub
+corrupting data when read or written, it's best to diagnose and fix the
+cause of the initial corruption before attempting to repair the repo. If
+the corruption is caused by a one time event such as a power outage,
+running `borg check --repair` will fix most problems.
 
 Miscellaneous
 #############

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -347,7 +347,7 @@ How can I backup huge file(s) over a unstable connection?
 
 This is not a problem any more, see previous FAQ item.
 
-How can I restore huge file(s) over a unstable connection?
+How can I restore huge file(s) over an unstable connection?
 ----------------------------------------------------------
 
 If you can not manage to extract the whole big file in one go, you can extract
@@ -381,7 +381,7 @@ If you run into that, try this:
 
 .. _a_status_oddity:
 
-I am seeing 'A' (added) status for a unchanged file!?
+I am seeing 'A' (added) status for an unchanged file!?
 -----------------------------------------------------
 
 The files cache is used to determine whether |project_name| already
@@ -492,6 +492,37 @@ maybe open an issue in their issue tracker. Do not file an issue in the
 
 If you can reproduce the issue with the proven filesystem, please file an
 issue in the |project_name| issue tracker about that.
+
+Why does running 'borgbackup check --repair' warn about data loss?
+------------------------------------------------------------------
+
+Due to the nature of backup, and especially deduplicated backups as used
+by |project_name|, some repair operations may require a roll-back to an
+earlier version of the repository. Some errors, especially where data
+corruption is involved, may require purging corrupted data to bring the
+repository back to a known good state.
+
+Also, we can't predict every possible corruption vector for a repository.
+Some forms of corruption may be undetected, and some attempts to repair
+corruption could break other parts of the repository.
+
+Repair is considered a destructive operation in that it will modify the
+repository in order to automatically repair some known methods of corruption.
+
+In other words, the warning is there to emphasize that |project_name| will:
+  - Perform automated routines that will modify your backup repository
+  - May not actually fix the problem you are experiencing
+  - May further corrupt your repository
+  - May cause other problems which may not be noticable
+  - May cause contents of backed up data to become corrupted or changed
+
+Aside from this, if you find yourself in a position where you believe your
+repository is corrupt, this operation may result in recovering at least
+some of your backup data. You are **STRONGLY ENCOURAGED** to attempt the
+repair on a copy of the repo in case the repository becomes more unusable
+after the repair.
+
+If you are still unsure, seek :ref:`support`!
 
 Miscellaneous
 #############

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -503,10 +503,10 @@ instances, such as malfunctioning storage hardware, additional repo
 corruption may occur. If you can't afford to lose the repo, it's strongly
 recommended that you perform repair on a copy of the repo.
 
-In other words, the warning is there to emphasize that |project_name| will:
-  - Perform automated routines that will modify your backup repository
-  - May not actually fix the problem you are experiencing
-  - In very rare cases, may further corrupt your repository
+In other words, the warning is there to emphasize that |project_name|:
+  - will perform automated routines that modify your backup repository.
+  - Might not actually fix the problem you are experiencing.
+  - might, in very rare cases, further corrupt your repository.
 
 In the case of malfunctioning hardware, such as a drive or USB hub
 corrupting data when read or written, it's best to diagnose and fix the

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -495,7 +495,7 @@ issue in the |project_name| issue tracker about that.
 
 
 Why does running 'borg check --repair' warn about data loss?
-------------------------------------------------------------------
+------------------------------------------------------------
 
 Repair usually works for recovering data in a corrupted archive. However,
 it's impossible to predict all modes of corruption. In some very rare
@@ -504,9 +504,9 @@ corruption may occur. If you can't afford to lose the repo, it's strongly
 recommended that you perform repair on a copy of the repo.
 
 In other words, the warning is there to emphasize that |project_name|:
-  - will perform automated routines that modify your backup repository.
-  - Might not actually fix the problem you are experiencing.
-  - might, in very rare cases, further corrupt your repository.
+  - Will perform automated routines that modify your backup repository
+  - Might not actually fix the problem you are experiencing
+  - Might, in very rare cases, further corrupt your repository
 
 In the case of malfunctioning hardware, such as a drive or USB hub
 corrupting data when read or written, it's best to diagnose and fix the

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -493,7 +493,7 @@ maybe open an issue in their issue tracker. Do not file an issue in the
 If you can reproduce the issue with the proven filesystem, please file an
 issue in the |project_name| issue tracker about that.
 
-Why does running 'borgbackup check --repair' warn about data loss?
+Why does running 'borg check --repair' warn about data loss?
 ------------------------------------------------------------------
 
 Repair usually works for recovering data in a corrupted archive. However,

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -493,6 +493,7 @@ maybe open an issue in their issue tracker. Do not file an issue in the
 If you can reproduce the issue with the proven filesystem, please file an
 issue in the |project_name| issue tracker about that.
 
+
 Why does running 'borg check --repair' warn about data loss?
 ------------------------------------------------------------------
 
@@ -512,6 +513,7 @@ corrupting data when read or written, it's best to diagnose and fix the
 cause of the initial corruption before attempting to repair the repo. If
 the corruption is caused by a one time event such as a power outage,
 running `borg check --repair` will fix most problems.
+
 
 Miscellaneous
 #############

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -505,7 +505,7 @@ recommended that you perform repair on a copy of the repo.
 In other words, the warning is there to emphasize that |project_name| will:
   - Perform automated routines that will modify your backup repository
   - May not actually fix the problem you are experiencing
-  - May further corrupt your repository
+  - In very rare cases, may further corrupt your repository
 
 In the case of malfunctioning hardware, such as a drive or USB hub
 corrupting data when read or written, it's best to diagnose and fix the


### PR DESCRIPTION
In reference to #2341

Added an explanation about the risks associated with running `borg check --repair` and why the program presents a warning to the user.

Also, fixed some _very minor_ grammar.