### PR TITLE
Simplify ssh authorized_keys file

### DIFF
--- a/docs/deployment/central-backup-server.rst
+++ b/docs/deployment/central-backup-server.rst
@@ -68,8 +68,7 @@ forced command and restrictions applied as shown below:
 
   command="cd /home/backup/repos/<client fqdn>;
            borg serve --restrict-to-path /home/backup/repos/<client fqdn>",
-           no-port-forwarding,no-X11-forwarding,no-pty,
-           no-agent-forwarding,no-user-rc <keytype> <key> <host>
+           restrict <keytype> <key> <host>
 
 .. note:: The text shown above needs to be written on a single line!
 
@@ -147,7 +146,7 @@ package manager to install and keep borg up-to-date.
     - file: path="{{ pool }}" owner="{{ user }}" group="{{ group }}" mode=0700 state=directory
     - authorized_key: user="{{ user }}"
                       key="{{ item.key }}"
-                      key_options='command="cd {{ pool }}/{{ item.host }};borg serve --restrict-to-path {{ pool }}/{{ item.host }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'
+                      key_options='command="cd {{ pool }}/{{ item.host }};borg serve --restrict-to-path {{ pool }}/{{ item.host }}",restrict'
       with_items: "{{ auth_users }}"
     - file: path="{{ home }}/.ssh/authorized_keys" owner="{{ user }}" group="{{ group }}" mode=0600 state=file
     - file: path="{{ pool }}/{{ item.host }}" owner="{{ user }}" group="{{ group }}" mode=0700 state=directory
@@ -198,11 +197,7 @@ Salt running on a Debian system.
       - source: salt://conf/ssh-pubkeys/{{host}}-backup.id_ecdsa.pub
       - options:
         - command="cd /home/backup/repos/{{host}}; borg serve --restrict-to-path /home/backup/repos/{{host}}"
-        - no-port-forwarding
-        - no-X11-forwarding
-        - no-pty
-        - no-agent-forwarding
-        - no-user-rc
+        - restrict
   {% endfor %}
 
 

--- a/docs/deployment/hosting-repositories.rst
+++ b/docs/deployment/hosting-repositories.rst
@@ -29,7 +29,7 @@ SSH access to safe operations only.
 
 ::
 
-  restrict,command="borg serve --restrict-to-repository /home/<user>/repository"
+  command="borg serve --restrict-to-repository /home/<user>/repository",restrict
   <key type> <key> <key host>
 
 .. note:: The text shown above needs to be written on a **single** line!

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -277,7 +277,7 @@ use of the SSH keypair by prepending a forced command to the SSH public key in
 the remote server's `authorized_keys` file. This example will start |project_name|
 in server mode and limit it to a specific filesystem path::
 
-  command="borg serve --restrict-to-path /path/to/repo",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc ssh-rsa AAAAB3[...]
+  command="borg serve --restrict-to-path /path/to/repo",restrict ssh-rsa AAAAB3[...]
 
 If it is not possible to install |project_name| on the remote host,
 it is still possible to use the remote host to store a repository by

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -37,5 +37,5 @@ locations like ``/etc/environment`` or in the forced command itself (example bel
     If you're using openssh-server < 7.2, however, you have to explicitly specify
     the ssh features to restrict and cannot simply use the restrict option as it
     has been introduced in v7.2. We recommend to use
-    ``,no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc``
+    ``no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc``
     in this case.

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -29,3 +29,13 @@ locations like ``/etc/environment`` or in the forced command itself (example bel
     $ cat ~/.ssh/authorized_keys
     command="export BORG_XXX=value; borg serve [...]",restrict ssh-rsa [...]
 
+.. note::
+    The examples above use the ``restrict`` directive. This does automatically
+    block potential dangerous ssh features, even when they are added in a future
+    update. Thus, this option should be prefered.
+    
+    If you're using openssh-server < 7.2, however, you have to explicitly specify
+    the ssh features to restrict and cannot simply use the restrict option as it
+    has been introduced in v7.2. We recommend to use
+    ``,no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc``
+    in this case.

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -23,7 +23,7 @@ locations like ``/etc/environment`` or in the forced command itself (example bel
     # Use key options to disable unneeded and potentially dangerous SSH functionality.
     # This will help to secure an automated remote backup system.
     $ cat ~/.ssh/authorized_keys
-    command="borg serve --restrict-to-path /path/to/repo",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc ssh-rsa AAAAB3[...]
+    command="borg serve --restrict-to-path /path/to/repo",restrict ssh-rsa AAAAB3[...]
 
     # Set a BORG_XXX environment variable on the "borg serve" side
     $ cat ~/.ssh/authorized_keys


### PR DESCRIPTION
Just using "restrict"; closes https://github.com/borgbackup/borg/issues/2121

Reasoning:
Even Debian 9 (now stable) [uses v7.4](https://packages.debian.org/de/stretch/openssh-server).

AFAIK it is still not possible in Ubuntu Trusty, but hopefully nobody uses that anyway. And waiting for this really nice doc change until April 2019 is not a good idea, IMHO.

Of course, we could also just add another note saying that you need to have support for that. If using it with an older ssh version it likely does not work, so users do not get into an insecure state.
E.g. a line saying:
> If you're using openssh-server < 7.2, you have to explicitly specify the ssh features to restrict and cannot simply use the `restrict` option. Use `,no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc` in this case, may be a good idea.

Also, this doc change may also *not* be backported, so only recent borg versions have it in their doc, so when installing borg from the package repos one still gets the working doc version.