### PR TITLE
files cache: improve exception handling, fixes #3553

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3325,13 +3325,9 @@ class ArchiverCorruptionTestCase(ArchiverTestCaseBase):
     def test_cache_files(self):
         self.cmd('create', self.repository_location + '::test', 'input')
         self.corrupt(os.path.join(self.cache_path, 'files'))
-
-        if self.FORK_DEFAULT:
-            out = self.cmd('create', self.repository_location + '::test1', 'input', exit_code=2)
-            assert 'failed integrity check' in out
-        else:
-            with pytest.raises(FileIntegrityError):
-                self.cmd('create', self.repository_location + '::test1', 'input')
+        out = self.cmd('create', self.repository_location + '::test1', 'input')
+        # borg warns about the corrupt files cache, but then continues without files cache.
+        assert 'files cache is corrupted' in out
 
     def test_chunks_archive(self):
         self.cmd('create', self.repository_location + '::test1', 'input')


### PR DESCRIPTION
now deals with:
- corrupted files cache (truncated or modified not by borg)
- inaccessible/unreadable files cache
- missing files cache

The latter fix is not sufficient, the cache transaction processing
would still stumble over expected, but missing files in the cache.
