### PR TITLE
do .h file content checks in binary mode, fixes #3544

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,8 +149,8 @@ def detect_openssl(prefixes):
     for prefix in prefixes:
         filename = os.path.join(prefix, 'include', 'openssl', 'evp.h')
         if os.path.exists(filename):
-            with open(filename, 'r') as fd:
-                if 'PKCS5_PBKDF2_HMAC(' in fd.read():
+            with open(filename, 'rb') as fd:
+                if b'PKCS5_PBKDF2_HMAC(' in fd.read():
                     return prefix
 
 

--- a/setup_b2.py
+++ b/setup_b2.py
@@ -24,8 +24,8 @@ def b2_system_prefix(prefixes):
     for prefix in prefixes:
         filename = os.path.join(prefix, 'include', 'blake2.h')
         if os.path.exists(filename):
-            with open(filename, 'r') as fd:
-                if 'blake2b_init' in fd.read():
+            with open(filename, 'rb') as fd:
+                if b'blake2b_init' in fd.read():
                     return prefix
 
 

--- a/setup_lz4.py
+++ b/setup_lz4.py
@@ -24,8 +24,8 @@ def lz4_system_prefix(prefixes):
     for prefix in prefixes:
         filename = os.path.join(prefix, 'include', 'lz4.h')
         if os.path.exists(filename):
-            with open(filename, 'r') as fd:
-                if 'LZ4_compress_default' in fd.read():  # requires lz4 >= 1.7.0 (r129)
+            with open(filename, 'rb') as fd:
+                if b'LZ4_compress_default' in fd.read():  # requires lz4 >= 1.7.0 (r129)
                     return prefix
 
 

--- a/setup_zstd.py
+++ b/setup_zstd.py
@@ -66,8 +66,8 @@ def zstd_system_prefix(prefixes):
     for prefix in prefixes:
         filename = os.path.join(prefix, 'include', 'zstd.h')
         if os.path.exists(filename):
-            with open(filename, 'r') as fd:
-                if 'ZSTD_getFrameContentSize' in fd.read():  # checks for zstd >= 1.3.0
+            with open(filename, 'rb') as fd:
+                if b'ZSTD_getFrameContentSize' in fd.read():  # checks for zstd >= 1.3.0
                     return prefix
 
 


### PR DESCRIPTION
we can't know the encoding header file authors will use, so using binary for our simple checks is the safest way.
