### PR TITLE
Embrace environment markers (a.k.a. PEP 508 compliance)!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,6 @@ prefer_system_libzstd = True
 # True: use the shared libb2 from the system, False: use the bundled blake2 code
 prefer_system_libb2 = True
 
-min_python = (3, 5)
-my_python = sys.version_info
-
-if my_python < min_python:
-    print("Borg requires Python %d.%d or later" % min_python)
-    sys.exit(1)
-
 cpu_threads = multiprocessing.cpu_count() if multiprocessing else 1
 
 # Are we building on ReadTheDocs?
@@ -77,16 +70,14 @@ extras_require = {
     # llfuse 1.2 (tested shortly, looks ok), needs FUSE version >= 2.8.0
     # llfuse 1.3 (tested shortly, looks ok), needs FUSE version >= 2.8.0
     # llfuse 2.0 will break API
-    'fuse': ['llfuse<2.0', ],
+    'fuse': [
+        'llfuse<2.0',
+        # llfuse was frequently broken / did not build on freebsd
+        # llfuse 0.41.1, 1.1 are ok
+        'llfuse !=0.42.*, !=0.43, !=1.0; platform_system == "FreeBSD"',
+        'llfuse >=1.3.4; python_version >="3.7"',
+    ],
 }
-
-if sys.platform.startswith('freebsd'):
-    # llfuse was frequently broken / did not build on freebsd
-    # llfuse 0.41.1, 1.1 are ok
-    extras_require['fuse'] = ['llfuse <2.0, !=0.42.*, !=0.43, !=1.0', ]
-
-if my_python >= (3, 7):
-    extras_require['fuse'][0] += ', >=1.3.4'
 
 compress_source = 'src/borg/compress.pyx'
 crypto_ll_source = 'src/borg/crypto/low_level.pyx'
@@ -844,4 +835,5 @@ setup(
     setup_requires=['setuptools_scm>=1.7'],
     install_requires=install_requires,
     extras_require=extras_require,
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
Failure to use environment markers means the dependencies are unconditionally added at build time based on the host instead of being always present and evaluated at runtime on the target; e.g. wheels have the wrong information.

Also use python_requires. This teaches pip how to natively comprehend when the current version of python is not supported by borg.

Returns errors in the format:
borgbackup requires Python '>=3.5' but the running Python is $oldver

...

Doesn't look like borg officially provides wheels, and since it includes binary extensions anyway the wheels are both OS and python version dependent, but it's the principle of the matter. :D

Environment markers are nicer. They've also been around since late 2015, so they should be getting used more in projects.