### PR TITLE
don't archive tagged dir when recursing an excluded dir, fixes #3991

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -583,13 +583,16 @@ class Archiver:
                 if recurse:
                     tag_paths = dir_is_tagged(path, exclude_caches, exclude_if_present)
                     if tag_paths:
-                        if keep_exclude_tags and not dry_run:
-                            fso.process_dir(path, st)
-                            for tag_path in tag_paths:
-                                self._process(fso, cache, matcher, exclude_caches, exclude_if_present,
-                                              keep_exclude_tags, skip_inodes, tag_path, restrict_dev,
-                                              read_special=read_special, dry_run=dry_run)
-                        self.print_file_status('x', path)
+                        # if we are already recursing in an excluded dir, we do not need to do anything else than
+                        # returning (we do not need to archive or recurse into tagged directories), see #3991:
+                        if not recurse_excluded_dir:
+                            if keep_exclude_tags and not dry_run:
+                                fso.process_dir(path, st)
+                                for tag_path in tag_paths:
+                                    self._process(fso, cache, matcher, exclude_caches, exclude_if_present,
+                                                  keep_exclude_tags, skip_inodes, tag_path, restrict_dev,
+                                                  read_special=read_special, dry_run=dry_run)
+                            self.print_file_status('x', path)
                         return
                 if not dry_run:
                     if not recurse_excluded_dir:


### PR DESCRIPTION
if we are recursing an explicitly excluded directory, we are only
looking for explicitly included items, but we do not need to archive
tagged directories or the tag files themselves - they are all excluded
by the explicit exclusion already.

for performance reasons, we still determine whether a directory is
tagged and if it is, we do not recurse into it as there can't be any
included items in there.
