### PR TITLE
do not check python/libc for borg serve, fixes #4483

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4322,8 +4322,10 @@ class Archiver:
             parser.error('Need at least one PATH argument.')
         return args
 
-    def prerun_checks(self, logger):
-        check_python()
+    def prerun_checks(self, logger, is_serve):
+        if not is_serve:
+            # this is the borg *client*, we need to check the python:
+            check_python()
         check_extension_modules()
         selftest(logger)
 
@@ -4362,7 +4364,7 @@ class Archiver:
         self._setup_topic_debugging(args)
         if args.show_version:
             logging.getLogger('borg.output.show-version').info('borgbackup version %s' % __version__)
-        self.prerun_checks(logger)
+        self.prerun_checks(logger, is_serve)
         if not is_supported_msgpack():
             logger.error("You do not have a supported msgpack[-python] version installed. Terminating.")
             logger.error("This should never happen as specific, supported versions are required by our setup.py.")


### PR DESCRIPTION
the check checks whether follow_symlinks=False is supported, which
requires that the glibc is recent enough / python was compiled
for a recent enough glibc. follow_symlinks=False is only used for borg
create and extract, but not needed for borg serve.

thus, this makes it possible to run "borg serve" even on a bit older
servers. be careful, due to the presence of this check on the server
side until now, older server systems are not really tested.
