### PR TITLE
Add example of exclude-norecurse rule in help patterns

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2181,7 +2181,9 @@ class Archiver:
                 # include susans home
                 + /home/susan
                 # don't backup the other home directories
-                - /home/*\n\n''')
+                - /home/*
+                # don't even look in /proc
+                ! /proc\n\n''')
     helptext['placeholders'] = textwrap.dedent('''
         Repository (or Archive) URLs, ``--prefix``, ``--glob-archives``, ``--comment``
         and ``--remote-path`` values support these placeholders:


### PR DESCRIPTION
I haven't generated the new docs - I wasn't sure from the contributions section whether they should be generated here or wait for a release, so I kept it minimal.

There may be a better example to use, but this is one that came up in #borgbackup today.