### PR TITLE
remove hardlinked symlinks warning, update docs, fixes #3175

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -97,6 +97,9 @@ Which file types, attributes, etc. are *not* preserved?
       Archive extraction has optional support to extract all-zero chunks as
       holes in a sparse file.
     * Some filesystem specific attributes, like btrfs NOCOW, see :ref:`platforms`.
+    * For hardlinked symlinks, the hardlinking can not be archived (and thus,
+      the hardlinking will not be done at extraction time). The symlinks will
+      be archived and extracted as non-hardlinked symlinks, see :issue:`2379`.
 
 Are there other known limitations?
 ----------------------------------

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -883,12 +883,11 @@ Utilization of max. archive size: {csize_max:.0%}
     def process_symlink(self, path, st):
         # note: using hardlinkable=False because we can not support hardlinked symlinks,
         #       due to the dual-use of item.source, see issue #2343:
+        # hardlinked symlinks will be archived [and extracted] as non-hardlinked symlinks.
         with self.create_helper(path, st, 's', hardlinkable=False) as (item, status, hardlinked, hardlink_master):
             with backup_io('readlink'):
                 source = os.readlink(path)
             item.source = source
-            if st.st_nlink > 1:
-                logger.warning('hardlinked symlinks will be archived as non-hardlinked symlinks!')
             item.update(self.stat_attrs(st, path))
             return status
 


### PR DESCRIPTION
the warning was annoying for people with a lot of such items and
they can not do anything about it anyway.

thus, just document this as a limitation.

(cherry picked from commit e674822888d12932216cfd9ff15f18ad77676d67)