### PR TITLE
tests: fetch less data via os.urandom

### DIFF
--- a/src/borg/testsuite/compress.py
+++ b/src/borg/testsuite/compress.py
@@ -45,9 +45,11 @@ def test_lz4():
 
 def test_lz4_buffer_allocation():
     # test with a rather huge data object to see if buffer allocation / resizing works
-    data = os.urandom(50 * 2**20)  # 50MiB incompressible data
+    data = os.urandom(5 * 2**20) * 10  # 50MiB badly compressible data
+    assert len(data) == 50 * 2**20
     c = get_compressor(name='lz4')
     cdata = c.compress(data)
+    assert len(cdata) > len(data)
     assert data == c.decompress(cdata)
 
 


### PR DESCRIPTION
freebsd12 is unhappy with having to deliver 50MiB random in one go
and fails with BlockingIOError "temporary unavailable" when trying.

for test_lz4_buffer_allocation, it is good enough to fetch 5MiB and
concatenate that 10 times.

(cherry picked from commit acb15fd960ed009b29e5f68f7470160a3bd116bf)
