### PR TITLE
1.2.0a: fix LibreSSL support, see #4403

### DIFF
--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -13,3 +13,8 @@ const EVP_CIPHER *EVP_aes_256_ocb(void);  /* dummy, so that code compiles */
 const EVP_CIPHER *EVP_chacha20_poly1305(void);  /* dummy, so that code compiles */
 
 #endif
+
+
+#if !defined(LIBRESSL_VERSION_NUMBER)
+#define LIBRESSL_VERSION_NUMBER 0
+#endif

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -115,6 +115,7 @@ cdef extern from "openssl/hmac.h":
 
 cdef extern from "_crypto_helpers.h":
     long OPENSSL_VERSION_NUMBER
+    long LIBRESSL_VERSION_NUMBER
 
     ctypedef struct HMAC_CTX:
         pass
@@ -126,7 +127,7 @@ cdef extern from "_crypto_helpers.h":
     const EVP_CIPHER *EVP_chacha20_poly1305()  # dummy
 
 
-openssl10 = OPENSSL_VERSION_NUMBER < 0x10100000
+openssl10 = OPENSSL_VERSION_NUMBER < 0x10100000 or LIBRESSL_VERSION_NUMBER
 
 
 import struct
@@ -673,7 +674,7 @@ cdef class _CHACHA_BASE(_AEAD_BASE):
 cdef class AES256_OCB(_AES_BASE):
     @classmethod
     def requirements_check(cls):
-        if OPENSSL_VERSION_NUMBER < 0x10100000:
+        if openssl10:
             raise ValueError('AES OCB requires OpenSSL >= 1.1.0. Detected: OpenSSL %08x' % OPENSSL_VERSION_NUMBER)
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
@@ -685,7 +686,7 @@ cdef class AES256_OCB(_AES_BASE):
 cdef class CHACHA20_POLY1305(_CHACHA_BASE):
     @classmethod
     def requirements_check(cls):
-        if OPENSSL_VERSION_NUMBER < 0x10100000:
+        if openssl10:
             raise ValueError('CHACHA20-POLY1305 requires OpenSSL >= 1.1.0. Detected: OpenSSL %08x' % OPENSSL_VERSION_NUMBER)
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):


### PR DESCRIPTION
See #4403, fixes issue below while running the testsuite.

```
borgbackup version 1.2.0a2
self test test_AE (borg.testsuite.crypto.CryptoTestCase) FAILED:
Traceback (most recent call last):
  File "/tmp/ports/pobj/borgbackup-1.2.0a2/borgbackup-1.2.0a2/src/borg/testsuite/crypto.py", line 115, in test_AE
    hdr_mac_iv_cdata = cs.encrypt(data, header=header)
  File "src/borg/crypto/low_level.pyx", line 544, in borg.crypto.low_level._AEAD_BASE.encrypt
borg.crypto.low_level.CryptoError: EVP_EncryptInit_ex failed

self test test_AEAD (borg.testsuite.crypto.CryptoTestCase) FAILED:
Traceback (most recent call last):
  File "/tmp/ports/pobj/borgbackup-1.2.0a2/borgbackup-1.2.0a2/src/borg/testsuite/crypto.py", line 159, in test_AEAD
    hdr_mac_iv_cdata = cs.encrypt(data, header=header)
  File "src/borg/crypto/low_level.pyx", line 544, in borg.crypto.low_level._AEAD_BASE.encrypt
borg.crypto.low_level.CryptoError: EVP_EncryptInit_ex failed

self test failed
This is a bug either in Borg or in the package / distribution you use.
```