### PR TITLE
add a push-style example to borg-create(1)

### DIFF
--- a/docs/man/borg-create.1
+++ b/docs/man/borg-create.1
@@ -251,6 +251,9 @@ $ borg create /path/to/repo::my\-files /home \e
 # use zlib compression (good, but slow) \- default is lz4 (fast, low compression ratio)
 $ borg create \-C zlib,6 \-\-one\-file\-system /path/to/repo::root\-{now:%Y\-%m\-%d} /
 
+# Backup onto a remote host ("push" style)
+$ borg create user@backup.example.com:/path/to/repo::example.com\-root\-{now:%Y\-%m\-%d} /
+
 # Backup a remote host locally ("pull" style) using sshfs
 $ mkdir sshfs\-mount
 $ sshfs root@example.com:/ sshfs\-mount

--- a/docs/man/borg-create.1
+++ b/docs/man/borg-create.1
@@ -251,9 +251,6 @@ $ borg create /path/to/repo::my\-files /home \e
 # use zlib compression (good, but slow) \- default is lz4 (fast, low compression ratio)
 $ borg create \-C zlib,6 \-\-one\-file\-system /path/to/repo::root\-{now:%Y\-%m\-%d} /
 
-# Backup onto a remote host ("push" style)
-$ borg create user@backup.example.com:/path/to/repo::example.com\-root\-{now:%Y\-%m\-%d} /
-
 # Backup a remote host locally ("pull" style) using sshfs
 $ mkdir sshfs\-mount
 $ sshfs root@example.com:/ sshfs\-mount

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -25,8 +25,9 @@ Examples
     # use zlib compression (good, but slow) - default is lz4 (fast, low compression ratio)
     $ borg create -C zlib,6 --one-file-system /path/to/repo::root-{now:%Y-%m-%d} /
 
-    # Backup onto a remote host ("push" style)
-    $ borg create user@backup.example.com:/path/to/repo::example.com-root-{now:%Y-%m-%d} /
+    # Backup onto a remote host ("push" style) via ssh to port 2222,
+    # logging in as user "borg" and storing into /path/to/repo
+    $ borg create ssh://borg@backup.example.org:2222/path/to/repo::{fqdn}-root-{now} /
 
     # Backup a remote host locally ("pull" style) using sshfs
     $ mkdir sshfs-mount

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -25,6 +25,9 @@ Examples
     # use zlib compression (good, but slow) - default is lz4 (fast, low compression ratio)
     $ borg create -C zlib,6 --one-file-system /path/to/repo::root-{now:%Y-%m-%d} /
 
+    # Backup onto a remote host ("push" style)
+    $ borg create user@backup.example.com:/path/to/repo::example.com-root-{now:%Y-%m-%d} /
+
     # Backup a remote host locally ("pull" style) using sshfs
     $ mkdir sshfs-mount
     $ sshfs root@example.com:/ sshfs-mount


### PR DESCRIPTION
When I browsed the readthedocs and manpages while setting up Borg for myself for the first time, I saw multiple hints that pushing backups via SSH is supported (e.g. the existence of the `borg serve` command and the `--rsh` option), but I never found a clear example. I only found <https://borgbackup.readthedocs.io/en/stable/usage/general.html#repository-urls> after being pointed to it by @ThomasWaldmann.

Therefore, an explicit example in the `borg create` documentation seems appropriate. I put it next to the pull-style example using sshfs which serves a similar usecase.