### PR TITLE
migrate locks to child PID when daemonize is used

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -1252,7 +1252,11 @@ def make_path_safe(path):
 
 def daemonize():
     """Detach process from controlling terminal and run in background
+
+    Returns: old and new get_process_id tuples
     """
+    from .locking import get_id as get_process_id
+    old_id = get_process_id()
     pid = os.fork()
     if pid:
         os._exit(0)
@@ -1268,6 +1272,8 @@ def daemonize():
     os.dup2(fd, 0)
     os.dup2(fd, 1)
     os.dup2(fd, 2)
+    new_id = get_process_id()
+    return old_id, new_id
 
 
 class StableDict(dict):

--- a/borg/repository.py
+++ b/borg/repository.py
@@ -170,6 +170,11 @@ class Repository:
     def break_lock(self):
         Lock(os.path.join(self.path, 'lock')).break_lock()
 
+    def migrate_lock(self, old_id, new_id):
+        # note: only needed for local repos
+        if self.lock is not None:
+            self.lock.migrate_lock(old_id, new_id)
+
     def open(self, path, exclusive, lock_wait=None, lock=True):
         self.path = path
         if not os.path.isdir(path):


### PR DESCRIPTION
(cherry picked from commit 09e3a02fbc5edd64125ac437cb3ec6fb20ce730a)