### PR TITLE
Simplified rate limiting wrapper in FAQ (1.0-maint)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -443,10 +443,10 @@ bandwidth limiting can be accomplished with pipeviewer_:
 
 Create a wrapper script:  /usr/local/bin/pv-wrapper  ::
 
-    #!/bin/bash
+    #!/bin/sh
         ## -q, --quiet              do not output any transfer information at all
         ## -L, --rate-limit RATE    limit transfer to RATE bytes per second
-    export RATE=307200
+    RATE=307200
     pv -q -L $RATE  | "$@"
 
 Add BORG_RSH environment variable to use pipeviewer wrapper script with ssh. ::


### PR DESCRIPTION
Exporting $RATE as environment variable is not need in this case.

And example does not use any bash specific features.
It should use default system shell instead.

(cherry picked from commit d3533de5f7f113dbcf4668524c89a04467947ee8)
