### PR TITLE
Replaced usage of os.statvfs with shutil.disk_usage

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -1112,8 +1112,7 @@ class RepositoryCache(RepositoryNoCache):
         self.enospc = 0
 
     def query_size_limit(self):
-        stat_fs = os.statvfs(self.basedir)
-        available_space = stat_fs.f_bavail * stat_fs.f_frsize
+        available_space = shutil.disk_usage(self.basedir).free
         self.size_limit = int(min(available_space * 0.25, 2**31))
 
     def key_filename(self, key):


### PR DESCRIPTION
The RepositoryCache used `os.statvfs` which is not available on Windows.
`shutil.disk_usage` provides the same information but in a cross platform way.

