### PR TITLE
Fix msgpack version constraints using proper setuptools metadata.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ install_requires = [
     # we are rather picky about msgpack versions, because a good working msgpack is
     # very important for borg, see https://github.com/borgbackup/borg/issues/3753
     # best versions seem to be 0.4.6, 0.4.7, 0.4.8 and 0.5.6:
-    'msgpack-python >=0.4.6, <=0.5.6, !=0.5.0, !=0.5.1, !=0.5.2, !=0.5.3, !=0.5.4, !=0.5.5',
+    'msgpack-python <0.5;python_version=="3.4"',
+    'msgpack >=0.5.6;python_version >="3.5"',
     # if you can't satisfy the above requirement, these are versions that might
     # also work ok, IF you make sure to use the COMPILED version of msgpack-python,
     # NOT the PURE PYTHON fallback implementation: ==0.5.1, ==0.5.4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     # we are rather picky about msgpack versions, because a good working msgpack is
     # very important for borg, see https://github.com/borgbackup/borg/issues/3753
     # best versions seem to be 0.4.6, 0.4.7, 0.4.8 and 0.5.6:
-    'msgpack-python <0.5;python_version=="3.4"',
+    'msgpack-python >=0.4.6, <0.5;python_version=="3.4"',
     'msgpack >=0.5.6;python_version >="3.5"',
     # if you can't satisfy the above requirement, these are versions that might
     # also work ok, IF you make sure to use the COMPILED version of msgpack-python,


### PR DESCRIPTION
Embrace environment markers (a.k.a. PEP 508 compliance)! They let you do sane handling of different requirements for different versions of python. There's no need to bend over backwards to try to ensure usage of python34-compatible dependencies on python36.

Trying to handle <=0.4 just because python34 needs to be able to match on that, results in a very awkward list. It also means that Arch Linux has to periodically patch this out, and then re-patch it when our previous patch does not apply, then get more bugs opened once it fails a third time.

It's really not worth it to support ancient PyPI names and versions when you can just use a separate branch for python34.