### PR TITLE
Allow borg with-lock children to grab locks on same repository.

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1545,7 +1545,7 @@ class Archiver:
                 self.print_error('Running borg with-lock using shared locks is supported only for local repositories.')
                 return self.exit_code
         env = prepare_subprocess_env(system=True)
-        os.setpgid(0,0)
+        os.setpgid(0, 0)
         # we exit with the return code we get from the subprocess
         return subprocess.call([args.command] + args.args, env=env)
 

--- a/src/borg/locking.py
+++ b/src/borg/locking.py
@@ -320,7 +320,7 @@ class Lock:
     This makes sure the lock is released again if the block is left, no
     matter how (e.g. if an exception occurred).
     """
-    def __init__(self, path, exclusive=False, sleep=None, timeout=None, id=None, kill_stale_locks=False):
+    def __init__(self, path, exclusive=False, sleep=None, timeout=None, id=None, kill_stale_locks=False, pgid=None):
         self.path = path
         self.is_exclusive = exclusive
         self.sleep = sleep

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -11,12 +11,12 @@ from .base import acl_get, acl_set
 from .base import set_flags, get_flags
 from .base import SaveFile, SyncFile, sync_dir, fdatasync, safe_fadvise
 from .base import swidth, API_VERSION
-from .base import process_alive, get_process_id, local_pid_alive, fqdn, hostname, hostid
+from .base import process_alive, get_process_id, get_process_group, local_pid_alive, fqdn, hostname, hostid
 
 OS_API_VERSION = API_VERSION
 
 if not sys.platform.startswith(('win32', )):
-    from .posix import process_alive, local_pid_alive
+    from .posix import process_alive, local_pid_alive, get_process_group
     # posix swidth implementation works for: linux, freebsd, darwin, openindiana, cygwin
     from .posix import swidth
 

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -270,6 +270,13 @@ def get_process_id():
     return hostid, pid, thread_id
 
 
+def get_process_group():
+    """
+    Return group tuple (hostname, pgid, thread_id) for 'us'.
+    """
+    raise NotImplementedError
+
+
 def process_alive(host, pid, thread):
     """
     Check if the (host, pid, thread_id) combination corresponds to a potentially alive process.

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -61,3 +61,15 @@ def local_pid_alive(pid):
             return False
         # Any other error (eg. permissions) means that the process ID refers to a live process.
         return True
+
+
+def get_process_group():
+    """
+    Return group id (hostname, pgid, thread_id) from identification tuple for 'us'.
+    This always returns the current pgid, which might be different from before, e.g. if os.setpgid() was used.
+    """
+    from . import hostid
+
+    thread_id = 0
+    pgid = os.getpgid(0)
+    return hostid, pgid, thread_id


### PR DESCRIPTION
This PR adds a `--shared-lock` option to `borg with-lock`, and allows borg children of `borg with-lock --shared-lock` to grab an exclusive or shared lock.
  
I have a server that hosts all my borg repositories, and the only access allowed is SSH with `borg server --append-only`. I want to run a daily cron on this server that runs borg prune only if no archive has been deleted since the last borg prune; in other words, the borg prune cron is the only way to delete archives. It could be easy enough to do :

`export BORG_REPO`
`borg with-lock $BORG_REPO /bin/bash -c 'is_subset "$(< $REPO_ARCHIVE_REFFILE)" "$(borg list)" && borg prune && borg list > $REPO_ARCHIVE_REFFILE'`

except that borg with-lock takes an exclusive lock on the repository.

This PR address this issue by allowing to downgrade borg with-lock to a shared lock, and by allowing a borg process to take an exclusive lock on top of a shared one. This is subject to restrictions : there can be at most one process holding the shared lock on the repository, and this process' PID must be equal to our PGID.
Because forked process inherit their parent PGID, and because shells with job control (set -m) enabled spawns jobs ("a set of processes, comprising a shell pipline" [Open Group Base Definitions 3.202]) in their own process groups, this means that, assuming the shared lock holder PGID equals its PID, without additional actions (i.e. setpgid(2)) only children of the shared lock holder will meet the conditions.