### PR TITLE
create: --no-cache-sync

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -62,16 +62,16 @@ def pytest_report_header(config, startdir):
 
 class DefaultPatches:
     def __init__(self, request):
-        self.org_cache_wipe_cache = borg.cache.Cache.wipe_cache
+        self.org_cache_wipe_cache = borg.cache.LocalCache.wipe_cache
 
         def wipe_should_not_be_called(*a, **kw):
             raise AssertionError("Cache wipe was triggered, if this is part of the test add @pytest.mark.allow_cache_wipe")
         if 'allow_cache_wipe' not in request.keywords:
-            borg.cache.Cache.wipe_cache = wipe_should_not_be_called
+            borg.cache.LocalCache.wipe_cache = wipe_should_not_be_called
         request.addfinalizer(self.undo)
 
     def undo(self):
-        borg.cache.Cache.wipe_cache = self.org_cache_wipe_cache
+        borg.cache.LocalCache.wipe_cache = self.org_cache_wipe_cache
 
 
 @pytest.fixture(autouse=True)

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -504,6 +504,7 @@ Errors
 
 Operations
     - cache.begin_transaction
+    - cache.download_chunks, appears with ``borg create --no-cache-sync``
     - cache.commit
     - cache.sync
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -504,7 +504,7 @@ class Archiver:
         t0_monotonic = time.monotonic()
         if not dry_run:
             with Cache(repository, key, manifest, do_files=args.cache_files, progress=args.progress,
-                       lock_wait=self.lock_wait) as cache:
+                       lock_wait=self.lock_wait, permit_adhoc_cache=args.no_cache_sync) as cache:
                 archive = Archive(repository, key, manifest, args.location.archive, cache=cache,
                                   create=True, checkpoint_interval=args.checkpoint_interval,
                                   numeric_owner=args.numeric_owner, noatime=args.noatime, noctime=args.noctime,
@@ -2826,6 +2826,8 @@ class Archiver:
                                help='only display items with the given status characters')
         subparser.add_argument('--json', action='store_true',
                                help='output stats as JSON (implies --stats)')
