### PR TITLE
give invalid repo error msg if repo config not found, fixes #4411

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -393,8 +393,12 @@ class Repository:
         else:
             self.lock = None
         self.config = ConfigParser(interpolation=None)
-        with open(os.path.join(self.path, 'config')) as fd:
-            self.config.read_file(fd)
+        try:
+            with open(os.path.join(self.path, 'config')) as fd:
+                self.config.read_file(fd)
+        except FileNotFoundError:
+            self.close()
+            raise self.InvalidRepository(self.path)
         if 'repository' not in self.config.sections() or self.config.getint('repository', 'version') != 1:
             self.close()
             raise self.InvalidRepository(path)


### PR DESCRIPTION
this isn't much different than it was before 1.1.9,i think the simplest solution is to make it like before (as in 1.1.8).

