### PR TITLE
Add a version hint for llfuse for python3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ if sys.platform.startswith('freebsd'):
     # llfuse 0.41.1, 1.1 are ok
     extras_require['fuse'] = ['llfuse <2.0, !=0.42.*, !=0.43, !=1.0', ]
 
+if my_python >= (3, 7):
+    extras_require['fuse'][0] += ', >=1.3.4'
+
 compress_source = 'src/borg/compress.pyx'
 crypto_ll_source = 'src/borg/crypto/low_level.pyx'
 crypto_helpers = 'src/borg/crypto/_crypto_helpers.c'


### PR DESCRIPTION
Python 3.7 requires llfuse >= 1.3.4.
Fixes https://github.com/borgbackup/borg/issues/3804
