### PR TITLE
FUSE vs. fuse

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,7 +149,7 @@ def packages_netbsd
     ln -s /usr/pkg/lib/liblz4* /usr/local/opt/lz4/lib/
     touch /etc/openssl/openssl.cnf  # avoids a flood of "can't open ..."
     mozilla-rootcerts install
-    pkg_add pkg-config  # avoids some "pkg-config missing" error msg, even without fuse
+    pkg_add pkg-config  # avoids some "pkg-config missing" error msg, even without fuse pkg
     # pkg_add fuse  # llfuse supports netbsd, but is still buggy.
     # https://bitbucket.org/nikratio/python-llfuse/issues/70/perfuse_open-setsockopt-no-buffer-space
     pkg_add python34 py34-setuptools
@@ -286,7 +286,7 @@ def install_borg(fuse)
   EOF
   if fuse
     script += <<-EOF
-      # by using [fuse], setup.py can handle different fuse requirements:
+      # by using [fuse], setup.py can handle different FUSE requirements:
       pip install -e .[fuse]
     EOF
   else

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -199,7 +199,7 @@ Fixes:
   error message when parsing fails.
 - mount: check whether llfuse is installed before asking for passphrase, #2540
 - mount: do pre-mount checks before opening repository, #2541
-- fuse:
+- FUSE:
 
   - fix crash if empty (None) xattr is read, #2534
   - fix read(2) caching data in metadata cache
@@ -243,7 +243,7 @@ Other changes:
 - increase DEFAULT_SEGMENTS_PER_DIR to 1000
 - chunker: fix invalid use of types (function only used by tests)
 - chunker: don't do uint32_t >> 32
-- fuse:
+- FUSE:
 
   - add instrumentation (--debug and SIGUSR1/SIGINFO)
   - reduced memory usage for repository mounts by lazily instantiating archives
@@ -651,8 +651,8 @@ Other changes:
 
 - tests:
 
-  - fuse tests: catch ENOTSUP on freebsd
-  - fuse tests: test troublesome xattrs last
+  - FUSE tests: catch ENOTSUP on freebsd
+  - FUSE tests: test troublesome xattrs last
   - fix byte range error in test, #1740
   - use monkeypatch to set env vars, but only on pytest based tests.
   - point XDG_*_HOME to temp dirs for tests, #1714
@@ -824,7 +824,7 @@ Other changes:
   - upgrade OSXfuse / FUSE for macOS to 3.5.3
   - remove llfuse from tox.ini at a central place
   - do not try to install llfuse on centos6
-  - fix fuse test for darwin, #1546
+  - fix FUSE test for darwin, #1546
   - add windows virtual machine with cygwin
   - Vagrantfile cleanup / code deduplication
 
@@ -1033,8 +1033,8 @@ Other changes:
 - vagrant / tests:
 
   - no chown when rsyncing (fixes boxes w/o vagrant group)
-  - fix fuse permission issues on linux/freebsd, #1544
-  - skip fuse test for borg binary + fakeroot
+  - fix FUSE permission issues on linux/freebsd, #1544
+  - skip FUSE test for borg binary + fakeroot
   - ignore security.selinux xattrs, fixes tests on centos, #1735
 
 
@@ -1099,7 +1099,7 @@ Other changes:
   - upgrade OSXfuse / FUSE for macOS to 3.5.2
   - update Debian Wheezy boxes, #1686
   - openbsd / netbsd: use own boxes, fixes misc rsync installation and
-    fuse/llfuse related testing issues, #1695 #1696 #1670 #1671 #1728
+    FUSE/llfuse related testing issues, #1695 #1696 #1670 #1671 #1728
 - docs:
 
   - add docs for "key export" and "key import" commands, #1641
@@ -1120,10 +1120,10 @@ Other changes:
   - clarify FAQ regarding backup of virtual machines, #1672
 - tests:
 
-  - work around fuse xattr test issue with recent fakeroot
+  - work around FUSE xattr test issue with recent fakeroot
   - simplify repo/hashindex tests
-  - travis: test fuse-enabled borg, use trusty to have a recent FUSE
-  - re-enable fuse tests for RemoteArchiver (no deadlocks any more)
+  - travis: test FUSE-enabled borg, use trusty to have a recent FUSE
+  - re-enable FUSE tests for RemoteArchiver (no deadlocks any more)
   - clean env for pytest based tests, #1714
   - fuse_mount contextmanager: accept any options
 
@@ -1264,7 +1264,7 @@ Other changes:
   - xenial64: use user "ubuntu", not "vagrant" (as usual), #1331
 - tests:
 
