### PR TITLE
crypto: LibreSSL has HMAC_CTX_free and *HMAC_CTX_new

### DIFF
--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -4,26 +4,28 @@
 #include <openssl/opensslv.h>
 #include <openssl/hmac.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 HMAC_CTX *HMAC_CTX_new(void)
 {
-   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
-   if (ctx != NULL) {
-       memset(ctx, 0, sizeof *ctx);
-       HMAC_CTX_cleanup(ctx);
-   }
-   return ctx;
+    HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+    if (ctx != NULL) {
+        memset(ctx, 0, sizeof *ctx);
+        HMAC_CTX_cleanup(ctx);
+    }
+    return ctx;
 }
 
 void HMAC_CTX_free(HMAC_CTX *ctx)
 {
-   if (ctx != NULL) {
-       HMAC_CTX_cleanup(ctx);
-       OPENSSL_free(ctx);
-   }
+    if (ctx != NULL) {
+        HMAC_CTX_cleanup(ctx);
+        OPENSSL_free(ctx);
+    }
 }
+#endif
 
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 const EVP_CIPHER *EVP_aes_256_ocb(void){  /* dummy, so that code compiles */
     return NULL;
 }
@@ -31,5 +33,4 @@ const EVP_CIPHER *EVP_aes_256_ocb(void){  /* dummy, so that code compiles */
 const EVP_CIPHER *EVP_chacha20_poly1305(void){  /* dummy, so that code compiles */
     return NULL;
 }
-
 #endif

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -4,14 +4,15 @@
 #include <openssl/hmac.h>
 #include <openssl/evp.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 HMAC_CTX *HMAC_CTX_new(void);
 void HMAC_CTX_free(HMAC_CTX *ctx);
+#endif
 
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 const EVP_CIPHER *EVP_aes_256_ocb(void);  /* dummy, so that code compiles */
 const EVP_CIPHER *EVP_chacha20_poly1305(void);  /* dummy, so that code compiles */
-
 #endif
 
 


### PR DESCRIPTION
While here improve spacing a bit (indentation of 4 spaces instead of 3).