### PR TITLE
vagrant: build python and borg with openssl 1.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,13 +97,13 @@ def packages_darwin
     brew update > /dev/null
     brew install pkg-config
     brew install readline
-    brew install openssl
+    brew install openssl@1.1
     brew install zstd
     brew install lz4
     brew install xz  # required for python lzma module
     brew install fakeroot
     brew install git
-    echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig' >> ~vagrant/.bash_profile
+    echo 'export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig' >> ~vagrant/.bash_profile
   EOF
 end
 
@@ -126,10 +126,9 @@ end
 def install_pythons(boxname)
   return <<-EOF
     . ~/.bash_profile
-    pyenv install 3.7.0  # tests
-    pyenv install 3.6.0  # tests
-    pyenv install 3.5.3  # tests, 3.5.3 is first to support openssl 1.1<k
-    pyenv install 3.6.8  # binary build, use latest 3.6.x release
+    pyenv install 3.7.0  # tests, version supporting openssl 1.1
+    pyenv install 3.6.8  # binary build, tests, version supporting openssl 1.1
+    pyenv install 3.5.3  # tests, 3.5.3 is first to support openssl 1.1
     pyenv rehash
   EOF
 end
@@ -208,8 +207,8 @@ def run_tests(boxname)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.5.3 3.6.0 3.7.0
-      pyenv local 3.5.3 3.6.0 3.7.0
+      pyenv global 3.5.3 3.6.8 3.7.0
+      pyenv local 3.5.3 3.6.8 3.7.0
     fi
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then


### PR DESCRIPTION
we need to use py 3.5.3 to support openssl 1.1.

we also would need at least 3.6.7 to have pyenv switch to openssl 1.1,
but as we also use the latest 3.6 (3.6.8 currently) for building the
binary, we just use that for tests also.