### PR TITLE
experiments related to #4094

### DIFF
--- a/borg/testsuite/archiver.py
+++ b/borg/testsuite/archiver.py
@@ -49,7 +49,7 @@ def exec_cmd(*args, archiver=None, fork=False, exe=None, input=b'', **kw):
     if fork:
         try:
             if exe is None:
-                borg = (sys.executable, '-m', 'borg.archiver')
+                borg = (sys.executable, '-m', 'borg')
             elif isinstance(exe, str):
                 borg = (exe, )
             elif not isinstance(exe, tuple):

--- a/conftest.py
+++ b/conftest.py
@@ -32,8 +32,8 @@ import borg.cache
 @pytest.fixture(autouse=True)
 def clean_env(tmpdir_factory, monkeypatch):
     # avoid that we access / modify the user's normal .config / .cache directory:
-    monkeypatch.setenv('XDG_CONFIG_HOME', tmpdir_factory.mktemp('xdg-config-home'))
-    monkeypatch.setenv('XDG_CACHE_HOME', tmpdir_factory.mktemp('xdg-cache-home'))
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmpdir_factory.mktemp('xdg-config-home')))
+    monkeypatch.setenv('XDG_CACHE_HOME', str(tmpdir_factory.mktemp('xdg-cache-home')))
     # also avoid to use anything from the outside environment:
     keys = [key for key in os.environ if key.startswith('BORG_')]
     for key in keys:

--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -1,9 +1,9 @@
 virtualenv==13.1.2
 setuptools-scm==3.1.0
-pluggy==0.6.0
-tox==3.1.3
-pytest==3.5.1
-pytest-xdist==1.24.0
-pytest-cov==2.6.0
-pytest-benchmark==3.1.1
+pluggy
+tox
+pytest
+pytest-xdist
+pytest-cov
+pytest-benchmark
 Cython==0.29

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -2,9 +2,9 @@ setuptools
 setuptools_scm
 pip
 virtualenv<14.0
-pluggy<0.7
-tox<3.2.0
-pytest<3.6.0
+pluggy
+tox
+pytest
 pytest-xdist
 pytest-cov
 pytest-benchmark

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 python_files = testsuite/*.py
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ changedir = {toxworkdir}
 deps =
      -rrequirements.d/development.lock.txt
      -rrequirements.d/fuse.txt
-commands = py.test -n {env:XDISTN:4} -rs --cov=borg --cov-config=../.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
+commands = py.test -k "not Remote" --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:
 passenv = *
 


### PR DESCRIPTION
#4094 was worked around by requiring `tox<3.2.0`, because back then, newer versions broke the tests.

trying again with the latest tox version: import issues still there, see linux tests on travis.