### PR TITLE
borg list: remove tag-file options, fixes #3226

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3233,7 +3233,7 @@ class Archiver:
         subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
                                help='paths to list; patterns are supported')
         define_archive_filters_group(subparser)
-        define_exclusion_group(subparser, tag_files=True)
+        define_exclusion_group(subparser)
 
         mount_epilog = process_epilog("""
         This command mounts an archive as a FUSE filesystem. This can be useful for


### PR DESCRIPTION
they are not used for borg list.

(cherry picked from commit 702afa9e4883f92feb00dcecee54681a60792519)
