### PR TITLE
Clarify create --stats duration vs. wall time (1.1-maint)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -288,6 +288,14 @@ needs to be ascertained and fixed.
 issues. We recommend to first run without ``--repair`` to assess the situation.
 If the found issues and proposed repairs seem right, re-run "check" with ``--repair`` enabled.
 
+Why is the time elapsed in the archive stats different from wall clock time?
+----------------------------------------------------------------------------
+
+Borg needs to write the time elapsed into the archive metadata before finalizing
+the archive, compacting the segments, and committing the repo & cache. This means
+when Borg is run with e.g. the ``time`` command, the duration shown in the archive
+stats may be shorter than the full time the command runs for.
+
 Security
 ########
 


### PR DESCRIPTION
See #3303.