### PR TITLE
DONTMERGE: give use_bin_type=False, see #3517

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -234,7 +234,7 @@ class ChunkBuffer:
 
     def __init__(self, key, chunker_params=ITEMS_CHUNKER_PARAMS):
         self.buffer = BytesIO()
-        self.packer = msgpack.Packer(unicode_errors='surrogateescape')
+        self.packer = msgpack.Packer(unicode_errors='surrogateescape', use_bin_type=False)
         self.chunks = []
         self.key = key
         self.chunker = Chunker(self.key.chunk_seed, *chunker_params)
@@ -746,7 +746,7 @@ Utilization of max. archive size: {csize_max:.0%}
     def set_meta(self, key, value):
         metadata = self._load_meta(self.id)
         setattr(metadata, key, value)
-        data = msgpack.packb(metadata.as_dict(), unicode_errors='surrogateescape')
+        data = msgpack.packb(metadata.as_dict(), unicode_errors='surrogateescape', use_bin_type=False)
         new_id = self.key.id_hash(data)
         self.cache.add_chunk(new_id, data, self.stats)
         self.manifest.archives[self.name] = (new_id, metadata.time)
@@ -1212,7 +1212,7 @@ class RobustUnpacker:
 
     def __init__(self, validator, item_keys):
         super().__init__()
-        self.item_keys = [msgpack.packb(name.encode()) for name in item_keys]
+        self.item_keys = [msgpack.packb(name.encode(), use_bin_type=False) for name in item_keys]
         self.validator = validator
         self._buffered_data = []
         self._resync = False
@@ -1442,7 +1442,7 @@ class ArchiveChecker:
         # lost manifest on a older borg version than the most recent one that was ever used
         # within this repository (assuming that newer borg versions support more item keys).
         manifest = Manifest(self.key, self.repository)
-        archive_keys_serialized = [msgpack.packb(name.encode()) for name in ARCHIVE_KEYS]
+        archive_keys_serialized = [msgpack.packb(name.encode(), use_bin_type=False) for name in ARCHIVE_KEYS]
         for chunk_id, _ in self.chunks.iteritems():
             cdata = self.repository.get(chunk_id)
             try:
@@ -1693,7 +1693,7 @@ class ArchiveChecker:
                 for previous_item_id in archive.items:
                     mark_as_possibly_superseded(previous_item_id)
                 archive.items = items_buffer.chunks
-                data = msgpack.packb(archive.as_dict(), unicode_errors='surrogateescape')
+                data = msgpack.packb(archive.as_dict(), unicode_errors='surrogateescape', use_bin_type=False)
                 new_archive_id = self.key.id_hash(data)
                 cdata = self.key.encrypt(data)
                 add_reference(new_archive_id, len(data), len(cdata), cdata)

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -208,10 +208,10 @@ class KeyBase:
             'hmac': bytes(64),
             'salt': os.urandom(64),
         })
-        packed = msgpack.packb(metadata_dict, unicode_errors='surrogateescape')
+        packed = msgpack.packb(metadata_dict, unicode_errors='surrogateescape', use_bin_type=False)
         tam_key = self._tam_key(tam['salt'], context)
         tam['hmac'] = HMAC(tam_key, packed, sha512).digest()
-        return msgpack.packb(metadata_dict, unicode_errors='surrogateescape')
+        return msgpack.packb(metadata_dict, unicode_errors='surrogateescape', use_bin_type=False)
 
     def unpack_and_verify_manifest(self, data, force_tam_not_required=False):
         """Unpack msgpacked *data* and return (object, did_verify)."""
@@ -622,7 +622,7 @@ class KeyfileKeyBase(AESKeyBase):
             hash=hash,
             data=cdata,
         )
-        return msgpack.packb(enc_key.as_dict())
+        return msgpack.packb(enc_key.as_dict(), use_bin_type=False)
 
     def _save(self, passphrase):
         key = Key(
@@ -634,7 +634,7 @@ class KeyfileKeyBase(AESKeyBase):
             chunk_seed=self.chunk_seed,
             tam_required=self.tam_required,
         )
