### PR TITLE
Vagrant: move cleanup steps to fs_init, fixes #3706

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -264,9 +264,6 @@ def install_borg(fuse)
     . borg-env/bin/activate
     pip install -U wheel  # upgrade wheel, too old for 3.5
     cd borg
-    # clean up (wrong/outdated) stuff we likely got via rsync:
-    rm -rf __pycache__
-    find src -name '__pycache__' -exec rm -rf {} \\;
     pip install -r requirements.d/development.txt
     python setup.py clean
   EOF
@@ -331,6 +328,10 @@ end
 
 def fs_init(user)
   return <<-EOF
+    # clean up (wrong/outdated) stuff we likely got via rsync:
+    rm -rf /vagrant/borg/borg/.tox
+    rm -rf /vagrant/borg/borg/__pycache__
+    find /vagrant/borg/borg/src -name '__pycache__' -exec rm -rf {} \\;
     chown -R #{user} /vagrant/borg
     touch ~#{user}/.bash_profile ; chown #{user} ~#{user}/.bash_profile
     echo 'export LANG=en_US.UTF-8' >> ~#{user}/.bash_profile


### PR DESCRIPTION
so after a vagrant up or vagrant reload (which both rsync), we
can just call the fs_init and run_tests provisioning steps and do
not need to call install_borg again.
