### PR TITLE
delete: remove short option for --cache-only

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3094,11 +3094,9 @@ class Archiver:
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           help='delete archive')
         subparser.set_defaults(func=self.do_delete)
-        subparser.add_argument('-s', '--stats', dest='stats',
-                               action='store_true', default=False,
+        subparser.add_argument('-s', '--stats', dest='stats', action='store_true',
                                help='print statistics for the deleted archive')
-        subparser.add_argument('-c', '--cache-only', dest='cache_only',
-                               action='store_true', default=False,
+        subparser.add_argument('--cache-only', dest='cache_only', action='store_true',
                                help='delete only the local cache for the given repository')
         subparser.add_argument('--force', dest='forced',
                                action='count', default=0,


### PR DESCRIPTION
Overlooked in #2692 

This -c also shadows create's -c option. I didn't even knew it existed.