### PR TITLE
check for py 3.5 minimum requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from distutils.core import Command
 
 import textwrap
 
-min_python = (3, 4)
+min_python = (3, 5)
 my_python = sys.version_info
 
 if my_python < min_python:


### PR DESCRIPTION
we do not test on 3.4 any more and have dropped support for it.
so we better enforce it in setup.py also.