### PR TITLE
pure-py msgpack warning shall not make a lot of tests fail, fixes #4558

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -92,6 +92,8 @@ assert EXIT_ERROR == 2, "EXIT_ERROR is not 2, as expected - fix assert AND excep
 
 STATS_HEADER = "                       Original size      Compressed size    Deduplicated size"
 
+PURE_PYTHON_MSGPACK_WARNING = "Using a pure-python msgpack! This will result in lower performance."
+
 
 def argument(args, str_or_bool):
     """If bool is passed, return it. If str is passed, retrieve named attribute from args."""
@@ -4398,7 +4400,7 @@ class Archiver:
             logger.error("Do not contact borgbackup support about this.")
             return set_ec(EXIT_ERROR)
         if is_slow_msgpack():
-            logger.warning("Using a pure-python msgpack! This will result in lower performance.")
+            logger.warning(PURE_PYTHON_MSGPACK_WARNING)
         if args.debug_profile:
             # Import only when needed - avoids a further increase in startup time
             import cProfile

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -33,7 +33,7 @@ except ImportError:
 import borg
 from .. import xattr, helpers, platform
 from ..archive import Archive, ChunkBuffer, flags_noatime, flags_normal
-from ..archiver import Archiver, parse_storage_quota
+from ..archiver import Archiver, parse_storage_quota, PURE_PYTHON_MSGPACK_WARNING
 from ..cache import Cache, LocalCache
 from ..constants import *  # NOQA
 from ..crypto.low_level import bytes_to_long, num_aes_blocks
@@ -284,12 +284,19 @@ class ArchiverTestCaseBase(BaseTestCase):
     def cmd(self, *args, **kw):
         exit_code = kw.pop('exit_code', 0)
         fork = kw.pop('fork', None)
+        binary_output = kw.get('binary_output', False)
         if fork is None:
             fork = self.FORK_DEFAULT
         ret, output = exec_cmd(*args, fork=fork, exe=self.EXE, archiver=self.archiver, **kw)
         if ret != exit_code:
             print(output)
         self.assert_equal(ret, exit_code)
+        # if tests are run with the pure-python msgpack, there will be warnings about
+        # this in the output, which would make a lot of tests fail.
+        pp_msg = PURE_PYTHON_MSGPACK_WARNING.encode() if binary_output else PURE_PYTHON_MSGPACK_WARNING
+        empty = b'' if binary_output else ''
+        output = empty.join(line for line in output.splitlines(keepends=True)
+                            if pp_msg not in line)
         return output
 
     def create_src_archive(self, name):

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -580,7 +580,7 @@ def test_is_slow_msgpack():
         assert is_slow_msgpack()
     finally:
         msgpack.Packer = saved_packer
-    # this assumes that we have fast msgpack on test platform:
+    # this tests that we have fast msgpack on test platform:
     assert not is_slow_msgpack()
 
 


### PR DESCRIPTION
if the tests use a pure-python msgpack, 1 test which is specifically
made for that, will fail. esp. for linux distribution packages, this
will still point to the problem (that the msgpack package is not built
or installed correctly).