-        data = self.encrypt_key_file(msgpack.packb(key.as_dict()), passphrase)
+        data = self.encrypt_key_file(msgpack.packb(key.as_dict(), use_bin_type=False), passphrase)
         key_data = '\n'.join(textwrap.wrap(b2a_base64(data).decode('ascii')))
         return key_data
 

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -262,7 +262,7 @@ class RepositoryServer:  # pragma: no cover
                                                     b'exception_full': ex_full,
                                                     b'exception_short': ex_short,
                                                     b'exception_trace': ex_trace,
-                                                    b'sysinfo': sysinfo()})
+                                                    b'sysinfo': sysinfo()}, use_bin_type=False)
                             except TypeError:
                                 msg = msgpack.packb({MSGID: msgid,
                                                     b'exception_class': e.__class__.__name__,
@@ -271,7 +271,7 @@ class RepositoryServer:  # pragma: no cover
                                                     b'exception_full': ex_full,
                                                     b'exception_short': ex_short,
                                                     b'exception_trace': ex_trace,
-                                                    b'sysinfo': sysinfo()})
+                                                    b'sysinfo': sysinfo()}, use_bin_type=False)
 
                             os_write(stdout_fd, msg)
                         else:
@@ -291,12 +291,12 @@ class RepositoryServer:  # pragma: no cover
                                 logging.error(msg)
                                 logging.log(tb_log_level, tb)
                             exc = 'Remote Exception (see remote log for the traceback)'
-                            os_write(stdout_fd, msgpack.packb((1, msgid, e.__class__.__name__, exc)))
+                            os_write(stdout_fd, msgpack.packb((1, msgid, e.__class__.__name__, exc), use_bin_type=False))
                     else:
                         if dictFormat:
-                            os_write(stdout_fd, msgpack.packb({MSGID: msgid, RESULT: res}))
+                            os_write(stdout_fd, msgpack.packb({MSGID: msgid, RESULT: res}, use_bin_type=False))
                         else:
-                            os_write(stdout_fd, msgpack.packb((1, msgid, None, res)))
+                            os_write(stdout_fd, msgpack.packb((1, msgid, None, res), use_bin_type=False))
             if es:
                 self.repository.close()
                 return
@@ -855,18 +855,18 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                                 self.msgid += 1
                                 waiting_for.append(self.msgid)
                                 if self.dictFormat:
-                                    self.to_send = msgpack.packb({MSGID: self.msgid, MSG: cmd, ARGS: args})
+                                    self.to_send = msgpack.packb({MSGID: self.msgid, MSG: cmd, ARGS: args}, use_bin_type=False)
                                 else:
-                                    self.to_send = msgpack.packb((1, self.msgid, cmd, self.named_to_positional(cmd, args)))
+                                    self.to_send = msgpack.packb((1, self.msgid, cmd, self.named_to_positional(cmd, args)), use_bin_type=False)
                     if not self.to_send and self.preload_ids:
                         chunk_id = self.preload_ids.pop(0)
                         args = {'id': chunk_id}
                         self.msgid += 1
                         self.chunkid_to_msgids.setdefault(chunk_id, []).append(self.msgid)
                         if self.dictFormat:
-                            self.to_send = msgpack.packb({MSGID: self.msgid, MSG: 'get', ARGS: args})
+                            self.to_send = msgpack.packb({MSGID: self.msgid, MSG: 'get', ARGS: args}, use_bin_type=False)
                         else:
-                            self.to_send = msgpack.packb((1, self.msgid, 'get', self.named_to_positional(cmd, args)))
+                            self.to_send = msgpack.packb((1, self.msgid, 'get', self.named_to_positional(cmd, args)), use_bin_type=False)
 
                 if self.to_send:
                     try:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -558,7 +558,7 @@ class Repository:
         hints_name = 'hints.%d' % transaction_id
         hints_file = os.path.join(self.path, hints_name)
         with IntegrityCheckedFile(hints_file + '.tmp', filename=hints_name, write=True) as fd:
