### PR TITLE
pyinstaller: use v3.3, fetch from v3.3-fixed branch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,7 +113,7 @@ def install_pyinstaller()
     . borg-env/bin/activate
     git clone https://github.com/thomaswaldmann/pyinstaller.git
     cd pyinstaller
-    git checkout v3.2.1
+    git checkout v3.3-fixed
     python setup.py install
   EOF
 end


### PR DESCRIPTION
v3.3 release does not work on freebsd, so fetch it from a branch where I can quickly commit fixes.