### PR TITLE
fix borgfs patterns/paths processing, fixes #3551

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2304,7 +2304,9 @@ class Archiver:
 
         parser = argparse.ArgumentParser(prog=self.prog, description='Borg - Deduplicated Backups',
                                          add_help=False)
-        parser.set_defaults(fallback2_func=functools.partial(self.do_maincommand_help, parser))
+        # paths and patterns must have an empty list as default everywhere
+        parser.set_defaults(fallback2_func=functools.partial(self.do_maincommand_help, parser),
+                            paths=[], patterns=[])
         parser.common_options = self.CommonOptions(define_common_options,
                                                    suffix_precedence=('_maincommand', '_midcommand', '_subcommand'))
         parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__,
@@ -2312,7 +2314,6 @@ class Archiver:
         parser.common_options.add_common_group(parser, '_maincommand', provide_defaults=True)
 
         common_parser = argparse.ArgumentParser(add_help=False, prog=self.prog)
-        # some empty defaults for all subparsers
         common_parser.set_defaults(paths=[], patterns=[])
         parser.common_options.add_common_group(common_parser, '_subcommand')
 


### PR DESCRIPTION
Just checking for None in patterns.py (and removing the set_defaults
calls in archiver.py) did not work as other arg parsing code relies on
having an empty list (in .patterns, .paths) to append to.

Thus I stayed away from pattern.py and rather fixed the defaults for
.paths and .patterns in all parsers.

@nachtgeist ^