### PR TITLE
Backport #4763 to 1.1-maint

### DIFF
--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -541,10 +541,12 @@ class FuseOperations(llfuse.Operations):
             entry.st_mtime_ns = mtime_ns
             entry.st_atime_ns = item.get('atime', mtime_ns)
             entry.st_ctime_ns = item.get('ctime', mtime_ns)
+            entry.st_birthtime_ns = item.get('birthtime', mtime_ns)
         else:
             entry.st_mtime = mtime_ns / 1e9
             entry.st_atime = item.get('atime', mtime_ns) / 1e9
             entry.st_ctime = item.get('ctime', mtime_ns) / 1e9
+            entry.st_birthtime = item.get('birthtime', mtime_ns) / 1e9
         return entry
 
     def listxattr(self, inode, ctx=None):


### PR DESCRIPTION
Same as #4763 in the 1.1-maint branch: this PR fixes the st_birthtime (used e.g. in macOS) missing from the entries when using borg mount (note that borg extract does not exhibit this error).