### PR TITLE
Improve formatting of GPG output in documentation

### DIFF
--- a/docs/support.rst
+++ b/docs/support.rst
@@ -29,17 +29,17 @@ Verifying signed releases
 
 `Releases <https://github.com/borgbackup/borg/releases>`_ are signed with the same GPG key and a .asc file is provided for each binary.
 
-To verify a signature, the public key needs to be known to GPG. It can be imported into the local keystore from a keyserver with the fingerprint:
+To verify a signature, the public key needs to be known to GPG. It can be imported into the local keystore from a keyserver with the fingerprint::
 
       gpg --recv-keys "6D5B EF9A DD20 7580 5747 B70F 9F88 FB52 FAF7 B393"
 
 If GPG successfully imported the key, the output should be (among other things): 'Total number processed: 1'.
 
-To verify for example the signature of the borg-linux64 binary:
+To verify for example the signature of the borg-linux64 binary::
 
       gpg --verify borg-linux64.asc
 
-GPG outputs if it finds a good signature. The output should look similar to this:
+GPG outputs if it finds a good signature. The output should look similar to this::
 
       gpg: Signature made Sat 30 Dec 2017 01:07:36 PM CET using RSA key ID 51F78E01
       gpg: Good signature from "Thomas Waldmann <email>"


### PR DESCRIPTION
Previously the GPG output in support.rst was formatted as a blockquote, so the linebreaks would not be preserved (at least when viewing directly on GitHub):

![image](https://user-images.githubusercontent.com/9433472/36977437-0a88fc06-2079-11e8-8491-f43e91573495.png)

Formatting it as a literal block preserves the linebreaks:

![image](https://user-images.githubusercontent.com/9433472/36977527-56fd334a-2079-11e8-9f42-925851ced3a0.png)