### PR TITLE
ignore EACCES (errno 13) when hardlinking, fixes #4730

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -298,7 +298,7 @@ class Repository:
             try:
                 os.link(config_path, old_config_path)
             except OSError as e:
-                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM, errno.ENOTSUP):
+                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM, errno.EACCES, errno.ENOTSUP):
                     logger.warning("Failed to securely erase old repository config file (hardlinks not supported>). "
                                    "Old repokey data, if any, might persist on physical storage.")
                 else:


### PR DESCRIPTION
we create the hardlink to be able to secure erase the old config file.

if we can't do that because there is just a problem with hardlinks not
working, the old config will be just overwritten normally (not secure
erased). the user will get a warning in that case, but other than that,
the overall borg operation will succeed.

if there is a bigger problem (like a general lack of permissions or a
general issue with the underlying fs), subsequent operations will fail.
