### PR TITLE
Use easy_install to install pkgconfig / Cython dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
 # borgbackup - main setup code (see also other setup_*.py files)
 
+# NOTE(pabelanger): This tries to workaround the chicken/egg issue where we
+# now need pkgconfig / Cython installed before we can properly compile our
+# setup.py script.
+from setuptools.command import easy_install
+easy_install.main(['pkgconfig'])
+easy_install.main(['Cython'])
+
+# We need to reload setup.py to ensure modules above are not in PYTHONPATH.
+import importlib
+import site
+importlib.reload(site)
+
 import os
 import sys
 from collections import defaultdict


### PR DESCRIPTION
Add logic to add require dependencies for Cython and pkgconfig. This fixes
the following error:

```
pip install .
Processing /home/pabelanger/src/github.com/borgbackup/borg
    Complete output from command python setup.py egg_info:
    Warning: can not import pkgconfig python package.
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-1i1fzjoa/setup.py", line 170, in <module>
        setup_crypto.crypto_ext_kwargs(pc, system_prefix_openssl),
      File "/tmp/pip-req-build-1i1fzjoa/setup_crypto.py", line 22, in crypto_ext_kwargs
        raise Exception('Could not find OpenSSL lib/headers, please set BORG_OPENSSL_PREFIX')
    Exception: Could not find OpenSSL lib/headers, please set BORG_OPENSSL_PREFIX
```