### PR TITLE
List help topics when invalid topic is requested

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1951,7 +1951,12 @@ class Archiver:
             else:
                 commands[args.topic].print_help()
         else:
-            parser.error('No help available on %s' % (args.topic,))
+            msg_lines = []
+            msg_lines += ['No help available on %s.' % args.topic]
+            msg_lines += ['Try one of the following:']
+            msg_lines += ['    Commands: %s' % ', '.join(sorted(commands.keys()))]
+            msg_lines += ['    Topics: %s' % ', '.join(sorted(self.helptext.keys()))]
+            parser.error('\n'.join(msg_lines))
         return self.exit_code
 
     def do_subcommand_help(self, parser, args):


### PR DESCRIPTION
Currently, the available help topics are only listed manually, scattered throughout different parts of the documentation.  
It would be helpful to have an option for `borg help` that lists all available topics (e.g. `borg help --list-topics`).

Until that's implemented, this commit adds a list of available topics to the "topic not found" error message.  
This might also remain useful even after the separate flag has been added. Alternatively, we could replace the list with a mention of the new `--list-topics` once that exists.