### PR TITLE
fix building the "borg prune" man page, fixes #3398

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -655,6 +655,8 @@ class build_man(Command):
             examples = examples.replace(usage_include, '')
             examples = examples.replace('Examples\n~~~~~~~~', '')
             examples = examples.replace('Miscellaneous Help\n------------------', '')
+            examples = examples.replace('``docs/misc/prune-example.txt``:', '``docs/misc/prune-example.txt``.')
+            examples = examples.replace('.. highlight:: none\n', '')  # we don't support highlight
             examples = re.sub('^(~+)$', lambda matches: '+' * len(matches.group(0)), examples, flags=re.MULTILINE)
             examples = examples.strip()
         if examples:


### PR DESCRIPTION
will fix all ".. highlight:: none" issues (just killing it).

also a slight punctuation fix, so there is a dot at the end of the prune man page.