### PR TITLE
recreate: keep timestamps as in original archive, fixes #2384

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1699,7 +1699,6 @@ class ArchiveRecreater:
     def save(self, archive, target, comment=None, replace_original=True):
         if self.dry_run:
             return
-        timestamp = archive.ts.replace(tzinfo=None)
         if comment is None:
             comment = archive.metadata.get('comment', '')
         target.save(comment=comment, additional_metadata={

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1702,8 +1702,12 @@ class ArchiveRecreater:
         timestamp = archive.ts.replace(tzinfo=None)
         if comment is None:
             comment = archive.metadata.get('comment', '')
-        target.save(timestamp=timestamp, comment=comment, additional_metadata={
+        target.save(comment=comment, additional_metadata={
+            # keep some metadata as in original archive:
+            'time': archive.metadata.time,
+            'time_end': archive.metadata.time_end,
             'cmdline': archive.metadata.cmdline,
+            # but also remember recreate metadata:
             'recreate_cmdline': sys.argv,
         })
         if replace_original:


### PR DESCRIPTION
the timestamps of the recreated archive (in the archive metadata and
also in the manifest) are now as they were for the original archive.

they are important metadata about the archive contents and should
therefore be kept "as is".

note: when using -v --stats, the timestamps shown there for recreate
      are about the recreate start/end/duration.

console log:
[fix.txt](https://github.com/borgbackup/borg/files/1050760/fix.txt)
