### PR TITLE
fix Archive's checkpoint_interval arg default (300 -> 1800s)

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -280,7 +280,7 @@ class Archive:
         """Failed to encode filename "{}" into file system encoding "{}". Consider configuring the LANG environment variable."""
 
     def __init__(self, repository, key, manifest, name, cache=None, create=False,
-                 checkpoint_interval=300, numeric_owner=False, noatime=False, noctime=False, nobirthtime=False, nobsdflags=False,
+                 checkpoint_interval=1800, numeric_owner=False, noatime=False, noctime=False, nobirthtime=False, nobsdflags=False,
                  progress=False, chunker_params=CHUNKER_PARAMS, start=None, start_monotonic=None, end=None,
                  consider_part_files=False, log_json=False):
         self.cwd = os.getcwd()


### PR DESCRIPTION
the commandline arg default was already at 1800, so likely this is only a cosmetic fix.
