### PR TITLE
use python 3.5.4 to build the binaries

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ def install_pythons(boxname)
     . ~/.bash_profile
     pyenv install 3.5.0  # tests
     pyenv install 3.6.0  # tests
-    pyenv install 3.5.3  # binary build, use latest 3.5.x release
+    pyenv install 3.5.4  # binary build, use latest 3.5.x release
     pyenv rehash
   EOF
 end
@@ -72,8 +72,8 @@ def build_pyenv_venv(boxname)
     . ~/.bash_profile
     cd /vagrant/borg
     # use the latest 3.5 release
-    pyenv global 3.5.3
-    pyenv virtualenv 3.5.3 borg-env
+    pyenv global 3.5.4
+    pyenv virtualenv 3.5.4 borg-env
     ln -s ~/.pyenv/versions/borg-env .
   EOF
 end


### PR DESCRIPTION
3.5.4 is the latest (and maybe also the last) python 3.5 release.