### PR TITLE
Name backup directories with 'before-upgrade'

### DIFF
--- a/docs/usage/upgrade.rst
+++ b/docs/usage/upgrade.rst
@@ -6,7 +6,7 @@ Examples
 
     # Upgrade the borg repository to the most recent version.
     $ borg upgrade -v /path/to/repo
-    making a hardlink copy in /path/to/repo.upgrade-2016-02-15-20:51:55
+    making a hardlink copy in /path/to/repo.before-upgrade-2016-02-15-20:51:55
     opening attic repository with borg and converting
     no key file found for repository
     converting repo index /path/to/repo/index.0

--- a/docs/usage/upgrade.rst.inc
+++ b/docs/usage/upgrade.rst.inc
@@ -134,7 +134,7 @@ make sure the cache files are also removed:
 
 Unless ``--inplace`` is specified, the upgrade process first
 creates a backup copy of the repository, in
-REPOSITORY.upgrade-DATETIME, using hardlinks. This takes
+REPOSITORY.before-upgrade-DATETIME, using hardlinks. This takes
 longer than in place upgrades, but is much safer and gives
 progress information (as opposed to ``cp -al``). Once you are
 satisfied with the conversion, you can safely destroy the

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3391,7 +3391,7 @@ class Archiver:
 
         Unless ``--inplace`` is specified, the upgrade process first
         creates a backup copy of the repository, in
-        REPOSITORY.upgrade-DATETIME, using hardlinks. This takes
+        REPOSITORY.before-upgrade-DATETIME, using hardlinks. This takes
         longer than in place upgrades, but is much safer and gives
         progress information (as opposed to ``cp -al``). Once you are
         satisfied with the conversion, you can safely destroy the

--- a/src/borg/upgrader.py
+++ b/src/borg/upgrader.py
@@ -35,7 +35,7 @@ class AtticRepositoryUpgrader(Repository):
         with self:
             backup = None
             if not inplace:
-                backup = '{}.upgrade-{:%Y-%m-%d-%H:%M:%S}'.format(self.path, datetime.datetime.now())
+                backup = '{}.before-upgrade-{:%Y-%m-%d-%H:%M:%S}'.format(self.path, datetime.datetime.now())
                 logger.info('making a hardlink copy in %s', backup)
                 if not dryrun:
                     shutil.copytree(self.path, backup, copy_function=os.link)


### PR DESCRIPTION
Because 'upgrade' can be confusing.

Closes gh-2811

This appears to be a straightforward change - as far as I can tell, borg doesn't attempt to use the backup directly, but relies on the user to handle it if upgrading fails. So there was only one place to change the code, and a few bits of documentation.