+        subparser.add_argument('--no-cache-sync', dest='no_cache_sync', action='store_true',
+                               help='experimental: do not synchronize the cache')
 
         exclude_group = subparser.add_argument_group('Exclusion options')
         exclude_group.add_argument('-e', '--exclude', dest='patterns',

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2827,7 +2827,7 @@ class Archiver:
         subparser.add_argument('--json', action='store_true',
                                help='output stats as JSON (implies --stats)')
         subparser.add_argument('--no-cache-sync', dest='no_cache_sync', action='store_true',
-                               help='experimental: do not synchronize the cache')
+                               help='experimental: do not synchronize the cache. Implies --no-files-cache.')
 
         exclude_group = subparser.add_argument_group('Exclusion options')
         exclude_group.add_argument('-e', '--exclude', dest='patterns',

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -974,7 +974,7 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
         size = len(chunk)
         refcount = self.seen_chunk(id, size)
         if refcount:
-            return self.chunk_incref(id, stats)
+            return self.chunk_incref(id, stats, size_=size)
         data = self.key.encrypt(chunk)
         csize = len(data)
         self.repository.put(id, data, wait=wait)
@@ -985,12 +985,12 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
     def seen_chunk(self, id, size=None):
         return self.chunks.get(id, ChunkIndexEntry(0, None, None)).refcount
 
-    def chunk_incref(self, id, stats):
+    def chunk_incref(self, id, stats, size_=None):
         if not self._txn_active:
             self._begin_txn()
         count, size, csize = self.chunks.incref(id)
-        stats.update(size, csize, False)
-        return ChunkListEntry(id, size, csize)
+        stats.update(size or size_, csize, False)
+        return ChunkListEntry(id, size or size_, csize)
 
     def chunk_decref(self, id, stats, wait=True):
         if not self._txn_active:

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -644,14 +644,17 @@ class LocalCache(CacheStatsMixin):
 
             all_missing_ids = chunk_idx.zero_csize_ids()
             fetch_ids = []
-            for id_ in all_missing_ids:
-                already_fetched_entry = chunks_fetched_size_index.get(id_)
-                if already_fetched_entry:
-                    entry = chunk_idx[id_]._replace(csize=already_fetched_entry.csize)
-                    assert entry.size == already_fetched_entry.size, 'Chunk size mismatch'
-                    chunk_idx[id_] = entry
-                else:
-                    fetch_ids.append(id_)
+            if len(chunks_fetched_size_index):
+                for id_ in all_missing_ids:
+                    already_fetched_entry = chunks_fetched_size_index.get(id_)
+                    if already_fetched_entry:
+                        entry = chunk_idx[id_]._replace(csize=already_fetched_entry.csize)
+                        assert entry.size == already_fetched_entry.size, 'Chunk size mismatch'
+                        chunk_idx[id_] = entry
+                    else:
+                        fetch_ids.append(id_)
+            else:
+                fetch_ids = all_missing_ids
 
             for id_, data in zip(fetch_ids, decrypted_repository.repository.get_many(fetch_ids)):
                 entry = chunk_idx[id_]._replace(csize=len(data))

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -4,6 +4,7 @@ import shutil
 import stat
 from binascii import unhexlify
 from collections import namedtuple
+from time import perf_counter
 
 import msgpack
 
@@ -30,6 +31,7 @@ from .crypto.file_integrity import IntegrityCheckedFile, DetachedIntegrityChecke
 from .locking import Lock
 from .platform import SaveFile
 from .remote import cache_if_remote
+from .repository import LIST_SCAN_LIMIT
 
 FileCacheEntry = namedtuple('FileCacheEntry', 'age inode size mtime chunk_ids')
 
@@ -347,6 +349,69 @@ class Cache:
             os.remove(config)  # kill config first
             shutil.rmtree(path)
 
+    def __new__(cls, repository, key, manifest, path=None, sync=True, do_files=False, warn_if_unencrypted=True,
+                progress=False, lock_wait=None, permit_adhoc_cache=False):
+        def local():
+            return LocalCache(repository=repository, key=key, manifest=manifest, path=path, sync=sync,
+                              do_files=do_files, warn_if_unencrypted=warn_if_unencrypted, progress=progress,
+                              lock_wait=lock_wait)
+
+        def adhoc():
+            return AdHocCache(repository=repository, key=key, manifest=manifest)
+
+        if not permit_adhoc_cache:
+            return local()
+
+        # ad-hoc cache may be permitted, but if the local cache is in sync it'd be stupid to invalidate
+        # it by needlessly using the ad-hoc cache.
+        # Check if the local cache exists and is in sync.
+
+        cache_config = CacheConfig(repository, path, lock_wait)
+        if cache_config.exists():
+            with cache_config:
+                cache_in_sync = cache_config.manifest_id == manifest.id
+            # Don't nest cache locks
+            if cache_in_sync:
+                # Local cache is in sync, use it
+                logger.debug('Cache: choosing local cache (in sync)')
+                return local()
+        logger.debug('Cache: choosing ad-hoc cache (local cache does not exist or is not in sync)')
+        return adhoc()
+
+
+class CacheStatsMixin:
+    str_format = """\
+All archives:   {0.total_size:>20s} {0.total_csize:>20s} {0.unique_csize:>20s}
+
+                       Unique chunks         Total chunks
+Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
+
+    def __str__(self):
+        return self.str_format.format(self.format_tuple())
+
+    Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks',
+                                     'total_chunks'])
+
+    def stats(self):
+        # XXX: this should really be moved down to `hashindex.pyx`
+        stats = self.Summary(*self.chunks.summarize())._asdict()
+        return stats
+
+    def format_tuple(self):
+        stats = self.stats()
+        for field in ['total_size', 'total_csize', 'unique_csize']:
+            stats[field] = format_file_size(stats[field])
+        return self.Summary(**stats)
+
+    def chunks_stored_size(self):
+        return self.stats()['unique_csize']
+
+
+class LocalCache(CacheStatsMixin):
+    """
+    Persistent, local (client-side) cache.
+    """
+
     def __init__(self, repository, key, manifest, path=None, sync=True, do_files=False, warn_if_unencrypted=True,
                  progress=False, lock_wait=None):
         """
@@ -393,31 +458,6 @@ class Cache:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
-
-    def __str__(self):
-        fmt = """\
-All archives:   {0.total_size:>20s} {0.total_csize:>20s} {0.unique_csize:>20s}
-
-                       Unique chunks         Total chunks
-Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
-        return fmt.format(self.format_tuple())
-
-    Summary = namedtuple('Summary', ['total_size', 'total_csize', 'unique_size', 'unique_csize', 'total_unique_chunks',
-                                     'total_chunks'])
-
-    def stats(self):
-        # XXX: this should really be moved down to `hashindex.pyx`
-        stats = self.Summary(*self.chunks.summarize())._asdict()
-        return stats
-
-    def format_tuple(self):
-        stats = self.stats()
-        for field in ['total_size', 'total_csize', 'unique_csize']:
-            stats[field] = format_file_size(stats[field])
-        return self.Summary(**stats)
-
-    def chunks_stored_size(self):
-        return self.stats()['unique_csize']
 
     def create(self):
         """Create a new empty cache at `self.path`
@@ -547,10 +587,14 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         archive indexes.
         """
         archive_path = os.path.join(self.path, 'chunks.archive.d')
+        # An index of chunks were the size had to be fetched
+        chunks_fetched_size_index = ChunkIndex()
         # Instrumentation
         processed_item_metadata_bytes = 0
         processed_item_metadata_chunks = 0
         compact_chunks_archive_saved_space = 0
+        fetched_chunks_for_csize = 0
+        fetched_bytes_for_csize = 0
 
         def mkpath(id, suffix=''):
             id_hex = bin_to_hex(id)
@@ -588,6 +632,34 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
             except FileNotFoundError:
                 pass
 
+        def fetch_missing_csize(chunk_idx):
+            """
+            Archives created with AdHocCache will have csize=0 in all chunk list entries whose
+            chunks were already in the repository.
+
+            Scan *chunk_idx* for entries where csize=0 and fill in the correct information.
+            """
+            nonlocal fetched_chunks_for_csize
+            nonlocal fetched_bytes_for_csize
+
+            all_missing_ids = chunk_idx.zero_csize_ids()
+            fetch_ids = []
+            for id_ in all_missing_ids:
+                already_fetched_entry = chunks_fetched_size_index.get(id_)
+                if already_fetched_entry:
+                    entry = chunk_idx[id_]._replace(csize=already_fetched_entry.csize)
+                    assert entry.size == already_fetched_entry.size, 'Chunk size mismatch'
+                    chunk_idx[id_] = entry
+                else:
+                    fetch_ids.append(id_)
+
+            for id_, data in zip(fetch_ids, decrypted_repository.repository.get_many(fetch_ids)):
+                entry = chunk_idx[id_]._replace(csize=len(data))
+                chunk_idx[id_] = entry
+                chunks_fetched_size_index[id_] = entry
+                fetched_chunks_for_csize += 1
+                fetched_bytes_for_csize += len(data)
+
         def fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx):
             nonlocal processed_item_metadata_bytes
             nonlocal processed_item_metadata_chunks
@@ -603,6 +675,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                 processed_item_metadata_chunks += 1
                 sync.feed(data)
             if self.do_cache:
+                fetch_missing_csize(chunk_idx)
                 write_archive_index(archive_id, chunk_idx)
 
         def write_archive_index(archive_id, chunk_idx):
@@ -698,8 +771,13 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                         chunk_idx = chunk_idx or ChunkIndex(master_index_capacity)
                         logger.info('Fetching archive index for %s ...', archive_name)
                         fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx)
+                if not self.do_cache:
+                    fetch_missing_csize(chunk_idx)
                 pi.finish()
-                logger.debug('Cache sync: processed %s bytes (%d chunks) of metadata',
+                logger.debug('Cache sync: had to fetch %s (%d chunks) because no archive had a csize set for them '
+                             '(due to --no-cache-sync)',
+                             format_file_size(fetched_bytes_for_csize), fetched_chunks_for_csize)
+                logger.debug('Cache sync: processed %s (%d chunks) of metadata',
                              format_file_size(processed_item_metadata_bytes), processed_item_metadata_chunks)
                 logger.debug('Cache sync: compact chunks.archive.d storage saved %s bytes',
                              format_file_size(compact_chunks_archive_saved_space))
@@ -843,3 +921,132 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
         entry = FileCacheEntry(age=0, inode=st.st_ino, size=st.st_size, mtime=int_to_bigint(mtime_ns), chunk_ids=ids)
         self.files[path_hash] = msgpack.packb(entry)
         self._newest_mtime = max(self._newest_mtime or 0, mtime_ns)
+
+
+class AdHocCache(CacheStatsMixin):
+    """
+    Ad-hoc, non-persistent cache.
+
+    Compared to the standard LocalCache the AdHocCache does not maintain accurate reference count,
+    nor does it provide a files cache (which would require persistence). Chunks that were not added
+    during the current AdHocCache lifetime won't have correct size/csize set (0 bytes) and will
+    have an infinite reference count (MAX_VALUE).
+    """
+
+    str_format = """\
+All archives:                unknown              unknown              unknown
+
+                       Unique chunks         Total chunks
+Chunk index:    {0.total_unique_chunks:20d}             unknown"""
+
+    def __init__(self, repository, key, manifest, warn_if_unencrypted=True):
+        self.repository = repository
+        self.key = key
+        self.manifest = manifest
+        self._txn_active = False
+
+        self.security_manager = SecurityManager(repository)
+        self.security_manager.assert_secure(manifest, key)
+
+        logger.warning('Note: --no-cache-sync is an experimental feature.')
+
+    # Public API
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    files = None
+    do_files = False
+
+    def file_known_and_unchanged(self, path_hash, st, ignore_inode=False):
+        pass
+
+    def memorize_file(self, path_hash, st, ids):
+        pass
+
+    def add_chunk(self, id, chunk, stats, overwrite=False, wait=True):
+        assert not overwrite, 'AdHocCache does not permit overwrites — trying to use it for recreate?'
+        if not self._txn_active:
+            self._begin_txn()
+        size = len(chunk)
+        refcount = self.seen_chunk(id, size)
+        if refcount:
+            return self.chunk_incref(id, stats)
+        data = self.key.encrypt(chunk)
+        csize = len(data)
+        self.repository.put(id, data, wait=wait)
+        self.chunks.add(id, 1, size, csize)
+        stats.update(size, csize, not refcount)
+        return ChunkListEntry(id, size, csize)
+
+    def seen_chunk(self, id, size=None):
+        return self.chunks.get(id, ChunkIndexEntry(0, None, None)).refcount
+
+    def chunk_incref(self, id, stats):
+        if not self._txn_active:
+            self._begin_txn()
+        count, size, csize = self.chunks.incref(id)
+        stats.update(size, csize, False)
+        return ChunkListEntry(id, size, csize)
+
+    def chunk_decref(self, id, stats, wait=True):
+        if not self._txn_active:
+            self._begin_txn()
+        count, size, csize = self.chunks.decref(id)
+        if count == 0:
+            del self.chunks[id]
+            self.repository.delete(id, wait=wait)
+            stats.update(-size, -csize, True)
+        else:
+            stats.update(-size, -csize, False)
+
+    def commit(self):
+        if not self._txn_active:
+            return
+        self.security_manager.save(self.manifest, self.key)
+        self._txn_active = False
+
+    def rollback(self):
+        self._txn_active = False
+        del self.chunks
+
+    # Private API
+
+    def _begin_txn(self):
+        self._txn_active = True
+        # Explicitly set the initial hash table capacity to avoid performance issues
+        # due to hash table "resonance".
+        # Since we're creating an archive, add 10 % from the start.
+        num_chunks = len(self.repository)
+        capacity = int(num_chunks / ChunkIndex.MAX_LOAD_FACTOR * 1.1)
+        self.chunks = ChunkIndex(capacity)
+        pi = ProgressIndicatorPercent(total=num_chunks, msg='Downloading chunk list... %3.0f%%',
+                                      msgid='cache.download_chunks')
+        t0 = perf_counter()
+        num_requests = 0
+        marker = None
+        while True:
+            result = self.repository.list(limit=LIST_SCAN_LIMIT, marker=marker)
+            num_requests += 1
+            if not result:
+                break
+            pi.show(increase=len(result))
+            marker = result[-1]
+            # All chunks from the repository have a refcount of MAX_VALUE, which is sticky,
+            # therefore we can't/won't delete them. Chunks we added ourselves in this transaction
+            # (e.g. checkpoint archives) are tracked correctly.
+            init_entry = ChunkIndexEntry(refcount=ChunkIndex.MAX_VALUE, size=0, csize=0)
+            for id_ in result:
+                self.chunks[id_] = init_entry
+        assert len(self.chunks) == num_chunks
+        # LocalCache does not contain the manifest, either.
+        del self.chunks[self.manifest.MANIFEST_ID]
+        duration = perf_counter() - t0
+        pi.finish()
+        logger.debug('AdHocCache: downloaded %d chunk IDs in %.2f s (%d requests), ~%s/s',
+                     num_chunks, duration, num_requests, format_file_size(num_chunks * 34 / duration))
+        # Chunk IDs in a list are encoded in 34 bytes: 1 byte msgpack header, 1 byte length, 32 ID bytes.
+        # Protocol overhead is neglected in this calculation.

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -656,6 +656,8 @@ class LocalCache(CacheStatsMixin):
             else:
                 fetch_ids = all_missing_ids
 
+            # This is potentially a rather expensive operation, but it's hard to tell at this point
+            # if it's a problem in practice (hence the experimental status of --no-cache-sync).
             for id_, data in zip(fetch_ids, decrypted_repository.repository.get_many(fetch_ids)):
                 entry = chunk_idx[id_]._replace(csize=len(data))
                 chunk_idx[id_] = entry

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -1001,6 +1001,9 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
             self._begin_txn()
         count, size, csize = self.chunks.incref(id)
         stats.update(size or size_, csize, False)
+        # When size is 0 and size_ is not given, then this chunk has not been locally visited yet (seen_chunk with
+        # size or add_chunk); we can't add references to those (size=0 is invalid) and generally don't try to.
+        assert size or size_
         return ChunkListEntry(id, size or size_, csize)
 
     def chunk_decref(self, id, stats, wait=True):

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -131,7 +131,7 @@ class MandatoryFeatureUnsupported(Error):
 
 def check_extension_modules():
     from . import platform, compress, item
-    if hashindex.API_VERSION != '1.1_05':
+    if hashindex.API_VERSION != '1.1_06':
         raise ExtensionModuleError
     if chunker.API_VERSION != '1.1_01':
         raise ExtensionModuleError
@@ -2010,7 +2010,7 @@ class BorgJsonEncoder(json.JSONEncoder):
         from .repository import Repository
         from .remote import RemoteRepository
         from .archive import Archive
-        from .cache import Cache
+        from .cache import LocalCache, AdHocCache
         if isinstance(o, Repository) or isinstance(o, RemoteRepository):
             return {
                 'id': bin_to_hex(o.id),
@@ -2018,9 +2018,13 @@ class BorgJsonEncoder(json.JSONEncoder):
             }
         if isinstance(o, Archive):
             return o.info()
-        if isinstance(o, Cache):
+        if isinstance(o, LocalCache):
             return {
                 'path': o.path,
+                'stats': o.stats(),
+            }
+        if isinstance(o, AdHocCache):
+            return {
                 'stats': o.stats(),
             }
         return super().default(o)

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -189,6 +189,7 @@ class Item(PropDict):
         If memorize is True, the computed size value will be stored into the item.
         """
         attr = 'csize' if compressed else 'size'
+        assert not (compressed and memorize), 'Item does not have a csize field.'
         try:
             if from_chunks:
                 raise AttributeError

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -34,7 +34,7 @@ TAG_PUT = 0
 TAG_DELETE = 1
 TAG_COMMIT = 2
 
-LIST_SCAN_LIMIT = 10000  # repo.list() / .scan() result count limit the borg client uses
+LIST_SCAN_LIMIT = 100000  # repo.list() / .scan() result count limit the borg client uses
 
 FreeSpace = partial(defaultdict, int)
 

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1041,6 +1041,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         create_stats = create_json['cache']['stats']
         info_stats = info_json['cache']['stats']
         assert create_stats == info_stats
+        self.cmd('delete', '--cache-only', self.repository_location)
+        self.cmd('create', '--no-cache-sync', self.repository_location + '::test2', 'input')
+        self.cmd('info', self.repository_location)
         self.cmd('check', self.repository_location)
 
     def test_extract_pattern_opt(self):

--- a/src/borg/testsuite/cache.py
+++ b/src/borg/testsuite/cache.py
@@ -1,11 +1,19 @@
 import io
+import os.path
 
 from msgpack import packb
 
 import pytest
 
-from ..hashindex import ChunkIndex, CacheSynchronizer
 from .hashindex import H
+from .key import TestKey
+from ..archive import Statistics
+from ..cache import AdHocCache
+from ..compress import CompressionSpec
+from ..crypto.key import RepoKey
+from ..hashindex import ChunkIndex, CacheSynchronizer
+from ..helpers import Manifest
+from ..repository import Repository
 
 
 class TestCacheSynchronizer:
@@ -196,3 +204,76 @@ class TestCacheSynchronizer:
         assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
         sync.feed(data)
         assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
+
+
+class TestAdHocCache:
+    @pytest.yield_fixture
+    def repository(self, tmpdir):
+        self.repository_location = os.path.join(str(tmpdir), 'repository')
+        with Repository(self.repository_location, exclusive=True, create=True) as repository:
+            repository.put(H(1), b'1234')
+            repository.put(Manifest.MANIFEST_ID, b'5678')
+            yield repository
+
+    @pytest.fixture
+    def key(self, repository, monkeypatch):
+        monkeypatch.setenv('BORG_PASSPHRASE', 'test')
+        key = RepoKey.create(repository, TestKey.MockArgs())
+        key.compressor = CompressionSpec('none').compressor
+        return key
+
+    @pytest.fixture
+    def manifest(self, repository, key):
+        Manifest(key, repository).write()
+        return Manifest.load(repository, key=key, operations=Manifest.NO_OPERATION_CHECK)[0]
+
+    @pytest.fixture
+    def cache(self, repository, key, manifest):
+        return AdHocCache(repository, key, manifest)
+
+    def test_does_not_contain_manifest(self, cache):
+        assert not cache.seen_chunk(Manifest.MANIFEST_ID)
+
+    def test_does_not_delete_existing_chunks(self, repository, cache):
+        assert cache.seen_chunk(H(1)) == ChunkIndex.MAX_VALUE
+        cache.chunk_decref(H(1), Statistics())
+        assert repository.get(H(1)) == b'1234'
+
+    def test_does_not_overwrite(self, cache):
+        with pytest.raises(AssertionError):
+            cache.add_chunk(H(1), b'5678', Statistics(), overwrite=True)
+
+    def test_seen_chunk_add_chunk_size(self, cache):
+        assert cache.add_chunk(H(1), b'5678', Statistics()) == (H(1), 4, 0)
+
+    def test_deletes_chunks_during_lifetime(self, cache, repository):
+        """E.g. checkpoint archives"""
+        cache.add_chunk(H(5), b'1010', Statistics())
+        assert cache.seen_chunk(H(5)) == 1
+        cache.chunk_decref(H(5), Statistics())
+        assert not cache.seen_chunk(H(5))
+        with pytest.raises(Repository.ObjectNotFound):
+            repository.get(H(5))
+
+    def test_files_cache(self, cache):
+        assert cache.file_known_and_unchanged(bytes(32), None) is None
+        assert not cache.do_files
+        assert cache.files is None
+
+    def test_txn(self, cache):
+        assert not cache._txn_active
+        cache.seen_chunk(H(5))
+        assert cache._txn_active
+        assert cache.chunks
+        cache.rollback()
+        assert not cache._txn_active
+        assert not hasattr(cache, 'chunks')
+
+    def test_incref_after_add_chunk(self, cache):
+        assert cache.add_chunk(H(3), b'5678', Statistics()) == (H(3), 4, 47)
+        assert cache.chunk_incref(H(3), Statistics()) == (H(3), 4, 47)
+
+    def test_existing_incref_after_add_chunk(self, cache):
+        """This case occurs with part files, see Archive.chunk_file."""
+        assert cache.add_chunk(H(1), b'5678', Statistics()) == (H(1), 4, 0)
+        assert cache.chunk_incref(H(1), Statistics()) == (H(1), 4, 0)

--- a/src/borg/testsuite/item.py
+++ b/src/borg/testsuite/item.py
@@ -154,6 +154,11 @@ def test_item_file_size():
         ChunkListEntry(csize=1, size=2000, id=None),
     ])
     assert item.get_size() == 3000
+    with pytest.raises(AssertionError):
+        item.get_size(compressed=True, memorize=True)
+    assert item.get_size(compressed=True) == 2
+    item.get_size(memorize=True)
+    assert item.size == 3000
 
 
 def test_item_file_size_no_chunks():


### PR DESCRIPTION
Fixes #2313 

There are likely some rough edges or smaller inconsistencies when using this, e.g. borg-diff might not quite work...? I don't know.

I'll be upfront; _this PR is not about fixing all these. It's called experimental for a reason._ This PR is about getting the data model, the basics right.

Stuff for the future:

- Add a dedicated RPC call like "get_size[_many]" -- perhaps even taking a list (over RPC) to allow the remote `Repository` to sort by (segment, offset).
- recreate could touch up chunk id lists with csize=0 with their correct csize (depending on mode it'll already do that as a side-effect). check--repair could do that as well.