### PR TITLE
catch ENOTSUP for os.link, fixes #3107

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -266,7 +266,7 @@ class Repository:
             try:
                 os.link(config_path, old_config_path)
             except OSError as e:
-                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM):
+                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM, errno.ENOTSUP):
                     logger.warning("Hardlink failed, cannot securely erase old config file")
                 else:
                     raise


### PR DESCRIPTION
(cherry picked from commit 203a5c8f197904b51fbced32f42cf0c383130292)