### PR TITLE
travis osx: run brew update first, fixes #3527 (1.0)

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update
     if [[ "${OPENSSL}" != "0.9.8" ]]; then
         brew outdated openssl || brew upgrade openssl
     fi


### PR DESCRIPTION
suggested as work around on the travis issue about this ruby version
issue (wanted: 2.3, having: 2.0).

(cherry picked from commit e4828078bbc6ceba34a1b923b4c50a31b10b4f08)
