### PR TITLE
require msgpack >= 0.4.6 and < 0.5.0 (1.1-maint).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,12 @@ if my_python < min_python:
 # Are we building on ReadTheDocs?
 on_rtd = os.environ.get('READTHEDOCS')
 
-# msgpack pure python data corruption was fixed in 0.4.6.
-# Also, we might use some rather recent API features.
-install_requires = ['msgpack-python>=0.4.6', ]
+install_requires = [
+    # msgpack pure python data corruption was fixed in 0.4.6.
+    # msgpack 0.5.0 was a bit of a troublemaker.
+    # also, msgpack dropped py34 support at 0.5.0.
+    'msgpack-python>=0.4.6,<0.5.0',
+]
 
 # note for package maintainers: if you package borgbackup for distribution,
 # please add llfuse as a *requirement* on all platforms that have a working


### PR DESCRIPTION
maybe this is the easiest way for us to deal with msgpack compatibility.

0.5.0 release had some troubles:
- FutureWarning on stderr disturbing other output there, breaking tests
- pip install -U broken due to a pip issue with the transisition pkg
  which was needed due to the package rename (ImportError for msgpack)
- some linux dists not packaging the transition pkg
- dropped py34 support/testing