### PR TITLE
docs: benchmark crud: clarify that space is used until compact

### DIFF
--- a/docs/usage/benchmark_crud.rst.inc
+++ b/docs/usage/benchmark_crud.rst.inc
@@ -54,6 +54,9 @@ command will create / read / update / delete some archives named borg-benchmark-
 
 Make sure you have free space there, you'll need about 1GB each (+ overhead).
 
+Important: The space used in the repository will **not** be freed until you run
+``borg compact``.
+
 If your repository is encrypted and borg needs a passphrase to unlock the key, use:
 
 BORG_PASSPHRASE=mysecret borg benchmark crud REPO PATH


### PR DESCRIPTION
This clarifies #4694 