### PR TITLE
fix partial extract for hardlinked contentless file types, fixes #4725

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -234,7 +234,8 @@ class DownloadPipeline:
                             if source not in masters_preloaded:
                                 # we only need to preload *once* (for the 1st selected slave)
                                 chunks, _ = hardlink_masters[source]
-                                preload(chunks)
+                                if chunks is not None:
+                                    preload(chunks)
                                 masters_preloaded.add(source)
                 else:
                     # easy: we do not have a filter, thus all items are selected, thus we need to preload all chunks.


### PR DESCRIPTION
if the file is not a regular file, but a hardlink slave with a not
extracted hardlink master, chunks will be None and we must not call
preload(chunks).
