### PR TITLE
Improve macOS faq entry

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -328,8 +328,8 @@ Using keyfile-based encryption with a blank passphrase
   ``repokey`` mode and use a blank passphrase for the key file. See :ref:`encrypted_repos`
   for more details.
 
-Using ``BORG_PASSCOMMAND`` with MacOS Keychain
-  MacOS has a native manager for secrets (such as passphrases) which is safer
+Using ``BORG_PASSCOMMAND`` with macOS Keychain
+  macOS has a native manager for secrets (such as passphrases) which is safer
   than just using a file as it is encrypted at rest and unlocked manually
   (fortunately, the login keyring automatically unlocks when you login). With
   the built-in ``security`` command, you can access it from the command line,
@@ -759,7 +759,7 @@ Here's a (incomplete) list of some major changes:
 * uses fadvise to not spoil / blow up the fs cache
 * better error messages / exception handling
 * better logging, screen output, progress indication
-* tested on misc. Linux systems, 32 and 64bit, FreeBSD, OpenBSD, NetBSD, MacOS
+* tested on misc. Linux systems, 32 and 64bit, FreeBSD, OpenBSD, NetBSD, macOS
 
 Please read the :ref:`changelog` (or ``docs/changes.rst`` in the source distribution) for more
 information.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -342,7 +342,7 @@ Using ``BORG_PASSCOMMAND`` with MacOS Keychain
 
   In your backup script retrieve it in the ``BORG_PASSCOMMAND``::
 
-    export BORG_PASSCOMMAND="security find-generic-password -a $USER -s borg-passphrase"
+    export BORG_PASSCOMMAND="security find-generic-password -a $USER -s borg-passphrase -w"
 
 Using ``BORG_PASSCOMMAND`` with GNOME Keyring
   GNOME also has a keyring daemon that can be used to store a Borg passphrase.


### PR DESCRIPTION
The macOS keychain integration guide is missing a `-w` in the `BORG_PASSCOMMAND` environment variable. This flag causes only the password to be written to stdout. Without this flag the integration does not work.