### PR TITLE
include .coveragerc, needed by tox.ini

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 # stuff we need to include into the sdist is handled automatically by
 # setuptools_scm - it includes all git-committed files.
 # but we want to exclude some committed files/dirs not needed in the sdist:
-exclude .coafile .coveragerc .editorconfig .gitattributes .gitignore .mailmap .travis.yml Vagrantfile
+exclude .coafile .editorconfig .gitattributes .gitignore .mailmap .travis.yml Vagrantfile
 prune .travis
 prune .github


### PR DESCRIPTION
I noticed that archlinux has an identical coveragerc and wondered why.

Then noticed that our tox.ini (which we bundle into the pypi package)
needs .coveragerc, but we did not bundle it until now.