### PR TITLE
ignore corrupt files cache, fixes #2939

### DIFF
--- a/borg/cache.py
+++ b/borg/cache.py
@@ -208,10 +208,16 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
                 if not data:
                     break
                 u.feed(data)
-                for path_hash, item in u:
-                    item[0] += 1
-                    # in the end, this takes about 240 Bytes per file
-                    self.files[path_hash] = msgpack.packb(item)
+                try:
+                    for path_hash, item in u:
+                        item[0] += 1
+                        # in the end, this takes about 240 Bytes per file
+                        self.files[path_hash] = msgpack.packb(item)
+                except (TypeError, ValueError) as exc:
+                    logger.warning('The files cache seems corrupt, ignoring it. '
+                                   'Expect lower performance. [%s]' % str(exc))
+                    self.files = {}
+                    return
 
     def begin_txn(self):
         # Initialize transaction snapshot


### PR DESCRIPTION
this addresses a problem that was already fixed in 1.1+ in a different
way (by protecting important files with hashes/checksum and invalidating
them when the check fails).

for 1.0, just do a simpler fix, ignore the files cache when corrupt and
emit a warning message so the users notices that there is a problem.
