### PR TITLE
make swidth available on all posix platforms, fixes #2667

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -16,18 +16,17 @@ OS_API_VERSION = API_VERSION
 
 if not sys.platform.startswith(('win32', )):
     from .posix import process_alive, local_pid_alive
+    # posix swidth implementation works for: linux, freebsd, darwin, openindiana, cygwin
+    from .posix import swidth
 
 if sys.platform.startswith('linux'):  # pragma: linux only
     from .linux import API_VERSION as OS_API_VERSION
     from .linux import acl_get, acl_set
     from .linux import set_flags, get_flags
     from .linux import SyncFile
-    from .linux import swidth
 elif sys.platform.startswith('freebsd'):  # pragma: freebsd only
     from .freebsd import API_VERSION as OS_API_VERSION
     from .freebsd import acl_get, acl_set
-    from .freebsd import swidth
 elif sys.platform == 'darwin':  # pragma: darwin only
     from .darwin import API_VERSION as OS_API_VERSION
     from .darwin import acl_get, acl_set
-    from .darwin import swidth

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -2,7 +2,6 @@ import os
 
 from ..helpers import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
-from .posix import swidth
 
 API_VERSION = '1.1_03'
 

--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -2,7 +2,6 @@ import os
 
 from ..helpers import posix_acl_use_stored_uid_gid
 from ..helpers import safe_encode, safe_decode
-from .posix import swidth
 
 API_VERSION = '1.1_03'
 

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -8,7 +8,6 @@ from ..helpers import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
 from .base import SyncFile as BaseSyncFile
 from .base import safe_fadvise
-from .posix import swidth
 
 from libc cimport errno
 from libc.stdint cimport int64_t


### PR DESCRIPTION
it is assumed that posix == everything else than win32.