### PR TITLE
make "borg config repo" possible without key

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1774,38 +1774,39 @@ class Archiver:
             assert_secure(repository, manifest)
             cache = Cache(repository, key, manifest, lock_wait=self.lock_wait)
 
-        if args.cache:
-            cache.cache_config.load()
-            config = cache.cache_config._config
-            save = cache.cache_config.save
-            validate = cache_validate
-        else:
-            config = repository.config
-            save = lambda: repository.save_config(repository.path, repository.config)
-            validate = repo_validate
+        try:
+            if args.cache:
+                cache.cache_config.load()
+                config = cache.cache_config._config
+                save = cache.cache_config.save
+                validate = cache_validate
+            else:
+                config = repository.config
+                save = lambda: repository.save_config(repository.path, repository.config)
+                validate = repo_validate
 
-        if args.delete:
-            validate(section, name, check_value=False)
-            config.remove_option(section, name)
-            if len(config.options(section)) == 0:
-                config.remove_section(section)
-            save()
-        elif args.value:
-            validate(section, name, args.value)
-            if section not in config.sections():
-                config.add_section(section)
-            config.set(section, name, args.value)
-            save()
-        else:
-            try:
-                print(config.get(section, name))
-            except (configparser.NoOptionError, configparser.NoSectionError) as e:
-                print(e, file=sys.stderr)
-                return EXIT_WARNING
-
-        if args.cache:
-            cache.close()
-        return EXIT_SUCCESS
+            if args.delete:
+                validate(section, name, check_value=False)
+                config.remove_option(section, name)
+                if len(config.options(section)) == 0:
+                    config.remove_section(section)
+                save()
+            elif args.value:
+                validate(section, name, args.value)
+                if section not in config.sections():
+                    config.add_section(section)
+                config.set(section, name, args.value)
+                save()
+            else:
+                try:
+                    print(config.get(section, name))
+                except (configparser.NoOptionError, configparser.NoSectionError) as e:
+                    print(e, file=sys.stderr)
+                    return EXIT_WARNING
+            return EXIT_SUCCESS
+        finally:
+            if args.cache:
+                cache.close()
 
     def do_debug_info(self, args):
         """display system information for debugging / bug reports"""

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1770,6 +1770,11 @@ class Archiver:
             name = args.name
 
         if args.cache:
+            manifest, key = Manifest.load(repository, (Manifest.Operation.WRITE,))
+            assert_secure(repository, manifest)
+            cache = Cache(repository, key, manifest, lock_wait=self.lock_wait)
+
+        if args.cache:
             cache.cache_config.load()
             config = cache.cache_config._config
             save = cache.cache_config.save
@@ -1797,6 +1802,9 @@ class Archiver:
             except (configparser.NoOptionError, configparser.NoSectionError) as e:
                 print(e, file=sys.stderr)
                 return EXIT_WARNING
+
+        if args.cache:
+            cache.close()
         return EXIT_SUCCESS
 
     def do_debug_info(self, args):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1718,8 +1718,8 @@ class Archiver:
             # see issue #1867.
             repository.commit()
 
-    @with_repository(exclusive=True, cache=True, compatibility=(Manifest.Operation.WRITE,))
-    def do_config(self, args, repository, manifest, key, cache):
+    @with_repository(exclusive=True, manifest=False)
+    def do_config(self, args, repository):
         """get, set, and delete values in a repository or cache config file"""
 
         def repo_validate(section, name, value=None, check_value=True):


### PR DESCRIPTION
the `with_repository` context manager was setting up repository and cache (because the cache config can also get changed via `borg config`).

but, setting up the cache needed to load the manifest because it did some checks against that - and that needs the key / passphrase to unlock the key (which is unneeded if we just want to use borg config on the repo config).

to solve, I only set up the repository with `with_repository` CM and only set up the cache (and key/manifest) when a cache configuration change is desired.

the individual, minimal commits are easier to review than the overall change.