### PR TITLE
for now, use old freebsd64 vagrant box for testing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -272,7 +272,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define "freebsd64" do |b|
-    b.vm.box = "freebsd12-amd64"
+    b.vm.box = "freebsd64"
     b.vm.provider :virtualbox do |v|
       v.memory = 1024 + $wmem
     end


### PR DESCRIPTION
the freebsd12-amd64 one is broken due to some pkg vs. openssl111 issue.
