### PR TITLE
Github new ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!--
+Thank you for reporting an issue.
+
+*IMPORTANT* -  *before* creating a new issue please look around:
+ - Borgbackup documentation: http://borgbackup.readthedocs.io/en/stable/index.html
+ - FAQ: https://borgbackup.readthedocs.io/en/stable/faq.html
+ and
+ - open issues in Github tracker: https://github.com/borgbackup/borg/issues
+  
+If you cannot find a similar problem, then create a new issue.
+
+Please fill in as much of the template as possible.
+-->
+
+## Have you checked borgbackup docs, FAQ, and open Github issues?
+
+No
+
+## Is this a BUG / ISSUE report or a QUESTION?
+
+Invalid
+
+## System information. For client/server mode post info for both machines.
+
+#### Your borg version (borg -V).
+
+#### Operating system (distribution) and version.
+
+#### Hardware / network configuration, and filesystems used.
+
+#### How much data is handled by borg?
+
+#### Full borg commandline that lead to the problem (leave away excludes and passwords)
+
+
+## Describe the problem you're observing.
+
+#### Can you reproduce the problem? If so, describe how. If not, describe troubleshooting steps you took before opening the issue.
+
+#### Include any warning/errors/backtraces from the system logs
+
+<!--
+
+If this complaint relates to borg performance, please include CRUD benchmark
+results and any steps you took to troubleshoot.
+How to run benchmark: http://borgbackup.readthedocs.io/en/stable/usage/benchmark.html
+
+*IMPORTANT* - Please mark logs and text output from terminal commands 
+or else Github will not display them correctly. 
+An example is provided below.
+
+Example:
+```
+this is an example how log text should be marked (wrap it with ```)
+```
+-->


### PR DESCRIPTION
This is a first stab at Github new issue template for borgbackup. Questions based on https://github.com/borgbackup/borg/issues/3773
