### PR TITLE
remove loggerDict.clear() from tearDown method, fixes #3805

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -279,8 +279,6 @@ class ArchiverTestCaseBase(BaseTestCase):
         os.chdir(self._old_wd)
         # note: ignore_errors=True as workaround for issue #862
         shutil.rmtree(self.tmpdir, ignore_errors=True)
-        # destroy logging configuration
-        logging.Logger.manager.loggerDict.clear()
         setup_logging()
 
     def cmd(self, *args, **kw):


### PR DESCRIPTION
It causes problems with the new caching in the py37 logger module.

Removing loggerDict.clear() fixes this and makes the tests work again.
Also, it does not seem to have any negative effect, neither on py36
nor on py37.

See also: https://bugs.python.org/issue34269

Thank you for contributing code to Borg, your help is appreciated!

Please, before you submit a pull request, make sure it complies with the
guidelines given in our documentation:

https://borgbackup.readthedocs.io/en/latest/development.html#contributions

**Please remove all above text before submitting your pull request.**
