### PR TITLE
Document consequences of changing the segments_per_dir value

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -60,8 +60,8 @@ and looks like this::
 
     [repository]
     version = 1
-    segments_per_dir = 10000
-    max_segment_size = 5242880
+    segments_per_dir = 1000
+    max_segment_size = 524288000
     id = 57d6c1d52ce76a836b532b0e42e677dec6af9fca3673db511279358828a21ed6
 
 This is where the ``repository.id`` is stored. It is a unique

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -88,7 +88,10 @@ Segments
 ~~~~~~~~
 
 Objects referenced by a key are stored inline in files (`segments`) of approx.
-500 MB size in numbered subdirectories of ``repo/data``.
+500 MB size in numbered subdirectories of ``repo/data``. The number of segments
+per directory is controlled by the value of ``segments_per_dir``. If you change
+this value in a non-empty repository, you may also need to relocate the segment
+files manually.
 
 A segment starts with a magic number (``BORG_SEG`` as an eight byte ASCII string),
 followed by a number of log entries. Each log entry consists of:


### PR DESCRIPTION
After a user changes `segments_per_dir`, the path returned by
`segment_filename()` is incorrect because it calculates the path with the
new `segments_per_dir` value.

In this case, we try to find the segment path manually.  If we still
can't find the segment, there could be two reasons:

- The segment to be read is missing on disk;
- The segment to be written is not created yet.

For either reason, we return the path calculated with new
`segments_per_dir` value as-is and let the caller decide what to do.

If everything goes well, after some period of time (new data get backed
up while old ones get pruned), segments will eventually be in their
right place.