### PR TITLE
Added documentation for BORG_CONFIG_DIR

### DIFF
--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -197,6 +197,8 @@ Directories and files:
     BORG_CACHE_DIR
         Default to '~/.cache/borg'. This directory contains the local cache and might need a lot
         of space for dealing with big repositories).
+    BORG_CONFIG_DIR
+        Default to '~/.config/borg'. This directory contains the whole config directories.
 
 Building:
     BORG_OPENSSL_PREFIX


### PR DESCRIPTION
As discussed in the PR: https://github.com/borgbackup/borg/pull/3217, added the documentation for BORG_CONFIG_DIR. 

@ThomasWaldmann, Please let me know if any changes are required.