### PR TITLE
Buffer: fix wrong thread-local storage use (#2951)

### DIFF
--- a/borg/helpers.py
+++ b/borg/helpers.py
@@ -925,7 +925,7 @@ def memoize(function):
 
 class Buffer:
     """
-    provide a thread-local buffer
+    Provides a managed, resizable buffer.
     """
 
     class MemoryLimitExceeded(Error, OSError):
@@ -938,13 +938,12 @@ class Buffer:
         """
         assert callable(allocator), 'must give alloc(size) function as first param'
         assert limit is None or size <= limit, 'initial size must be <= limit'
-        self._thread_local = threading.local()
         self.allocator = allocator
         self.limit = limit
         self.resize(size, init=True)
 
     def __len__(self):
-        return len(self._thread_local.buffer)
+        return len(self.buffer)
 
     def resize(self, size, init=False):
         """
@@ -956,7 +955,7 @@ class Buffer:
         if self.limit is not None and size > self.limit:
             raise Buffer.MemoryLimitExceeded(size, self.limit)
         if init or len(self) < size:
-            self._thread_local.buffer = self.allocator(size)
+            self.buffer = self.allocator(size)
 
     def get(self, size=None, init=False):
         """
@@ -965,7 +964,7 @@ class Buffer:
         """
         if size is not None:
             self.resize(size, init)
-        return self._thread_local.buffer
+        return self.buffer
 
 
 @memoize


### PR DESCRIPTION
Buffer: delete support for multiple threads

Thread-local objects are a fairly complex footgun, so avoid them in
the first place. When a Compressor uses a Buffer (for example),
just create multiple Compressor instances for each thread, owned by
each thread. Minimize multiple ownership of objects across
threads if at all possible!

(cherry picked from commit f7ed5d72201b0791a50707aefc68bcd22f12c800)
