### PR TITLE
lz4: replace deprecated compression function by current one

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -141,7 +141,7 @@ following dependencies first:
   optional install.
 * OpenSSL_ >= 1.0.0, plus development headers.
 * libacl_ (which depends on libattr_), both plus development headers.
-* liblz4_, plus development headers.
+* liblz4_ >= r129 (1.7.0), plus development headers.
 * ZeroMQ_ >= 4.0.0, plus development headers.
 * some Python dependencies, pip will automatically install them for you
 * optionally, the llfuse_ Python package is required if you wish to mount an

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ def detect_lz4(prefixes):
         filename = os.path.join(prefix, 'include', 'lz4.h')
         if os.path.exists(filename):
             with open(filename, 'r') as fd:
-                if 'LZ4_decompress_safe' in fd.read():
+                if 'LZ4_compress_default' in fd.read():  # requires lz4 >= r129
                     return prefix
 
 

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -27,7 +27,7 @@ from .helpers import Buffer, DecompressionError
 API_VERSION = '1.1_03'
 
 cdef extern from "lz4.h":
-    int LZ4_compress_limitedOutput(const char* source, char* dest, int inputSize, int maxOutputSize) nogil
+    int LZ4_compress_default(const char* source, char* dest, int inputSize, int maxOutputSize) nogil
     int LZ4_decompress_safe(const char* source, char* dest, int inputSize, int maxOutputSize) nogil
     int LZ4_compressBound(int inputSize) nogil
 
@@ -127,7 +127,7 @@ class LZ4(CompressorBase):
         buf = buffer.get(osize)
         dest = <char *> buf
         with nogil:
-            osize = LZ4_compress_limitedOutput(source, dest, isize, osize)
+            osize = LZ4_compress_default(source, dest, isize, osize)
         if not osize:
             raise Exception('lz4 compress failed')
         return super().compress(dest[:osize])


### PR DESCRIPTION
requires lz4 >= r129 (1.7.0)

fixes #2103 
