### PR TITLE
add "# cython: language_level=3" directive to .pyx files, fixes #4214

### DIFF
--- a/src/borg/algorithms/checksums.pyx
+++ b/src/borg/algorithms/checksums.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 from ..helpers import bin_to_hex
 
 from libc.stdint cimport uint32_t

--- a/src/borg/chunker.pyx
+++ b/src/borg/chunker.pyx
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# cython: language_level=3
 
 API_VERSION = '1.1_01'
 

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 """
 borg.compress
 =============

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 """A thin OpenSSL wrapper"""
 
 import hashlib

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# cython: language_level=3
+
 from collections import namedtuple
 import locale
 import os

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import stat
 from collections import namedtuple
 

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import os
 
 from ..helpers import user2uid, group2gid

--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import os
 
 from ..helpers import posix_acl_use_stored_uid_gid

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import os
 import re
 import stat

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import errno
 import os
 


### PR DESCRIPTION
in master branch, it was possible to do this via setup.py's
cythonize() calls, but we do not have them in 1.1.

thus, i modified the source files, setting the language level to 3,
which is supported since long in Cython (3str is only supported since
recently so might fail with older Cython versions).

Before this changeset, current Cython 0.29.x emitted a FutureWarning,
but still compiled. The next major release of Cython is said to emit
an error instead, so this changeset hopefully avoids the build breaking
after a Cython upgrade.

Note: I also removed some "coding utf-8" lines as this is the default nowadays anyway.