### PR TITLE
fail in borg package if version metadata is completely broken

### DIFF
--- a/src/borg/__init__.py
+++ b/src/borg/__init__.py
@@ -4,3 +4,15 @@ from ._version import version as __version__
 
 
 __version_tuple__ = tuple(LooseVersion(__version__).version[:3])
+
+# assert that all semver components are integers
+# this is mainly to show errors when people repackage poorly
+# and setuptools_scm determines a 0.1.dev... version
+assert all(isinstance(v, int) for v in __version_tuple__), \
+    """\
+broken borgbackup version metadata: %r
+
+version metadata is obtained dynamically on installation via setuptools_scm,
+please ensure your git repo has the correct tags or you provide the version
+using SETUPTOOLS_SCM_PRETEND_VERSION in your build script.
+""" % __version__


### PR DESCRIPTION
this helps to fail early when people do badly done scm based repackaging

this should resolve  #2538