### PR TITLE
Fix openSUSE command and add openSUSE section

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -101,7 +101,7 @@ NetBSD       `pkgsrc`_                                     ``pkg_add py-borgback
 NixOS        `.nix file`_                                  N/A
 OpenBSD      `OpenBSD ports`_                              ``pkg_add borgbackup``
 OpenIndiana  `OpenIndiana hipster repository`_             ``pkg install borg``
-openSUSE     `openSUSE official repository`_               ``zypper in python3-borgbackup``
+openSUSE     `openSUSE official repository`_               ``zypper in borgbackup``
 OS X         `Brew cask`_                                  ``brew cask install borgbackup``
 Raspbian     `Raspbian testing`_                           ``apt install borgbackup``
 Ubuntu       `Ubuntu packages`_, `Ubuntu PPA`_             ``apt install borgbackup``
@@ -301,6 +301,20 @@ Install the dependencies with development headers::
     sudo dnf install redhat-rpm-config                 # not needed in Korora
     sudo dnf install fuse-devel fuse pkgconfig         # optional, for FUSE support
 
+openSUSE Tumbleweed / Leap
+++++++++++++++++++++++++++
+
+Install the dependencies automatically using zypper::
+
+    sudo zypper source-install --build-deps-only borgbackup
+
+Alternatively, you can enumerate all build dependencies in the command line::
+
+    sudo zypper install python3 python3-devel \
+    libacl-devel liblz4-devel openssl-devel \
+    python3-Cython python3-Sphinx python3-msgpack-python \
+    python3-pytest python3-setuptools python3-setuptools_scm \
+    python3-sphinx_rtd_theme python3-llfuse gcc gcc-c++
 
 Mac OS X
 ++++++++


### PR DESCRIPTION
Fix the name of the borgbackup package in openSUSE and
add an openSUSE section on how to install development dependencies
to build borgbackup from sources.