### PR TITLE
Buffer: fix wrong thread-local storage use

### DIFF
--- a/src/borg/helpers/datastruct.py
+++ b/src/borg/helpers/datastruct.py
@@ -10,8 +10,10 @@ class StableDict(dict):
         return sorted(super().items())
 
 
-class Buffer:
-    """provide a thread-local buffer"""
+class Buffer(threading.local):
+    """
+    provide a thread-local buffer
+    """
 
     class MemoryLimitExceeded(Error, OSError):
         """Requested buffer size {} is above the limit of {}."""
@@ -23,13 +25,12 @@ class Buffer:
         """
         assert callable(allocator), 'must give alloc(size) function as first param'
         assert limit is None or size <= limit, 'initial size must be <= limit'
-        self._thread_local = threading.local()
         self.allocator = allocator
         self.limit = limit
         self.resize(size, init=True)
 
     def __len__(self):
-        return len(self._thread_local.buffer)
+        return len(self.buffer)
 
     def resize(self, size, init=False):
         """
@@ -41,7 +42,7 @@ class Buffer:
         if self.limit is not None and size > self.limit:
             raise Buffer.MemoryLimitExceeded(size, self.limit)
         if init or len(self) < size:
-            self._thread_local.buffer = self.allocator(size)
+            self.buffer = self.allocator(size)
 
     def get(self, size=None, init=False):
         """
@@ -50,4 +51,4 @@ class Buffer:
         """
         if size is not None:
             self.resize(size, init)
-        return self._thread_local.buffer
+        return self.buffer

--- a/src/borg/helpers/datastruct.py
+++ b/src/borg/helpers/datastruct.py
@@ -1,6 +1,3 @@
-import threading
-from collections import namedtuple
-
 from .errors import Error
 
 
@@ -10,9 +7,9 @@ class StableDict(dict):
         return sorted(super().items())
 
 
-class Buffer(threading.local):
+class Buffer:
     """
-    provide a thread-local buffer
+    Provides a managed, resizable buffer.
     """
 
     class MemoryLimitExceeded(Error, OSError):


### PR DESCRIPTION
Instead of backporting, just remove threading-related things from older branches.