### PR TITLE
lock travis-ci test env to py 3.4 compatible versions, fixes #4343

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -51,7 +51,7 @@ fi
 
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
-pip install -r requirements.d/development.txt
+pip install -r requirements.d/development.lock.txt
 pip install codecov
 python setup.py --version
 pip install -e .[fuse]

--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -1,0 +1,12 @@
+setuptools==40.8.0
+setuptools-scm==3.2.0
+pip==19.0.3
+virtualenv==16.4.3
+pluggy==0.9.0
+tox==3.7.0
+pytest==4.3.1
+pytest-xdist==1.27.0
+pytest-cov==2.6.1
+pytest-benchmark==3.2.2
+Cython==0.29.6
+twine==1.13.0


### PR DESCRIPTION
maybe slightly newer will also work, e.g. pip < 19.2, pytest < 5.0.
