### PR TITLE
exclude Cython 0.27(.0) in requirements, fixes #3066

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -7,4 +7,4 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-benchmark
-Cython
+Cython!=0.27


### PR DESCRIPTION
https://github.com/cython/cython/issues/1880

(cherry picked from commit f170641bd46b0b36aedf2fcc997f92d29e891779)
