### PR TITLE
Added repository URL output for creation function on info log level.

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -446,6 +446,8 @@ class Archiver:
         matcher = PatternMatcher(fallback=True)
         matcher.add_inclexcl(args.patterns)
 
+        logger.info('Creating archive at "%s"' % args.location.orig)
+
         def create_inner(archive, cache, fso):
             # Add cache dir to inode_skip list
             skip_inodes = set()


### PR DESCRIPTION
Fixes #3561
Repo-URL output is added onto info log level. Having that before create_inner() invocation will ensure repo's name and path will be shown in case of an error.