### PR TITLE
Shell completions: removed deprecated, add new options; borg diff second archive

### DIFF
--- a/scripts/shell_completions/bash/borg
+++ b/scripts/shell_completions/bash/borg
@@ -75,18 +75,18 @@ _borg()
                 local opts="-e --encryption --append-only --storage-quota --make-parent-dirs ${common_opts}"
                 ;;
             *' create '*)
-                local opts="-n --dry-run -s --stats --list --filter --json --no-cache-sync --stdin-name -e --exclude --exclude-from --pattern --patterns-from --exclude-caches --exclude-if-present --keep-exclude-tags --keep-tag-files --exclude-nodump -x --one-file-system --numeric-owner --noatime --noctime --nobirthtime --nobsdflags --ignore-inode --files-cache --read-special --comment --timestamp -c --checkpoint-interval --chunker-params -C --compression ${common_opts}"
+                local opts="-n --dry-run -s --stats --list --filter --json --no-cache-sync --stdin-name -e --exclude --exclude-from --pattern --patterns-from --exclude-caches --exclude-if-present --keep-exclude-tags --exclude-nodump -x --one-file-system --numeric-owner --noatime --noctime --nobirthtime --nobsdflags --files-cache --read-special --comment --timestamp -c --checkpoint-interval --chunker-params -C --compression ${common_opts}"
                 ;;
             *' extract '*)
                 local opts="--list -n --dry-run --numeric-owner --nobsdflags --stdout --sparse -e --exclude --exclude-from --pattern --patterns-from --strip-components ${common_opts}"
                 ;;
             *' check '*)
-                local opts="--repository-only --archives-only --verify-data --repair --save-space -P --prefix -a --glob-archives --sort-by --first --last ${common_opts}"
+                local opts="--repository-only --archives-only --verify-data --repair --save-space --max-duration -P --prefix -a --glob-archives --sort-by --first --last ${common_opts}"
                 ;;
             # rename
             #   no specific options
             *" list "*)
-                local opts="--short --list-format --format --json --json-lines -P --prefix -a --glob-archives --sort-by --first --last -e --exclude --exclude-from --pattern --patterns-from ${common_opts}"
+                local opts="--short --format --json --json-lines -P --prefix -a --glob-archives --sort-by --first --last -e --exclude --exclude-from --pattern --patterns-from ${common_opts}"
                 ;;
             *' diff '*)
                 local opts="--numeric-owner --same-chunker-params --sort -e --exclude --exclude-from --pattern --patterns-from ${common_opts}"
@@ -120,7 +120,7 @@ _borg()
                 local opts="-n --dry-run --inplace --force --tam --disable-tam ${common_opts}"
                 ;;
             *' recreate '*)
-                local opts="--list --filter -n dry-run -s stats -e exclude --exclude-from --pattern --patterns-from --exclude-caches --exclude-if-present --keep-exclude-tags --keep-tag-files --target -c checkpoint-interval --comment --timestamp --timestamp -C compression --recompress --chunker-params ${common_opts}"
+                local opts="--list --filter -n dry-run -s stats -e exclude --exclude-from --pattern --patterns-from --exclude-caches --exclude-if-present --keep-exclude-tags --target -c checkpoint-interval --comment --timestamp --timestamp -C compression --recompress --chunker-params ${common_opts}"
                 ;;
             *' export-tar '*)
                 local opts="--tar-filter --list -e exclude --exclude-from --pattern --patterns-from --strip-components ${common_opts}"

--- a/scripts/shell_completions/bash/borg
+++ b/scripts/shell_completions/bash/borg
@@ -156,6 +156,12 @@ _borg()
         repository_name=${prevprev}
         typed_word=${cur}
     fi
