### PR TITLE
Don't generate HTML docs page for borgfs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,9 +242,11 @@ class build_usage(Command):
         # allows us to build docs without the C modules fully loaded during help generation
         from borg.archiver import Archiver
         parser = Archiver(prog='borg').build_parser()
-        borgfs_parser = Archiver(prog='borgfs').build_parser()
+        # borgfs has a separate man page to satisfy debian's "every program from a package
+        # must have a man page" requirement, but it doesn't need a separate HTML docs page
+        #borgfs_parser = Archiver(prog='borgfs').build_parser()
 
-        self.generate_level("", parser, Archiver, {'borgfs': borgfs_parser})
+        self.generate_level("", parser, Archiver)
 
     def generate_level(self, prefix, parser, Archiver, extra_choices=None):
         is_subcommand = False


### PR DESCRIPTION
Fixes #3404. This one was my fault: I thought because it wasn't listed in the TOC, there was no harm in generating it anyway; turns out it still shows up in the search results :P