### PR TITLE
make the C compiler happy, fixes #3490

### DIFF
--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -729,7 +729,7 @@ cdef class AES:
         cdef Py_buffer idata = ro_buffer(data)
         cdef int ilen = len(data)
         cdef int offset
-        cdef int olen
+        cdef int olen = 0
         cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(ilen + self.cipher_blk_len)
         if not odata:
             raise MemoryError
@@ -753,7 +753,7 @@ cdef class AES:
         cdef Py_buffer idata = ro_buffer(data)
         cdef int ilen = len(data)
         cdef int offset
-        cdef int olen
+        cdef int olen = 0
         cdef unsigned char *odata = <unsigned char *>PyMem_Malloc(ilen + self.cipher_blk_len)
         if not odata:
             raise MemoryError


### PR DESCRIPTION
fix a false positive compiler warning about olen being referenced
before assignment (which is not true, see comments in #3490).

master only, no 1.1 / 1.0 backport needed.