### PR TITLE
fix detection of non-local path, fixes #3108

### DIFF
--- a/borg/archive.py
+++ b/borg/archive.py
@@ -374,7 +374,7 @@ Number of files: {0.stats.nfiles}'''.format(
             return
 
         dest = self.cwd
-        if item[b'path'].startswith('/') or item[b'path'].startswith('..'):
+        if item[b'path'].startswith(('/', '../')):
             raise Exception('Path should be relative and local')
         path = os.path.join(dest, item[b'path'])
         # Attempt to remove existing files, ignore errors on failure


### PR DESCRIPTION
filenames like ..foobar are valid, so, to detect stuff in upper dirs,
we need to include the path separator and check if it starts with '../'.

(cherry picked from commit 60e924910034b86d3d9c6e9af706e5559cdb4d19)
