### PR TITLE
Implement storage quotas

### DIFF
--- a/docs/usage/init.rst.inc
+++ b/docs/usage/init.rst.inc
@@ -17,6 +17,8 @@ optional arguments
         | select encryption key mode **(required)**
     ``-a``, ``--append-only``
         | create an append-only mode repository
+    ``--storage-quota``
+        | Set storage quota of the new repository (e.g. 5G, 1.5T). Default: no quota.
 
 `Common options`_
     |

--- a/docs/usage/serve.rst.inc
+++ b/docs/usage/serve.rst.inc
@@ -13,6 +13,8 @@ optional arguments
         | restrict repository access to PATH. Can be specified multiple times to allow the client access to several directories. Access to all sub-directories is granted implicitly; PATH doesn't need to directly point to a repository.
     ``--append-only``
         | only allow appending to repository segment files
+    ``--storage-quota``
+        | Override storage quota of the repository (e.g. 5G, 1.5T). When a new repository is initialized, sets the storage quota on the new repository as well. Default: no quota.
 
 `Common options`_
     |

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4000,7 +4000,7 @@ def main():  # pragma: no cover
             tb = "%s\n%s" % (traceback.format_exc(), sysinfo())
             exit_code = e.exit_code
         except RemoteRepository.RPCError as e:
-            important = e.exception_class not in ('LockTimeout', )
+            important = e.exception_class not in ('LockTimeout', ) and e.traceback
             msgid = e.exception_class
             tb_log_level = logging.ERROR if important else logging.DEBUG
             if important:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -46,7 +46,7 @@ from .helpers import Error, NoManifestError, set_ec
 from .helpers import location_validator, archivename_validator, ChunkerParams
 from .helpers import PrefixSpec, SortBySpec, HUMAN_SORT_KEYS
 from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter
-from .helpers import format_timedelta, format_file_size, format_archive
+from .helpers import format_timedelta, format_file_size, parse_file_size, format_archive
 from .helpers import safe_encode, remove_surrogates, bin_to_hex, prepare_dump_dict
 from .helpers import prune_within, prune_split
 from .helpers import timestamp
@@ -142,6 +142,13 @@ def with_archive(method):
     return wrapper
 
 
+def parse_storage_quota(storage_quota):
+    parsed = parse_file_size(storage_quota)
+    if parsed < parse_file_size('10M'):
+        raise argparse.ArgumentTypeError('quota is too small (%s). At least 10M are required.' % storage_quota)
+    return parsed
+
+
 class Archiver:
 
     def __init__(self, lock_wait=None, prog=None):
@@ -206,7 +213,11 @@ class Archiver:
 
     def do_serve(self, args):
         """Start in server mode. This command is usually not used manually."""
-        return RepositoryServer(restrict_to_paths=args.restrict_to_paths, append_only=args.append_only).serve()
+        return RepositoryServer(
+            restrict_to_paths=args.restrict_to_paths,
+            append_only=args.append_only,
+            storage_quota=args.storage_quota,
+        ).serve()
 
     @with_repository(create=True, exclusive=True, manifest=False)
     def do_init(self, args, repository):
@@ -2330,6 +2341,11 @@ class Archiver:
                                                     'Access to all sub-directories is granted implicitly; PATH doesn\'t need to directly point to a repository.')
         subparser.add_argument('--append-only', dest='append_only', action='store_true',
                                help='only allow appending to repository segment files')
+        subparser.add_argument('--storage-quota', dest='storage_quota', default=None,
+                               type=parse_storage_quota,
+                               help='Override storage quota of the repository (e.g. 5G, 1.5T). '
+                                    'When a new repository is initialized, sets the storage quota on the new '
+                                    'repository as well. Default: no quota.')
 
         init_epilog = process_epilog("""
         This command initializes an empty repository. A repository is a filesystem
@@ -2420,6 +2436,9 @@ class Archiver:
                                help='select encryption key mode **(required)**')
         subparser.add_argument('-a', '--append-only', dest='append_only', action='store_true',
                                help='create an append-only mode repository')
+        subparser.add_argument('--storage-quota', dest='storage_quota', default=None,
+                               type=parse_storage_quota,
+                               help='Set storage quota of the new repository (e.g. 5G, 1.5T). Default: no quota.')
 
         check_epilog = process_epilog("""
         The check command verifies the consistency of a repository and the corresponding archives.

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -178,7 +178,7 @@ class RepositoryServer:  # pragma: no cover
         'inject_exception',
     )
 
-    def __init__(self, restrict_to_paths, append_only):
+    def __init__(self, restrict_to_paths, append_only, storage_quota):
         self.repository = None
         self.restrict_to_paths = restrict_to_paths
         # This flag is parsed from the serve command line via Archiver.do_serve,
@@ -186,6 +186,7 @@ class RepositoryServer:  # pragma: no cover
         # whatever the client wants, except when initializing a new repository
         # (see RepositoryServer.open below).
         self.append_only = append_only
+        self.storage_quota = storage_quota
         self.client_version = parse_version('1.0.8')  # fallback version if client is too old to send version information
 
     def positional_to_named(self, method, argv):
@@ -360,6 +361,7 @@ class RepositoryServer:  # pragma: no cover
         append_only = (not create and self.append_only) or append_only
         self.repository = Repository(path, create, lock_wait=lock_wait, lock=lock,
                                      append_only=append_only,
+                                     storage_quota=self.storage_quota,
                                      exclusive=exclusive)
         self.repository.__enter__()  # clean exit handled by serve() method
         return self.repository.id
@@ -671,6 +673,9 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                     topic = 'borg.debug.' + topic
                 if 'repository' in topic:
                     opts.append('--debug-topic=%s' % topic)
+
+            if 'storage_quota' in args and args.storage_quota:
+                opts.append('--storage-quota=%s' % args.storage_quota)
         env_vars = []
         if not hostname_is_unique():
             env_vars.append('BORG_HOSTNAME_IS_UNIQUE=no')

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from .. import xattr, helpers, platform
 from ..archive import Archive, ChunkBuffer, flags_noatime, flags_normal
-from ..archiver import Archiver
+from ..archiver import Archiver, parse_storage_quota
 from ..cache import Cache
 from ..constants import *  # NOQA
 from ..crypto.low_level import bytes_to_long, num_aes_blocks
@@ -3242,3 +3242,9 @@ class TestCommonOptions:
         result[args_key] = args_value
 
         assert parse_vars_from_line(*line) == result
+
+
+def test_parse_storage_quota():
+    assert parse_storage_quota('50M') == 50 * 1000**2
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_storage_quota('5M')


### PR DESCRIPTION
Fixes #2517 

I gave #2517 some thought; implementing it in Borg has some advantages:

- Error messages are more helpful
- Our pre-commit checks do not capture FS quotas
- As implemented, the client can always back out of a 100.0 % used quota, which is not possible with (hard) FS quotas

Disadvantages:

- More difficult to deploy compared to FS quotas

  Perhaps a complementary option to --restrict-to-path that matches the path exactly would simplify handling of repo hosting in general?

- The storage quota and the actual bound on disk space use have a somewhat loose relationship.

  (In case anyone feels reminded of file systems and filling them up completely... it's the same structures, the same math — an exercise for the reader: design a transactional data store that has a fixed upper bound X, independent of contents, such that using SPACE(X) the store's contents can still be cleaned up :)

~~TODO: Add tests for quota tracking.~~