### PR TITLE
stats: do not count data volume twice when checkpointing, fixes #3224

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -942,8 +942,9 @@ Utilization of max. archive size: {csize_max:.0%}
 
                 # if we created part files, we have referenced all chunks from the part files,
                 # but we also will reference the same chunks also from the final, complete file:
+                dummy_stats = Statistics()  # do not count this data volume twice
                 for chunk in item.chunks:
-                    cache.chunk_incref(chunk.id, stats, size=chunk.size)
+                    cache.chunk_incref(chunk.id, dummy_stats, size=chunk.size)
 
     def process_stdin(self, path, cache):
         uid, gid = 0, 0


### PR DESCRIPTION
(cherry picked from commit 66cd1cd240f078e2d5c9e32656b42dccf2d62935)
