### PR TITLE
4081 - Add note about files changing during backup

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -100,14 +100,16 @@ Important note about files changing during the backup process
 
 Borg does not do anything about the internal consistency of the data
 it backs up.  It just reads and backs up each file in whatever state
-that file is when Borg gets to it.  On an active system, this means
-that by the time Borg backs up a file, it might have changed since the
-backup process was initiated.
+that file is when Borg gets to it.  On an active system, this can lead
+to two kinds of inconsistency:
+
+- By the time Borg backs up a file, it might have changed since the backup process was initiated
+- A file could change while Borg is backing it up, making the file internally inconsistent
 
 If you have a set of files and want to ensure that they are backed up
-in a specific or consistent state, you must take steps to give Borg an
-unchanging view of those files until it is done archiving them.  There
-are a few common techniques to achieve this.
+in a specific or consistent state, you must take steps to prevent
+changes to those files during the backup processgive.  There are a few
+common techniques to achieve this.
 
 - Avoid running any programs that might change the files.
 
@@ -120,18 +122,18 @@ are a few common techniques to achieve this.
 - Shut down containers before backing up their storage volumes.
 
 For some systems Borg might work well enough without these
-precautions.  If you are simply backing up the files in your home
-directory, Borg usually works well enough without further care for
-consistency.  Log files and caches might not be in a perfect state,
-but this is rarely a problem.
+precautions.  If you are simply backing up the files on a system that
+isn't very active (e.g. in a typical home directory), Borg usually
+works well enough without further care for consistency.  Log files and
+caches might not be in a perfect state, but this is rarely a problem.
 
 For databases, virtual machines, and containers, there are specific
 techniques for backing them up that do not simply use Borg to backup
 the underlying filesystem.  For databases, check your database
 documentation for techniques that will save the database state between
 transactions.  For virtual machines, consider running the backup on
-the VM itself or mounting the filesystem.  For Docker containers,
-perhaps the docker's "save" command can help.
+the VM itself or mounting the filesystem while the VM is shut down.
+For Docker containers, perhaps docker's "save" command can help.
 
 Automating backups
 ------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -108,7 +108,7 @@ to two kinds of inconsistency:
 
 If you have a set of files and want to ensure that they are backed up
 in a specific or consistent state, you must take steps to prevent
-changes to those files during the backup processgive.  There are a few
+changes to those files during the backup process.  There are a few
 common techniques to achieve this.
 
 - Avoid running any programs that might change the files.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -95,6 +95,44 @@ borg.
 If you need to access a local repository from different users, you can use the
 same method by using ssh to borg@localhost.
 
+Important note about files changing during the backup process
+-------------------------------------------------------------
+
+Borg does not do anything about the internal consistency of the data
+it backs up.  It just reads and backs up each file in whatever state
+that file is when Borg gets to it.  On an active system, this means
+that by the time Borg backs up a file, it might have changed since the
+backup process was initiated.
+
+If you have a set of files and want to ensure that they are backed up
+in a specific or consistent state, you must take steps to give Borg an
+unchanging view of those files until it is done archiving them.  There
+are a few common techniques to achieve this.
+
+- Avoid running any programs that might change the files.
+
+- Snapshot files, filesystems, container storage volumes, or logical volumes.  LVM or ZFS might be useful here.
+
+- Dump databases or stop the database servers.
+
+- Shut down virtual machines before backing up their images.
+
+- Shut down containers before backing up their storage volumes.
+
+For some systems Borg might work well enough without these
+precautions.  If you are simply backing up the files in your home
+directory, Borg usually works well enough without further care for
+consistency.  Log files and caches might not be in a perfect state,
+but this is rarely a problem.
+
+For databases, virtual machines, and containers, there are specific
+techniques for backing them up that do not simply use Borg to backup
+the underlying filesystem.  For databases, check your database
+documentation for techniques that will save the database state between
+transactions.  For virtual machines, consider running the backup on
+the VM itself or mounting the filesystem.  For Docker containers,
+perhaps the docker's "save" command can help.
+
 Automating backups
 ------------------
 


### PR DESCRIPTION
This is an addition to the documentation explaining that files sometimes change during the backup process and by the time Borg gets to the file, it is not in the same shape as when things began.  See [issue 4081](https://github.com/borgbackup/borg/issues/4081), where a user asked about this and the documentation label was added to the issue.