### PR TITLE
add auto-generated docs for borg config (1.1)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -49,9 +49,9 @@ Usage
    usage/recreate
    usage/tar
    usage/serve
+   usage/config
    usage/lock
    usage/benchmark
-   usage/config
 
    usage/help
    usage/debug

--- a/docs/usage/config.rst.inc
+++ b/docs/usage/config.rst.inc
@@ -1,0 +1,73 @@
+.. IMPORTANT: this file is auto-generated from borg's built-in help, do not edit!
+
+.. _borg_config:
+
+borg config
+-----------
+.. code-block:: none
+
+    borg [common options] config [options] REPOSITORY NAME [VALUE]
+
+.. only:: html
+
+    .. class:: borg-options-table
+
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    | **positional arguments**                                                                                              |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    |                                                       | ``REPOSITORY``       | repository to configure                |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    |                                                       | ``NAME``             | name of config key                     |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    |                                                       | ``VALUE``            | new value for key                      |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    | **optional arguments**                                                                                                |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    |                                                       | ``-c``, ``--cache``  | get and set values from the repo cache |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    |                                                       | ``-d``, ``--delete`` | delete the key from the config file    |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+    | .. class:: borg-common-opt-ref                                                                                        |
+    |                                                                                                                       |
+    | :ref:`common_options`                                                                                                 |
+    +-------------------------------------------------------+----------------------+----------------------------------------+
+
+    .. raw:: html
+
+        <script type='text/javascript'>
+        $(document).ready(function () {
+            $('.borg-options-table colgroup').remove();
+        })
+        </script>
+
+.. only:: latex
+
+    REPOSITORY
+        repository to configure
+    NAME
+        name of config key
+    VALUE
+        new value for key
+
+
+    optional arguments
+        -c, --cache      get and set values from the repo cache
+        -d, --delete     delete the key from the config file
+
+
+    :ref:`common_options`
+        |
+
+Description
+~~~~~~~~~~~
+
+This command gets and sets options in a local repository or cache config file.
+For security reasons, this command only works on local repositories.
+
+To delete a config value entirely, use ``--delete``. To get an existing key, pass
+only the key name. To set a key, pass both the key name and the new value. Keys
+can be specified in the format "section.name" or simply "name"; the section will
+default to "repository" and "cache" for the repo and cache configs, respectively.
+
+By default, borg config manipulates the repository config file. Using ``--cache``
+edits the repository cache's config file instead.


### PR DESCRIPTION
also: move a bit upwards in the use docs
