### PR TITLE
FUSE versions view: keep original file extension at end, fixes #2769

### DIFF
--- a/docs/usage/mount.rst
+++ b/docs/usage/mount.rst
@@ -22,13 +22,13 @@ Examples
     root  sbin  srv  tmp  usr  var
     $ borg umount /tmp/mymountpoint
 
-    # The experimental versions view merges all archives in the repository
+    # The experimental "versions view" merges all archives in the repository
     # and provides a versioned view on files.
     $ borg mount -o versions /path/to/repo /tmp/mymountpoint
     $ ls -l /tmp/mymountpoint/home/user/doc.txt/
     total 24
-    -rw-rw-r-- 1 user group 12357 Aug 26 21:19 doc.txt.cda00bc9
-    -rw-rw-r-- 1 user group 12204 Aug 26 21:04 doc.txt.fa760f28
+    -rw-rw-r-- 1 user group 12357 Aug 26 21:19 doc.cda00bc9.txt
+    -rw-rw-r-- 1 user group 12204 Aug 26 21:04 doc.fa760f28.txt
     $ borg umount /tmp/mymountpoint
 
 borgfs

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -351,7 +351,10 @@ class FuseOperations(llfuse.Operations):
                 # add intermediate directory with same name as filename
                 path_fname = name.rsplit(b'/', 1)
                 name += b'/' + path_fname[-1]
-            return name + os.fsencode('.%08x' % version)
+            # keep original extension at end to avoid confusing tools
+            name, ext = os.path.splitext(name)
+            version_enc = os.fsencode('.%08x' % version)
+            return name + version_enc + ext
 
         if self.versions and not is_dir:
             parent = self.process_inner(name, parent)


### PR DESCRIPTION
some tools depend on seeing the correct file extension to operate
correctly, so put our version to the left of the file extension.