### PR TITLE
travis OS X: use xcode 8.3 (not broken)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ matrix:
           env: TOXENV=flake8
         - language: generic
           os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.3
           env: TOXENV=py34
         - language: generic
           os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.3
           env: TOXENV=py35
         - language: generic
           os: osx
-          osx_image: xcode6.4
+          osx_image: xcode8.3
           env: TOXENV=py36
 
 before_install:


### PR DESCRIPTION
builds on xcode6.4 are broken since quite a while.
other xcode versions < 8.3 are also broken in the same way.

(cherry picked from commit 2426bb5d20cd3dbacb9021dc6e1d5e5ab5aee4d6)
