### PR TITLE
Clarify docs on patterns

### DIFF
--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -58,8 +58,16 @@ Regular expressions, selector `re:`
     the re module <https://docs.python.org/3/library/re.html>`_.
 
 Path prefix, selector `pp:`
-    This pattern style is useful to match whole sub-directories. The pattern
-    `pp:root/somedir` matches `root/somedir` and everything therein.
+    This pattern style is useful to match whole sub-directories without worrying
+    about escaping special characters. Otherwise, you can just use the default
+    `fm:` or `sh:` styles, which also match whole sub-directories. Unlike those
+    styles, a trailing slash here has no effect on what gets matched. The pattern
+    `pp:root/somedir` (and `pp:root/somedir/`) matches `root/somedir` and
+    everything therein.
+
+    When using exclude-norecurse rules, this style is equivalent to `pf:`,
+    except that `pf:` won't match patterns with trailing slashes (and `pp:`
+    won't be as efficient, though that may be optimized in the future).
 
 Path full-match, selector `pf:`
     This pattern style is (only) useful to match full paths.
@@ -138,7 +146,8 @@ Examples::
     path. The first matching pattern is used so if an include pattern matches before
     an exclude pattern, the file is backed up. If an exclude-norecurse pattern matches
     a directory, it won't recurse into it and won't discover any potential matches for
-    include rules below that directory.
+    include rules below that directory. Note that this is the behavior that gets applied
+    to all patterns from `--exclude` and `--exclude-from`.
 
     Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
     shell style (`sh:`), so those patterns behave similar to rsync include/exclude

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -58,16 +58,8 @@ Regular expressions, selector `re:`
     the re module <https://docs.python.org/3/library/re.html>`_.
 
 Path prefix, selector `pp:`
-    This pattern style is useful to match whole sub-directories without worrying
-    about escaping special characters. Otherwise, you can just use the default
-    `fm:` or `sh:` styles, which also match whole sub-directories. Unlike those
-    styles, a trailing slash here has no effect on what gets matched. The pattern
-    `pp:root/somedir` (and `pp:root/somedir/`) matches `root/somedir` and
-    everything therein.
-
-    When using exclude-norecurse rules, this style is equivalent to `pf:`,
-    except that `pf:` won't match patterns with trailing slashes (and `pp:`
-    won't be as efficient, though that may be optimized in the future).
+    This pattern style is useful to match whole sub-directories. The pattern
+    `pp:root/somedir` matches `root/somedir` and everything therein.
 
 Path full-match, selector `pf:`
     This pattern style is (only) useful to match full paths.
@@ -146,8 +138,7 @@ Examples::
     path. The first matching pattern is used so if an include pattern matches before
     an exclude pattern, the file is backed up. If an exclude-norecurse pattern matches
     a directory, it won't recurse into it and won't discover any potential matches for
-    include rules below that directory. Note that this is the behavior that gets applied
-    to all patterns from `--exclude` and `--exclude-from`.
+    include rules below that directory.
 
     Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
     shell style (`sh:`), so those patterns behave similar to rsync include/exclude

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2067,14 +2067,21 @@ class Archiver:
             the re module <https://docs.python.org/3/library/re.html>`_.
 
         Path prefix, selector `pp:`
-            This pattern style is useful to match whole sub-directories. The pattern
-            `pp:root/somedir` matches `root/somedir` and everything therein.
+            This pattern style is useful to match whole sub-directories without worrying
+            about escaping special characters. Otherwise, you can just use the default
+            `fm:` or `sh:` styles, which also match whole sub-directories. Unlike those
+            styles, a trailing slash here makes no difference. The pattern `pp:root/somedir`
+            (and `pp:root/somedir/`) matches `root/somedir` and everything therein.
+
+            When used with exclude-norecurse rules, this style is equivalent to `pf:`
+            (except not as efficient).
 
         Path full-match, selector `pf:`
             This pattern style is (only) useful to match full paths.
             This is kind of a pseudo pattern as it can not have any variable or
