### PR TITLE
info: use CacheSynchronizer & HashIndex.stats_against

### DIFF
--- a/src/borg/cache_sync/cache_sync.c
+++ b/src/borg/cache_sync/cache_sync.c
@@ -38,6 +38,7 @@ cache_sync_init(HashIndex *chunks)
     unpack_init(&ctx->ctx);
     /* needs to be set only once */
     ctx->ctx.user.chunks = chunks;
+    ctx->ctx.user.num_files = 0;
     ctx->buf = NULL;
     ctx->head = 0;
     ctx->tail = 0;
@@ -56,9 +57,15 @@ cache_sync_free(CacheSyncCtx *ctx)
 }
 
 static const char *
-cache_sync_error(CacheSyncCtx *ctx)
+cache_sync_error(const CacheSyncCtx *ctx)
 {
     return ctx->ctx.user.last_error;
+}
+
+static uint64_t
+cache_sync_num_files(const CacheSyncCtx *ctx)
+{
+    return ctx->ctx.user.num_files;
 }
 
 /**

--- a/src/borg/cache_sync/unpack.h
+++ b/src/borg/cache_sync/unpack.h
@@ -50,6 +50,8 @@ typedef struct unpack_user {
 
     HashIndex *chunks;
 
+    uint64_t num_files;
+
     /*
      * We don't care about most stuff. This flag tells us whether we're at the chunks structure,
      * meaning:
@@ -358,6 +360,7 @@ static inline int unpack_callback_raw(unpack_user* u, const char* b, const char*
         if(length == 6 && !memcmp("chunks", p, 6)) {
             u->expect = expect_chunks_begin;
             u->inside_chunks = 1;
+            u->num_files++;
         } else {
             u->expect = expect_map_item_end;
         }

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -131,7 +131,7 @@ class MandatoryFeatureUnsupported(Error):
 
 def check_extension_modules():
     from . import platform, compress, item
-    if hashindex.API_VERSION != '1.1_03':
+    if hashindex.API_VERSION != '1.1_04':
         raise ExtensionModuleError
     if chunker.API_VERSION != '1.1_01':
         raise ExtensionModuleError


### PR DESCRIPTION
Gets rid of the cache "abuse" (avoiding some I/O, should be nice for `borg info ... --last/--first/-a`) and is also faster. Also, cached archive chunks indices could be used, but that code is touched in the --no-cache-sync PR.

Logically, nothing changes. size and csize are taken from the master (Cache.chunks) index.