### PR TITLE
1101.integration.cache

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -566,7 +566,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                 for item in unpacker:
                     if not isinstance(item, dict):
                         logger.error('Error: Did not get expected metadata dict - archive corrupted!')
-                        continue
+                        continue   # XXX: continue?!
                     for chunk_id, size, csize in item.get(b'chunks', []):
                         chunk_idx.add(chunk_id, 1, size, csize)
             if self.do_cache:
@@ -589,9 +589,9 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
             logger.info('Synchronizing chunks cache...')
             cached_ids = cached_archives()
             archive_ids = repo_archives()
-            logger.info('Archives: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.' % (
+            logger.info('Archives: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.',
                 len(archive_ids), len(cached_ids),
-                len(cached_ids - archive_ids), len(archive_ids - cached_ids), ))
+                len(cached_ids - archive_ids), len(archive_ids - cached_ids))
             # deallocates old hashindex, creates empty hashindex:
             chunk_idx.clear()
             cleanup_outdated(cached_ids - archive_ids)
@@ -608,7 +608,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                     if self.do_cache:
                         if archive_id in cached_ids:
                             archive_chunk_idx_path = mkpath(archive_id)
-                            logger.info("Reading cached archive chunk index for %s ..." % archive_name)
+                            logger.info("Reading cached archive chunk index for %s ...", archive_name)
                             try:
                                 with DetachedIntegrityCheckedFile(path=archive_chunk_idx_path, write=False) as fd:
                                     archive_chunk_idx = ChunkIndex.read(fd)
@@ -620,7 +620,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                         if archive_id not in cached_ids:
                             # Do not make this an else branch; the FileIntegrityError exception handler
                             # above can remove *archive_id* from *cached_ids*.
-                            logger.info('Fetching and building archive index for %s ...' % archive_name)
+                            logger.info('Fetching and building archive index for %s ...', archive_name)
                             archive_chunk_idx = ChunkIndex()
                             fetch_and_build_idx(archive_id, repository, self.key, archive_chunk_idx)
                         logger.info("Merging into master chunks index ...")
@@ -633,7 +633,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                             chunk_idx.merge(archive_chunk_idx)
                     else:
                         chunk_idx = chunk_idx or ChunkIndex()
-                        logger.info('Fetching archive index for %s ...' % archive_name)
+                        logger.info('Fetching archive index for %s ...', archive_name)
                         fetch_and_build_idx(archive_id, repository, self.key, chunk_idx)
                 if self.progress:
                     pi.finish()

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -22,6 +22,7 @@ from .helpers import safe_ns
 from .helpers import yes, hostname_is_unique
 from .helpers import remove_surrogates
 from .helpers import ProgressIndicatorPercent, ProgressIndicatorMessage
+from .helpers import set_ec, EXIT_WARNING
 from .item import ArchiveItem, ChunkListEntry
 from .crypto.key import PlaintextKey
 from .crypto.file_integrity import IntegrityCheckedFile, DetachedIntegrityCheckedFile, FileIntegrityError
@@ -617,6 +618,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                                 # Delete it and fetch a new index
                                 cleanup_cached_archive(archive_id)
                                 cached_ids.remove(archive_id)
+                                set_ec(EXIT_WARNING)
                         if archive_id not in cached_ids:
                             # Do not make this an else branch; the FileIntegrityError exception handler
                             # above can remove *archive_id* from *cached_ids*.

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -264,10 +264,10 @@ class CacheConfig:
                 # is modified and then written out.), not re-created.
                 # Thus, older versions will leave our [integrity] section alone, making the section's data invalid.
                 # Therefore, we also add the manifest ID to this section and
-                # can discern whether an older version interfere by comparing the manifest IDs of this section
+                # can discern whether an older version interfered by comparing the manifest IDs of this section
                 # and the main [cache] section.
                 self.integrity = {}
-                logger.warning('Cache integrity data lost: old Borg version modified the cache.')
+                logger.warning('Cache integrity data not available: old Borg version modified the cache.')
         except configparser.NoSectionError:
             logger.debug('Cache integrity: No integrity data found (files, chunks). Cache is from old version.')
             self.integrity = {}

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -585,13 +585,14 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
             if self.do_cache:
                 fn = mkpath(archive_id)
                 fn_tmp = mkpath(archive_id, suffix='.tmp')
-                with DetachedIntegrityCheckedFile(path=fn_tmp, write=True, filename=bin_to_hex(archive_id)) as fd:
-                    try:
+                try:
+                    with DetachedIntegrityCheckedFile(path=fn_tmp, write=True,
+                                                      filename=bin_to_hex(archive_id)) as fd:
                         chunk_idx.write(fd)
