### PR TITLE
move capacity calculation to IndexBase, fixes #2646

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1332,11 +1332,10 @@ class ArchiveChecker:
     def init_chunks(self):
         """Fetch a list of all object keys from repository
         """
-        # Explicitly set the initial hash table capacity to avoid performance issues
+        # Explicitly set the initial usable hash table capacity to avoid performance issues
         # due to hash table "resonance".
-        # Since reconstruction of archive items can add some new chunks, add 10 % headroom
-        capacity = int(len(self.repository) / ChunkIndex.MAX_LOAD_FACTOR * 1.1)
-        self.chunks = ChunkIndex(capacity)
+        # Since reconstruction of archive items can add some new chunks, add 10 % headroom.
+        self.chunks = ChunkIndex(usable=len(self.repository) * 1.1)
         marker = None
         while True:
             result = self.repository.list(limit=LIST_SCAN_LIMIT, marker=marker)

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -84,7 +84,7 @@ cdef class IndexBase:
     MAX_LOAD_FACTOR = HASH_MAX_LOAD
     MAX_VALUE = _MAX_VALUE
 
-    def __cinit__(self, capacity=0, path=None, permit_compact=False):
+    def __cinit__(self, capacity=0, path=None, permit_compact=False, usable=None):
         self.key_size = self._key_size
         if path:
             if isinstance(path, (str, bytes)):
@@ -94,6 +94,8 @@ cdef class IndexBase:
                 self.index = hashindex_read(path, permit_compact)
             assert self.index, 'hashindex_read() returned NULL with no exception set'
         else:
+            if usable is not None:
+                capacity = int(usable / self.MAX_LOAD_FACTOR)
             self.index = hashindex_init(capacity, self.key_size, self.value_size)
             if not self.index:
                 raise Exception('hashindex_init failed')


### PR DESCRIPTION
we just give how many "usable" hashtable entries we want and it computes
the hashtable capacity internally via int(usable / MAX_LOAD_FACTOR).
