### PR TITLE
exclude Cython 0.27(.0) in requirements, fixes #3066

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -7,4 +7,4 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-benchmark
-Cython
+Cython!=0.27


### PR DESCRIPTION
https://github.com/cython/cython/issues/1880

(cherry picked from commit 7e94d42853b29639169d308853f14d0454a33123)
