### PR TITLE
Fix remote logging and progress

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3815,15 +3815,15 @@ class Archiver:
         """ turn on INFO level logging for args that imply that they will produce output """
         # map of option name to name of logger for that option
         option_logger = {
-                'output_list': 'borg.output.list',
-                'show_version': 'borg.output.show-version',
-                'show_rc': 'borg.output.show-rc',
-                'stats': 'borg.output.stats',
-                'progress': 'borg.output.progress',
-                }
+            'output_list': 'borg.output.list',
+            'show_version': 'borg.output.show-version',
+            'show_rc': 'borg.output.show-rc',
+            'stats': 'borg.output.stats',
+            'progress': 'borg.output.progress',
+        }
         for option, logger_name in option_logger.items():
-            if args.get(option, False):
-                logging.getLogger(logger_name).setLevel('INFO')
+            option_set = args.get(option, False)
+            logging.getLogger(logger_name).setLevel('INFO' if option_set else 'WARN')
 
     def _setup_topic_debugging(self, args):
         """Turn on DEBUG level logging for specified --debug-topics."""
@@ -3839,8 +3839,10 @@ class Archiver:
         # This works around http://bugs.python.org/issue9351
         func = getattr(args, 'func', None) or getattr(args, 'fallback_func')
         # do not use loggers before this!
-        setup_logging(level=args.log_level, is_serve=func == self.do_serve, json=args.log_json)
+        is_serve = func == self.do_serve
+        setup_logging(level=args.log_level, is_serve=is_serve, json=args.log_json)
         self.log_json = args.log_json
+        args.progress |= is_serve
         self._setup_implied_logging(vars(args))
         self._setup_topic_debugging(args)
         if args.show_version:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1226,6 +1226,14 @@ class ProgressIndicatorBase:
             if self.logger.level == logging.NOTSET:
                 self.logger.setLevel(logging.WARN)
             self.logger.propagate = False
+
+        # If --progress is not set then the progress logger level will be WARN
+        # due to setup_implied_logging (it may be NOTSET with a logging config file,
+        # but the interactions there are generally unclear), so self.emit becomes
+        # False, which is correct.
+        # If --progress is set then the level will be INFO as per setup_implied_logging;
+        # note that this is always the case for serve processes due to a "args.progress |= is_serve".
+        # In this case self.emit is True.
         self.emit = self.logger.getEffectiveLevel() == logging.INFO
 
     def __del__(self):

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -654,6 +654,23 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                 opts.append('--critical')
             else:
                 raise ValueError('log level missing, fix this code')
+
+            # Tell the remote server about debug topics it may need to consider.
+            # Note that debug topics are usable for "spew" or "trace" logs which would
+            # be too plentiful to transfer for normal use, so the server doesn't send
+            # them unless explicitly enabled.
+            #
+            # Needless to say, if you do --debug-topic=repository.compaction, for example,
+            # with a 1.0.x server it won't work, because the server does not recognize the
+            # option.
+            #
+            # This is not considered a problem, since this is a debugging feature that
+            # should not be used for regular use.
+            for topic in args.debug_topics:
+                if '.' not in topic:
+                    topic = 'borg.debug.' + topic
+                if 'repository' in topic:
+                    opts.append('--debug-topic=%s' % topic)
         env_vars = []
         if not hostname_is_unique():
             env_vars.append('BORG_HOSTNAME_IS_UNIQUE=no')

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -714,6 +714,7 @@ class RemoteRepositoryTestCase(RepositoryTestCase):
         class MockArgs:
             remote_path = 'borg'
             umask = 0o077
+            debug_topics = []
 
         assert self.repository.borg_cmd(None, testing=True) == [sys.executable, '-m', 'borg.archiver', 'serve']
         args = MockArgs()

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -724,6 +724,9 @@ class RemoteRepositoryTestCase(RepositoryTestCase):
         assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--umask=077', '--info']
         args.remote_path = 'borg-0.28.2'
         assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--umask=077', '--info']
+        args.debug_topics = ['something_client_side', 'repository_compaction']
+        assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--umask=077', '--info',
+                                                                 '--debug-topic=borg.debug.repository_compaction']
 
 
 class RemoteLegacyFree(RepositoryTestCaseBase):


### PR DESCRIPTION
Fixes #2241 

Remarkably annoying patch to create.

Compatiblity:

```
     Remote |               |               |               |
            |     1.0.x     |   <1.1.0b5    |   master      |
Client      |               |               |   (>1.1.0b6)  |
------------+---------------+---------------+---------------+
1.0.x       |log w/o prefix | sees log messages w/ prefix   |
            |always progress| progress:never| always        |
------------+               +---------------+---------------+
<1.1.0b5    |progress spreads| broken *1    | always progress + spreads     |
------------+               +---------------+---------------+
>1.1.0b6    |progress stays |  log ok,      | superb *3     |
(master)    |in same line   | no progress *2|               |
------------+---------------+---------------+---------------+

*1 --progress does not work on remote
   --log-json only works with new server
*2 bug is in server
*3
  - progress works with old and new server, but can't
    disable with old server (1.0.x)
  - everything works with --log-json
  - debug topics work
  - progress alway stays in the same line
  - behaves virtually the same as a 1.0.x server towards 1.0.x clients
    (unlike <1.1.0b5)
```

~~So 1.1.0b5 is a bit unpleasant to read with this patch applied, but it won't miss any messages, so I consider that level of breakage unfortunate but ok for a beta. One could work around that via client_data in negotiate but it would be code that only serves this minor compatibility issue with beta releases.~~ (Addressed via client_supports_log_v3)

I elected to fix the existing system, but I think more than ever that it'd be good to redesign the propagation of logging, output and progress configuration within a process (RPC is good now). It would also be good to drop BORG_LOGGING_CONF, since --log-json now exists and apart from use cases covered by --log-json there are imho no convincing reasons to have it, but it makes the code significantly more complex, because it forces us to couples a lot of stuff to the logging system *and* consider the possibility of a logging config changing basically everything about it. (Well that and it's largely useless without *extensive* use of internals that aren't stable).