### PR TITLE
Properly quote repo path in `borg init` output (1.1)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -279,10 +279,10 @@ class Archiver:
                 'errors if written to with an older version (up to and including Borg 1.0.8).\n'
                 '\n'
                 'If you want to use these older versions, you can disable the check by running:\n'
-                'borg upgrade --disable-tam \'%s\'\n'
+                'borg upgrade --disable-tam %s\n'
                 '\n'
                 'See https://borgbackup.readthedocs.io/en/stable/changes.html#pre-1-0-9-manifest-spoofing-vulnerability '
-                'for details about the security implications.', path)
+                'for details about the security implications.', shlex.quote(path))
         return self.exit_code
 
     @with_repository(exclusive=True, manifest=False)


### PR DESCRIPTION
Instead of printing this invalid command:

    borg upgrade --disable-tam '/path/test'repo'

print this valid one:

    borg upgrade --disable-tam '/path/test'"'"'repo'

(cherry picked from commit e7806608309b52e4aa71be306d967083b28d46f9)
