### PR TITLE
remove skipping the noatime tests on GNU/Hurd, fixes #2710

### DIFF
--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -375,9 +375,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         # the interesting parts of info_output2 and info_output should be same
         self.assert_equal(filter(info_output), filter(info_output2))
 
-    # Search for O_NOATIME there: https://www.gnu.org/software/hurd/contributing.html - we just
-    # skip the test on Hurd, it is not critical anyway, just testing a performance optimization.
-    @pytest.mark.skipif(sys.platform == 'gnu0', reason="O_NOATIME is strangely broken on GNU Hurd")
     def test_atime(self):
         def has_noatime(some_file):
             atime_before = os.stat(some_file).st_atime_ns


### PR DESCRIPTION
I recently installed GNU/Hurd 2017 and found the atime test works now.

(cherry picked from commit 49411d1c6c4a0d99cfab2f2d31eec6e31a7b8dbb)
