### PR TITLE
Use f_frsize instead of f_bsize to calculate free space. Fixes #4289

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -1108,7 +1108,7 @@ class RepositoryCache(RepositoryNoCache):
 
     def query_size_limit(self):
         stat_fs = os.statvfs(self.basedir)
-        available_space = stat_fs.f_bsize * stat_fs.f_bavail
+        available_space = stat_fs.f_bavail * stat_fs.f_frsize
         self.size_limit = int(min(available_space * 0.25, 2**31))
 
     def key_filename(self, key):

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -644,7 +644,7 @@ class Repository:
             logger.warning('Failed to check free space before committing: ' + str(os_error))
             return
         # f_bavail: even as root - don't touch the Federal Block Reserve!
-        free_space = st_vfs.f_bavail * st_vfs.f_bsize
+        free_space = st_vfs.f_bavail * st_vfs.f_frsize
         logger.debug('check_free_space: required bytes {}, free bytes {}'.format(required_free_space, free_space))
         if free_space < required_free_space:
             if self.created:


### PR DESCRIPTION
(cherry picked from commit c3a882b509d9213bb9fc4ff2af561c09c07afe97)
