### PR TITLE
SecurityManager.known(): check all files, fixes #4614

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -73,7 +73,8 @@ class SecurityManager:
             shutil.rmtree(path)
 
     def known(self):
-        return os.path.exists(self.key_type_file)
+        return all(os.path.exists(f)
+                   for f in (self.key_type_file, self.location_file, self.manifest_ts_file))
 
     def key_matches(self, key):
         if not self.known():


### PR DESCRIPTION
Before this fix, because known() only checked the key-type file, the
location file could go missing without being automatically regenerated.

Now a save() is triggered if not all files are present.
