### PR TITLE
work around the backslash issue, see #4280

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2175,7 +2175,7 @@ class Archiver:
             any number of characters, '?' matching any single character, '[...]'
             matching any single character specified, including ranges, and '[!...]'
             matching any character not specified. For the purpose of these patterns,
-            the path separator ('\\' for Windows and '/' on other systems) is not
+            the path separator (backslash for Windows and '/' on other systems) is not
             treated specially. Wrap meta-characters in brackets for a literal
             match (i.e. `[?]` to match the literal character `?`). For a path
             to match a pattern, the full path must match, or it must match
@@ -2196,7 +2196,7 @@ class Archiver:
             shell patterns regular expressions are not required to match the full
             path and any substring match is sufficient. It is strongly recommended to
             anchor patterns to the start ('^'), to the end ('$') or both. Path
-            separators ('\\' for Windows and '/' on other systems) in paths are
+            separators (backslash for Windows and '/' on other systems) in paths are
             always normalized to a forward slash ('/') before applying a pattern. The
             regular expression syntax is described in the `Python documentation for
             the re module <https://docs.python.org/3/library/re.html>`_.


### PR DESCRIPTION
supercedes #4280 - thanks to AJ Jordan @strugee for finding this.

while using "\\" gives a single backslash when using "borg help pattern"
on the shell, our rendered html docs did not show the single backslash
at all.

i was lazy do dig into that issue, so i just used the word "backslash".

:-)
