### PR TITLE
Use code markup for command line option headings

### DIFF
--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -12,7 +12,7 @@ The chunker params influence how input files are cut into pieces (chunks)
 which are then considered for deduplication. They also have a big impact on
 resource usage (RAM and disk space) as the amount of resources needed is
 (also) determined by the total amount of chunks in the repository (see
-`Indexes / Caches memory usage` for details).
+:ref:`cache-memory-usage` for details).
 
 ``--chunker-params=10,23,16,4095`` results in a fine-grained deduplication|
 and creates a big amount of chunks and thus uses a lot of resources to manage

--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -5,8 +5,8 @@ Here are misc. notes about topics that are maybe not covered in enough detail in
 
 .. _chunker-params:
 
---chunker-params
-~~~~~~~~~~~~~~~~
+``--chunker-params``
+~~~~~~~~~~~~~~~~~~~~
 
 The chunker params influence how input files are cut into pieces (chunks)
 which are then considered for deduplication. They also have a big impact on
@@ -50,8 +50,8 @@ a new repository when changing chunker params.
 For more details, see :ref:`chunker_details`.
 
 
---umask
-~~~~~~~
+``--umask``
+~~~~~~~~~~~
 
 If you use ``--umask``, make sure that all repository-modifying borg commands
 (create, delete, prune) that access the repository in question use the same
@@ -60,8 +60,8 @@ If you use ``--umask``, make sure that all repository-modifying borg commands
 If multiple machines access the same repository, this should hold true for all
 of them.
 
---read-special
-~~~~~~~~~~~~~~
+``--read-special``
+~~~~~~~~~~~~~~~~~~
 
 The ``--read-special`` option is special - you do not want to use it for normal
 full-filesystem backups, but rather after carefully picking some targets for it.


### PR DESCRIPTION
Closes gh-2815

The diff here looks big, but it's mostly just indenting the text that was already there.

I've also fixed a Sphinx cross link in the page.

Before:
![screenshot from 2017-07-15 11-36-42](https://user-images.githubusercontent.com/327925/28238365-5f11338a-6952-11e7-9e9e-00c1486c8343.png)

After:
![screenshot from 2017-07-15 11-36-48](https://user-images.githubusercontent.com/327925/28238366-637836d0-6952-11e7-9407-4d0d96830e2e.png)