+    # Second archive listing for borg diff
+    if [[ ${COMP_LINE} =~ ^.*\ diff\ .*::[^\ ]+\ ${cur}$ ]] ; then
+        repository_name=`expr match "${COMP_LINE}" "\(.*\)::"`
+        repository_name=${repository_name##* }
+        typed_word=${cur}
+    fi
     if [[ ${repository_name} != "" ]] ; then
         if [[ ${COMP_LINE} == *" ::"* ]] ; then
             # There is a space before the "::"

--- a/scripts/shell_completions/fish/borg.fish
+++ b/scripts/shell_completions/fish/borg.fish
@@ -117,7 +117,6 @@ complete -c borg -f      -l 'noatime'               -d 'Do not store atime'     
 complete -c borg -f      -l 'noctime'               -d 'Do not store ctime'                         -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'nobirthtime'           -d 'Do not store creation date'                 -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'nobsdflags'            -d 'Do not store bsdflags'                      -n "__fish_seen_subcommand_from create"
-complete -c borg -f      -l 'ignore-inode'          -d 'Ignore inode data in file metadata cache'   -n "__fish_seen_subcommand_from create"
 set -l files_cache_mode "ctime,size,inode mtime,size,inode ctime,size mtime,size rechunk,ctime rechunk,mtime disabled"
 complete -c borg -f      -l 'files-cache'           -d 'Operate files cache in MODE' -a "$files_cache_mode" -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'read-special'          -d 'Open device files like regular files'       -n "__fish_seen_subcommand_from create"
@@ -150,6 +149,7 @@ complete -c borg -f      -l 'archives-only'         -d 'Only perform archives ch
 complete -c borg -f      -l 'verify-data'           -d 'Cryptographic integrity verification'       -n "__fish_seen_subcommand_from check"
 complete -c borg -f      -l 'repair'                -d 'Attempt to repair found inconsistencies'    -n "__fish_seen_subcommand_from check"
 complete -c borg -f      -l 'save-space'            -d 'Work slower but using less space'           -n "__fish_seen_subcommand_from check"
+complete -c borg -f      -l 'max-duration'          -d 'Partial repo check for max. SECONDS'        -n "__fish_seen_subcommand_from check"
 # Archive filters
 complete -c borg -f -s P -l 'prefix'                -d 'Only archive names starting with PREFIX'    -n "__fish_seen_subcommand_from check"
 complete -c borg -f -s a -l 'glob-archives'         -d 'Only archive names matching GLOB'           -n "__fish_seen_subcommand_from check"
@@ -163,7 +163,6 @@ complete -c borg -f      -l 'last'                  -d 'Only last N archives'   
 
 # borg list options
 complete -c borg -f      -l 'short'                 -d 'Only print file/directory names'            -n "__fish_seen_subcommand_from list"
-complete -c borg -f      -l 'list-format'           -d 'Specify FORMAT for file listing'            -n "__fish_seen_subcommand_from list"
 complete -c borg -f      -l 'format'                -d 'Specify FORMAT for file listing'            -n "__fish_seen_subcommand_from list"
 complete -c borg -f      -l 'json'                  -d 'List contents in json format'               -n "__fish_seen_subcommand_from list"
 complete -c borg -f      -l 'json-lines'            -d 'List contents in json lines format'         -n "__fish_seen_subcommand_from list"
@@ -284,7 +283,6 @@ complete -c borg         -l 'patterns-from'         -d 'Include/exclude paths fr
 complete -c borg -f      -l 'exclude-caches'        -d 'Exclude directories tagged as cache'        -n "__fish_seen_subcommand_from recreate"
 complete -c borg         -l 'exclude-if-present'    -d 'Exclude directories that contain FILENAME'  -n "__fish_seen_subcommand_from recreate"
 complete -c borg -f      -l 'keep-exclude-tags'     -d 'Keep tag files of excluded directories'     -n "__fish_seen_subcommand_from recreate"
-complete -c borg -f      -l 'keep-tag-files'        -d 'Keep tag files of excluded directories'     -n "__fish_seen_subcommand_from recreate"
 # Archive options
 complete -c borg -f      -l 'target'                -d "Create a new ARCHIVE"                       -n "__fish_seen_subcommand_from recreate"
 complete -c borg -f -s c -l 'checkpoint-interval'   -d 'Write checkpoint every N seconds [1800]'    -n "__fish_seen_subcommand_from recreate"

--- a/scripts/shell_completions/fish/borg.fish
+++ b/scripts/shell_completions/fish/borg.fish
@@ -341,3 +341,17 @@ function __fish_borg_list_archives
 end
 
 complete -c borg -f -n __fish_borg_is_repository -a '(__fish_borg_list_archives)'
+
+# Second archive listing for borg diff
+
+function __fish_borg_is_diff_second_archive
+    return (string match --quiet --regex ' diff .*::[^ ]+ '(commandline --current-token)'$' (commandline))
+end
+
+function __fish_borg_list_diff_archives
+    set -l repository_name (string match --regex '[^ ]*::' (commandline))
+    set -l repository_name (string replace '::' '' $repository_name)
+    borg list --format="{archive}{NEWLINE}" "$repository_name" ^/dev/null
+end
+
+complete -c borg -f -n __fish_borg_is_diff_second_archive -a '(__fish_borg_list_diff_archives)'

--- a/scripts/shell_completions/zsh/_borg
+++ b/scripts/shell_completions/zsh/_borg
@@ -95,13 +95,12 @@ _borg() {
                 --patterns-from'[experimental: read include/exclude patterns from PATTERNFILE, one per line]:_files'\
                 --exclude-caches'[exclude directories that contain a CACHEDIR.TAG file ]'\
                 --exclude-if-present'[exclude directories that are tagged by containing a filesystem object with the given NAME]:NAME'\
-                {--keep-exclude-tags,--keep-tag-files}'[if tag objects are specified with --exclude-if-present, don’t omit the tag objects themselves]'\
+                --keep-exclude-tags'[if tag objects are specified with --exclude-if-present, don’t omit the tag objects themselves]'\
                 {-x,--one-file-system}'[stay in the same file system ]'\
                 --numeric-owner'[only store numeric user and group identifiers]'\
                 --noatime'[do not store atime into archive]'\
                 --nobirthtime'[do not store birthtime (creation date) into archive]'\
                 --nobsdflags'[do not read and store bsdflags (e.g. NODUMP, IMMUTABLE) into archive]'\
-                --ignore-inode'[ignore inode data in the file metadata cache used to detect unchanged files.]'\
                 --files-cache'[operate files cache in MODE. default: ctime,size,inode]:mode:(ctime,size,inode mtime,size,inode ctime,size mtime,size rechunk,ctime rechunk,mtime disabled)'\
                 --read-special'[open and read block and char device files as well as FIFOs as if they were regular files.]'\
                 --comment'[add a comment text to the archive]:COMMENT'\
@@ -137,6 +136,7 @@ _borg() {
                 --verify-data'[perform cryptographic archive data integrity verification]'\
                 --repair'[attempt to repair any inconsistencies found]'\
                 --save-space'[work slower, but using less space]'\
+                --max-duration'[partial repo check for max. SECONDS]:SECONDS'\
                 {-P,--prefix}'[only consider archive names starting with this prefix.]:PREFIX'\
                 {-a,--glob-archives}'[only consider archive names matching the glob]:GLOB'\
                 --sort-by'[Comma-separated list of sorting keys]:keys:(timestamp name id)'\
@@ -155,7 +155,7 @@ _borg() {
                 '2:archives:__borg_archive'\
                 '*:path:_files'\
                 --short'[only print file/directory names, nothing else]'\
-                {--format,--list-format}'[specify format for file listing]:FORMAT'\
+                --format'[specify format for file listing]:FORMAT'\
                 --json'[Only valid for listing repository contents. Format output as JSON.]'\
                 --json-lines'[Only valid for listing archive contents. Format output as JSON Lines. ]'\
                 {-P,--prefix}'[only consider archive names starting with this prefix.]:PREFIX'\
@@ -316,7 +316,7 @@ _borg() {
                 --patterns-from'[experimental: read include/exclude patterns from PATTERNFILE, one per line]:_files'\
                 --exclude-caches'[exclude directories that contain a CACHEDIR.TAG file ]'\
                 --exclude-if-present'[exclude directories that are tagged by containing a filesystem object with the given NAME]:NAME'\
-                {--keep-exclude-tags,--keep-tag-files}'[if tag objects are specified with --exclude-if-present, don’t omit the tag objects themselves]'\
+                --keep-exclude-tags'[if tag objects are specified with --exclude-if-present, don’t omit the tag objects themselves]'\
                 --target'[create a new archive with the name ARCHIVE]:ARCHIVE'\
                 {-c,--checkpoint-interval}'[write checkpoint every SECONDS seconds]:SECONDS'\
                 --comment'[add a comment text to the archive]:COMMENT'\

--- a/scripts/shell_completions/zsh/_borg
+++ b/scripts/shell_completions/zsh/_borg
@@ -172,7 +172,7 @@ _borg() {
         (diff)
             _arguments \
                 '2:archives:__borg_archive'\
-                '3:archives:__borg_archive'\
+                '3:archives:__borg_archive2'\
                 '*:path:_files'\
                 --numeric-owner'[only obey numeric user and group identifiers]'\
                 --same-chunker-params'[override check of chunker parameters.]'\
@@ -418,15 +418,26 @@ _borg() {
 }
 
 __borg_archive() {
+    __borg_list_archives 1
+}
+__borg_archive2() {
+    __borg_list_archives 2
+}
+
+__borg_list_archives() {
     local -a items
-    if (($+BORG_REPO)); then
-        items=("${(@f)$(borg list $cpath --short 2>/dev/null | sed "s#^#::#")}")
-    else
-        local cpath
-        cpath=$words[-1]
-        cpath=${cpath%::*}
-        items=("${(@f)$(borg list $cpath --short 2>/dev/null | sed "s#^#${cpath}::#")}")
+    local cpath
+    cpath=`expr match "${words}" "\(.*\)::"`
+    cpath=${cpath##* }
+    if (( $1 == 1 )); then
+        # To achieve "repository::archive" listing:
+        prefix_repo="${cpath}::"
     fi
+    if (( $1 == 2 )); then
+        # To achieve only "archive" listing:
+        prefix_repo=
+    fi
+    items=("${(@f)$(borg list --format=$prefix_repo\{archive\}\{NEWLINE\} $cpath 2>/dev/null)}")
     if [[ $items[1] == "" ]]; then
         _files -/
     else


### PR DESCRIPTION
Added shell completions for
```borg diff repo::archive1 archive2```

Removed deprecated options.
Added new option ```--max-duration```
