### PR TITLE
borg diff: remove tag-file options, fixes #3226

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2945,7 +2945,7 @@ class Archiver:
                                help='ARCHIVE2 name (no repository location allowed)')
         subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
                                help='paths of items inside the archives to compare; patterns are supported')
-        define_exclusion_group(subparser, tag_files=True)
+        define_exclusion_group(subparser)
 
         rename_epilog = process_epilog("""
         This command renames an archive in the repository.


### PR DESCRIPTION
they are not used for borg diff.
