### PR TITLE
Added BORG_PASSCOMMAND environment variable

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -257,11 +257,11 @@ Security
 How can I specify the encryption passphrase programmatically?
 -------------------------------------------------------------
 
-The encryption passphrase can be specified programmatically using the
-`BORG_PASSPHRASE` environment variable. This is convenient when setting up
-automated encrypted backups. Another option is to use
-key file based encryption with a blank passphrase. See
-:ref:`encrypted_repos` for more details.
+The encryption passphrase or a command to retrieve a the passphrase can be
+specified programmatically using the `BORG_PASSPHRASE` and `BORG_PASSCOMMAND`
+environment variables. This is convenient when setting up automated encrypted
+backups. Another option is to use key file based encryption with a blank passphrase.
+See :ref:`encrypted_repos` for more details.
 
 .. _password_env:
 .. note:: Be careful how you set the environment; using the ``env``

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -257,8 +257,8 @@ Security
 How can I specify the encryption passphrase programmatically?
 -------------------------------------------------------------
 
-The encryption passphrase or a command to retrieve a the passphrase can be
-specified programmatically using the `BORG_PASSPHRASE` and `BORG_PASSCOMMAND`
+The encryption passphrase or a command to retrieve the passphrase can be
+specified programmatically using the `BORG_PASSPHRASE` or `BORG_PASSCOMMAND`
 environment variables. This is convenient when setting up automated encrypted
 backups. Another option is to use key file based encryption with a blank passphrase.
 See :ref:`encrypted_repos` for more details.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -86,7 +86,7 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
 
     # Setting this, so you won't be asked for your repository passphrase:
     export BORG_PASSPHRASE='XYZl0ngandsecurepa_55_phrasea&&123'
-    # or this
+    # or this to ask an external program to supply the passphrase:
     export BORG_PASSCOMMAND='pass show backup'
 
     # some helpers and error handling:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -86,6 +86,8 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
 
     # Setting this, so you won't be asked for your repository passphrase:
     export BORG_PASSPHRASE='XYZl0ngandsecurepa_55_phrasea&&123'
+    # or this
+    export BORG_PASSCOMMAND='pass show backup'
 
     # some helpers and error handling:
     function info  () { echo -e "\n"`date` $@"\n" >&2; }

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -134,9 +134,16 @@ General:
         It is used when a passphrase is needed to access a encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo.
         See also BORG_NEW_PASSPHRASE.
+    BORG_PASSCOMMAND
+        When set, use the command to answer the passphrase question for encrypted repositories.
+        It is used when a passphrase is needed to access a encrypted repo as well as when a new
+        passphrase should be initially set when initializing an encrypted repo.
+        If BORG_PASSPHRASE is also set, it takes precedence.
+        See also BORG_NEW_PASSPHRASE.
     BORG_NEW_PASSPHRASE
         When set, use the value to answer the passphrase question when a **new** passphrase is asked for.
-        This variable is checked first. If it is not set, BORG_PASSPHRASE will be checked also.
+        This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will be
+        checked also.
         Main usecase for this is to fully automate ``borg change-passphrase``.
     BORG_DISPLAY_PASSPHRASE
         When set, use the value to answer the "display the passphrase for verification" question when defining a new passphrase for encrypted repositories.

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -131,12 +131,12 @@ General:
         can either leave it away or abbreviate as `::`, if a positional parameter is required.
     BORG_PASSPHRASE
         When set, use the value to answer the passphrase question for encrypted repositories.
-        It is used when a passphrase is needed to access a encrypted repo as well as when a new
+        It is used when a passphrase is needed to access an encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo.
         See also BORG_NEW_PASSPHRASE.
     BORG_PASSCOMMAND
         When set, use the command to answer the passphrase question for encrypted repositories.
-        It is used when a passphrase is needed to access a encrypted repo as well as when a new
+        It is used when a passphrase is needed to access an encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo.
         If BORG_PASSPHRASE is also set, it takes precedence.
         See also BORG_NEW_PASSPHRASE.

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -142,8 +142,8 @@ General:
         See also BORG_NEW_PASSPHRASE.
     BORG_NEW_PASSPHRASE
         When set, use the value to answer the passphrase question when a **new** passphrase is asked for.
-        This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will be
-        checked also.
+        This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will also
+        be checked.
         Main usecase for this is to fully automate ``borg change-passphrase``.
     BORG_DISPLAY_PASSPHRASE
         When set, use the value to answer the "display the passphrase for verification" question when defining a new passphrase for encrypted repositories.

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -135,7 +135,8 @@ General:
         passphrase should be initially set when initializing an encrypted repo.
         See also BORG_NEW_PASSPHRASE.
     BORG_PASSCOMMAND
-        When set, use the command to answer the passphrase question for encrypted repositories.
+        When set, use the standard output of the command (trailing newlines are stripped) to answer the
+        passphrase question for encrypted repositories.
         It is used when a passphrase is needed to access an encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo.
         If BORG_PASSPHRASE is also set, it takes precedence.

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -30,7 +30,7 @@ PREFIX = b'\0' * 8
 
 
 class PassphraseWrong(Error):
-    """passphrase supplied in BORG_PASSPHRASE is incorrect."""
+    """passphrase supplied in BORG_PASSPHRASE or by BORG_PASSCOMMAND is incorrect."""
 
 class PasscommandFailure(Error):
     """passcommand supplied in BORG_PASSCOMMAND failed: {}"""

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -30,7 +30,7 @@ PREFIX = b'\0' * 8
 
 
 class PassphraseWrong(Error):
-    """passphrase supplied in BORG_PASSPHRASE is incorrect"""
+    """passphrase supplied in BORG_PASSPHRASE or by BORG_PASSCOMMAND is incorrect"""
 
 
 class PasswordRetriesExceeded(Error):


### PR DESCRIPTION
The BORG_PASSCOMMAND variable can be used to specify an external program that is asked to supply the passphrase.