### PR TITLE
Added output for create function. Solves #3561

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -534,7 +534,7 @@ class Archiver:
                     process_file_chunks=cp.process_file_chunks, add_item=archive.add_item,
                     chunker_params=args.chunker_params, show_progress=args.progress)
                 create_inner(archive, cache, fso)
-                logger.error("Directory %s has been created successfully" % archive.name)
+                logger.error("Repository %s has been created successfully" % archive.name)
         else:
             create_inner(None, None, None)
         return self.exit_code

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -534,6 +534,7 @@ class Archiver:
                     process_file_chunks=cp.process_file_chunks, add_item=archive.add_item,
                     chunker_params=args.chunker_params, show_progress=args.progress)
                 create_inner(archive, cache, fso)
+                logger.error("Directory %s has been created successfully" % archive.name)
         else:
             create_inner(None, None, None)
         return self.exit_code


### PR DESCRIPTION
Solved issue #3561.
The create function now logs the name of the repository to std.err
The output logs the message "Repository x has been created successfully". Where x is the repo name