-            msgpack.pack(hints, fd)
+            msgpack.pack(hints, fd, use_bin_type=False)
             flush_and_sync(fd)
         integrity[b'hints'] = fd.integrity_data
 
@@ -575,7 +575,7 @@ class Repository:
         integrity_name = 'integrity.%d' % transaction_id
         integrity_file = os.path.join(self.path, integrity_name)
         with open(integrity_file + '.tmp', 'wb') as fd:
-            msgpack.pack(integrity, fd)
+            msgpack.pack(integrity, fd, use_bin_type=False)
             flush_and_sync(fd)
 
         # Rename the integrity file first

--- a/src/borg/testsuite/archive.py
+++ b/src/borg/testsuite/archive.py
@@ -138,7 +138,7 @@ class ChunkBufferTestCase(BaseTestCase):
 class RobustUnpackerTestCase(BaseTestCase):
 
     def make_chunks(self, items):
-        return b''.join(msgpack.packb({'path': item}) for item in items)
+        return b''.join(msgpack.packb({'path': item}, use_bin_type=False) for item in items)
 
     def _validator(self, value):
         return isinstance(value, dict) and value.get(b'path') in (b'foo', b'bar', b'boo', b'baz')
@@ -193,12 +193,12 @@ class RobustUnpackerTestCase(BaseTestCase):
 
 @pytest.fixture
 def item_keys_serialized():
-    return [msgpack.packb(name) for name in ITEM_KEYS]
+    return [msgpack.packb(name, use_bin_type=False) for name in ITEM_KEYS]
 
 
 @pytest.mark.parametrize('packed',
     [b'', b'x', b'foobar', ] +
-    [msgpack.packb(o) for o in (
+    [msgpack.packb(o, use_bin_type=False) for o in (
         [None, 0, 0.0, False, '', {}, [], ()] +
         [42, 23.42, True, b'foobar', {b'foo': b'bar'}, [b'foo', b'bar'], (b'foo', b'bar')]
     )])
@@ -211,7 +211,7 @@ IK = sorted(list(ITEM_KEYS))
 
 
 @pytest.mark.parametrize('packed',
-    [msgpack.packb(o) for o in [
+    [msgpack.packb(o, use_bin_type=False) for o in [
         {b'path': b'/a/b/c'},  # small (different msgpack mapping type!)
         OrderedDict((k, b'') for k in IK),  # as big (key count) as it gets
         OrderedDict((k, b'x' * 1000) for k in IK),  # as big (key count and volume) as it gets
@@ -223,8 +223,8 @@ def test_valid_msgpacked_items(packed, item_keys_serialized):
 def test_key_length_msgpacked_items():
     key = b'x' * 32  # 31 bytes is the limit for fixstr msgpack type
     data = {key: b''}
-    item_keys_serialized = [msgpack.packb(key), ]
-    assert valid_msgpacked_dict(msgpack.packb(data), item_keys_serialized)
+    item_keys_serialized = [msgpack.packb(key, use_bin_type=False), ]
+    assert valid_msgpacked_dict(msgpack.packb(data, use_bin_type=False), item_keys_serialized)
 
 
 def test_backup_io():

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3071,7 +3071,7 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
                 'name': 'archive1',
                 'time': '2016-12-15T18:49:51.849711',
                 'version': 1,
-            })
+            }, use_bin_type=False)
             archive_id = key.id_hash(archive)
             repository.put(archive_id, key.encrypt(archive))
             repository.commit()
@@ -3166,7 +3166,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
                 'archives': {},
                 'config': {},
                 'timestamp': (datetime.utcnow() + timedelta(days=1)).strftime(ISO_FORMAT),
-            })))
+            }, use_bin_type=False)))
             repository.commit()
 
     def test_fresh_init_tam_required(self):
@@ -3178,7 +3178,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
                 'version': 1,
                 'archives': {},
                 'timestamp': (datetime.utcnow() + timedelta(days=1)).strftime(ISO_FORMAT),
-            })))
+            }, use_bin_type=False)))
             repository.commit()
 
         with pytest.raises(TAMRequiredError):