-            unspecified parts - the full path must be given.
-            `pf:root/file.ext` matches `root/file.txt` only.
+            unspecified parts - the full path must be given. Trailing slashes make no
+            difference. `pf:root/file.ext` (and `pp:root/file.ext/`) matches `root/file.txt`
+            only.
 
             Implementation note: this is implemented via very time-efficient O(1)
             hashtable lookups (this means you can have huge amounts of such patterns
@@ -2147,7 +2154,8 @@ class Archiver:
             path. The first matching pattern is used so if an include pattern matches before
             an exclude pattern, the file is backed up. If an exclude-norecurse pattern matches
             a directory, it won't recurse into it and won't discover any potential matches for
-            include rules below that directory.
+            include rules below that directory. Note that this is the behavior that gets applied
+            to all patterns from `--exclude` and `--exclude-from`.
 
             Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
             shell style (`sh:`), so those patterns behave similar to rsync include/exclude

--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -71,6 +71,7 @@ class PatternMatcher:
     *fallback* is a boolean value that *match()* returns if no matching patterns are found.
 
     """
+
     def __init__(self, fallback=None):
         self._items = []
 
@@ -340,6 +341,10 @@ def parse_pattern(pattern, fallback=FnmatchPattern, recurse_dir=True):
     """Read pattern from string and return an instance of the appropriate implementation class.
 
     """
+    # Potential optimization for fm, sh, and pf patterns: if recurse_dir is False and the pattern
+    # doesn't do any special matching, it could be converted to a PathFullPattern (we would also
+    # need to remove any trailing slashes from pf patterns, and exclude fm and sh patterns with
+    # trailing slashes from the optimization).
     if len(pattern) > 2 and pattern[2] == ":" and pattern[:2].isalnum():
         (style, pattern) = (pattern[:2], pattern[3:])
         cls = get_pattern_class(style)

--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -212,7 +212,7 @@ class PatternBase:
 
 
 class PathFullPattern(PatternBase):
-    """Full match of a path."""
+    """Full match of a path.  A trailing slash makes no difference."""
     PREFIX = "pf"
 
     def _prepare(self, pattern):
@@ -236,6 +236,7 @@ class PathPrefixPattern(PatternBase):
     PREFIX = "pp"
 
     def _prepare(self, pattern):
+        # rstrip is for when normpath is "/"
         self.pattern = os.path.normpath(pattern).rstrip(os.path.sep) + os.path.sep
 
     def _match(self, path):
@@ -250,6 +251,7 @@ class FnmatchPattern(PatternBase):
 
     def _prepare(self, pattern):
         if pattern.endswith(os.path.sep):
+            # rstrip is for when normpath is "/"
             pattern = os.path.normpath(pattern).rstrip(os.path.sep) + os.path.sep + '*' + os.path.sep
         else:
             pattern = os.path.normpath(pattern) + os.path.sep + '*'
@@ -274,6 +276,7 @@ class ShellPattern(PatternBase):
         sep = os.path.sep
 
         if pattern.endswith(sep):
+            # rstrip is for when normpath is "/"
             pattern = os.path.normpath(pattern).rstrip(sep) + sep + "**" + sep + "*" + sep
         else:
             pattern = os.path.normpath(pattern) + sep + "**" + sep + "*"
@@ -341,10 +344,6 @@ def parse_pattern(pattern, fallback=FnmatchPattern, recurse_dir=True):
     """Read pattern from string and return an instance of the appropriate implementation class.
 
     """
-    # Potential optimization for fm, sh, and pf patterns: if recurse_dir is False and the pattern
-    # doesn't do any special matching, it could be converted to a PathFullPattern (we would also
-    # need to remove any trailing slashes from pf patterns, and exclude fm and sh patterns with
-    # trailing slashes from the optimization).
     if len(pattern) > 2 and pattern[2] == ":" and pattern[:2].isalnum():
         (style, pattern) = (pattern[:2], pattern[3:])
         cls = get_pattern_class(style)

--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -71,7 +71,6 @@ class PatternMatcher:
     *fallback* is a boolean value that *match()* returns if no matching patterns are found.
 
     """
-
     def __init__(self, fallback=None):
         self._items = []
 


### PR DESCRIPTION
The docs for the `pp:` selector were misleading to me -- they seemed to imply that matching whole sub-directories isn't already straightforward with the default styles (`fm:` and `sh:`). It also wasn't clear to me why `pp:` needed to exist at all given the similar behavior of `pf:`, until I thought about the behavior without exclude-norecurse (which isn't introduced until later in the document).

Thinking about this also gave me an idea for an optimization, which I added a comment for in the code.

Happy to update things if I misunderstood anything here.