### PR TITLE
Remove re docs

### DIFF
--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -16,11 +16,6 @@ Examples
         ~/src                             \
         --exclude '*.pyc'
 
-    # Backup home directories excluding image thumbnails (i.e. only
-    # /home/*/.thumbnails is excluded, not /home/*/*/.thumbnails)
-    $ borg create /path/to/repo::my-files /home \
-        --exclude 're:^/home/[^/]+/\.thumbnails/'
-
     # Do the same using a shell-style pattern
     $ borg create /path/to/repo::my-files /home \
         --exclude 'sh:/home/*/.thumbnails'


### PR DESCRIPTION
Fixes https://github.com/borgbackup/borg/issues/2458

The `/home`/`tmp` example has already been removed, so now there is no `re:` example in there, anymore.
