### PR TITLE
link to the homepage for support/service

### DIFF
--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,6 +1,11 @@
+Support
+=======
 
-Security
-========
+Support and Services
+--------------------
+
+Please see https://www.borgbackup.org/ for free and paid support and service options.
+
 
 .. _security-contact:
 


### PR DESCRIPTION
otherwise people ONLY reading the docs (and not coming from the
homepage) will miss these options.

(cherry picked from commit 7438cb2ef48e3cad9c220fc25de0a462a425bed8)
