### PR TITLE
Fixed tab completion problem in Bash

### DIFF
--- a/scripts/shell_completions/bash/borg
+++ b/scripts/shell_completions/bash/borg
@@ -7,6 +7,7 @@
 
 _borg()
 {
+	compopt -o default
 	COMPREPLY=()
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -18,7 +19,8 @@ _borg()
 	if [[ ${COMP_CWORD} == 1 ]] ; then
 		local borg_commands="init create extract check rename list diff delete prune info mount umount key serve upgrade recreate export-tar with-lock break-lock benchmark config"
 		COMPREPLY=( $(compgen -W "${borg_commands}" -- ${cur}) )
-		return 0
+		compopt +o default
+        	return 0
 	fi
 
 	case "${prev}" in
@@ -159,7 +161,6 @@ _borg()
 		return 0
 	fi
 
-	COMPREPLY=( $(compgen -f ${cur}) )
 	return 0
 }
 


### PR DESCRIPTION
 Fixed tab completion problem where a space is always added after path even when it shouldn't

When using tab completion, an unwanted space was always added after the path, e.g. borg info /path/to/repo<space>, which meant a backspace always had to be pressed in between directories when traversing them. This commit fixes that.