### PR TITLE
give invalid repo error msg if repo config not found, fixes #4411

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -404,8 +404,12 @@ class Repository:
         else:
             self.lock = None
         self.config = ConfigParser(interpolation=None)
-        with open(os.path.join(self.path, 'config')) as fd:
-            self.config.read_file(fd)
+        try:
+            with open(os.path.join(self.path, 'config')) as fd:
+                self.config.read_file(fd)
+        except FileNotFoundError:
+            self.close()
+            raise self.InvalidRepository(self.path)
         if 'repository' not in self.config.sections() or self.config.getint('repository', 'version') != 1:
             self.close()
             raise self.InvalidRepository(path)


### PR DESCRIPTION
if the repo config is not there, we definitely have a invalid repo.

for other problems (like permission issues), we'll just let it blow
up with a traceback, so the user can see what the precise problem is.

backport from master.