### PR TITLE
tox / travis: add testing on py38-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py37
+        - python: "3.8-dev"
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
         - python: 3.5
           os: linux
           dist: xenial

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36,37},flake8
+envlist = py{35,36,37,38},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
I think this is all that's required for python3.8-dev testing. Travis ran without errors pn python3.8

fixes #4682 