### PR TITLE
add parens for C preprocessor macro argument usages (1.0-maint)

### DIFF
--- a/borg/_chunker.c
+++ b/borg/_chunker.c
@@ -39,7 +39,7 @@ static uint32_t table_base[] =
     0xc5ae37bb, 0xa76ce12a, 0x8150d8f3, 0x2ec29218, 0xa35f0984, 0x48c0647e, 0x0b5ff98c, 0x71893f7b
 };
 
-#define BARREL_SHIFT(v, shift) ( ((v) << shift) | ((v) >> ((32 - shift) & 0x1f)) )
+#define BARREL_SHIFT(v, shift) ( ((v) << (shift)) | ((v) >> ((32 - (shift)) & 0x1f)) )
 
 size_t pagemask;
 

--- a/borg/_hashindex.c
+++ b/borg/_hashindex.c
@@ -87,7 +87,7 @@ static int hash_sizes[] = {
 #define EMPTY _htole32(0xffffffff)
 #define DELETED _htole32(0xfffffffe)
 
-#define BUCKET_ADDR(index, idx) (index->buckets + (idx * index->bucket_size))
+#define BUCKET_ADDR(index, idx) (index->buckets + ((idx) * index->bucket_size))
 
 #define BUCKET_MATCHES_KEY(index, idx, key) (memcmp(key, BUCKET_ADDR(index, idx), index->key_size) == 0)
 


### PR DESCRIPTION
this is needed for correctness because the preprocessor is just
doing text replacement.

This is the correct way:

#define MUL(x, y) ((x) * (y))

MUL(1+2, 3-4) -> ((1+2) * (3-4))    # not: (1+2 * 3-4)

I didn't put parens around all arg usages for readability.

Some stuff (like index) is not expected to be an expression.

Also, when a arg is only used in another macro or function call,
no parens are needed either.

I reviewed the code: no harm was done (yet) due to this fault.

Thanks to @rciorba who found this.

(cherry picked from commit 981a936f47473e8c3a16595264a1be0b064fad12)

