### PR TITLE
Don't reformat path after finding match in item_filter

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -661,7 +661,7 @@ class Archiver:
     def build_filter(matcher, peek_and_store_hardlink_masters, strip_components):
         if strip_components:
             def item_filter(item):
-                matched = matcher.match(item.path) and os.sep.join(item.path.split(os.sep)[strip_components:])
+                matched = matcher.match(item.path) and len(item.path.split(os.sep)) > strip_components
                 peek_and_store_hardlink_masters(item, matched)
                 return matched
         else:


### PR DESCRIPTION
Implements the micro-opt described in #3390.