### PR TITLE
Highlight that information is obtained from security dir

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -326,7 +326,7 @@ class Cache:
         """Cache is newer than repository - do you have multiple, independently updated repos with same ID?"""
 
     class RepositoryReplay(Error):
-        """Cache is newer than repository - this is either an attack or unsafe (multiple repos with same ID)"""
+        """Cache, or information obtained from the security directory is newer than repository - this is either an attack or unsafe (multiple repos with same ID)"""
 
     class CacheInitAbortedError(Error):
         """Cache initialization aborted"""


### PR DESCRIPTION
Deleting the cache will not bypass this error in the event the user knows this is a legitimate repo.

Change points the user in the right direction in the event that they obtain an old copy of a repo and want to resume backups to it.