### PR TITLE
chunker: don't do uint32_t >> 32

### DIFF
--- a/src/borg/_chunker.c
+++ b/src/borg/_chunker.c
@@ -63,7 +63,7 @@ static uint32_t table_base[] =
     0xc5ae37bb, 0xa76ce12a, 0x8150d8f3, 0x2ec29218, 0xa35f0984, 0x48c0647e, 0x0b5ff98c, 0x71893f7b
 };
 
-#define BARREL_SHIFT(v, shift) ( ((v) << shift) | ((v) >> (32 - shift)) )
+#define BARREL_SHIFT(v, shift) ( ((v) << shift) | ((v) >> ((32 - shift) & 0x1f)) )
 
 size_t pagemask;
 


### PR DESCRIPTION
As luck would have it at least x86 already performs this masking. Others probably do as well. GCC knows this and emits the same code.

Found by ubsan. With #2670 and #2671 applied, running the test suite is ubsan-clean.