### PR TITLE
borg recreate: correctly compute part file sizes, fixes #3157

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -897,7 +897,9 @@ Utilization of max. archive size: {csize_max:.0%}
         length = len(item.chunks)
         # the item should only have the *additional* chunks we processed after the last partial item:
         item.chunks = item.chunks[from_chunk:]
-        item.get_size(memorize=True)
+        # for borg recreate, we already have a size member in the source item (giving the total file size),
+        # but we consider only a part of the file here, thus we must recompute the size from the chunks:
+        item.get_size(memorize=True, from_chunks=True)
         item.path += '.borg_part_%d' % number
         item.part = number
         number += 1


### PR DESCRIPTION
when doing in-file checkpointing, borg creates *.borg_part_N files.
complete_file = part_1 + part_2 + ... + part_N

the source item for recreate already has a precomputed (total) size
member, thus we must force recomputation from the (partial) chunks
list to correct the size to be the part's size only.

borg create avoided this problem by computing the size member after
writing all the parts. this is now not required any more.

the bug is mostly cosmetic, borg check will complain, borg extract on
a part file would also complain. but all the complaints only refer to
the wrong metadata of the part files, the part files' contents are
correct.

usually you will never extract or look at part files, but only deal
with the full file, which will be completely valid, all metadata and
content.

you can get rid of the archives with these cosmetic errors by running
borg recreate on them with a fixed borg version. the old part files
will get dropped (because they are usually ignored) and any new part
file created due to checkpointing will be correct.

(cherry picked from commit 9d6b125e989b02487cc05f6c5371ad2058cc9579)
