### PR TITLE
docs: --format is required for some expensive-to-compute values

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -340,6 +340,16 @@ username
 comment
     Archive comment, if any
 
+Some keys/values are more expensive to compute than others (e.g. because it requires opening the archive,
+not just the manifest). To optimize for speed, `borg list repo` does not determine these values except
+when they are requested. The `--format` option is used for that (for normal mode as well as for `--json`
+mode), so, to have the comment included in the json output, you will need:
+
+::
+
+    borg list repo --format "{name}{comment}" --json`
+
+
 Example of a simple archive listing (``borg list --last 1 --json``)::
 
     {


### PR DESCRIPTION
borg list by default does not compute expensive values except when
they are needed. whether they are needed is determined by the format,
in standard mode as well as in --json mode.
