### PR TITLE
add test for preserved intermediate folder permissions

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -960,8 +960,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_not_in('input/x/a', output)
         self.assert_in('A input/y/foo_y', output)
 
-    def test_create_pattern_intermediate_folder_permissions(self):
-        """test for correct metadata when patterns exclude a parent folder but include a child"""
+    def test_create_pattern_intermediate_folders_first(self):
+        """test that intermediate folders appear first when patterns exclude a parent folder but include a child"""
         self.patterns_file_path2 = os.path.join(self.tmpdir, 'patterns2')
         with open(self.patterns_file_path2, 'wb') as fd:
             fd.write(b'+ input/x/a\n+ input/x/b\n- input/x*\n')
@@ -971,19 +971,19 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.create_regular_file('x/a/foo_a', size=1024 * 80)
         self.create_regular_file('x/b/foo_b', size=1024 * 80)
         with changedir('input'):
-            os.chmod('x/a', 0o750)
-            os.chmod('x/b', 0o700)
             self.cmd('create', '--patterns-from=' + self.patterns_file_path2,
                      self.repository_location + '::test', '.')
 
-        # extract the archive and verify that the "intermediate" folder
-        # permissions have been preserved.
-        with changedir('output'):
-            self.cmd('extract', self.repository_location + '::test')
+        # list the archive and verify that the "intermediate" folders appear before
+        # their contents
+        out = self.cmd('list', '--format', '{type} {path}{NL}', self.repository_location + '::test')
+        out_list = out.splitlines()
 
-            for fname, mode in [('x/a', 0o750), ('x/b', 0o700)]:
-                st = os.stat(fname)
-                self.assert_equal(st.st_mode & 0o777, mode)
+        self.assert_in('d x/a', out_list)
+        self.assert_in('d x/b', out_list)
+
+        assert out_list.index('d x/a') < out_list.index('- x/a/foo_a')
+        assert out_list.index('d x/b') < out_list.index('- x/b/foo_b')
 
     def test_extract_pattern_opt(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
This tests whether the permissions metadata is preserved when a folder is excluded but still recursed into to find a matching file in a subfolder.

To my surprise, it passes, which seems to indicate that the concern raised by @ThomasWaldmann in PR #2322 may not be a problem after all.