### PR TITLE
set rc=1 when extracting damaged files, fixes #3448

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -139,6 +139,12 @@ def is_special(mode):
     return stat.S_ISBLK(mode) or stat.S_ISCHR(mode) or stat.S_ISFIFO(mode)
 
 
+class BackupError(Exception):
+    """
+    Exception raised for non-OSError-based exceptions while accessing backup files.
+    """
+
+
 class BackupOSError(Exception):
     """
     Wrapper for OSError raised while accessing backup files.
@@ -562,11 +568,10 @@ Utilization of max. archive size: {csize_max:.0%}
                 if 'size' in item:
                     item_size = item.size
                     if item_size != item_chunks_size:
-                        logger.warning('{}: size inconsistency detected: size {}, chunks size {}'.format(
-                            item.path, item_size, item_chunks_size))
+                        raise BackupError('Size inconsistency detected: size {}, chunks size {}'.format(
+                                          item_size, item_chunks_size))
             if has_damaged_chunks:
-                logger.warning('File %s has damaged (all-zero) chunks. Try running borg check --repair.' %
-                               remove_surrogates(item.path))
+                raise BackupError('File has damaged (all-zero) chunks. Try running borg check --repair.')
             return
 
         original_path = original_path or item.path
@@ -622,11 +627,10 @@ Utilization of max. archive size: {csize_max:.0%}
                 if 'size' in item:
                     item_size = item.size
                     if item_size != item_chunks_size:
-                        logger.warning('{}: size inconsistency detected: size {}, chunks size {}'.format(
-                            item.path, item_size, item_chunks_size))
+                        raise BackupError('Size inconsistency detected: size {}, chunks size {}'.format(
+                                          item_size, item_chunks_size))
                 if has_damaged_chunks:
-                    logger.warning('File %s has damaged (all-zero) chunks. Try running borg check --repair.' %
-                                   remove_surrogates(item.path))
+                    raise BackupError('File has damaged (all-zero) chunks. Try running borg check --repair.')
             return
         with backup_io:
             # No repository access beyond this point.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -36,7 +36,7 @@ from . import __version__
 from . import helpers
 from .algorithms.checksums import crc32
 from .archive import Archive, ArchiveChecker, ArchiveRecreater, Statistics, is_special
-from .archive import BackupOSError, backup_io
+from .archive import BackupError, BackupOSError, backup_io
 from .archive import FilesystemObjectProcessors, MetadataCollector, ChunksProcessor
 from .cache import Cache, assert_secure, SecurityManager
 from .constants import *  # NOQA
@@ -731,7 +731,7 @@ class Archiver:
                     else:
                         archive.extract_item(item, stdout=stdout, sparse=sparse, hardlink_masters=hardlink_masters,
                                              stripped_components=strip_components, original_path=orig_path, pi=pi)
-            except BackupOSError as e:
+            except (BackupOSError, BackupError) as e:
                 self.print_warning('%s: %s', remove_surrogates(orig_path), e)
 
         if pi:


### PR DESCRIPTION
- size inconsistencies
- file has all-zero replacement chunks

introduced new BackupError exception. when raised while extracting
files, gets handled via emitting a warning, setting rc=1 and
proceeding to next file.
