### PR TITLE
flush json mode progress stderr output

### DIFF
--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -86,7 +86,7 @@ class ProgressIndicatorBase:
             finished=finished,
             time=time.time(),
         ))
-        print(json.dumps(kwargs), file=sys.stderr)
+        print(json.dumps(kwargs), file=sys.stderr, flush=True)
 
     def finish(self):
         if self.json:


### PR DESCRIPTION
if borg stderr is not connected to a tty, but to ssh (when using
borg client/server), sys.stderr is block buffered (tty: line buffered).

thus we better flush explicitly after emitting a line as the receiving
side can not handle partial json at the end of the block.

also, it might solve some delays, when output didn't arrive at
receiving side in time.

hopefully a partial fix for #2637 (progress indication in json mode)