### PR TITLE
create: make --noatime the default, deprecate --noatime, fixes #4673

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -192,6 +192,8 @@ Compatibility notes:
   which does not need an external Python interpreter.
   Maybe this requirement will be raised to Python 3.6 later.
 - freeing repository space only happens when "borg compact" is invoked.
+- borg create --noatime is deprecated. Not storing atime is the default behaviour
+  now (use --atime if you want to store the atime).
 - list: corrected mix-up of "isomtime" and "mtime" formats. Previously,
   "isomtime" was the default but produced a verbose human format,
   while "mtime" produced a ISO-8601-like format.
@@ -245,6 +247,16 @@ New features:
 - enable placeholder usage in --comment, #4559
 - enable placeholder usage in --glob-archives, #4495
 - ability to use a system-provided version of "xxhash"
+- create:
+
+  - changed the default behaviour to not store the atime of fs items. atime is
+    often rather not interesting and fragile - it easily changes even if nothing
+    else has changed and, if stored into the archive, spoils deduplication of
+    the archive metadata stream.
+  - if you give the --noatime option, borg will output a deprecation warning
+    because it is currently ignored / does nothing.
+    Please remove the --noatime option when using borg 1.2.
+  - added a --atime option for storing files' atime into an archive
 
 Other changes:
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -561,11 +561,11 @@ class Archiver:
                        cache_mode=args.files_cache_mode) as cache:
                 archive = Archive(repository, key, manifest, args.location.archive, cache=cache,
                                   create=True, checkpoint_interval=args.checkpoint_interval,
-                                  numeric_owner=args.numeric_owner, noatime=args.noatime, noctime=args.noctime,
+                                  numeric_owner=args.numeric_owner, noatime=not args.atime, noctime=args.noctime,
                                   progress=args.progress,
                                   chunker_params=args.chunker_params, start=t0, start_monotonic=t0_monotonic,
                                   log_json=args.log_json)
-                metadata_collector = MetadataCollector(noatime=args.noatime, noctime=args.noctime,
+                metadata_collector = MetadataCollector(noatime=not args.atime, noctime=args.noctime,
                     nobsdflags=args.nobsdflags, numeric_owner=args.numeric_owner, nobirthtime=args.nobirthtime)
                 cp = ChunksProcessor(cache=cache, key=key,
                     add_item=archive.add_item, write_checkpoint=archive.write_checkpoint,
@@ -2332,6 +2332,7 @@ class Archiver:
     def preprocess_args(self, args):
         deprecations = [
             # ('--old', '--new' or None, 'Warning: "--old" has been deprecated. Use "--new" instead.'),
+            ('--noatime', None, 'Warning: "--noatime" has been deprecated because it is the default now.')
         ]
         for i, arg in enumerate(args[:]):
             for old_name, new_name, warning in deprecations:
@@ -3014,8 +3015,12 @@ class Archiver:
                               help='stay in the same file system and do not store mount points of other file systems')
         fs_group.add_argument('--numeric-owner', dest='numeric_owner', action='store_true',
                               help='only store numeric user and group identifiers')
+        # --noatime is the default now and the flag is deprecated. args.noatime is not used any more.
+        # use --atime if you want to store the atime (default behaviour before borg 1.2.0a7)..
         fs_group.add_argument('--noatime', dest='noatime', action='store_true',
                               help='do not store atime into archive')
+        fs_group.add_argument('--atime', dest='atime', action='store_true',
+                              help='do store atime into archive')
         fs_group.add_argument('--noctime', dest='noctime', action='store_true',
                               help='do not store ctime into archive')
         fs_group.add_argument('--nobirthtime', dest='nobirthtime', action='store_true',

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -501,7 +501,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         have_noatime = has_noatime('input/file1')
         os.utime('input/file1', (atime, mtime))
         self.cmd('init', '--encryption=repokey', self.repository_location)
-        self.cmd('create', self.repository_location + '::test', 'input')
+        self.cmd('create', '--atime', self.repository_location + '::test', 'input')
         with changedir('output'):
             self.cmd('extract', self.repository_location + '::test')
         sti = os.stat('input/file1')
@@ -2172,8 +2172,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.create_test_files()
         have_noatime = has_noatime('input/file1')
-        self.cmd('create', '--exclude-nodump', self.repository_location + '::archive', 'input')
-        self.cmd('create', '--exclude-nodump', self.repository_location + '::archive2', 'input')
+        self.cmd('create', '--exclude-nodump', '--atime', self.repository_location + '::archive', 'input')
+        self.cmd('create', '--exclude-nodump', '--atime', self.repository_location + '::archive2', 'input')
         if has_lchflags:
             # remove the file we did not backup, so input and output become equal
             os.remove(os.path.join('input', 'flagfile'))


### PR DESCRIPTION
also: add --atime option to enable storing files' atime.
