### PR TITLE
don't crash in first part of truncate_and_unlink, fixes #3117

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -2,6 +2,7 @@ import argparse
 import contextlib
 import collections
 import enum
+import errno
 import grp
 import hashlib
 import logging
@@ -2283,8 +2284,13 @@ def truncate_and_unlink(path):
     recover. Refer to the "File system interaction" section
     in repository.py for further explanations.
     """
-    with open(path, 'r+b') as fd:
-        fd.truncate()
+    try:
+        with open(path, 'r+b') as fd:
+            fd.truncate()
+    except OSError as err:
+        if err.errno != errno.ENOTSUP:
+            raise
+        # don't crash if the above ops are not supported.
     os.unlink(path)
 
 


### PR DESCRIPTION
(cherry picked from commit 7a689b1295ca647a7f9008df508f303214930d08)
