### PR TITLE
fix server-side IndexError for 4-arg open() of old clients, fixes #3192

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -179,7 +179,15 @@ class RepositoryServer:  # pragma: no cover
 
     def positional_to_named(self, method, argv):
         """Translate from positional protocol to named protocol."""
-        return {name: argv[pos] for pos, name in enumerate(compatMap[method])}
+        try:
+            return {name: argv[pos] for pos, name in enumerate(compatMap[method])}
+        except IndexError:
+            if method == 'open' and len(argv) == 4:
+                # borg clients < 1.0.7 use open() with 4 args
+                mapping = compatMap[method][:4]
+            else:
+                raise
+            return {name: argv[pos] for pos, name in enumerate(mapping)}
 
     def filter_args(self, f, kwargs):
         """Remove unknown named parameters from call, because client did (implicitly) say it's ok."""


### PR DESCRIPTION
borg 1.1(.0) server didn't support the 4 argument open() calls made by < 1.0.7 clients.

@textshell can you have a look at this and #3192 also?