### PR TITLE
Fix bashism in shell scripts

### DIFF
--- a/.travis/upload_coverage.sh
+++ b/.travis/upload_coverage.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 NO_COVERAGE_TOXENVS=(pep8)
-if ! [[ "${NO_COVERAGE_TOXENVS[*]}" =~ "${TOXENV}" ]]; then
+if ! [[ "${NO_COVERAGE_TOXENVS[*]}" =~ ${TOXENV} ]]; then
     source ~/.venv/bin/activate
     # on osx, tests run as root, need access to .coverage
     sudo chmod 666 .coverage

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -91,7 +91,6 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
 
     # some helpers and error handling:
     info() { printf "\n%s %s\n\n" "$( date )" "$*" >&2; }
-    # OR: info() { echo; echo "$( date ) $*" >&2; echo; }
     trap 'echo $( date ) Backup interrupted >&2; exit 2' INT TERM
 
     info "Starting backup"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -90,8 +90,9 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
     export BORG_PASSCOMMAND='pass show backup'
 
     # some helpers and error handling:
-    function info  () { echo -e "\n"`date` $@"\n" >&2; }
-    trap "echo `date` Backup interrupted >&2; exit 2" SIGINT SIGTERM
+    info() { printf "\n%s %s\n\n" "$( date )" "$*" >&2; }
+    # OR: info() { echo; echo "$( date ) $*" >&2; echo; }
+    trap 'echo $( date ) Backup interrupted >&2; exit 2' INT TERM
 
     info "Starting backup"
 
@@ -135,7 +136,8 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
 
     prune_exit=$?
 
-    global_exit=$(( ${backup_exit} >  ${prune_exit} ? ${backup_exit} : ${prune_exit} ))
+    # use highest exit code as global exit code
+    global_exit=$(( backup_exit > prune_exit ? backup_exit : prune_exit ))
 
     if [ ${global_exit} -eq 1 ];
     then


### PR DESCRIPTION
This makes the scripts fully POSIX-compatible and fixes some other small errors.
Used shellcheck.

Also fixes https://github.com/borgbackup/borg/issues/2816

Some errors, which were in the script:
* https://github.com/koalaman/shellcheck/wiki/SC1090
* https://github.com/koalaman/shellcheck/wiki/SC2076
* https://github.com/koalaman/shellcheck/wiki/SC2064

The modified parts of the quickstart script have been tested and it has exactly the same behaviour, i.e. "info" starts with a newline character and ends with ~one~ two, so that the line is separated by an empty line above and below.
Also this line has an alternative way with the same behaviour, I included there too. Choose what you like best. :smiley: 