### PR TITLE
switch to "msgpack" pypi pkg name, fixes #3890

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ on_rtd = os.environ.get('READTHEDOCS')
 install_requires = [
     # we are rather picky about msgpack versions, because a good working msgpack is
     # very important for borg, see https://github.com/borgbackup/borg/issues/3753
-    # best versions seem to be 0.4.6, 0.4.7, 0.4.8 and 0.5.6:
-    'msgpack-python >=0.4.6, <=0.5.6, !=0.5.0, !=0.5.1, !=0.5.2, !=0.5.3, !=0.5.4, !=0.5.5',
+    # as of now, 0.5.6 is the only preferred version of msgpack:
+    'msgpack==0.5.6',
     # if you can't satisfy the above requirement, these are versions that might
     # also work ok, IF you make sure to use the COMPILED version of msgpack-python,
     # NOT the PURE PYTHON fallback implementation: ==0.5.1, ==0.5.4


### PR DESCRIPTION
MASTER BRANCH ONLY, DO NOT BACKPORT TO 1.1 or 1.0!

As there are no 0.4.x msgpack releases (under this new name, 0.4.x
used to be named "msgpack-python"), currently only 0.5.6 can be
recommended. See comments for other versions that are acceptable
under certain conditions.

We will add new msgpack versions later, after testing them.
