### PR TITLE
cope with ANY error when importing pytest into borg.testsuite, #4652

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -27,7 +27,7 @@ except ImportError:
 
 try:
     from pytest import raises
-except ImportError:
+except:  # noqa
     raises = None
 
 has_lchflags = hasattr(os, 'lchflags') or sys.platform.startswith('linux')


### PR DESCRIPTION
this happened because the user had pytest5 installed somehow,
although it is incompatible with python 3.4:
```
# python3 /usr/local/bin/borg --version
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/borg/archiver.py", line 81, in <module>
    from .selftest import selftest
  File "/usr/local/lib/python3.4/dist-packages/borg/selftest.py", line 21, in <module>
    from .testsuite.hashindex import HashIndexDataTestCase, HashIndexRefcountingTestCase, HashIndexTestCase
  File "/usr/local/lib/python3.4/dist-packages/borg/testsuite/__init__.py", line 29, in <module>
    from pytest import raises
  File "/usr/local/lib/python3.4/dist-packages/pytest.py", line 6, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "/usr/local/lib/python3.4/dist-packages/_pytest/assertion/__init__.py", line 6, in <module>
    from _pytest.assertion import rewrite
  File "/usr/local/lib/python3.4/dist-packages/_pytest/assertion/rewrite.py", line 443, in <module>
    ast.MatMult: "@",
AttributeError: 'module' object has no attribute 'MatMult'
```
