### PR TITLE
Add "SSH Configuration" section

### DIFF
--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -55,7 +55,7 @@ In the client side's ``~/.ssh/config`` file:
 
 Replacing ``backupserver`` with the hostname, FQDN or IP address of the borg server.
 
-This will cause the client to send a keepalive to the server every 10 seconds. If 30 consecutive keepalives are sent without a response (a time of 300 seconds), the connection will be terminated, causing the borg process to terminate gracefully.
+This will cause the client to send a keepalive to the server every 10 seconds. If 30 consecutive keepalives are sent without a response (a time of 300 seconds), the ssh client process will be terminated, causing the borg process to terminate gracefully.
 
 On the server side's ``sshd`` configuration file (typically ``/etc/ssh/sshd_config``):
 ::

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -46,7 +46,7 @@ SSH Configuration
 
 In order to avoid this, it is recommended to perform the following additional SSH configuration:
 
-In the client side's ``~/.ssh/config`` file:
+Either in the client side's ``~/.ssh/config`` file, or in the client's ``/etc/ssh/ssh_config`` file:
 ::
 
     Host backupserver

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -42,7 +42,7 @@ locations like ``/etc/environment`` or in the forced command itself (example bel
     
 SSH Configuration
 ~~~~~~~~~~~~~~~~~
-``borg serve``'s pipes (``stdin``/``stdout``/``stderr``) are connected to the ``sshd`` process on the server side. In the event that the SSH connection between ``borg serve`` and the client is disconnected abnormally (for example, due to a network outage), it can take a long time for ``sshd`` to notice the client is disconnected. In the meantime, ``sshd`` continues running, and as a result so does the ``borg serve`` process holding the lock on the repository. This can cause subsequent ``borg`` operations on the remote repository to fail with the error: ``Failed to create/acquire the lock``.
+``borg serve``'s pipes (``stdin``/``stdout``/``stderr``) are connected to the ``sshd`` process on the server side. In the event that the SSH connection between ``borg serve`` and the client is disconnected or stuck abnormally (for example, due to a network outage), it can take a long time for ``sshd`` to notice the client is disconnected. In the meantime, ``sshd`` continues running, and as a result so does the ``borg serve`` process holding the lock on the repository. This can cause subsequent ``borg`` operations on the remote repository to fail with the error: ``Failed to create/acquire the lock``.
 
 In order to avoid this, it is recommended to perform the following additional SSH configuration:
 

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -63,7 +63,7 @@ On the server side's ``sshd`` configuration file (typically ``/etc/ssh/sshd_conf
     ClientAliveInterval 10
     ClientAliveCountMax 30
 
-This will cause the server to send a keep alive to the client every 10 seconds. If 30 consecutive keepalives are sent without a response (a time of 300 seconds), the connection will be terminated, causing the ``borg serve`` process to terminate gracefully and release the lock on the repository.
+This will cause the server to send a keep alive to the client every 10 seconds. If 30 consecutive keepalives are sent without a response (a time of 300 seconds), the server's sshd process will be terminated, causing the ``borg serve`` process to terminate gracefully and release the lock on the repository.
 
 If you then run borg commands with ``--lock-wait 600``, this gives sufficient time for the borg serve processes to terminate after the SSH connection is torn down after the 300 second wait for the keepalives to fail.
 

--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -53,7 +53,7 @@ In the client side's ``~/.ssh/config`` file:
             ServerAliveInterval 10
             ServerAliveCountMax 30
 
-Replacing ``backupserver`` with the hostname or FQDN of of the borg server.
+Replacing ``backupserver`` with the hostname, FQDN or IP address of the borg server.
 
 This will cause the client to send a keepalive to the server every 10 seconds. If 30 consecutive keepalives are sent without a response (a time of 300 seconds), the connection will be terminated, causing the borg process to terminate gracefully.
 


### PR DESCRIPTION
Add "SSH Configuration" section to "borg serve" documentation page. This new section documents the additional ssh configuration necessary to prevent the borg serve process from keeping a lock on a repo in the event the ssh connection is abnormally disconnected (leaving borg serve running until sshd times out, which can take upwards of an hour in some cases). This pull request is in response to issues #3988, #636 and #4485 (and probably others).