### PR TITLE
Improve formatting of GPG output in documentation (backport to 1.1)

### DIFF
--- a/docs/support.rst
+++ b/docs/support.rst
@@ -29,17 +29,17 @@ Verifying signed releases
 
 `Releases <https://github.com/borgbackup/borg/releases>`_ are signed with the same GPG key and a .asc file is provided for each binary.
 
-To verify a signature, the public key needs to be known to GPG. It can be imported into the local keystore from a keyserver with the fingerprint:
+To verify a signature, the public key needs to be known to GPG. It can be imported into the local keystore from a keyserver with the fingerprint::
 
       gpg --recv-keys "6D5B EF9A DD20 7580 5747 B70F 9F88 FB52 FAF7 B393"
 
 If GPG successfully imported the key, the output should be (among other things): 'Total number processed: 1'.
 
-To verify for example the signature of the borg-linux64 binary:
+To verify for example the signature of the borg-linux64 binary::
 
       gpg --verify borg-linux64.asc
 
-GPG outputs if it finds a good signature. The output should look similar to this:
+GPG outputs if it finds a good signature. The output should look similar to this::
 
       gpg: Signature made Sat 30 Dec 2017 01:07:36 PM CET using RSA key ID 51F78E01
       gpg: Good signature from "Thomas Waldmann <email>"


### PR DESCRIPTION
Backport of #3665