### PR TITLE
replace modulo with if to check for wraparound in hashmap

### DIFF
--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -146,7 +146,10 @@ hashindex_lookup(HashIndex *index, const void *key, int *start_idx)
             }
             return idx;
         }
-        idx = (idx + 1) % index->num_buckets;
+        idx++;
+        if (idx >= index->num_buckets) {
+            idx -= index->num_buckets;
+        }
         if(idx == start) {
             break;
         }
@@ -547,7 +550,10 @@ hashindex_set(HashIndex *index, const void *key, const void *value)
         }
         idx = start_idx;
         while(!BUCKET_IS_EMPTY(index, idx) && !BUCKET_IS_DELETED(index, idx)) {
-            idx = (idx + 1) % index->num_buckets;
+            idx++;
+            if (idx >= index->num_buckets){
+                idx -= index->num_buckets;
+            }
         }
         if(BUCKET_IS_EMPTY(index, idx)){
             index->num_empty--;


### PR DESCRIPTION
Integer division is slow, and this improves the speed of all operations on the hashmap.

Benchmarks:
https://cdn.rawgit.com/rciorba/e3eded290e91a361f74eefdbc84416bb/raw/9e5d61e03c5842712d629e3e5567da3a512f1d79/results.html

Benchmarked this patch on the [rciorba/master-bench](https://github.com/borgbackup/borg/compare/master...rciorba:master-bench), where I applied the robin-hood benchmarks on master, if anyone cares to check the benchmark code