### PR TITLE
Use same datetime object for {now} and {utcnow} (1.1 backport)

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -665,14 +665,14 @@ def format_line(format, data):
 def replace_placeholders(text):
     """Replace placeholders in text with their values."""
     from .platform import fqdn
-    current_time = datetime.now()
+    current_time = datetime.now(timezone.utc)
     data = {
         'pid': os.getpid(),
         'fqdn': fqdn,
         'reverse-fqdn': '.'.join(reversed(fqdn.split('.'))),
         'hostname': socket.gethostname(),
-        'now': DatetimeWrapper(current_time.now()),
-        'utcnow': DatetimeWrapper(current_time.utcnow()),
+        'now': DatetimeWrapper(current_time.astimezone(None)),
+        'utcnow': DatetimeWrapper(current_time),
         'user': uid2user(os.getuid(), os.getuid()),
         'uuid4': str(uuid.uuid4()),
         'borgversion': borg_version,


### PR DESCRIPTION
See #3734.