@@ -3196,7 +3196,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
 
             manifest = msgpack.unpackb(key.decrypt(None, repository.get(Manifest.MANIFEST_ID)))
             del manifest[b'tam']
-            repository.put(Manifest.MANIFEST_ID, key.encrypt(msgpack.packb(manifest)))
+            repository.put(Manifest.MANIFEST_ID, key.encrypt(msgpack.packb(manifest, use_bin_type=False)))
             repository.commit()
         output = self.cmd('list', '--debug', self.repository_location)
         assert 'archive1234' in output

--- a/src/borg/testsuite/cache.py
+++ b/src/borg/testsuite/cache.py
@@ -32,7 +32,7 @@ class TestCacheSynchronizer:
             'bar': 5678,
             'user': 'chunks',
             'chunks': []
-        })
+        }, use_bin_type=False)
         sync.feed(data)
         assert not len(index)
 
@@ -46,7 +46,7 @@ class TestCacheSynchronizer:
                 (H(1), 1, 2),
                 (H(2), 2, 3),
             ]
-        })
+        }, use_bin_type=False)
         sync.feed(data)
         assert len(index) == 2
         assert index[H(1)] == (1, 1, 2)
@@ -62,7 +62,7 @@ class TestCacheSynchronizer:
                 (H(1), 1, 2),
                 (H(2), 2, 3),
             ]
-        })
+        }, use_bin_type=False)
         data += packb({
             'xattrs': {
                 'security.foo': 'bar',
@@ -71,7 +71,7 @@ class TestCacheSynchronizer:
             'stuff': [
                 (1, 2, 3),
             ]
-        })
+        }, use_bin_type=False)
         data += packb({
             'xattrs': {
                 'security.foo': 'bar',
@@ -84,17 +84,17 @@ class TestCacheSynchronizer:
             'stuff': [
                 (1, 2, 3),
             ]
-        })
+        }, use_bin_type=False)
         data += packb({
             'chunks': [
                 (H(3), 1, 2),
             ],
-        })
+        }, use_bin_type=False)
         data += packb({
             'chunks': [
                 (H(1), 1, 2),
             ],
-        })
+        }, use_bin_type=False)
 
         part1 = data[:70]
         part2 = data[70:120]
@@ -124,7 +124,7 @@ class TestCacheSynchronizer:
         lambda elem: {'chunks': [(elem, 1, 2)]},
     ))
     def test_corrupted(self, sync, structure, elem, error):
-        packed = packb(structure(elem))
+        packed = packb(structure(elem), use_bin_type=False)
         with pytest.raises(ValueError) as excinfo:
             sync.feed(packed)
         if isinstance(error, str):
@@ -142,7 +142,7 @@ class TestCacheSynchronizer:
         ({'chunks': [(bytes(32), 1.0, 2)]}, 'Unexpected object: double'),
     ))
     def test_corrupted_ancillary(self, index, sync, data, error):
-        packed = packb(data)
+        packed = packb(data, use_bin_type=False)
         with pytest.raises(ValueError) as excinfo:
             sync.feed(packed)
         assert str(excinfo.value) == 'cache_sync_feed failed: ' + error
@@ -175,7 +175,7 @@ class TestCacheSynchronizer:
             'chunks': [
                 (H(0), 1, 2),
             ]
-        })
+        }, use_bin_type=False)
         with pytest.raises(ValueError) as excinfo:
             sync.feed(data)
         assert str(excinfo.value) == 'cache_sync_feed failed: invalid reference count'
@@ -187,7 +187,7 @@ class TestCacheSynchronizer:
             'chunks': [
                 (H(0), 1, 2),
             ]
-        })
+        }, use_bin_type=False)
         sync.feed(data)
         assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
 
@@ -198,7 +198,7 @@ class TestCacheSynchronizer:
             'chunks': [
                 (H(0), 1, 2),
             ]
