### PR TITLE
correctly release memoryview

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1395,8 +1395,7 @@ class LoggedIO:
         with open(backup_filename, 'rb') as backup_fd:
             # note: file must not be 0 size (windows can't create 0 size mapping)
             with mmap.mmap(backup_fd.fileno(), 0, access=mmap.ACCESS_READ) as mm:
-                data = memoryview(mm)
-                with open(filename, 'wb') as fd:
+                with memoryview(mm) as data, open(filename, 'wb') as fd:
                     fd.write(MAGIC)
                     while len(data) >= self.header_fmt.size:
                         crc, size, tag = self.header_fmt.unpack(data[:self.header_fmt.size])
@@ -1408,7 +1407,6 @@ class LoggedIO:
                             continue
                         fd.write(data[:size])
                         data = data[size:]
-                data.release()
 
     def read(self, segment, offset, id, read_data=True):
         """

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1395,21 +1395,24 @@ class LoggedIO:
         with open(backup_filename, 'rb') as backup_fd:
             # note: file must not be 0 size (windows can't create 0 size mapping)
             with mmap.mmap(backup_fd.fileno(), 0, access=mmap.ACCESS_READ) as mm:
-                data = memoryview(mm)  # didn't use memoryview context manager, it does not work correctly.
+                # memoryview context manager is problematic, see https://bugs.python.org/issue35686
+                data = memoryview(mm)
+                d = data
                 try:
                     with open(filename, 'wb') as fd:
                         fd.write(MAGIC)
-                        while len(data) >= self.header_fmt.size:
-                            crc, size, tag = self.header_fmt.unpack(data[:self.header_fmt.size])
-                            if size < self.header_fmt.size or size > len(data):
-                                data = data[1:]
+                        while len(d) >= self.header_fmt.size:
+                            crc, size, tag = self.header_fmt.unpack(d[:self.header_fmt.size])
+                            if size < self.header_fmt.size or size > len(d):
+                                d = d[1:]
                                 continue
-                            if crc32(data[4:size]) & 0xffffffff != crc:
-                                data = data[1:]
+                            if crc32(d[4:size]) & 0xffffffff != crc:
+                                d = d[1:]
                                 continue
-                            fd.write(data[:size])
-                            data = data[size:]
+                            fd.write(d[:size])
+                            d = d[size:]
                 finally:
+                    del d
                     data.release()
 
     def read(self, segment, offset, id, read_data=True):


### PR DESCRIPTION
seen in #4243:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 911, in check
    objects = list(self.io.iter_objects(segment))
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 1341, in iter_objects
    read_data=read_data)
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 1428, in _read
    segment, offset))
borg.helpers.IntegrityError: Data integrity error: Segment entry checksum mismatch [segment 4405, offset 936892]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 1373, in recover_segment
    if crc32(data[4:size]) & 0xffffffff != crc:
  File "/usr/lib/python3/dist-packages/borg/helpers.py", line 2239, in handler
    raise exc_cls
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/borg/archiver.py", line 4436, in main
    exit_code = archiver.run(args)
  File "/usr/lib/python3/dist-packages/borg/archiver.py", line 4368, in run
    return set_ec(func(args))
  File "/usr/lib/python3/dist-packages/borg/archiver.py", line 152, in wrapper
    return method(self, args, repository=repository, **kwargs)
  File "/usr/lib/python3/dist-packages/borg/archiver.py", line 313, in do_check
    if not repository.check(repair=args.repair, save_space=args.save_space):
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 916, in check
    self.io.recover_segment(segment, filename)
  File "/usr/lib/python3/dist-packages/borg/repository.py", line 1378, in recover_segment
    data.release()
***BufferError: cannot close exported pointers exist***

Platform: Linux vps 4.18.0-2-amd64 #1 SMP Debian 4.18.10-2 (2018-10-07) x86_64
Linux: debian buster/sid 
Borg: 1.1.8  Python: CPython 3.7.2
PID: 25460  CWD: /home/bryan
sys.argv: ['/usr/bin/borg', '-p', '-v', 'check', '--repair']
SSH_ORIGINAL_COMMAND: None
```

After a quick online research, I had the impression that the BufferError might not be caused by `data.release` but rather by the surrounding mmap contextmanager exiting caused by the KeyboardInterrupt.

Full code:
https://github.com/borgbackup/borg/blob/1.1.8/src/borg/repository.py#L1356