### PR TITLE
Chunk seed is generated per /repository/

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -596,9 +596,9 @@ can be used to tune the chunker parameters, the default is:
 - HASH_WINDOW_SIZE = 4095 [B] (`0xFFF`)
 
 The buzhash table is altered by XORing it with a seed randomly generated once
-for the archive, and stored encrypted in the keyfile. This is to prevent chunk
-size based fingerprinting attacks on your encrypted repo contents (to guess
-what files you have based on a specific set of chunk sizes).
+for the repository, and stored encrypted in the keyfile. This is to prevent
+chunk size based fingerprinting attacks on your encrypted repo contents (to
+guess what files you have based on a specific set of chunk sizes).
 
 For some more general usage hints see also ``--chunker-params``.
 


### PR DESCRIPTION
Storage in the keyfile implies to me that the chunk seed is unique per /repository/ not archive; otherwise deduplication would hardly work.

Is this correct?