### PR TITLE
recover_segment: handle too small segment files correctly, see #4272

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1360,8 +1360,14 @@ class LoggedIO:
             del self.fds[segment]
         backup_filename = filename + '.beforerecover'
         os.rename(filename, backup_filename)
+        if os.path.getsize(backup_filename) < MAGIC_LEN + self.header_fmt.size:
+            # this is either a zero-byte file (which would crash mmap() below) or otherwise
+            # just too small to be a valid non-empty segment file, so do a shortcut here:
+            with open(filename, 'wb') as fd:
+                fd.write(MAGIC)
+            return
         with open(backup_filename, 'rb') as backup_fd:
-            # note: file must not be 0 size (windows can't create 0 size mapping)
+            # note: file must not be 0 size or mmap() will crash.
             with mmap.mmap(backup_fd.fileno(), 0, access=mmap.ACCESS_READ) as mm:
                 data = memoryview(mm)
                 with open(filename, 'wb') as fd:


### PR DESCRIPTION
nothing left to recover there, but at least we must not crash in mmap().
