### PR TITLE
support xxh64 checksum in addition to the hashlib hashes in borg list

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -648,8 +648,6 @@ class ArchiveFormatter(BaseFormatter):
 
 
 class ItemFormatter(BaseFormatter):
-    from ..algorithms.checksums import StreamingXXH64
-    xxh64 = StreamingXXH64
     hash_algorithms = hashlib.algorithms_guaranteed.union({'xxh64'})
     KEY_DESCRIPTIONS = {
         'bpath': 'verbatim POSIX path, can contain any character except NUL',
@@ -714,6 +712,8 @@ class ItemFormatter(BaseFormatter):
         return any(key in cls.KEYS_REQUIRING_CACHE for key in format_keys)
 
     def __init__(self, archive, format, *, json_lines=False):
+        from ..algorithms.checksums import StreamingXXH64
+        self.xxh64 = StreamingXXH64
         self.archive = archive
         self.json_lines = json_lines
         static_keys = {

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -741,7 +741,7 @@ class ItemFormatter(BaseFormatter):
             'ctime': partial(self.format_time, 'ctime'),
             'atime': partial(self.format_time, 'atime'),
         }
-        for hash_function in self.__class__.hash_algorithms:
+        for hash_function in self.hash_algorithms:
             self.add_key(hash_function, partial(self.hash_item, hash_function))
         self.used_call_keys = set(self.call_keys) & self.format_keys
 
@@ -818,7 +818,7 @@ class ItemFormatter(BaseFormatter):
         if hash_function in hashlib.algorithms_guaranteed:
             hash = hashlib.new(hash_function)
         elif hash_function == 'xxh64':
-            hash = self.__class__.xxh64()
+            hash = self.xxh64()
         for data in self.archive.pipeline.fetch_many([c.id for c in item.chunks]):
             hash.update(data)
         return hash.hexdigest()

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -661,6 +661,7 @@ class ItemFormatter(BaseFormatter):
         'dcsize': 'deduplicated compressed size',
         'num_chunks': 'number of chunks in this file',
         'unique_chunks': 'number of unique chunks in this file',
+        'xxh64': 'XXH64 checksum of this file (note: this is NOT a cryptographic hash!)',
         'health': 'either "healthy" (file ok) or "broken" (if file has all-zero replacement chunks)',
     }
     KEY_GROUPS = (

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -648,7 +648,7 @@ class ArchiveFormatter(BaseFormatter):
 
 
 class ItemFormatter(BaseFormatter):
-    from .algorithms.checksums import StreamingXXH64
+    from ..algorithms.checksums import StreamingXXH64
     xxh64 = StreamingXXH64
     hash_algorithms = hashlib.algorithms_guaranteed.union({'xxh64'})
     KEY_DESCRIPTIONS = {


### PR DESCRIPTION
Sopport xxh64 checksum in `borg list` besides the existing hashes provided by hashlib, using the built-in xxh64 implementation.

This e.g. allows to generate an archive listing that could be used with `xxh64sum` to quickly compare (verify) actual archive contents with existing files. While there may not be a noticeable speedup in borg's operation on a current system, it does lower CPU usage and may help  systems with slow CPUs.
It also gives people that happen to already have `xxh64sum` generated checksum files for their data another option.