### PR TITLE
Moving the flags of the compiled regex to the front to fix #4137

### DIFF
--- a/src/borg/shellpattern.py
+++ b/src/borg/shellpattern.py
@@ -62,4 +62,4 @@ def translate(pat, match_end=r"\Z"):
         else:
             res += re.escape(c)
 
-    return res + match_end + "(?ms)"
+    return "(?ms)" + res + match_end


### PR DESCRIPTION
As the title says, after setting up my environment and the tests, I think I fixed this one. All tests seem to pass. So unless there is some regex magic that I missed it should be fine.
As far as I can tell, I complied with all the contribution guidelines.