### PR TITLE
prune enhancements / fixes

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1476,8 +1476,11 @@ class Archiver:
             return self.exit_code
         if args.prefix:
             args.glob_archives = args.prefix + '*'
-        archives_checkpoints = manifest.archives.list(glob=args.glob_archives, sort_by=['ts'], reverse=True)
-        is_checkpoint = re.compile(r'\.checkpoint(\.\d+)?$').search
+        checkpoint_re = r'\.checkpoint(\.\d+)?'
+        archives_checkpoints = manifest.archives.list(glob=args.glob_archives,
+                                                      match_end=r'(%s)?\Z' % checkpoint_re,
+                                                      sort_by=['ts'], reverse=True)
+        is_checkpoint = re.compile(r'(%s)\Z' % checkpoint_re).search
         checkpoints = [arch for arch in archives_checkpoints if is_checkpoint(arch.name)]
         # keep the latest checkpoint, if there is no later non-checkpoint archive
         if archives_checkpoints and checkpoints and archives_checkpoints[0] is checkpoints[0]:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1474,12 +1474,9 @@ class Archiver:
                              '"keep-secondly", "keep-minutely", "keep-hourly", "keep-daily", '
                              '"keep-weekly", "keep-monthly" or "keep-yearly" settings must be specified.')
             return self.exit_code
-        archives_checkpoints = manifest.archives.list(sort_by=['ts'], reverse=True)  # just a ArchiveInfo list
         if args.prefix:
             args.glob_archives = args.prefix + '*'
-        if args.glob_archives:
-            regex = re.compile(shellpattern.translate(args.glob_archives))
-            archives_checkpoints = [arch for arch in archives_checkpoints if regex.match(arch.name) is not None]
+        archives_checkpoints = manifest.archives.list(glob=args.glob_archives, sort_by=['ts'], reverse=True)
         is_checkpoint = re.compile(r'\.checkpoint(\.\d+)?$').search
         checkpoints = [arch for arch in archives_checkpoints if is_checkpoint(arch.name)]
         # keep the latest checkpoint, if there is no later non-checkpoint archive

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -219,18 +219,18 @@ class Archives(abc.MutableMapping):
         name = safe_encode(name)
         del self._archives[name]
 
-    def list(self, *, glob=None, sort_by=(), first=None, last=None, reverse=False):
+    def list(self, *, glob=None, match_end=r'\Z', sort_by=(), first=None, last=None, reverse=False):
         """
         Return list of ArchiveInfo instances according to the parameters.
 
-        First match *glob*, then *sort_by*. Apply *first* and *last* filters,
-        and possibly *reverse* the list.
+        First match *glob* (considering *match_end*), then *sort_by*.
+        Apply *first* and *last* filters, and then possibly *reverse* the list.
 
         *sort_by* is a list of sort keys applied in reverse order.
         """
         if isinstance(sort_by, (str, bytes)):
             raise TypeError('sort_by must be a sequence of str')
-        regex = re.compile(shellpattern.translate(glob or '*'))
+        regex = re.compile(shellpattern.translate(glob or '*', match_end=match_end))
         archives = [x for x in self.values() if regex.match(x.name) is not None]
         for sortkey in reversed(sort_by):
             archives.sort(key=attrgetter(sortkey))

--- a/src/borg/shellpattern.py
+++ b/src/borg/shellpattern.py
@@ -2,13 +2,16 @@ import os
 import re
 
 
-def translate(pat):
+def translate(pat, match_end=r"\Z"):
     """Translate a shell-style pattern to a regular expression.
 
     The pattern may include ``**<sep>`` (<sep> stands for the platform-specific path separator; "/" on POSIX systems) for
     matching zero or more directory levels and "*" for matching zero or more arbitrary characters with the exception of
     any path separator. Wrap meta-characters in brackets for a literal match (i.e. "[?]" to match the literal character
     "?").
+
+    Using match_end=regex one can give a regular expression that is used to match after the regex that is generated from
+    the pattern. The default is to match the end of the string.
 
     This function is derived from the "fnmatch" module distributed with the Python standard library.
 
@@ -59,4 +62,4 @@ def translate(pat):
         else:
             res += re.escape(c)
 
-    return res + r"\Z(?ms)"
+    return res + match_end + "(?ms)"

--- a/src/borg/testsuite/shellpattern.py
+++ b/src/borg/testsuite/shellpattern.py
@@ -111,3 +111,14 @@ def test_match(path, patterns):
 def test_mismatch(path, patterns):
     for p in patterns:
         assert not check(path, p)
+
+
+def test_match_end():
+    regex = shellpattern.translate("*-home")  # default is match_end == string end
+    assert re.match(regex, '2017-07-03-home')
+    assert not re.match(regex, '2017-07-03-home.checkpoint')
+
+    match_end = r'(%s)?\Z' % r'\.checkpoint(\.\d+)?'  # with/without checkpoint ending
+    regex = shellpattern.translate("*-home", match_end=match_end)
+    assert re.match(regex, '2017-07-03-home')
+    assert re.match(regex, '2017-07-03-home.checkpoint')


### PR DESCRIPTION
- noticed that prune does own globbing, which Archives.list can do.
- also, checkpoint handling with glob option is broken there, because the checkpoints won't be in the list due to shellpatterns doing fullmatches, so the checkpoints are not in the list.