### PR TITLE
travis: use openssl 1.1 for borg, use python 3.5.3 for 1.1 compat

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -14,7 +14,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew outdated pkg-config || brew upgrade pkg-config
     # do NOT update openssl 1.0.x, brew will also update a lot of dependent pkgs (and their dependencies) then!
     #brew outdated openssl || brew upgrade openssl
-    export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
+    export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
     brew install readline
     export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig:$PKG_CONFIG_PATH"
     brew install zstd
@@ -29,8 +29,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     case "${TOXENV}" in
         py35)
-            pyenv install 3.5.2
-            pyenv global 3.5.2
+            pyenv install 3.5.3  # minimum for openssl 1.1.x
+            pyenv global 3.5.3
             ;;
         py36)
             pyenv install 3.6.0

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -7,7 +7,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     eval "$(pyenv init -)"
     # set our flags to use homebrew openssl
     export ARCHFLAGS="-arch x86_64"
-    export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
+    export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
 fi
 
 # do not use fakeroot, but run as root on travis.


### PR DESCRIPTION
pyenv recently gained the ability to use (and actually prefer) openssl
1.1 on mac OS.

we need to use python 3.5.3, older is not compatible with openssl 1.1.
with python 3.5.2, python was built without ssl support.

also, we need to set the right PKG_CONFIG_PATH, so borg also uses 1.1.
