### PR TITLE
BORG_SHOW_SYSINFO=no to hide system information from exceptions

### DIFF
--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -197,6 +197,10 @@ General:
         When set to a numeric value, this determines the maximum "time to live" for the files cache
         entries (default: 20). The files cache is used to quickly determine whether a file is unchanged.
         The FAQ explains this more detailed in: :ref:`always_chunking`
+    BORG_SHOW_SYSINFO
+        When set to no (default: yes), system information (like OS, Python version, ...) in
+        exceptions is not shown.
+        Please only use for good reasons as it makes issues harder to analyze.
     TMPDIR
         where temporary files are stored (might need a lot of temporary space for some operations)
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1602,6 +1602,10 @@ class ProgressIndicatorEndless:
 
 
 def sysinfo():
+    show_sysinfo = os.environ.get('BORG_SHOW_SYSINFO', 'yes').lower()
+    if show_sysinfo == 'no':
+        return ''
+
     python_implementation = platform.python_implementation()
     python_version = platform.python_version()
     # platform.uname() does a shell call internally to get processor info,


### PR DESCRIPTION
Can be used:

- in case of troubles with the sysinfo code
- by borg backup providers who do not want to show system information
