### PR TITLE
travis OS X: use xcode 8.3 (not broken)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
           env: TOXENV=py36
         - language: generic
           os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.3
           env: TOXENV=py35
         - language: generic
           os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.3
           env: TOXENV=py36
 
 before_install:


### PR DESCRIPTION
builds on xcode6.4 are broken since quite a while.
other xcode versions < 8.3 are also broken in the same way.
