### PR TITLE
Enable placeholder usage in all extra archive arguments

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1238,8 +1238,7 @@ class Archiver:
     @with_archive
     def do_rename(self, args, repository, manifest, key, cache, archive):
         """Rename an existing archive"""
-        name = replace_placeholders(args.name)
-        archive.rename(name)
+        archive.rename(args.name)
         manifest.write()
         repository.commit()
         cache.commit()
@@ -1706,11 +1705,10 @@ class Archiver:
 
         if args.location.archive:
             name = args.location.archive
-            target = replace_placeholders(args.target) if args.target else None
             if recreater.is_temporary_archive(name):
                 self.print_error('Refusing to work on temporary archive of prior recreate: %s', name)
                 return self.exit_code
-            if not recreater.recreate(name, args.comment, target):
+            if not recreater.recreate(name, args.comment, args.target):
                 self.print_error('Nothing to do. Archive was not processed.\n'
                                  'Specify at least one pattern, PATH, --comment, re-compression or re-chunking option.')
         else:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1203,6 +1203,7 @@ def location_validator(archive=None, proto=None):
 
 def archivename_validator():
     def validator(text):
+        text = replace_placeholders(text)
         if '/' in text or '::' in text or not text:
             raise argparse.ArgumentTypeError('Invalid repository name: "%s"' % text)
         return text


### PR DESCRIPTION
PR #4636 rebased on 1.1-maint and adapted for non-split `helpers.py`.