### PR TITLE
pure-py msgpack warning shall not make a lot of tests fail, fixes #4558

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -92,6 +92,8 @@ assert EXIT_ERROR == 2, "EXIT_ERROR is not 2, as expected - fix assert AND excep
 
 STATS_HEADER = "                       Original size      Compressed size    Deduplicated size"
 
+PURE_PYTHON_MSGPACK_WARNING = "Using a pure-python msgpack! This will result in lower performance."
+
 
 def argument(args, str_or_bool):
     """If bool is passed, return it. If str is passed, retrieve named attribute from args."""
@@ -4328,7 +4330,7 @@ class Archiver:
             logger.error("Do not contact borgbackup support about this.")
             return set_ec(EXIT_ERROR)
         if is_slow_msgpack():
-            logger.warning("Using a pure-python msgpack! This will result in lower performance.")
+            logger.warning(PURE_PYTHON_MSGPACK_WARNING)
         if args.debug_profile:
             # Import only when needed - avoids a further increase in startup time
             import cProfile

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -619,7 +619,7 @@ def test_is_slow_msgpack():
         assert is_slow_msgpack()
     finally:
         msgpack.Packer = saved_packer
-    # this assumes that we have fast msgpack on test platform:
+    # this tests that we have fast msgpack on test platform:
     assert not is_slow_msgpack()
 
 


### PR DESCRIPTION
if the tests use a pure-python msgpack, 1 test which is specifically
made for that, will fail. esp. for linux distribution packages, this
will still point to the problem (that the msgpack package is not built
or installed correctly).