### PR TITLE
fix preloading for old remote servers, fixes #4652

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -880,7 +880,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                         if self.dictFormat:
                             self.to_send = msgpack.packb({MSGID: self.msgid, MSG: 'get', ARGS: args})
                         else:
-                            self.to_send = msgpack.packb((1, self.msgid, 'get', self.named_to_positional(cmd, args)))
+                            self.to_send = msgpack.packb((1, self.msgid, 'get', self.named_to_positional('get', args)))
 
                 if self.to_send:
                     try:


### PR DESCRIPTION
if the remote server does not support the dict-based argument passing
yet (e.g. when accidentally using borg 0.29 on rsync.net), the GET rpc
call argument list failed to generate if the command currently being
processed was not a GET also.

note: rsync.net has a more recent borg as "borg1".
