### PR TITLE
avoid diaper pattern in configparser by opening files, fixes #4263

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -263,7 +263,8 @@ class CacheConfig:
 
     def load(self):
         self._config = configparser.ConfigParser(interpolation=None)
-        self._config.read(self.config_path)
+        with open(self.config_path) as fd:
+            self._config.read_file(fd)
         self._check_upgrade(self.config_path)
         self.id = self._config.get('cache', 'repository')
         self.manifest_id = unhexlify(self._config.get('cache', 'manifest'))

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -382,7 +382,8 @@ class Repository:
         else:
             self.lock = None
         self.config = ConfigParser(interpolation=None)
-        self.config.read(os.path.join(self.path, 'config'))
+        with open(os.path.join(self.path, 'config')) as fd:
+            self.config.read_file(fd)
         if 'repository' not in self.config.sections() or self.config.getint('repository', 'version') != 1:
             self.close()
             raise self.InvalidRepository(path)


### PR DESCRIPTION
this will fail early with correct error msg / exception traceback if a config file is not readable.