-                    except Exception:
-                        os.unlink(fn_tmp)
-                    else:
-                        os.rename(fn_tmp, fn)
+                except Exception:
+                    os.unlink(fn_tmp)
+                else:
+                    os.rename(fn_tmp, fn)
 
         def lookup_name(archive_id):
             for info in self.manifest.archives.list():

--- a/src/borg/crypto/file_integrity.py
+++ b/src/borg/crypto/file_integrity.py
@@ -152,6 +152,7 @@ class IntegrityCheckedFile(FileLikeWrapper):
     def hash_part(self, partname, is_final=False):
         if not self.writing and not self.digests:
             return
+        self.hasher.update(('%10d' % len(partname)).encode())
         self.hasher.update(partname.encode())
         self.hasher.hash_length(seek_to_end=is_final)
         digest = self.hasher.hexdigest()

--- a/src/borg/crypto/file_integrity.py
+++ b/src/borg/crypto/file_integrity.py
@@ -182,6 +182,9 @@ class IntegrityCheckedFile(FileLikeWrapper):
 class DetachedIntegrityCheckedFile(IntegrityCheckedFile):
     def __init__(self, path, write, filename=None, override_fd=None):
         super().__init__(path, write, filename, override_fd)
+        filename = filename or os.path.basename(path)
+        output_dir = os.path.dirname(path)
+        self.output_integrity_file = self.integrity_file_path(os.path.join(output_dir, filename))
         if not write:
             self.digests = self.read_integrity_file(self.path, self.hasher)
 
@@ -201,5 +204,5 @@ class DetachedIntegrityCheckedFile(IntegrityCheckedFile):
             raise FileIntegrityError(path)
 
     def store_integrity_data(self, data: str):
-        with open(self.integrity_file_path(self.path), 'w') as fd:
+        with open(self.output_integrity_file, 'w') as fd:
             fd.write(data)

--- a/src/borg/crypto/file_integrity.py
+++ b/src/borg/crypto/file_integrity.py
@@ -135,13 +135,13 @@ class IntegrityCheckedFile(FileLikeWrapper):
     @classmethod
     def parse_integrity_data(cls, path: str, data: str, hasher: SHA512FileHashingWrapper):
         try:
-            integrity_file = json.loads(data)
+            integrity_data = json.loads(data)
             # Provisions for agility now, implementation later, but make sure the on-disk joint is oiled.
-            algorithm = integrity_file['algorithm']
+            algorithm = integrity_data['algorithm']
             if algorithm != hasher.ALGORITHM:
                 logger.warning('Cannot verify integrity of %s: Unknown algorithm %r', path, algorithm)
                 return
-            digests = integrity_file['digests']
+            digests = integrity_data['digests']
             # Require at least presence of the final digest
             digests['final']
             return digests

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -67,8 +67,11 @@ cdef class IndexBase:
     def __cinit__(self, capacity=0, path=None, key_size=32):
         self.key_size = key_size
         if path:
-            with open(path, 'rb') as fd:
-                self.index = hashindex_read(fd)
+            if isinstance(path, (str, bytes)):
+                with open(path, 'rb') as fd:
+                    self.index = hashindex_read(fd)
+            else:
+                self.index = hashindex_read(path)
             assert self.index, 'hashindex_read() returned NULL with no exception set'
         else:
             self.index = hashindex_init(capacity, self.key_size, self.value_size)
@@ -84,8 +87,11 @@ cdef class IndexBase:
         return cls(path=path)
 
     def write(self, path):
-        with open(path, 'wb') as fd:
-            hashindex_write(self.index, fd)
+        if isinstance(path, (str, bytes)):
+            with open(path, 'wb') as fd:
+                hashindex_write(self.index, fd)
+        else:
+            hashindex_write(self.index, path)
 
     def clear(self):
         hashindex_free(self.index)


### PR DESCRIPTION
~~TODO: Corruption tests (manual testing: All good!); Add dedicated test cases for ICF (e: not really necessary).~~

Initially the design provided only the equivalent of "detached signatures", i.e. those .integrity files. However, that caused various design pains, because these files naturally did not use the same transaction mechanisms.

Therefore, I adjusted the design. Detached integrity files are now the exception, not the norm, and can be used where they are apt (archive.chunks.d). Otherwise, integrity data is stored where the surrounding code can accommodate it well. For the cache, this is the `config`. For the repository I will make it `N.ancillary`, since `N.hints` requires integrity checks (N>0 tickets with hints corruption; they're also much larger than the cache config).

Part of our ongoing series to realize #1101 (#1688 #2496 #2502) 

~~NOTE: HashIndex does not use file parts yet. This should probably be changed in this PR as well, to avoid merging a known-unstable format into `master`.~~

✔ Borg 1.0.x interop (with grace!)
✔ Tests
✔ Works in practice
✔ Not tested on animals