### PR TITLE
fix for borg check --repair malfunction, #3444 (1.1-maint)

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1457,7 +1457,7 @@ class ArchiveChecker:
             """
             item_keys = frozenset(key.encode() for key in self.manifest.item_keys)
             required_item_keys = frozenset(key.encode() for key in REQUIRED_ITEM_KEYS)
-            unpacker = RobustUnpacker(lambda item: isinstance(item, dict) and 'path' in item,
+            unpacker = RobustUnpacker(lambda item: isinstance(item, StableDict) and b'path' in item,
                                       self.manifest.item_keys)
             _state = 0
 

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3006,7 +3006,7 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
     def test_missing_archive_item_chunk(self):
         archive, repository = self.open_archive('archive1')
         with repository:
-            repository.delete(archive.metadata.items[-5])
+            repository.delete(archive.metadata.items[0])
             repository.commit()
         self.cmd('check', self.repository_location, exit_code=1)
         self.cmd('check', '--repair', self.repository_location, exit_code=0)


### PR DESCRIPTION
due to a malfunctioning validator, resyncing to the next item metadata dict in the archive metadata stream after a lost / zero-replaced chunk did not work.

this is a borg 1.1 regression, code in 1.0 is fine.