### PR TITLE
--prefix / -P: fix processing, avoid argparse issue, fixes #4769

### DIFF
--- a/src/borg/helpers/manifest.py
+++ b/src/borg/helpers/manifest.py
@@ -103,7 +103,7 @@ class Archives(abc.MutableMapping):
         """
         if args.location.archive:
             raise Error('The options --first, --last, --prefix and --glob-archives can only be used on repository targets.')
-        if args.prefix:
+        if args.prefix is not None:
             args.glob_archives = args.prefix + '*'
         return self.list(sort_by=args.sort_by.split(','), glob=args.glob_archives, first=args.first, last=args.last)
 


### PR DESCRIPTION
changes:

- changed --prefix default to None (was: ''), so we can check using "is not None" to determine when --prefix has been given.

- the previous check for --prefix being used was just for a truthy value, so using --prefix='' was not really supported, but happened to behave the same as the default processing anyway.

- argparse python stdlib code seems to have a bug when processing an option like --prefix='--', args.prefix will be [] in that case (should be '--'). With previous code this behaved like no prefix given ([] value is not truthy). Now, as we check for "is not None", it will try to process that value but blow up with a TypeError as it can't do [] + '*'.
This is a bit unpretty end, but at least borg prune won't delete all your archives and it will be a reminder that argparse is broken.
- for borg check --repository-only, we also check for --glob-archives not being used and give the warning otherwise.
