### PR TITLE
drop support for python 3.5, fixes #3919

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,11 @@ cache:
 
 matrix:
     include:
-        - python: 3.5
-          os: linux
-          dist: trusty
-          env: TOXENV=py35
         - python: 3.6
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - python: 3.5
+        - python: 3.6
           os: linux
           dist: trusty
           env: TOXENV=flake8
@@ -24,10 +20,6 @@ matrix:
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - language: generic
-          os: osx
-          osx_image: xcode8.3
-          env: TOXENV=py35
         - language: generic
           os: osx
           osx_image: xcode8.3

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,10 +19,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew install Caskroom/cask/osxfuse
 
     case "${TOXENV}" in
-        py35)
-            pyenv install 3.5.2
-            pyenv global 3.5.2
-            ;;
         py36)
             pyenv install 3.6.0
             pyenv global 3.6.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,7 @@ def install_borg(fuse)
     . ~/.bash_profile
     cd /vagrant/borg
     . borg-env/bin/activate
-    pip install -U wheel  # upgrade wheel, too old for 3.5
+    pip install -U wheel  # upgrade wheel, too old for 3.6
     cd borg
     pip install -r requirements.d/development.txt
     python setup.py clean
@@ -261,6 +261,6 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("freebsd64")
   end
 
-  # TODO: create more VMs with python 3.5+ and openssl 1.1.
+  # TODO: create more VMs with python 3.6 and openssl 1.1.
   # See branch 1.1-maint for a better equipped Vagrantfile (but still on py34 and openssl 1.0).
 end

--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Security :: Cryptography',
         'Topic :: System :: Archiving :: Backup',
@@ -302,5 +301,5 @@ setup(
     setup_requires=['setuptools_scm>=1.7'],
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2024,11 +2024,11 @@ class Archiver:
 
         {now}
             The current local date and time, by default in ISO-8601 format.
-            You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
+            You can also supply your own `format string <https://docs.python.org/3.6/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
 
         {utcnow}
             The current UTC date and time, by default in ISO-8601 format.
-            You can also supply your own `format string <https://docs.python.org/3.5/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
+            You can also supply your own `format string <https://docs.python.org/3.6/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
 
         {user}
             The user name (or UID, if no name is available) of the user running borg.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36},flake8
+envlist = py{36},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
if you do not have python 3.6.x, you can still use borg 1.1.x or 1.0.x.

another option is to use the fat binary from github releases, which includes python 3.6 and all other stuff needed.
