### PR TITLE
[DOC] #4118 - Explain difference between --exclude and --pattern.

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2159,9 +2159,8 @@ class Archiver:
             .. note::
 
                 Via ``--pattern`` or ``--patterns-from`` you can define BOTH inclusion and exclusion
-                of files using pattern prefixes ``+`` and ``-``, so the PATH argument of the command
-                can be omitted. With ``--exclude`` and ``--exlude-from`` ONLY excludes are defined,
-                and the PATH argument defines the includes.
+                of files using pattern prefixes ``+`` and ``-``. With ``--exclude`` and
+                ``--exlude-from`` ONLY excludes are defined.
 
             Inclusion patterns are useful to include paths that are contained in an excluded
             path. The first matching pattern is used so if an include pattern matches before

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2159,8 +2159,9 @@ class Archiver:
             .. note::
 
                 Via ``--pattern`` or ``--patterns-from`` you can define BOTH inclusion and exclusion
-                of files using pattern prefixes ``+`` and ``-``. With ``--exclude`` and
-                ``--exlude-file`` ONLY excludes are defined.
+                of files using pattern prefixes ``+`` and ``-``, so the PATH argument of the command
+                can be omitted. With ``--exclude`` and ``--exlude-from`` ONLY excludes are defined,
+                and the PATH argument defines the includes.
 
             Inclusion patterns are useful to include paths that are contained in an excluded
             path. The first matching pattern is used so if an include pattern matches before

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2155,6 +2155,13 @@ class Archiver:
             A root path starts with the prefix `R`, followed by a path (a plain path, not a
             file pattern). An include rule starts with the prefix +, an exclude rule starts
             with the prefix -, an exclude-norecurse rule starts with !, all followed by a pattern.
+
+            .. note::
+
+                Via ``--pattern`` or ``--patterns-from`` you can define BOTH inclusion and exclusion
+                of files using pattern prefixes ``+`` and ``-``. With ``--exclude`` and
+                ``--exlude-file`` ONLY excludes are defined.
+
             Inclusion patterns are useful to include paths that are contained in an excluded
             path. The first matching pattern is used so if an include pattern matches before
             an exclude pattern, the file is backed up. If an exclude-norecurse pattern matches


### PR DESCRIPTION
In my opinion the borg help pattern is already quite good in explaining the --exclude and --pattern features, so I just added a note that explicitly states the additional prefix in --pattern lines.
If you read this help carefully it should be sufficient.