### PR TITLE
changed the date of "day without backup"

### DIFF
--- a/docs/misc/prune-example.txt
+++ b/docs/misc/prune-example.txt
@@ -2,7 +2,7 @@ borg prune visualized
 =====================
 
 Assume it is 2016-01-01, today's backup has not yet been made and you have
-created at least one backup on each day in 2015 except on 2015-12-20 (no
+created at least one backup on each day in 2015 except on 2015-12-19 (no
 backup made on that day).
 
 This is what borg prune --keep-daily 14 --keep-monthly 6 would keep.
@@ -45,7 +45,7 @@ Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su
 Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su
           1  2  3  4                     1      1  2  3  4  5  6
  5  6  7  8  9 10 11   2  3  4  5  6  7  8   7  8  9 10 11 12 13
-12 13 14 15 16 17 18   9 10 11 12 13 14 15  14 15 16 17d18d19d20
+12 13 14 15 16 17 18   9 10 11 12 13 14 15  14 15 16 17d18d19 20d
 19 20 21 22 23 24 25  16 17 18 19 20 21 22  21d22d23d24d25d26d27d
 26 27 28 29 30 31m    23 24 25 26 27 28 29  28d29d30d31d
                       30m
@@ -66,8 +66,8 @@ List view
  9. 2015-12-23
 10. 2015-12-22
 11. 2015-12-21
-    (no backup made on 2015-12-20)
-12. 2015-12-19
+12. 2015-12-20
+    (no backup made on 2015-12-19)
 13. 2015-12-18
 14. 2015-12-17
 
@@ -83,7 +83,7 @@ Jun. December is not considered for this rule, because that backup was already
 kept because of the daily rule.
 
 2015-12-17 is kept to satisfy the --keep-daily 14 rule - because no backup was
-made on 2015-12-20. If a backup had been made on that day, it would not keep
+made on 2015-12-19. If a backup had been made on that day, it would not keep
 the one from 2015-12-17.
 
 We did not include yearly, weekly, hourly, minutely or secondly rules to keep


### PR DESCRIPTION
Changed from 20. December to 19. December for easier comprehension (viewing the calendar.)
The missing 'd' at 20. December is hardly noticeable compared to e.g. the 19. December.