### PR TITLE
migrate locks to child PID when daemonize is used

### DIFF
--- a/src/borg/helpers/checks.py
+++ b/src/borg/helpers/checks.py
@@ -28,7 +28,7 @@ def check_extension_modules():
         raise ExtensionModuleError
     if borg.crypto.low_level.API_VERSION != '1.1_02':
         raise ExtensionModuleError
-    if platform.API_VERSION != platform.OS_API_VERSION != '1.1_01':
+    if platform.API_VERSION != platform.OS_API_VERSION != '1.1_02':
         raise ExtensionModuleError
     if item.API_VERSION != '1.1_03':
         raise ExtensionModuleError

--- a/src/borg/helpers/process.py
+++ b/src/borg/helpers/process.py
@@ -11,7 +11,12 @@ logger = create_logger()
 
 
 def daemonize():
-    """Detach process from controlling terminal and run in background"""
+    """Detach process from controlling terminal and run in background
+
+    Returns: old and new get_process_id tuples
+    """
+    from ..platform import get_process_id
+    old_id = get_process_id()
     pid = os.fork()
     if pid:
         os._exit(0)
@@ -27,6 +32,8 @@ def daemonize():
     os.dup2(fd, 0)
     os.dup2(fd, 1)
     os.dup2(fd, 2)
+    new_id = get_process_id()
+    return old_id, new_id
 
 
 class SignalException(BaseException):

--- a/src/borg/locking.py
+++ b/src/borg/locking.py
@@ -202,6 +202,16 @@ class ExclusiveLock:
                 os.unlink(os.path.join(self.path, name))
             os.rmdir(self.path)
 
+    def migrate_lock(self, old_id, new_id):
+        """migrate the lock ownership from old_id to new_id"""
+        if self.id == old_id:
+            new_unique_name = os.path.join(self.path, "%s.%d-%x" % new_id)
+            if self.is_locked() and self.by_me():
+                with open(new_unique_name, "wb"):
+                    pass
+                os.unlink(self.unique_name)
+            self.id, self.unique_name = new_id, new_unique_name
+
 
 class LockRoster:
     """
@@ -270,6 +280,25 @@ class LockRoster:
             raise ValueError('Unknown LockRoster op %r' % op)
         roster[key] = list(list(e) for e in elements)
         self.save(roster)
+
+    def migrate_lock(self, key, old_id, new_id):
+        """migrate the lock ownership from old_id to new_id"""
+        if self.id == old_id:
+            # need to temporarily switch off stale lock killing as we want to
+            # rather migrate than kill them (at least the one made by old_id).
+            killing, self.kill_stale_locks = self.kill_stale_locks, False
+            try:
+                try:
+                    self.modify(key, REMOVE)
+                except KeyError:
+                    # entry was not there, so no need to add a new one, but still update our id
+                    self.id = new_id
+                else:
+                    # old entry removed, update our id and add a updated entry
+                    self.id = new_id
+                    self.modify(key, ADD)
+            finally:
+                self.kill_stale_locks = killing
 
 
 class Lock:
@@ -373,3 +402,14 @@ class Lock:
     def break_lock(self):
         self._roster.remove()
         self._lock.break_lock()
+
+    def migrate_lock(self, old_id, new_id):
+        if self.id == old_id:
+            self.id = new_id
+            if self.is_exclusive:
+                self._lock.migrate_lock(old_id, new_id)
+                self._roster.migrate_lock(EXCLUSIVE, old_id, new_id)
+            else:
+                with self._lock:
+                    self._lock.migrate_lock(old_id, new_id)
+                    self._roster.migrate_lock(SHARED, old_id, new_id)

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -15,7 +15,7 @@ platform API: that way platform APIs provided by the platform-specific support m
 are correctly composed into the base functionality.
 """
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 fdatasync = getattr(os, 'fdatasync', os.fsync)
 

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -4,7 +4,7 @@ from ..helpers import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
 from .posix import swidth
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 cdef extern from "sys/acl.h":
     ctypedef struct _acl_t:

--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -4,7 +4,7 @@ from ..helpers import posix_acl_use_stored_uid_gid
 from ..helpers import safe_encode, safe_decode
 from .posix import swidth
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 cdef extern from "errno.h":
     int errno

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -13,7 +13,7 @@ from .posix import swidth
 from libc cimport errno
 from libc.stdint cimport int64_t
 
-API_VERSION = '1.1_01'
+API_VERSION = '1.1_02'
 
 cdef extern from "sys/types.h":
     int ACL_TYPE_ACCESS

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -18,23 +18,21 @@ def swidth(s):
         return str_len
 
 
-# only determine the PID and hostname once.
-# for FUSE mounts, we fork a child process that needs to release
-# the lock made by the parent, so it needs to use the same PID for that.
-_pid = os.getpid()
+# for performance reasons, only determine the hostname once.
 # XXX this sometimes requires live internet access for issuing a DNS query in the background.
 _hostname = '%s@%s' % (socket.getfqdn(), uuid.getnode())
 
 
 def get_process_id():
     """
-    Return identification tuple (hostname, pid, thread_id) for 'us'. If this is a FUSE process, then the PID will be
-    that of the parent, not the forked FUSE child.
+    Return identification tuple (hostname, pid, thread_id) for 'us'.
+    This always returns the current pid, which might be different from before, e.g. if daemonize() was used.
 
     Note: Currently thread_id is *always* zero.
     """
     thread_id = 0
-    return _hostname, _pid, thread_id
+    pid = os.getpid()
+    return _hostname, pid, thread_id
 
 
 def process_alive(host, pid, thread):

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -346,6 +346,11 @@ class Repository:
     def break_lock(self):
         Lock(os.path.join(self.path, 'lock')).break_lock()
 
+    def migrate_lock(self, old_id, new_id):
+        # note: only needed for local repos
+        if self.lock is not None:
+            self.lock.migrate_lock(old_id, new_id)
+
     def open(self, path, exclusive, lock_wait=None, lock=True):
         self.path = path
         if not os.path.isdir(path):


### PR DESCRIPTION
fixes #2923 

the pid change due to daemonize didn't work well with the stale lock detection (as the initial/parent process was gone). thus we better transfer the locks to the new pid.

this is only needed for client-side (local) repos because the daemonize happens there.
remote repos are locked by borg serve and the pid problem does not happen there.