### PR TITLE
after double-force delete, warn about necessary repair, fixes #4704

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1291,7 +1291,7 @@ class Archiver:
                 manifest.write()
                 # note: might crash in compact() after committing the repo
                 repository.commit()
-                logger.info('Done. Run "borg check --repair" to clean up the mess.')
+                logger.warning('Done. Run "borg check --repair" to clean up the mess.')
             else:
                 logger.warning('Aborted.')
             return self.exit_code


### PR DESCRIPTION
the borg check --repair is needed to clean up all the orphaned chunks.

if the message is emitted on INFO log level, people likely do not see
it if they use default WARNING log level (they did not give -v).