### PR TITLE
change --checkpoint-interval default from 600s to 1800s, fixes #2841

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -185,7 +185,7 @@ class Archive:
         """Failed to encode filename "{}" into file system encoding "{}". Consider configuring the LANG environment variable."""
 
     def __init__(self, repository, key, manifest, name, cache=None, create=False,
-                 checkpoint_interval=300, numeric_owner=False, noatime=False, noctime=False, progress=False,
+                 checkpoint_interval=1800, numeric_owner=False, noatime=False, noctime=False, progress=False,
                  chunker_params=CHUNKER_PARAMS, start=None, start_monotonic=None, end=None):
         self.cwd = os.getcwd()
         self.key = key

--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1428,8 +1428,8 @@ class Archiver:
                                action='store_true', default=False,
                                help='keep tag files of excluded caches/directories')
         subparser.add_argument('-c', '--checkpoint-interval', dest='checkpoint_interval',
-                               type=int, default=300, metavar='SECONDS',
-                               help='write checkpoint every SECONDS seconds (Default: 300)')
+                               type=int, default=1800, metavar='SECONDS',
+                               help='write checkpoint every SECONDS seconds (Default: 1800)')
         subparser.add_argument('-x', '--one-file-system', dest='one_file_system',
                                action='store_true', default=False,
                                help='stay in same file system')


### PR DESCRIPTION
a user was (rightfully) complaining that borg does a whole lot of
writing to .cache and was also quite inefficient because that took
rather long and occurred too frequently.

this was caused by big indexes/caches and the relatively high default
checkpoint frequency (every 300s) in 1.0.

we already have increased that value to 1800s in master (which soon will
be 1.1), so this changeset just does the same for 1.0.x.
