### PR TITLE
Only modify window.location when redirecting

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,10 @@ Usage
 
    // Redirect to general docs
    if(hash == "") {
-       window.location.pathname = window.location.pathname.replace("usage.html", "usage/general.html");
+       var replaced = window.location.pathname.replace("usage.html", "usage/general.html");
+       if (replaced != window.location.pathname) {
+           window.location.pathname = replaced;
+       }
    }
    // Fixup anchored links from when usage.html contained all the commands
    else if(hash.startsWith("borg-key") || hash == "borg-change-passphrase") {


### PR DESCRIPTION
Fixes #4133. `window.location.pathname = window.location.pathname` triggers a redirect, which caused `usage.html` to refresh the page on `pathname.replace()` even if the URL wasn't changing.