### PR TITLE
cache sync: don't do memcpy(..., 0, 0)

### DIFF
--- a/src/borg/cache_sync/cache_sync.c
+++ b/src/borg/cache_sync/cache_sync.c
@@ -87,8 +87,10 @@ cache_sync_feed(CacheSyncCtx *ctx, void *data, uint32_t length)
                 ctx->ctx.user.last_error = "cache_sync_feed: unable to allocate buffer";
                 return 0;
             }
-            memcpy(new_buf, ctx->buf + ctx->head, ctx->tail - ctx->head);
-            free(ctx->buf);
+            if(ctx->buf) {
+                memcpy(new_buf, ctx->buf + ctx->head, ctx->tail - ctx->head);
+                free(ctx->buf);
+            }
             ctx->buf = new_buf;
             ctx->tail -= ctx->head;
             ctx->head = 0;


### PR DESCRIPTION
!ctx->buf => ctx->tail - ctx->head == 0

(ubsan is annoyed by this)