### PR TITLE
skip test if argparse is broken, fixes #3705

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -58,6 +58,8 @@ from .platform import fakeroot_detected
 from .upgrader import attic_repo
 from . import key
 
+# 3.4.3 == first version with argparse bugfix for nargs='*' and 0 arguments given
+argparse_nargs0_fixed = sys.version_info >= (3, 4, 3)
 
 src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -1017,9 +1019,10 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.create_regular_file('file1', size=1024 * 80)
         self.create_regular_file('file2', size=1024 * 80)
-        output = self.cmd('create', '-v', '--list', '--pattern=R input', self.repository_location + '::test')
-        self.assert_in("A input/file1", output)
-        self.assert_in("A input/file2", output)
+        if argparse_nargs0_fixed:
+            output = self.cmd('create', '-v', '--list', '--pattern=R input', self.repository_location + '::test')
+            self.assert_in("A input/file1", output)
+            self.assert_in("A input/file2", output)
 
     def test_create_pattern(self):
         """test file patterns during create"""


### PR DESCRIPTION
the borg command in the test has 0 path arguments.

Our PATH arg is specified with nargs='*', so that should be valid,
but it crashes python 3.4.0 .. 3.4.2. Python >=3.4.3 works.

no port to master needed, we require >= 3.5 there.