-        })
+        }, use_bin_type=False)
         sync.feed(data)
         # Incremented to maximum
         assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -457,7 +457,7 @@ class StableDictTestCase(BaseTestCase):
     def test(self):
         d = StableDict(foo=1, bar=2, boo=3, baz=4)
         self.assert_equal(list(d.items()), [('bar', 2), ('baz', 4), ('boo', 3), ('foo', 1)])
-        self.assert_equal(hashlib.md5(msgpack.packb(d)).hexdigest(), 'fc78df42cd60691b3ac3dd2a2b39903f')
+        self.assert_equal(hashlib.md5(msgpack.packb(d, use_bin_type=False)).hexdigest(), 'fc78df42cd60691b3ac3dd2a2b39903f')
 
 
 class TestParseTimestamp(BaseTestCase):

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -337,12 +337,12 @@ class TestTAM:
             key.unpack_and_verify_manifest(blob)
 
     def test_missing_when_required(self, key):
-        blob = msgpack.packb({})
+        blob = msgpack.packb({}, use_bin_type=False)
         with pytest.raises(TAMRequiredError):
             key.unpack_and_verify_manifest(blob)
 
     def test_missing(self, key):
-        blob = msgpack.packb({})
+        blob = msgpack.packb({}, use_bin_type=False)
         key.tam_required = False
         unpacked, verified = key.unpack_and_verify_manifest(blob)
         assert unpacked == {}
@@ -353,7 +353,7 @@ class TestTAM:
             'tam': {
                 'type': 'HMAC_VOLLBIT',
             },
-        })
+        }, use_bin_type=False)
         with pytest.raises(TAMUnsupportedSuiteError):
             key.unpack_and_verify_manifest(blob)
 
@@ -362,7 +362,7 @@ class TestTAM:
             'tam': {
                 'type': 'HMAC_VOLLBIT',
             },
-        })
+        }, use_bin_type=False)
         key.tam_required = False
         unpacked, verified = key.unpack_and_verify_manifest(blob)
         assert unpacked == {}
@@ -377,7 +377,7 @@ class TestTAM:
     def test_invalid(self, key, tam, exc):
         blob = msgpack.packb({
             'tam': tam,
-        })
+        }, use_bin_type=False)
         with pytest.raises(exc):
             key.unpack_and_verify_manifest(blob)
 
@@ -400,7 +400,7 @@ class TestTAM:
             del tam['hmac']
         if salt is None:
             del tam['salt']
-        blob = msgpack.packb(data)
+        blob = msgpack.packb(data, use_bin_type=False)
         with pytest.raises(TAMInvalid):
             key.unpack_and_verify_manifest(blob)
 
@@ -427,7 +427,7 @@ class TestTAM:
         assert len(unpacked[b'tam'][which]) == 64
         unpacked[b'tam'][which] = unpacked[b'tam'][which][0:32] + bytes(32)
         assert len(unpacked[b'tam'][which]) == 64
-        blob = msgpack.packb(unpacked)
+        blob = msgpack.packb(unpacked, use_bin_type=False)
 
         with pytest.raises(TAMInvalid):
             key.unpack_and_verify_manifest(blob)

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -606,7 +606,7 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
             msgpack.pack({
                 # Borg only understands version 2
                 b'version': 4.7,
-            }, fd)
+            }, fd, use_bin_type=False)
             fd.truncate()
         with self.repository:
             # No issues accessing the repository
@@ -631,7 +631,7 @@ class RepositoryAuxiliaryCorruptionTestCase(RepositoryTestCaseBase):
             # Corrupt segment refcount
             assert hints[b'segments'][2] == 1
             hints[b'segments'][2] = 0
-            msgpack.pack(hints, fd)
+            msgpack.pack(hints, fd, use_bin_type=False)
             fd.truncate()
 
     def test_subtly_corrupted_hints(self):


### PR DESCRIPTION
since 0.5.0, msgpack always wants use_bin_type.

if not given, it emits a FutureWarning about the intention to change the default value later.


Note: code is getting uglier.

I am thinking about introducing a wrapper around msgpack to deal with such stuff. But likely, that will cost a bit of performance, not sure how much.
  