### PR TITLE
init: fix wrong encryption choices in command line parser

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -40,7 +40,7 @@ from .archive import BackupOSError, backup_io
 from .cache import Cache, assert_secure
 from .constants import *  # NOQA
 from .compress import CompressionSpec
-from .crypto.key import key_creator, tam_required_file, tam_required, RepoKey, PassphraseKey
+from .crypto.key import key_creator, key_argument_names, tam_required_file, tam_required, RepoKey, PassphraseKey
 from .crypto.keymanager import KeyManager
 from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
 from .helpers import Error, NoManifestError, set_ec
@@ -2580,7 +2580,7 @@ class Archiver:
                                type=location_validator(archive=False),
                                help='repository to create')
         subparser.add_argument('-e', '--encryption', metavar='MODE', dest='encryption', required=True,
-                               choices=('none', 'keyfile', 'repokey', 'keyfile-blake2', 'repokey-blake2', 'authenticated'),
+                               choices=key_argument_names(),
                                help='select encryption key mode **(required)**')
         subparser.add_argument('--append-only', dest='append_only', action='store_true',
                                help='create an append-only mode repository')

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -103,9 +103,14 @@ class KeyBlobStorage:
 def key_creator(repository, args):
     for key in AVAILABLE_KEY_TYPES:
         if key.ARG_NAME == args.encryption:
+            assert key.ARG_NAME is not None
             return key.create(repository, args)
     else:
         raise ValueError('Invalid encryption mode "%s"' % args.encryption)
+
+
+def key_argument_names():
+    return [key.ARG_NAME for key in AVAILABLE_KEY_TYPES if key.ARG_NAME]
 
 
 def identify_key(manifest_data):


### PR DESCRIPTION
(cherry picked from commit b00179ff784fbd959d7ee1e331ac62a1c9bbc25a)
