### PR TITLE
new BORG_WORKAROUNDS mechanism, basesyncfile, fixes #4710

### DIFF
--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -218,6 +218,18 @@ General:
         When set to no (default: yes), system information (like OS, Python version, ...) in
         exceptions is not shown.
         Please only use for good reasons as it makes issues harder to analyze.
+    BORG_WORKAROUNDS
+        A list of comma separated strings that trigger workarounds in borg,
+        e.g. to work around bugs in other software.
+
+        Currently known strings are:
+
+        basesyncfile
+            Use the more simple BaseSyncFile code to avoid issues with sync_file_range.
+            You might need this to run borg on WSL (Windows Subsystem for Linux) or
+            in systemd.nspawn containers on some architectures (e.g. ARM).
+            Using this does not affect data safety, but might result in a more bursty
+            write to disk behaviour (not continuously streaming to disk).
     TMPDIR
         where temporary files are stored (might need a lot of temporary space for some operations), see tempfile_ for details
 

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -81,6 +81,12 @@ from . import shellpattern
 from .constants import *  # NOQA
 
 
+# generic mechanism to enable users to invoke workarounds by setting the
+# BORG_WORKAROUNDS environment variable to a list of comma-separated strings.
+# see the docs for a list of known workaround strings.
+workarounds = tuple(os.environ.get('BORG_WORKAROUNDS', '').split(','))
+
+
 '''
 The global exit_code variable is used so that modules other than archiver can increase the program exit code if a
 warning or error occurred during their operation. This is different from archiver.exit_code, which is only accessible

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -5,6 +5,7 @@ import re
 import stat
 import subprocess
 
+from ..helpers import workarounds
 from ..helpers import posix_acl_use_stored_uid_gid
 from ..helpers import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
@@ -240,23 +241,11 @@ cdef _sync_file_range(fd, offset, length, flags):
 cdef unsigned PAGE_MASK = sysconf(_SC_PAGESIZE) - 1
 
 
-def _is_WSL():
-    """detect Windows Subsystem for Linux"""
-    try:
-        with open('/proc/version') as fd:
-            linux_version = fd.read()
-        # hopefully no non-WSL Linux will ever mention 'Microsoft' in the kernel version:
-        return 'Microsoft' in linux_version
-    except:  # noqa
-        # make sure to never ever crash due to this check.
-        return False
-
-
-if _is_WSL():
+if 'basesyncfile' in workarounds:
     class SyncFile(BaseSyncFile):
-        # if we are on Microsoft's "Windows Subsytem for Linux", use the
-        # more generic BaseSyncFile to avoid issues like seen there:
-        # https://github.com/borgbackup/borg/issues/1961
+        # if we are on platforms with a broken or not implemented sync_file_range,
+        # use the more generic BaseSyncFile to avoid issues.
+        # see basesyncfile description in our docs for details.
         pass
 else:
     # a real Linux, so we can do better. :)


### PR DESCRIPTION
remove WSL autodetection. if WSL still has this problem, you need to
set BORG_WORKAROUNDS=basesyncfile in the borg process environment to
work around it.