### PR TITLE
support borg list repo --format {comment}, fixes #2081

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -291,7 +291,9 @@ class Archive:
         self.hard_links = {}
         self.stats = Statistics(output_json=log_json)
         self.show_progress = progress
-        self.name = name
+        self.name = name  # overwritten later with name from archive metadata
+        self.name_in_manifest = name  # can differ from .name later (if borg check fixed duplicate archive names)
+        self.comment = None
         self.checkpoint_interval = checkpoint_interval
         self.numeric_owner = numeric_owner
         self.noatime = noatime
@@ -340,6 +342,7 @@ class Archive:
         self.metadata = self._load_meta(self.id)
         self.metadata.cmdline = [safe_decode(arg) for arg in self.metadata.cmdline]
         self.name = self.metadata.name
+        self.comment = self.metadata.get('comment', '')
 
     @property
     def ts(self):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1323,7 +1323,7 @@ class Archiver:
             if args.json_lines:
                 self.print_error('The --json-lines option is only valid for listing archive contents, not archives.')
                 return self.exit_code
-            return self._list_repository(args, manifest, write)
+            return self._list_repository(args, repository, manifest, key, write)
 
     def _list_archive(self, args, repository, manifest, key, write):
         matcher = self.build_matcher(args.patterns, args.paths)
@@ -1351,14 +1351,14 @@ class Archiver:
 
         return self.exit_code
 
-    def _list_repository(self, args, manifest, write):
+    def _list_repository(self, args, repository, manifest, key, write):
         if args.format is not None:
             format = args.format
         elif args.short:
             format = "{archive}{NL}"
         else:
             format = "{archive:<36} {time} [{id}]{NL}"
-        formatter = ArchiveFormatter(format)
+        formatter = ArchiveFormatter(format, repository, manifest, key, json=args.json)
 
         output_data = []
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1787,9 +1787,10 @@ class ItemFormatter(BaseFormatter):
         self.used_call_keys = set(self.call_keys) & self.format_keys
 
     def get_item_data(self, item):
+        item_data = {}
+        item_data.update(self.item_data)
         mode = stat.filemode(item.mode)
         item_type = mode[0]
-        item_data = self.item_data
 
         source = item.get('source', '')
         extra = ''

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1791,8 +1791,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     def test_list_repository_format(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
-        self.cmd('create', self.repository_location + '::test-1', src_dir)
-        self.cmd('create', self.repository_location + '::test-2', src_dir)
+        self.cmd('create', '--comment', 'comment 1', self.repository_location + '::test-1', src_dir)
+        self.cmd('create', '--comment', 'comment 2', self.repository_location + '::test-2', src_dir)
         output_1 = self.cmd('list', self.repository_location)
         output_2 = self.cmd('list', '--format', '{archive:<36} {time} [{id}]{NL}', self.repository_location)
         self.assertEqual(output_1, output_2)
@@ -1800,6 +1800,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assertEqual(output_1, 'test-1\ntest-2\n')
         output_1 = self.cmd('list', '--format', '{barchive}/', self.repository_location)
         self.assertEqual(output_1, 'test-1/test-2/')
+        output_3 = self.cmd('list', '--format', '{name} {comment}{NL}', self.repository_location)
+        self.assert_in('test-1 comment 1\n', output_3)
+        self.assert_in('test-2 comment 2\n', output_3)
 
     def test_list_hash(self):
         self.create_regular_file('empty_file', size=0)


### PR DESCRIPTION
Load full-blown Archive instance if required.

Also supported: {bcomment} for binary and {end}.
