### PR TITLE
Document interaction of ``--timestamp`` and time placeholders

### DIFF
--- a/docs/man/borg-placeholders.1
+++ b/docs/man/borg-placeholders.1
@@ -45,10 +45,14 @@ The full name of the machine.
 .B {now}
 The current local date and time, by default in ISO\-8601 format.
 You can also supply your own \fI\%format string\fP, e.g. {now:%Y\-%m\-%d_%H:%M:%S}
+.sp
+Retrieves the current time during placeholder evaluation and does not honor \fB\-\-timestamp\fP if given.
 .TP
 .B {utcnow}
 The current UTC date and time, by default in ISO\-8601 format.
 You can also supply your own \fI\%format string\fP, e.g. {utcnow:%Y\-%m\-%d_%H:%M:%S}
+.sp
+Retrieves the current time during placeholder evaluation and does not honor \fB\-\-timestamp\fP if given.
 .TP
 .B {user}
 The user name (or UID, if no name is available) of the user running borg.

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -173,9 +173,13 @@ placeholders:
     The current local date and time, by default in ISO-8601 format.
     You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
 
+    Retrieves the current time during placeholder evaluation and does not honor ``--timestamp`` if given.
+
 {utcnow}
     The current UTC date and time, by default in ISO-8601 format.
     You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
+
+    Retrieves the current time during placeholder evaluation and does not honor ``--timestamp`` if given.
 
 {user}
     The user name (or UID, if no name is available) of the user running borg.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1905,9 +1905,13 @@ class Archiver:
             The current local date and time, by default in ISO-8601 format.
             You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
 
+            Retrieves the current time during placeholder evaluation and does not honor ``--timestamp`` if given.
+
         {utcnow}
             The current UTC date and time, by default in ISO-8601 format.
             You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
+
+            Retrieves the current time during placeholder evaluation and does not honor ``--timestamp`` if given.
 
         {user}
             The user name (or UID, if no name is available) of the user running borg.


### PR DESCRIPTION
I was surprised to see that placeholders do not honor ``--timestamp``.

At least documenting that interaction seems like a good idea.

---

Is this expected behavior?