### PR TITLE
Correct some confusing error messages from `borg init`

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -116,11 +116,8 @@ class Repository:
     class AlreadyExists(Error):
         """A repository already exists at {}."""
 
-    class OtherFilesExist(Error):
-        """Files not created by Borg already exist at {}."""
-
-    class NotADirectory(Error):
-        """{} is not a directory."""
+    class PathAlreadyExists(Error):
+        """There is already something at {}."""
 
     class InvalidRepository(Error):
         """{} is not a valid repository. Check repo config."""
@@ -229,12 +226,10 @@ class Repository:
             at the user's repository.
         """
         if os.path.exists(path):
-            if not os.path.isdir(path):
-                raise self.NotADirectory(path)
-            elif self.is_repository(path):
+            if self.is_repository(path):
                 raise self.AlreadyExists(path)
-            elif os.listdir(path):
-                raise self.OtherFilesExist(path)
+            if not os.path.isdir(path) or os.listdir(path):
+                raise self.PathAlreadyExists(path)
 
         while True:
             # Check all parent directories for Borg's repository README


### PR DESCRIPTION
Fixes #3465.

Examples:

```
$ borg init -e none /tmp/borg-test/
Files not created by Borg already exist at /tmp/borg-test.
$ borg init -e none /tmp/borg-test/foo
/tmp/borg-test/foo is not a directory.
```

whereas previously this would have happened:

```
$ borg init -e none /tmp/borg-test/
A repository already exists at /tmp/borg-test.
$ borg init -e none /tmp/borg-test/foo 
A repository already exists at /tmp/borg-test/foo.
```

Notes:

- this presumably needs tests, I have no idea how to even start doing that
- I'm open to suggestions on the exact wording of the new error messages