### PR TITLE
patching objects does not work with the borg.exe binary, fixes #2700

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2732,6 +2732,14 @@ class ArchiverTestCaseBinary(ArchiverTestCase):
     def test_init_interrupt(self):
         pass
 
+    @unittest.skip('patches objects')
+    def test_extract_capabilities(self):
+        pass
+
+    @unittest.skip('patches objects')
+    def test_extract_xattrs_errors(self):
+        pass
+
     @unittest.skip('test_basic_functionality seems incompatible with fakeroot and/or the binary.')
     def test_basic_functionality(self):
         pass


### PR DESCRIPTION
Note: I did not reproduce the issue, but this should fix it.