### PR TITLE
security fix: configure FUSE with "default_permissions", fixes #3903

### DIFF
--- a/borg/archiver.py
+++ b/borg/archiver.py
@@ -1613,12 +1613,15 @@ class Archiver:
         memory usage can be up to ~8 MiB times this number. The default is the number
         of CPU cores.
 
-        For mount options, see the fuse(8) manual page. Additional mount options
-        supported by borg:
+        For FUSE configuration and mount options, see the mount.fuse(8) manual page.
 
+        Additional mount options supported by borg:
         - allow_damaged_files: by default damaged files (where missing chunks were
           replaced with runs of zeros by borg check --repair) are not readable and
           return EIO (I/O error). Set this option to read such files.
+        - ignore_permissions: for security reasons the "default_permissions" mount
+          option is internally enforced by borg. "ignore_permissions" can be given
+          to not enforce "default_permissions".
 
         When the daemonized process receives a signal or crashes, it does not unmount.
         Unmounting in these cases could cause an active rsync or similar process


### PR DESCRIPTION
"default_permissions" is now enforced by borg by default to let the
kernel check uid/gid/mode based permissions.

"ignore_permissions" can be given to not enforce "default_permissions".

note: man mount.fuse explicitly tells about the security issue:

    default_permissions
	By  default FUSE doesn't check file access permissions, ...
	This option enables permission checking, restricting access
	based on file mode.
	This option is usually useful together with the allow_other
	mount option.

We consider this a pitfall waiting for someone to fall into and this is
why we chose to change the default behaviour for borg.

(cherry picked from commit 1b277cb1ff5c299d3431e40d01af16e02c5f0115)
