### PR TITLE
 flush json mode progress stderr output (1.1-maint)

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1444,7 +1444,7 @@ class ProgressIndicatorBase:
             finished=finished,
             time=time.time(),
         ))
-        print(json.dumps(kwargs), file=sys.stderr)
+        print(json.dumps(kwargs), file=sys.stderr, flush=True)
 
     def finish(self):
         if self.json:


### PR DESCRIPTION
if borg stderr is not connected to a tty, but to ssh (when using
borg client/server), sys.stderr is block buffered (tty: line buffered).

thus we better flush explicitly after emitting a line as the receiving
side can not handle partial json at the end of the block.

also, it might solve some delays, when output didn't arrive at
receiving side in time.

(cherry picked from commit 2b75b278dab59b18a64aeb627bfcfc259804e825)