### PR TITLE
Properly quote repo path in `borg init` output

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -252,10 +252,10 @@ class Archiver:
                 'errors if written to with an older version (up to and including Borg 1.0.8).\n'
                 '\n'
                 'If you want to use these older versions, you can disable the check by running:\n'
-                'borg upgrade --disable-tam \'%s\'\n'
+                'borg upgrade --disable-tam %s\n'
                 '\n'
                 'See https://borgbackup.readthedocs.io/en/stable/changes.html#pre-1-0-9-manifest-spoofing-vulnerability '
-                'for details about the security implications.', path)
+                'for details about the security implications.', shlex.quote(path))
         return self.exit_code
 
     @with_repository(exclusive=True, manifest=False)


### PR DESCRIPTION
This is a really unimportant issue, but when the message about the manifest spoofing check is printed by `borg init`, if your repository path has a quote in it, then the command Borg prints won't be valid. This fixes that by passing the path through [`shlex.quote`].

[`shlex.quote`]: https://docs.python.org/3/library/shlex.html#shlex.quote

example: this invalid command

    borg upgrade --disable-tam '/path/test'repo'

is now printed as

    borg upgrade --disable-tam '/path/test'"'"'repo'