### PR TITLE
do not test logger name, fixes #2504

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1678,7 +1678,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         log_message = messages['log_message']
         assert isinstance(log_message['time'], float)
         assert log_message['levelname'] == 'DEBUG'  # there should only be DEBUG messages
-        assert log_message['name'].startswith('borg.')
         assert isinstance(log_message['message'], str)
 
     def test_common_options(self):


### PR DESCRIPTION
looks like PyInstaller modifies the module names.