-  - fix fuse tests on OS X, #1433
+  - fix FUSE tests on OS X, #1433
 - docs:
 
   - FAQ: add backup using stable filesystem names recommendation
@@ -1325,7 +1325,7 @@ Other changes:
 - tests:
 
   - add more FUSE tests, #1284
-  - deduplicate fuse (u)mount code
+  - deduplicate FUSE (u)mount code
   - fix borg binary test issues, #862
 - docs:
 
@@ -1700,7 +1700,7 @@ Other changes:
   - fix order in release process
   - updated usage docs and other minor / cosmetic fixes
   - verified borg examples in docs, #644
-  - freebsd dependency installation and fuse configuration, #649
+  - freebsd dependency installation and FUSE configuration, #649
   - add example how to restore a raw device, #671
   - add a hint about the dev headers needed when installing from source
   - add examples for delete (and handle delete after list, before prune), #656
@@ -2545,7 +2545,7 @@ Version 0.7
 
 - Ported to FreeBSD
 - Improved documentation
-- Experimental: Archives mountable as fuse filesystems.
+- Experimental: Archives mountable as FUSE filesystems.
 - The "user." prefix is no longer stripped from xattrs on Linux
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -321,7 +321,7 @@ FUSE for OS X, which is available as a pre-release_.
 FreeBSD
 ++++++++
 Listed below are packages you will need to install |project_name|, its dependencies,
-and commands to make fuse work for using the mount command.
+and commands to make FUSE work for using the mount command.
 
 ::
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1266,7 +1266,7 @@ class Archiver:
         try:
             import borg.fuse
         except ImportError as e:
-            self.print_error('borg mount not available: loading fuse support failed [ImportError: %s]' % str(e))
+            self.print_error('borg mount not available: loading FUSE support failed [ImportError: %s]' % str(e))
             return self.exit_code
 
         if not os.path.isdir(args.mountpoint) or not os.access(args.mountpoint, os.R_OK | os.W_OK | os.X_OK):
@@ -1285,7 +1285,7 @@ class Archiver:
             try:
                 operations.mount(args.mountpoint, args.options, args.foreground)
             except RuntimeError:
-                # Relevant error message already printed to stderr by fuse
+                # Relevant error message already printed to stderr by FUSE
                 self.exit_code = EXIT_ERROR
         return self.exit_code
 

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -201,7 +201,7 @@ class ItemCache:
 
 
 class FuseOperations(llfuse.Operations):
-    """Export archive as a fuse filesystem
+    """Export archive as a FUSE filesystem
     """
     # mount options
     allow_damaged_files = False
@@ -310,7 +310,7 @@ class FuseOperations(llfuse.Operations):
         return ino
 
     def process_archive(self, archive_name, prefix=[]):
-        """Build fuse inode hierarchy from archive metadata
+        """Build FUSE inode hierarchy from archive metadata
         """
         self.file_versions = {}  # for versions mode: original path -> version
         t0 = time.perf_counter()

--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -162,7 +162,7 @@ class BaseTestCase(unittest.TestCase):
             fuse = s1.st_dev != s2.st_dev
             attrs = ['st_uid', 'st_gid', 'st_rdev']
             if not fuse or not os.path.isdir(path1):
-                # dir nlink is always 1 on our fuse filesystem
+                # dir nlink is always 1 on our FUSE filesystem
                 attrs.append('st_nlink')
             d1 = [filename] + [getattr(s1, a) for a in attrs]
             d2 = [filename] + [getattr(s2, a) for a in attrs]

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -326,7 +326,7 @@ class ArchiverTestCaseBase(BaseTestCase):
             os.symlink('somewhere', os.path.join(self.input_path, 'link1'))
         self.create_regular_file('fusexattr', size=1)
         if not xattr.XATTR_FAKEROOT and xattr.is_enabled(self.input_path):
-            # ironically, due to the way how fakeroot works, comparing fuse file xattrs to orig file xattrs
+            # ironically, due to the way how fakeroot works, comparing FUSE file xattrs to orig file xattrs
             # will FAIL if fakeroot supports xattrs, thus we only set the xattr if XATTR_FAKEROOT is False.
             # This is because fakeroot with xattr-support does not propagate xattrs of the underlying file
             # into "fakeroot space". Because the xattrs exposed by borgfs are these of an underlying file


### PR DESCRIPTION
fixes #2739 

there are some debug log messages in fuse.py where it is "fuse" still - I interpreted that as module name and kept it.