### PR TITLE
Explicitly convert environment variable to str to address #4136

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,8 +30,8 @@ from borg import xattr
 @pytest.fixture(autouse=True)
 def clean_env(tmpdir_factory, monkeypatch):
     # avoid that we access / modify the user's normal .config / .cache directory:
-    monkeypatch.setenv('XDG_CONFIG_HOME', tmpdir_factory.mktemp('xdg-config-home'))
-    monkeypatch.setenv('XDG_CACHE_HOME', tmpdir_factory.mktemp('xdg-cache-home'))
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmpdir_factory.mktemp('xdg-config-home')))
+    monkeypatch.setenv('XDG_CACHE_HOME', str(tmpdir_factory.mktemp('xdg-cache-home')))
     # also avoid to use anything from the outside environment:
     keys = [key for key in os.environ if key.startswith('BORG_')]
     for key in keys:

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -68,7 +68,7 @@ class TestKey:
 
     @pytest.fixture
     def keys_dir(self, request, monkeypatch, tmpdir):
-        monkeypatch.setenv('BORG_KEYS_DIR', tmpdir)
+        monkeypatch.setenv('BORG_KEYS_DIR', str(tmpdir))
         return tmpdir
 
     @pytest.fixture(params=(


### PR DESCRIPTION
After running the tests again locally, it seems I had already found all relevant places. Assuming tests pass.