### PR TITLE
Add a try catch when formatting the info string.

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1145,12 +1145,16 @@ class Archiver:
         stats = Statistics()
         with Cache(repository, key, manifest, progress=args.progress, lock_wait=self.lock_wait) as cache:
             for i, archive_name in enumerate(archive_names, 1):
-                msg = 'Would delete archive: {} ({}/{})' if dry_run else 'Deleting archive: {} ({}/{})'
-                logger.info(msg.format(format_archive(manifest.archives[archive_name]), i, len(archive_names)))
-                if not dry_run:
-                    archive = Archive(repository, key, manifest, archive_name, cache=cache,
-                                      consider_part_files=args.consider_part_files)
-                    archive.delete(stats, progress=args.progress, forced=args.forced)
+                try:
+                    msg = 'Would delete archive: {} ({}/{})' if dry_run else 'Deleting archive: {} ({}/{})'
+                    logger.info(msg.format(format_archive(manifest.archives[archive_name]), i, len(archive_names)))
+                    if not dry_run:
+                        archive = Archive(repository, key, manifest, archive_name, cache=cache,
+                                          consider_part_files=args.consider_part_files)
+                        archive.delete(stats, progress=args.progress, forced=args.forced)
+                except KeyError:
+                    logger.warning('Archive {} not found ({}/{}).'.format(archive_name, i, len(archive_names)))
+
             if not dry_run:
                 manifest.write()
                 repository.commit(compact=False, save_space=args.save_space)

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1153,9 +1153,9 @@ class Archiver:
                     logger.warning(msg_not_found.format(archive_name, i, len(archive_names)))
                 else:
                     logger.info(msg_delete.format(format_archive(archive_info), i, len(archive_names)))
-                    archive = Archive(repository, key, manifest, archive_name, cache=cache,
-                                      consider_part_files=args.consider_part_files)
                     if not dry_run:
+                        archive = Archive(repository, key, manifest, archive_name, cache=cache,
+                                          consider_part_files=args.consider_part_files)
                         archive.delete(stats, progress=args.progress, forced=args.forced)
 
             if not dry_run:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -45,7 +45,7 @@ try:
     from .crypto.key import key_creator, key_argument_names, tam_required_file, tam_required, RepoKey, PassphraseKey
     from .crypto.keymanager import KeyManager
     from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
-    from .helpers import Error, NoManifestError, set_ec
+    from .helpers import Error, NoManifestError, NoArchiveError, set_ec
     from .helpers import positive_int_validator, location_validator, archivename_validator, ChunkerParams, Location
     from .helpers import PrefixSpec, GlobSpec, CommentSpec, SortBySpec, FilesCacheMode
     from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter
@@ -1145,14 +1145,14 @@ class Archiver:
         stats = Statistics()
         with Cache(repository, key, manifest, progress=args.progress, lock_wait=self.lock_wait) as cache:
             for i, archive_name in enumerate(archive_names, 1):
+                archive = Archive(repository, key, manifest, archive_name, cache=cache,
+                                  consider_part_files=args.consider_part_files)
                 try:
                     msg = 'Would delete archive: {} ({}/{})' if dry_run else 'Deleting archive: {} ({}/{})'
                     logger.info(msg.format(format_archive(manifest.archives[archive_name]), i, len(archive_names)))
                     if not dry_run:
-                        archive = Archive(repository, key, manifest, archive_name, cache=cache,
-                                          consider_part_files=args.consider_part_files)
                         archive.delete(stats, progress=args.progress, forced=args.forced)
-                except KeyError:
+                except NoArchiveError:
                     logger.warning('Archive {} not found ({}/{}).'.format(archive_name, i, len(archive_names)))
 
             if not dry_run:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -45,7 +45,7 @@ try:
     from .crypto.key import key_creator, key_argument_names, tam_required_file, tam_required, RepoKey, PassphraseKey
     from .crypto.keymanager import KeyManager
     from .helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR
-    from .helpers import Error, NoManifestError, NoArchiveError, set_ec
+    from .helpers import Error, NoManifestError, set_ec
     from .helpers import positive_int_validator, location_validator, archivename_validator, ChunkerParams, Location
     from .helpers import PrefixSpec, GlobSpec, CommentSpec, SortBySpec, FilesCacheMode
     from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter
@@ -1144,16 +1144,19 @@ class Archiver:
 
         stats = Statistics()
         with Cache(repository, key, manifest, progress=args.progress, lock_wait=self.lock_wait) as cache:
+            msg_delete = 'Would delete archive: {} ({}/{})' if dry_run else 'Deleting archive: {} ({}/{})'
+            msg_not_found = 'Archive {} not found ({}/{}).'
             for i, archive_name in enumerate(archive_names, 1):
-                archive = Archive(repository, key, manifest, archive_name, cache=cache,
-                                  consider_part_files=args.consider_part_files)
                 try:
-                    msg = 'Would delete archive: {} ({}/{})' if dry_run else 'Deleting archive: {} ({}/{})'
-                    logger.info(msg.format(format_archive(manifest.archives[archive_name]), i, len(archive_names)))
+                    archive_info = manifest.archives[archive_name]
+                except KeyError:
+                    logger.warning(msg_not_found.format(archive_name, i, len(archive_names)))
+                else:
+                    logger.info(msg_delete.format(format_archive(archive_info), i, len(archive_names)))
+                    archive = Archive(repository, key, manifest, archive_name, cache=cache,
+                                      consider_part_files=args.consider_part_files)
                     if not dry_run:
                         archive.delete(stats, progress=args.progress, forced=args.forced)
-                except NoArchiveError:
-                    logger.warning('Archive {} not found ({}/{}).'.format(archive_name, i, len(archive_names)))
 
             if not dry_run:
                 manifest.write()

--- a/src/borg/helpers/manifest.py
+++ b/src/borg/helpers/manifest.py
@@ -21,9 +21,6 @@ from ..constants import *  # NOQA
 class NoManifestError(Error):
     """Repository has no manifest."""
 
-class NoArchiveError(KeyError):
-    """Archive not present in the Archives list."""
-
 
 class MandatoryFeatureUnsupported(Error):
     """Unsupported repository feature(s) {}. A newer version of borg is required to access this repository."""
@@ -56,7 +53,7 @@ class Archives(abc.MutableMapping):
         _name = safe_encode(name)
         values = self._archives.get(_name)
         if values is None:
-            raise NoArchiveError
+            raise KeyError
         ts = parse_timestamp(values[b'time'].decode())
         return ArchiveInfo(name=name, id=values[b'id'], ts=ts)
 

--- a/src/borg/helpers/manifest.py
+++ b/src/borg/helpers/manifest.py
@@ -21,6 +21,9 @@ from ..constants import *  # NOQA
 class NoManifestError(Error):
     """Repository has no manifest."""
 
+class NoArchiveError(KeyError):
+    """Archive not present in the Archives list."""
+
 
 class MandatoryFeatureUnsupported(Error):
     """Unsupported repository feature(s) {}. A newer version of borg is required to access this repository."""
@@ -53,7 +56,7 @@ class Archives(abc.MutableMapping):
         _name = safe_encode(name)
         values = self._archives.get(_name)
         if values is None:
-            raise KeyError
+            raise NoArchiveError
         ts = parse_timestamp(values[b'time'].decode())
         return ArchiveInfo(name=name, id=values[b'id'], ts=ts)
 


### PR DESCRIPTION
This way, if the archive does not exist, we print a pretty message and
abort.

Fixes #4793.