### PR TITLE
clean up and simplify packaging (1.1-maint)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
-include README.rst AUTHORS LICENSE CHANGES.rst MANIFEST.in
-exclude .coafile .coveragerc .gitattributes .gitignore .travis.yml Vagrantfile
+# stuff we need to include into the sdist is handled automatically by
+# setuptools_scm - it includes all git-committed files.
+# but we want to exclude some committed files/dirs not needed in the sdist:
+exclude .coafile .coveragerc .editorconfig .gitattributes .gitignore .mailmap .travis.yml Vagrantfile
 prune .travis
 prune .github
-graft src
-graft docs
-prune docs/_build
-global-exclude *.py[co] *.orig *.so *.dll

--- a/setup.py
+++ b/setup.py
@@ -807,10 +807,12 @@ setup(
             'borgfs = borg.archiver:main',
         ]
     },
+    # See also the MANIFEST.in file.
+    # We want to install all the files in the package directories...
     include_package_data=True,
-    package_data={
-        'borg': ['paperkey.html'],
-        'borg.testsuite': ['attic.tar.gz'],
+    # ...except the source files which have been compiled (C extensions):
+    exclude_package_data={
+        '': ['*.c', '*.h', '*.pyx', ],
     },
     cmdclass=cmdclass,
     ext_modules=ext_modules,


### PR DESCRIPTION
1.1.2 was released with a sdist that included quite some files that
did not belong into the package (I tried nuitka at some time).

This was because the old MANIFEST.in / setup.py included all the stuff
in the package dir.

Now, setuptools_scm is to automatically deal with the INCLUDES and
MANIFEST.in only handles the EXCLUDES, so only committed files get
into the sdist (minus some we do not want).

Also, no .c .h .pyx files will be installed - they are not needed as
they have been compiled into binary files.

(cherry picked from commit feb428b4e012686d42cf0240663660757dcf231a)