### PR TITLE
Add placeholder for fqdn in reverse notation

### DIFF
--- a/docs/man/borg-placeholders.1
+++ b/docs/man/borg-placeholders.1
@@ -42,6 +42,9 @@ The (short) hostname of the machine.
 .B {fqdn}
 The full name of the machine.
 .TP
+.B {reverse-fqdn}
+The full name of the machine in reverse domain name notation.
+.TP
 .B {now}
 The current local date and time, by default in ISO\-8601 format.
 You can also supply your own \fI\%format string\fP, e.g. {now:%Y\-%m\-%d_%H:%M:%S}

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -169,6 +169,9 @@ placeholders:
 {fqdn}
     The full name of the machine.
 
+{reverse-fqdn}
+    The full name of the machine in reverse domain name notation.
+
 {now}
     The current local date and time, by default in ISO-8601 format.
     You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1901,6 +1901,9 @@ class Archiver:
         {fqdn}
             The full name of the machine.
 
+        {reverse-fqdn}
+            The full name of the machine in reverse domain name notation.
+
         {now}
             The current local date and time, by default in ISO-8601 format.
             You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -180,10 +180,11 @@ def format_line(format, data):
 def replace_placeholders(text):
     """Replace placeholders in text with their values."""
     current_time = datetime.now()
+    fqdn = socket.getfqdn()
     data = {
         'pid': os.getpid(),
-        'fqdn': socket.getfqdn(),
-        'reverse-fqdn': '.'.join(reversed(socket.getfqdn().split('.'))),
+        'fqdn': fqdn,
+        'reverse-fqdn': '.'.join(reversed(fqdn.split('.'))),
         'hostname': socket.gethostname(),
         'now': DatetimeWrapper(current_time.now()),
         'utcnow': DatetimeWrapper(current_time.utcnow()),

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -183,6 +183,7 @@ def replace_placeholders(text):
     data = {
         'pid': os.getpid(),
         'fqdn': socket.getfqdn(),
+        'reverse-fqdn': '.'.join(reversed(socket.getfqdn().split('.'))),
         'hostname': socket.gethostname(),
         'now': DatetimeWrapper(current_time.now()),
         'utcnow': DatetimeWrapper(current_time.utcnow()),


### PR DESCRIPTION
This allows for having lexicographic sorting coincide with domain structure without having to hardcode fqdns in automated scripts.