### PR TITLE
debug dump-repo-objs should not depend on a manifest obj

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1884,9 +1884,15 @@ class Archiver:
             json.dump(meta, fd, indent=4)
         return EXIT_SUCCESS
 
-    @with_repository(compatibility=Manifest.NO_OPERATION_CHECK)
-    def do_debug_dump_repo_objs(self, args, repository, manifest, key):
+    @with_repository(manifest=False)
+    def do_debug_dump_repo_objs(self, args, repository):
         """dump (decrypted, decompressed) repo objects"""
+        from .crypto.key import key_factory
+        # set up the key without depending on a manifest obj
+        ids = repository.list(limit=1, marker=None)
+        cdata = repository.get(ids[0])
+        key = key_factory(repository, cdata)
+
         marker = None
         i = 0
         while True:


### PR DESCRIPTION
thus, we should not use the with_repository decorator to set up
the key as it uses Manifest.load() to set up the key.

if the Manifest is lost, that does not work.

but we can use some arbitrary object to set up the key, so just
do that.