### PR TITLE
cache sync: suppress GCC C90/C99 int literal warning

### DIFF
--- a/src/borg/cache_sync/unpack.h
+++ b/src/borg/cache_sync/unpack.h
@@ -26,7 +26,7 @@
 #include "unpack_define.h"
 
 // 2**32 - 1025
-#define _MAX_VALUE ( (uint32_t) 4294966271 )
+#define _MAX_VALUE ( (uint32_t) 4294966271UL )
 
 #define MIN(x, y) ((x) < (y) ? (x): (y))
 


### PR DESCRIPTION
warning: this decimal constant is unsigned only in ISO C90

Raised by GCC 4.9.2 on PowerPC.

The warning is bogus here due to the immediate explicit cast; newer
versions don't emit it.

Remove it, since GCC emits it on *every use of the macro*.