### PR TITLE
remove evil trailing comma, fixes #3244 (1.1)

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -603,7 +603,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                     # emit this msg in the same way as the 'Remote: ...' lines that show the remote TypeError
                     sys.stderr.write(msg)
                     self.server_version = parse_version('1.0.6')
-                    compatMap['open'] = ('path', 'create', 'lock_wait', 'lock', ),
+                    compatMap['open'] = ('path', 'create', 'lock_wait', 'lock', )
                     # try again with corrected version and compatMap
                     do_open()
         except Exception:


### PR DESCRIPTION
value type of compatMap is a tuple of strings.

due to the trailing comma, this was a 1-tuple of a tuple of strings.

(cherry picked from commit 117d30d17126f2118e43dec2f08d502d3369f6c8)
