### PR TITLE
use timezone-aware datetime objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import io
 import re
 import sys
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 
 from distutils.command.build import build
@@ -643,7 +643,7 @@ class build_man(Command):
         self.write_heading(write, description, double_sided=True)
         # man page metadata
         write(':Author: The Borg Collective')
-        write(':Date:', datetime.utcnow().date().isoformat())
+        write(':Date:', datetime.now(timezone.utc).date().isoformat())
         write(':Manual section: 1')
         write(':Manual group: borg backup tool')
         write()

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -313,13 +313,13 @@ class Archive:
         self.nobsdflags = nobsdflags
         assert (start is None) == (start_monotonic is None), 'Logic error: if start is given, start_monotonic must be given as well and vice versa.'
         if start is None:
-            start = datetime.utcnow()
+            start = datetime.now(timezone.utc)
             start_monotonic = time.monotonic()
         self.chunker_params = chunker_params
         self.start = start
         self.start_monotonic = start_monotonic
         if end is None:
-            end = datetime.utcnow()
+            end = datetime.now(timezone.utc)
         self.end = end
         self.consider_part_files = consider_part_files
         self.pipeline = DownloadPipeline(self.repository, self.key)
@@ -457,7 +457,7 @@ Utilization of max. archive size: {csize_max:.0%}
         self.items_buffer.flush(flush=True)
         duration = timedelta(seconds=time.monotonic() - self.start_monotonic)
         if timestamp is None:
-            end = datetime.utcnow()
+            end = datetime.now(timezone.utc)
             start = end - duration
         else:
             end = timestamp + duration
@@ -1867,7 +1867,7 @@ class ArchiveRecreater:
             archive.delete(Statistics(), progress=self.progress)
             target.rename(archive.name)
         if self.stats:
-            target.end = datetime.utcnow()
+            target.end = datetime.now(timezone.utc)
             log_multi(DASHES,
                       str(target),
                       DASHES,

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -22,7 +22,7 @@ import time
 import traceback
 from binascii import unhexlify
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from itertools import zip_longest
 
 from .logger import create_logger, setup_logging
@@ -506,7 +506,7 @@ class Archiver:
         self.exclude_nodump = args.exclude_nodump
         self.files_cache_mode = args.files_cache_mode
         dry_run = args.dry_run
-        t0 = datetime.utcnow()
+        t0 = datetime.now(timezone.utc)
         t0_monotonic = time.monotonic()
         if not dry_run:
             with Cache(repository, key, manifest, do_files=args.cache_files, progress=args.progress,

--- a/src/borg/helpers/manifest.py
+++ b/src/borg/helpers/manifest.py
@@ -3,7 +3,7 @@ import os
 import os.path
 import re
 from collections import abc, namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from operator import attrgetter
 
 from .errors import Error
@@ -236,11 +236,11 @@ class Manifest:
             self.config[b'tam_required'] = True
         # self.timestamp needs to be strictly monotonically increasing. Clocks often are not set correctly
         if self.timestamp is None:
-            self.timestamp = datetime.utcnow().strftime(ISO_FORMAT)
+            self.timestamp = datetime.now(timezone.utc).strftime(ISO_FORMAT)
         else:
             prev_ts = self.last_timestamp
             incremented = (prev_ts + timedelta(microseconds=1)).strftime(ISO_FORMAT)
-            self.timestamp = max(incremented, datetime.utcnow().strftime(ISO_FORMAT))
+            self.timestamp = max(incremented, datetime.now(timezone.utc).strftime(ISO_FORMAT))
         # include checks for limits as enforced by limited unpacker (used by load())
         assert len(self.archives) <= MAX_ARCHIVES
         assert all(len(name) <= 255 for name in self.archives)

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -180,14 +180,14 @@ def format_line(format, data):
 def replace_placeholders(text):
     """Replace placeholders in text with their values."""
     from ..platform import fqdn
-    current_time = datetime.now()
+    frozen_datetime = datetime.now()
     data = {
         'pid': os.getpid(),
         'fqdn': fqdn,
         'reverse-fqdn': '.'.join(reversed(fqdn.split('.'))),
         'hostname': socket.gethostname(),
-        'now': DatetimeWrapper(current_time.now()),
-        'utcnow': DatetimeWrapper(current_time.utcnow()),
+        'now': DatetimeWrapper(frozen_datetime.now()),
+        'utcnow': DatetimeWrapper(frozen_datetime.now(timezone.utc)),
         'user': uid2user(os.getuid(), os.getuid()),
         'uuid4': str(uuid.uuid4()),
         'borgversion': borg_version,

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -6,7 +6,7 @@ import struct
 from binascii import hexlify, unhexlify
 from collections import defaultdict
 from configparser import ConfigParser
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 from itertools import islice
 
@@ -552,7 +552,7 @@ class Repository:
         if self.append_only:
             with open(os.path.join(self.path, 'transactions'), 'a') as log:
                 print('transaction %d, UTC time %s' % (
-                      transaction_id, datetime.utcnow().strftime(ISO_FORMAT)), file=log)
+                      transaction_id, datetime.now(timezone.utc).strftime(ISO_FORMAT)), file=log)
 
         # Write hints file
         hints_name = 'hints.%d' % transaction_id

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -17,7 +17,7 @@ import time
 import unittest
 from binascii import unhexlify, b2a_base64
 from configparser import ConfigParser
-from datetime import datetime
+from datetime import datetime, timezone
 from datetime import timedelta
 from hashlib import sha256
 from io import BytesIO, StringIO
@@ -3165,7 +3165,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
                 'version': 1,
                 'archives': {},
                 'config': {},
-                'timestamp': (datetime.utcnow() + timedelta(days=1)).strftime(ISO_FORMAT),
+                'timestamp': (datetime.now(timezone.utc) + timedelta(days=1)).strftime(ISO_FORMAT),
             })))
             repository.commit()
 
@@ -3177,7 +3177,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
             repository.put(Manifest.MANIFEST_ID, key.encrypt(msgpack.packb({
                 'version': 1,
                 'archives': {},
-                'timestamp': (datetime.utcnow() + timedelta(days=1)).strftime(ISO_FORMAT),
+                'timestamp': (datetime.now(timezone.utc) + timedelta(days=1)).strftime(ISO_FORMAT),
             })))
             repository.commit()
 


### PR DESCRIPTION
Calls to `datetime.utcnow()` were replaced with `datetime.now(timezone.utc)`.
The `utcnow()` return naive datetime object, one unaware of timezones. The
`datetime.now(timezone.utc)` results in exact same datetime value, but
object aware of timezones[1].

The change should  allow use of `%z` and `%Z` in `{utcnow}` format string[2].

Minor change: `current_time` was renamed to `frozen_datetime`.

1. https://docs.python.org/3.6/library/datetime.html#strftime-and-strptime-behavior
2. https://docs.python.org/3.6/library/datetime.html#datetime.datetime.utcnow