### PR TITLE
make freebsd xattr platform code api compatible with linux, fixes #3952 (1.1-maint bp)

### DIFF
--- a/src/borg/testsuite/xattr.py
+++ b/src/borg/testsuite/xattr.py
@@ -44,13 +44,13 @@ class XattrTestCase(BaseTestCase):
     def test_listxattr_buffer_growth(self):
         # make it work even with ext4, which imposes rather low limits
         buffer.resize(size=64, init=True)
-        # xattr raw key list will be size 9 * (10 + 1), which is > 64
-        keys = ['user.attr%d' % i for i in range(9)]
+        # xattr raw key list will be > 64
+        keys = ['user.attr%d' % i for i in range(20)]
         for key in keys:
             setxattr(self.tmpfile.name, key, b'x')
         got_keys = listxattr(self.tmpfile.name)
         self.assert_equal_se(got_keys, keys)
-        self.assert_equal(len(buffer), 128)
+        self.assert_true(len(buffer) > 64)
 
     def test_getxattr_buffer_growth(self):
         # make it work even with ext4, which imposes rather low limits


### PR DESCRIPTION
i.e. prefix the keys with the namespace, so it is ns.key like on linux.

still only dealing with the "user" namespace, like before.
in the "system" namespaces there are ACLs (we deal with them via the acl
api, so no problem) and stuff from pnfsd (not sure what exactly).

this change is needed because FreeBSD's FUSE code expects the xattr
keys to be in that format.

it is also needed for cross-platform data exchange, so e.g. if one wants to:
- create archive on linux, extract on freebsd - with "user.xxx" xattrs.
- or vice versa.

archives made with older borg versions on freebsd will still extract correctly
on freebsd (not on linux though) even though they do not have the
namespace prefixes in the archived metadata (it will be interpreted in
same way as if they were prefixed by "user." as we do not support any
other namespace anyway).

(cherry picked from commit 068623748428b80e92c247a7bd692e5a2261c94e)
