### PR TITLE
test_detect_attic_repo: don't test mount

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2745,7 +2745,6 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
             ['delete', path],
             ['prune', path],
             ['info', path + '::test'],
-            ['mount', path, self.tmpdir],
             ['key', 'export', path, 'exported'],
             ['key', 'import', path, 'import'],
             ['change-passphrase', path],


### PR DESCRIPTION
since mount is not always available and if it works for all the other
commands, then it is likely it works for mount as well.

Fixes #2975