### PR TITLE
travis: only short-circuit docs-only changes for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,12 @@ matrix:
 
 before_install:
 - |
-    echo Checking whether $TRAVIS_COMMIT_RANGE changed only docs
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(AUTHORS|README\.rst|^(docs)/)' || {
-      echo "Only docs were updated, stopping build process."
-      exit
+    test $TRAVIS_EVENT_TYPE != "pull_request" || {
+        echo Checking whether $TRAVIS_COMMIT_RANGE changed only docs
+        git diff --name-only $TRAVIS_COMMIT_RANGE | grep --quiet --invert-match --extended-regexp '(AUTHORS|README\.rst|^(docs)/)' || {
+            echo "Only docs were updated, stopping build process."
+            exit
+        }
     }
 
 install:


### PR DESCRIPTION
if a branch build is stopped, then codecov will complain about
missing base branch coverage.