### PR TITLE
Remove deprecated keyword "sudo" from travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: python
 
 cache:


### PR DESCRIPTION
cf.
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

as requested in #4799

modified:   .travis.yml