### PR TITLE
only store compressed data if the result actually is smaller

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -16,7 +16,7 @@ import traceback
 from subprocess import Popen, PIPE
 
 from . import __version__
-from .compress import LZ4
+from .compress import Compressor
 from .constants import *  # NOQA
 from .helpers import Error, IntegrityError
 from .helpers import bin_to_hex
@@ -1215,7 +1215,7 @@ def cache_if_remote(repository, *, decrypted_cache=False, pack=None, unpack=None
         key = decrypted_cache
         # 32 bit csize, 64 bit (8 byte) xxh64
         cache_struct = struct.Struct('=I8s')
-        compressor = LZ4()
+        compressor = Compressor('lz4')
 
         def pack(data):
             csize, decrypted = data

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2140,7 +2140,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     def test_compression_lz4_uncompressible(self):
         size, csize = self._get_sizes('lz4', compressible=False)
-        assert csize >= size
+        assert csize == size + 3  # same as compression 'none'
 
     def test_compression_lzma_compressible(self):
         size, csize = self._get_sizes('lzma', compressible=True)
@@ -2148,7 +2148,15 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     def test_compression_lzma_uncompressible(self):
         size, csize = self._get_sizes('lzma', compressible=False)
-        assert csize >= size
+        assert csize == size + 3  # same as compression 'none'
+
+    def test_compression_zstd_compressible(self):
+        size, csize = self._get_sizes('zstd', compressible=True)
+        assert csize < size * 0.1
+
+    def test_compression_zstd_uncompressible(self):
+        size, csize = self._get_sizes('zstd', compressible=False)
+        assert csize == size + 3  # same as compression 'none'
 
     def test_change_passphrase(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)

--- a/src/borg/testsuite/compress.py
+++ b/src/borg/testsuite/compress.py
@@ -43,11 +43,13 @@ def test_lz4():
     assert data == Compressor(**params).decompress(cdata)  # autodetect
 
 
-def test_lz4_buffer_allocation():
+def test_lz4_buffer_allocation(monkeypatch):
+    # disable fallback to no compression on incompressible data
+    monkeypatch.setattr(LZ4, 'decide', lambda always_compress: LZ4)
     # test with a rather huge data object to see if buffer allocation / resizing works
     data = os.urandom(5 * 2**20) * 10  # 50MiB badly compressible data
     assert len(data) == 50 * 2**20
-    c = get_compressor(name='lz4')
+    c = Compressor('lz4')
     cdata = c.compress(data)
     assert len(cdata) > len(data)
     assert data == c.decompress(cdata)

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -264,9 +264,8 @@ class TestKey:
         assert len(key.id_key) == 32
         plaintext = b'123456789'
         authenticated = key.encrypt(plaintext)
-        # 0x07 is the key TYPE, 0x0100 identifies LZ4 compression, 0x90 is part of LZ4 and means that an uncompressed
-        # block of length nine follows (the plaintext).
-        assert authenticated == b'\x07\x01\x00\x90' + plaintext
+        # 0x07 is the key TYPE, \x0000 identifies no compression.
+        assert authenticated == b'\x07\x00\x00' + plaintext
 
     def test_blake2_authenticated_encrypt(self, monkeypatch):
         monkeypatch.setenv('BORG_PASSPHRASE', 'test')
@@ -275,9 +274,8 @@ class TestKey:
         assert len(key.id_key) == 128
         plaintext = b'123456789'
         authenticated = key.encrypt(plaintext)
-        # 0x06 is the key TYPE, 0x0100 identifies LZ4 compression, 0x90 is part of LZ4 and means that an uncompressed
-        # block of length nine follows (the plaintext).
-        assert authenticated == b'\x06\x01\x00\x90' + plaintext
+        # 0x06 is the key TYPE, 0x0000 identifies no compression.
+        assert authenticated == b'\x06\x00\x00' + plaintext
 
 
 class TestPassphrase:


### PR DESCRIPTION
- add decide() function to LZ4, LZMA and ZSTD classes that
  falls back to NONE if the compressed data turns out bigger than
  the original data
- leave ZLIB as is, as it does not use an ID header and compatibility
  being the only reason to use it instead of above algorithms anyway
- adapt testsuite to cope with incompressible test data not being
  compressed
- add tests to verify that incompressible data is not compressed to
  larger size compressed data

Watching the progress output in one of my initial backups using borg I did notice compressed showing a larger number than original at some point. Unlike done in issues #4516 and #385, I actually tested with borg to verify that indeed compressed chunks being stored that were larger than an uncompressed chunk would have been.
Based on this I addressed that problem in this PR.

In addition to the test suite, I also ran a test on real world data with this change applied to Debian's borg 1.1.9 package from the same snapshot to two newly created, otherwise empty repositories (different chunking due to different hashing due to different key adds extra differences).

Using LZ4 and the original 1.1.9:
```
------------------------------------------------------------------------------
                       Original size      Compressed size    Deduplicated size
This archive:              304.99 GB            124.05 GB             92.03 GB
All archives:              314.41 GB            130.24 GB             92.03 GB

                       Unique chunks         Total chunks
Chunk index:                  493930               559552
------------------------------------------------------------------------------
```

Using LZ4 and a patched 1.1.9 with this change:
```
------------------------------------------------------------------------------
                       Original size      Compressed size    Deduplicated size
This archive:              304.99 GB            123.87 GB             91.86 GB
All archives:              314.41 GB            130.05 GB             91.86 GB

                       Unique chunks         Total chunks
Chunk index:                  493644               558659
------------------------------------------------------------------------------
```

The actual repositories on disk on the backup server:
```
# du -s comp-*
89921264	comp-orig
89760448	comp-patch
```

Oh, and a `borg list --format '{sha256}  {path}{NL}' ` lead to identical results (and matching on disk files) for both, too. :wink: