### PR TITLE
fuse: versions view, linear numbering by archive time

### DIFF
--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -695,3 +695,11 @@ hashindex_size(HashIndex *index)
 {
     return sizeof(HashHeader) + index->num_buckets * index->bucket_size;
 }
+
+/*
+ * Used by the FuseVersionsIndex.
+ */
+typedef struct {
+    uint32_t version;
+    char hash[16];
+} __attribute__((__packed__)) FuseVersionsElement;

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -8,7 +8,7 @@ from libc.stdlib cimport malloc, free
 from cpython.buffer cimport PyBUF_SIMPLE, PyObject_GetBuffer, PyBuffer_Release
 from cpython.bytes cimport PyBytes_FromStringAndSize
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 
 cdef extern from "../algorithms/blake2-libselect.h":
@@ -250,6 +250,25 @@ def blake2b_256(key, data):
         raise Exception('blake2b_final() failed')
 
     return PyBytes_FromStringAndSize(<char*> &md[0], 32)
+
+
+def blake2b_128(data):
+    cdef blake2b_state state
+    cdef unsigned char md[16]
+    cdef unsigned char *data_ptr = data
+
+    if blake2b_init(&state, 16) == -1:
+        raise Exception('blake2b_init() failed')
+
+    rc = blake2b_update(&state, data_ptr, len(data))
+    if rc == -1:
+        raise Exception('blake2b_update() failed')
+
+    rc = blake2b_final(&state, &md[0], 16)
+    if rc == -1:
+        raise Exception('blake2b_final() failed')
+
+    return PyBytes_FromStringAndSize(<char*> &md[0], 16)
 
 
 def hkdf_hmac_sha512(ikm, salt, info, output_length):

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -131,13 +131,13 @@ class MandatoryFeatureUnsupported(Error):
 
 def check_extension_modules():
     from . import platform, compress, item
-    if hashindex.API_VERSION != '1.1_06':
+    if hashindex.API_VERSION != '1.1_07':
         raise ExtensionModuleError
     if chunker.API_VERSION != '1.1_01':
         raise ExtensionModuleError
     if compress.API_VERSION != '1.1_03':
         raise ExtensionModuleError
-    if borg.crypto.low_level.API_VERSION != '1.1_01':
+    if borg.crypto.low_level.API_VERSION != '1.1_02':
         raise ExtensionModuleError
     if platform.API_VERSION != platform.OS_API_VERSION != '1.1_01':
         raise ExtensionModuleError

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2101,11 +2101,11 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         with self.fuse_mount(self.repository_location, mountpoint, '-o', 'versions'):
             path = os.path.join(mountpoint, 'input', 'test')  # filename shows up as directory ...
             files = os.listdir(path)
-            assert all(f.startswith('test.') for f in files)  # ... with files test.xxxxxxxx in there
+            assert all(f.startswith('test.') for f in files)  # ... with files test.xxxxx in there
             assert {b'first', b'second'} == {open(os.path.join(path, f), 'rb').read() for f in files}
             if are_hardlinks_supported():
-                st1 = os.stat(os.path.join(mountpoint, 'input', 'hardlink1', 'hardlink1.00000000'))
-                st2 = os.stat(os.path.join(mountpoint, 'input', 'hardlink2', 'hardlink2.00000000'))
+                st1 = os.stat(os.path.join(mountpoint, 'input', 'hardlink1', 'hardlink1.00001'))
+                st2 = os.stat(os.path.join(mountpoint, 'input', 'hardlink2', 'hardlink2.00001'))
                 assert st1.st_ino == st2.st_ino
 
     @unittest.skipUnless(has_llfuse, 'llfuse not installed')


### PR DESCRIPTION
The nested directories feel rather unergonomic to me.

This seems to regress about ~10 % compared to master. The effect of keep-exts seems similar.