### PR TITLE
move files-cache related options to borg create, fixes #3146

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2154,6 +2154,9 @@ class Archiver:
                               help='show/log the return code (rc)')
             add_common_option('--no-files-cache', dest='cache_files', action='store_false',
                               help='do not load/update the file metadata cache used to detect unchanged files')
+            add_common_option('--files-cache', metavar='MODE', dest='files_cache_mode',
+                              type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
+                              help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
             add_common_option('--umask', metavar='M', dest='umask', type=lambda s: int(s, 8), default=UMASK_DEFAULT,
                               help='set umask to M (local and remote, default: %(default)04o)')
             add_common_option('--remote-path', metavar='PATH', dest='remote_path',
@@ -2737,9 +2740,6 @@ class Archiver:
                               help='do not store ctime into archive')
         fs_group.add_argument('--ignore-inode', dest='ignore_inode', action='store_true',
                               help='ignore inode data in the file metadata cache used to detect unchanged files.')
-        fs_group.add_argument('--files-cache', metavar='MODE', dest='files_cache_mode',
-                              type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
-                              help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
         fs_group.add_argument('--read-special', dest='read_special', action='store_true',
                               help='open and read block and char device files as well as FIFOs as if they were '
                                    'regular files. Also follows symlinks pointing to these kinds of files.')

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2723,9 +2723,6 @@ class Archiver:
                                help='experimental: do not synchronize the cache. Implies not using the files cache.')
         subparser.add_argument('--no-files-cache', dest='cache_files', action='store_false',
                                help='do not load/update the file metadata cache used to detect unchanged files')
-        subparser.add_argument('--files-cache', metavar='MODE', dest='files_cache_mode',
-                               type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
-                               help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
 
         define_exclusion_group(subparser, tag_files=True)
 
@@ -2740,6 +2737,9 @@ class Archiver:
                               help='do not store ctime into archive')
         fs_group.add_argument('--ignore-inode', dest='ignore_inode', action='store_true',
                               help='ignore inode data in the file metadata cache used to detect unchanged files.')
+        fs_group.add_argument('--files-cache', metavar='MODE', dest='files_cache_mode',
+                              type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
+                              help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
         fs_group.add_argument('--read-special', dest='read_special', action='store_true',
                               help='open and read block and char device files as well as FIFOs as if they were '
                                    'regular files. Also follows symlinks pointing to these kinds of files.')

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1326,7 +1326,7 @@ class Archiver:
             keep += prune_split(archives, '%Y', args.yearly, keep)
         to_delete = (set(archives) | checkpoints) - (set(keep) | set(keep_checkpoints))
         stats = Statistics()
-        with Cache(repository, key, manifest, do_files=args.cache_files, lock_wait=self.lock_wait) as cache:
+        with Cache(repository, key, manifest, do_files=False, lock_wait=self.lock_wait) as cache:
             list_logger = logging.getLogger('borg.output.list')
             if args.output_list:
                 # set up counters for the progress display
@@ -2152,11 +2152,6 @@ class Archiver:
                               help='show/log the borg version')
             add_common_option('--show-rc', dest='show_rc', action='store_true',
                               help='show/log the return code (rc)')
-            add_common_option('--no-files-cache', dest='cache_files', action='store_false',
-                              help='do not load/update the file metadata cache used to detect unchanged files')
-            add_common_option('--files-cache', metavar='MODE', dest='files_cache_mode',
-                              type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
-                              help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
             add_common_option('--umask', metavar='M', dest='umask', type=lambda s: int(s, 8), default=UMASK_DEFAULT,
                               help='set umask to M (local and remote, default: %(default)04o)')
             add_common_option('--remote-path', metavar='PATH', dest='remote_path',
@@ -2726,6 +2721,11 @@ class Archiver:
                                help='output stats as JSON. Implies ``--stats``.')
         subparser.add_argument('--no-cache-sync', dest='no_cache_sync', action='store_true',
                                help='experimental: do not synchronize the cache. Implies not using the files cache.')
+        subparser.add_argument('--no-files-cache', dest='cache_files', action='store_false',
+                               help='do not load/update the file metadata cache used to detect unchanged files')
+        subparser.add_argument('--files-cache', metavar='MODE', dest='files_cache_mode',
+                               type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
+                               help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
 
         define_exclusion_group(subparser, tag_files=True)
 


### PR DESCRIPTION
while the files cache is only really used by borg create, the value
of this argument is used for the Cache context manager at more places,
e.g. also for borg prune.