### PR TITLE
Forward the `format_spec` to `datetime` class

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -747,11 +747,11 @@ def safe_timestamp(item_timestamp_ns):
     return datetime.fromtimestamp(t_ns / 1e9)
 
 
-def format_time(ts: datetime):
+def format_time(ts: datetime, format_spec=''):
     """
     Convert *ts* to a human-friendly format with textual weekday.
     """
-    return ts.strftime('%a, %Y-%m-%d %H:%M:%S')
+    return ts.strftime('%a, %Y-%m-%d %H:%M:%S' if format_spec == '' else format_spec)
 
 
 def isoformat_time(ts: datetime):
@@ -786,7 +786,7 @@ class OutputTimestamp:
         self.ts = ts
 
     def __format__(self, format_spec):
-        return format_time(self.ts)
+        return format_time(self.ts, format_spec=format_spec)
 
     def __str__(self):
         return '{}'.format(self)


### PR DESCRIPTION
If specified, the argument `format_spec` is forwarded from the method
`OutputTimestamp.__format__` to the method `format_time` method.  Thus,
we are able to specify the format, in a way supported by the class
`datetime`.

The default behaviour of `format_time` is not affected.  The other parts
of code that does not provide a `format_spec` are not affected by the
change.

Refer borgbackup/borg#4063