### PR TITLE
Split up parsing and filtering for --keep-within

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -21,7 +21,7 @@ import collections
 from . import __version__
 from .helpers import Error, location_validator, archivename_validator, format_line, format_time, format_file_size, \
     parse_pattern, PathPrefixPattern, to_localtime, timestamp, safe_timestamp, bin_to_hex, \
-    get_cache_dir, within_range, prune_within, prune_split, check_python, \
+    get_cache_dir, interval, prune_within, prune_split, check_python, \
     Manifest, NoManifestError, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
     dir_is_tagged, bigint_to_int, ChunkerParams, CompressionSpec, PrefixSpec, is_slow_msgpack, yes, sysinfo, \
     EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR, log_multi, PatternMatcher, ErrorIgnoringTextIOWrapper, set_ec, \
@@ -1717,7 +1717,7 @@ class Archiver:
         subparser.add_argument('--list', dest='output_list',
                                action='store_true', default=False,
                                help='output verbose list of archives it keeps/prunes. Requires -v/--verbose.')
-        subparser.add_argument('--keep-within', dest='within', type=within_range, metavar='WITHIN',
+        subparser.add_argument('--keep-within', dest='within', type=interval, metavar='INTERVAL',
                                help='keep all archives within this time interval')
         subparser.add_argument('-H', '--keep-hourly', dest='hourly', type=int, default=0,
                                help='number of hourly archives to keep')

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -21,7 +21,7 @@ import collections
 from . import __version__
 from .helpers import Error, location_validator, archivename_validator, format_line, format_time, format_file_size, \
     parse_pattern, PathPrefixPattern, to_localtime, timestamp, safe_timestamp, bin_to_hex, \
-    get_cache_dir, prune_within, prune_split, check_python, \
+    get_cache_dir, within_range, prune_within, prune_split, check_python, \
     Manifest, NoManifestError, remove_surrogates, update_excludes, format_archive, check_extension_modules, Statistics, \
     dir_is_tagged, bigint_to_int, ChunkerParams, CompressionSpec, PrefixSpec, is_slow_msgpack, yes, sysinfo, \
     EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR, log_multi, PatternMatcher, ErrorIgnoringTextIOWrapper, set_ec, \
@@ -1717,7 +1717,7 @@ class Archiver:
         subparser.add_argument('--list', dest='output_list',
                                action='store_true', default=False,
                                help='output verbose list of archives it keeps/prunes. Requires -v/--verbose.')
-        subparser.add_argument('--keep-within', dest='within', type=str, metavar='WITHIN',
+        subparser.add_argument('--keep-within', dest='within', type=within_range, metavar='WITHIN',
                                help='keep all archives within this time interval')
         subparser.add_argument('-H', '--keep-hourly', dest='hourly', type=int, default=0,
                                help='number of hourly archives to keep')

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -290,12 +290,12 @@ def interval(s):
         # range suffixes in ascending multiplier order
         ranges = [k for k, v in sorted(multiplier.items(), key=lambda t: t[1])]
         raise argparse.ArgumentTypeError(
-            'Unexpected interval time unit "%s": expected one of %s' % (s[-1], ranges))
+            'Unexpected interval time unit "%s": expected one of %r' % (s[-1], ranges))
 
     try:
         hours = int(number) * multiplier[suffix]
     except ValueError:
-        hours = -1      # swallow the string to int ValueError stack trace
+        hours = -1
 
     if hours <= 0:
         raise argparse.ArgumentTypeError(

--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -279,8 +279,8 @@ class Manifest:
         return archives
 
 
-def within_range(s):
-    """Convert a string representing a valid 'within' range to a number of hours."""
+def interval(s):
+    """Convert a string representing a valid interval to a number of hours."""
     multiplier = {'H': 1, 'd': 24, 'w': 24 * 7, 'm': 24 * 31, 'y': 24 * 365}
 
     if s.endswith(tuple(multiplier.keys())):
@@ -288,18 +288,18 @@ def within_range(s):
         suffix = s[-1]
     else:
         # range suffixes in ascending multiplier order
-        ranges = [ k for k, v in sorted(multiplier.items(), key=lambda t: t[1]) ]
+        ranges = [k for k, v in sorted(multiplier.items(), key=lambda t: t[1])]
         raise argparse.ArgumentTypeError(
-            'Unexpected --keep-within suffix "%s": expected one of %s' % (s[-1], ranges))
+            'Unexpected interval time unit "%s": expected one of %s' % (s[-1], ranges))
 
     try:
         hours = int(number) * multiplier[suffix]
     except ValueError:
-        hours = None    # swallow the string to int ValueError stack trace
+        hours = -1      # swallow the string to int ValueError stack trace
 
-    if hours is None or hours <= 0:
+    if hours <= 0:
         raise argparse.ArgumentTypeError(
-            'Unexpected --keep-within number "%s": expected an integer greater than 0' % number)
+            'Unexpected interval number "%s": expected an integer greater than 0' % number)
 
     return hours
 

