### PR TITLE
 Fixed links to cachedir spec in docs and code to address #4140 

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2487,7 +2487,7 @@ class Archiver:
             if tag_files:
                 add_option('--exclude-caches', dest='exclude_caches', action='store_true',
                            help='exclude directories that contain a CACHEDIR.TAG file '
-                                '(http://www.brynosaurus.com/cachedir/spec.html)')
+                                '(http://www.bford.info/cachedir/spec.html)')
                 add_option('--exclude-if-present', metavar='NAME', dest='exclude_if_present',
                            action='append', type=str,
                            help='exclude directories that are tagged by containing a filesystem object with '

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -66,7 +66,7 @@ def get_cache_dir():
             fd.write(textwrap.dedent("""
                 # This file is a cache directory tag created by Borg.
                 # For information about cache directory tags, see:
-                #       http://www.brynosaurus.com/cachedir/
+                #       http://www.bford.info/cachedir/spec.html
                 """).encode('ascii'))
     return cache_dir
 
@@ -85,7 +85,7 @@ def dir_is_cachedir(path):
     """Determines whether the specified path is a cache directory (and
     therefore should potentially be excluded from the backup) according to
     the CACHEDIR.TAG protocol
-    (http://www.brynosaurus.com/cachedir/spec.html).
+    (http://www.bford.info/cachedir/spec.html).
     """
 
     tag_path = os.path.join(path, CACHE_TAG_NAME)


### PR DESCRIPTION
As far as I am aware, all other instances of the link should be derived/created for doc/man/etc.