### PR TITLE
Enable placeholder usage in all extra archive arguments

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1071,8 +1071,7 @@ class Archiver:
     @with_archive
     def do_rename(self, args, repository, manifest, key, cache, archive):
         """Rename an existing archive"""
-        name = replace_placeholders(args.name)
-        archive.rename(name)
+        archive.rename(args.name)
         manifest.write()
         repository.commit(compact=False)
         cache.commit()
@@ -1545,11 +1544,10 @@ class Archiver:
 
         if args.location.archive:
             name = args.location.archive
-            target = replace_placeholders(args.target) if args.target else None
             if recreater.is_temporary_archive(name):
                 self.print_error('Refusing to work on temporary archive of prior recreate: %s', name)
                 return self.exit_code
-            if not recreater.recreate(name, args.comment, target):
+            if not recreater.recreate(name, args.comment, args.target):
                 self.print_error('Nothing to do. Archive was not processed.\n'
                                  'Specify at least one pattern, PATH, --comment, re-compression or re-chunking option.')
         else:

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -498,6 +498,7 @@ def location_validator(archive=None, proto=None):
 
 def archivename_validator():
     def validator(text):
+        text = replace_placeholders(text)
         if '/' in text or '::' in text or not text:
             raise argparse.ArgumentTypeError('Invalid repository name: "%s"' % text)
         return text


### PR DESCRIPTION
This fixes the issue, that with `borg diff REPO::ARCHIVE1 ARCHIVE2`, placeholders only work in `ARCHIVE1`, not in `ARCHIVE2`.

The `REPO::ARCHIVE1` argument uses `location_validator` as its type, which does replace placeholders, the `ARCHIVE2` argument uses  `archivename_validator`, which prior to this change did not.

This other two commands using arguments of type `archivename_validator`, namely `rename` and `recreate`, did do replacing of placeholders in the extra archive arguments on their own. With the change to `archivename_validator()` this duplicate code could be removed.