### PR TITLE
cache lock: use lock_wait everywhere to fix infinite wait

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -140,7 +140,7 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
                     if 'compression' in args:
                         kwargs['key'].compressor = args.compression.compressor
                     if secure:
-                        assert_secure(repository, kwargs['manifest'])
+                        assert_secure(repository, kwargs['manifest'], self.lock_wait)
                 if cache:
                     with Cache(repository, kwargs['key'], kwargs['manifest'],
                                do_files=getattr(args, 'cache_files', False),
@@ -1804,7 +1804,7 @@ class Archiver:
 
         if args.cache:
             manifest, key = Manifest.load(repository, (Manifest.Operation.WRITE,))
-            assert_secure(repository, manifest)
+            assert_secure(repository, manifest, self.lock_wait)
             cache = Cache(repository, key, manifest, lock_wait=self.lock_wait)
 
         try:

--- a/src/borg/locking.py
+++ b/src/borg/locking.py
@@ -14,7 +14,7 @@ logger = create_logger(__name__)
 
 class TimeoutTimer:
     """
-    A timer for timeout checks (can also deal with no timeout, give timeout=None [default]).
+    A timer for timeout checks (can also deal with "never timeout").
     It can also compute and optionally execute a reasonable sleep time (e.g. to avoid
     polling too often or to support thread/process rescheduling).
     """
@@ -22,10 +22,10 @@ class TimeoutTimer:
         """
         Initialize a timer.
 
-        :param timeout: time out interval [s] or None (no timeout)
+        :param timeout: time out interval [s] or None (never timeout, wait forever) [default]
         :param sleep: sleep interval [s] (>= 0: do sleep call, <0: don't call sleep)
                       or None (autocompute: use 10% of timeout [but not more than 60s],
-                      or 1s for no timeout)
+                      or 1s for "never timeout" mode)
         """
         if timeout is not None and timeout < 0:
             raise ValueError("timeout must be >= 0")


### PR DESCRIPTION
in the absence of a specific lock_wait / timeout value (int, to timeout after waiting n seconds), the default of lock_wait / timeout is None (meaning to never timeout and wait forever).