--- a/borg/testsuite/helpers.py
+++ b/borg/testsuite/helpers.py
@@ -12,7 +12,7 @@ import msgpack.fallback
 import time
 
 from ..helpers import Location, format_file_size, format_timedelta, format_line, PlaceholderError, make_path_safe, \
-    within_range, prune_within, prune_split, get_cache_dir, get_keys_dir, get_security_dir, Statistics, is_slow_msgpack, \
+    interval, prune_within, prune_split, get_cache_dir, get_keys_dir, get_security_dir, Statistics, is_slow_msgpack, \
     yes, TRUISH, FALSISH, DEFAULTISH, \
     StableDict, int_to_bigint, bigint_to_int, parse_timestamp, CompressionSpec, ChunkerParams, \
     ProgressIndicatorPercent, ProgressIndicatorEndless, load_excludes, parse_pattern, \
@@ -666,39 +666,36 @@ class PruneSplitTestCase(BaseTestCase):
 
 
 class PruneWithinTestCase(BaseTestCase):
-    def test_with_range(self):
-        self.assert_equal(within_range('1H'), 1)
-        self.assert_equal(within_range('1d'), 24)
-        self.assert_equal(within_range('1w'), 168)
-        self.assert_equal(within_range('1m'), 744)
-        self.assert_equal(within_range('1y'), 8760)
+    def test_interval(self):
+        self.assert_equal(interval('1H'), 1)
+        self.assert_equal(interval('1d'), 24)
+        self.assert_equal(interval('1w'), 168)
+        self.assert_equal(interval('1m'), 744)
+        self.assert_equal(interval('1y'), 8760)
 
-
-    def test_with_range_prefix(self):
+    def test_interval_time_unit(self):
         with pytest.raises(ArgumentTypeError) as exc:
-            within_range('H')
+            interval('H')
         self.assert_equal(
             exc.value.args,
-            ('Unexpected --keep-within prefix "": expected an integer greater than 0',))
+            ('Unexpected interval number "": expected an integer greater than 0',))
         with pytest.raises(ArgumentTypeError) as exc:
-            within_range('-1d')
+            interval('-1d')
         self.assert_equal(
             exc.value.args,
-            ('Unexpected --keep-within prefix "-1": expected an integer greater than 0',))
+            ('Unexpected interval number "-1": expected an integer greater than 0',))
         with pytest.raises(ArgumentTypeError) as exc:
-            within_range('food')
+            interval('food')
         self.assert_equal(
             exc.value.args,
-            ('Unexpected --keep-within prefix "foo": expected an integer greater than 0',))
+            ('Unexpected interval number "foo": expected an integer greater than 0',))
 
-
-    def test_with_range_suffix(self):
+    def test_interval_number(self):
         with pytest.raises(ArgumentTypeError) as exc:
-            within_range('5')
+            interval('5')
         self.assert_equal(
             exc.value.args,
-            ("Unexpected --keep-within suffix \"5\": expected one of ['H', 'd', 'w', 'm', 'y']",))
-
+            ("Unexpected interval time unit \"5\": expected one of ['H', 'd', 'w', 'm', 'y']",))
 
     def test_prune_within(self):
 
@@ -707,7 +704,7 @@ class PruneWithinTestCase(BaseTestCase):
 
         def dotest(test_archives, within, indices):
             for ta in test_archives, reversed(test_archives):
-                self.assert_equal(set(prune_within(ta, within_range(within))),
+                self.assert_equal(set(prune_within(ta, interval(within))),
                                   subset(test_archives, indices))
 
         # 1 minute, 1.5 hours, 2.5 hours, 3.5 hours, 25 hours, 49 hours

--- a/borg/testsuite/helpers.py
+++ b/borg/testsuite/helpers.py
@@ -665,7 +665,7 @@ class PruneSplitTestCase(BaseTestCase):
         dotest(test_archives, 0, [], [])
 
 
-class PruneWithinTestCase(BaseTestCase):
+class IntervalTestCase(BaseTestCase):
     def test_interval(self):
         self.assert_equal(interval('1H'), 1)
         self.assert_equal(interval('1d'), 24)
@@ -697,6 +697,8 @@ class PruneWithinTestCase(BaseTestCase):
             exc.value.args,
             ("Unexpected interval time unit \"5\": expected one of ['H', 'd', 'w', 'm', 'y']",))
 
+
+class PruneWithinTestCase(BaseTestCase):
     def test_prune_within(self):
 
         def subset(lst, indices):


### PR DESCRIPTION
Fixes #2610

Parse --keep-within argument early, via new method within_range passed to argparse type=, so that better error messages can be given.

Also swallows ValueError stacktrace per the comment in the old code that including it wasn't desirable.  I can split this out (maybe just for master?) if desired.