### PR TITLE
Fix build_man issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -678,7 +678,7 @@ class build_man(Command):
         roles.register_local_role('issue', issue)
         # We give the source_path so that docutils can find relative includes
         # as-if the document where located in the docs/ directory.
-        man_page = publish_string(source=rst, source_path='docs/virtmanpage.rst', writer=manpage.Writer())
+        man_page = publish_string(source=rst, source_path='docs/%s.rst' % name, writer=manpage.Writer())
         with open('docs/man/%s.1' % name, 'wb') as fd:
             fd.write(man_page)
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3768,7 +3768,7 @@ class Archiver:
         R- == borg extract (extract archive, dry-run, do everything, but do not write files to disk)
               R-Z- == all zero files. Measuring heavily duplicated files.
               R-R- == random files. No duplication here, measuring throughput through all processing
-                      stages, except writing to disk.
+              stages, except writing to disk.
 
         U- == borg create (2nd archive creation of unchanged input files, measure files cache speed)
               The throughput value is kind of virtual here, it does not actually read the file.


### PR DESCRIPTION
Fixes #3364, except for the last warnings, which seem harmless anyway. Somebody could open an issue for sphinx as detailed [here](https://github.com/borgbackup/borg/issues/3364#issuecomment-346976483) to get rid of the last warnings if they were a little less lazy than me.