### PR TITLE
borg list: remove tag-file options, fixes #3226

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3040,7 +3040,7 @@ class Archiver:
         subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
                                help='paths to list; patterns are supported')
         define_archive_filters_group(subparser)
-        define_exclusion_group(subparser, tag_files=True)
+        define_exclusion_group(subparser)
 
         mount_epilog = process_epilog("""
         This command mounts an archive as a FUSE filesystem. This can be useful for


### PR DESCRIPTION
they are not used for borg list.

```
$ borg list --help
...
  --exclude-caches      exclude directories that contain a CACHEDIR.TAG file
                        (http://www.brynosaurus.com/cachedir/spec.html)
  --exclude-if-present NAME
                        exclude directories that are tagged by containing a
                        filesystem object with the given NAME
  --keep-exclude-tags, --keep-tag-files
                        if tag objects are specified with ``--exclude-if-
                        present``, don't omit the tag objects themselves from
                        the backup archive
```
