### PR TITLE
ignore corrupt files cache, fixes #2939

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -503,10 +503,16 @@ class LocalCache(CacheStatsMixin):
                 if not data:
                     break
                 u.feed(data)
-                for path_hash, item in u:
-                    entry = FileCacheEntry(*item)
-                    # in the end, this takes about 240 Bytes per file
-                    self.files[path_hash] = msgpack.packb(entry._replace(age=entry.age + 1))
+                try:
+                    for path_hash, item in u:
+                        entry = FileCacheEntry(*item)
+                        # in the end, this takes about 240 Bytes per file
+                        self.files[path_hash] = msgpack.packb(entry._replace(age=entry.age + 1))
+                except (TypeError, ValueError) as exc:
+                    logger.warning('The files cache seems corrupt, ignoring it. '
+                                   'Expect lower performance. [%s]' % str(exc))
+                    self.files = {}
+                    return
 
     def begin_txn(self):
         # Initialize transaction snapshot


### PR DESCRIPTION
ignore the files cache when corrupt and emit a warning message
so the users notices that there is a problem.

(cherry picked from commit 4eadb59c10d3d9afeb1ce569119423532060f431)

forward port of #2945.