### PR TITLE
chunker speedup

### DIFF
--- a/src/borg/testsuite/chunker_slow.py
+++ b/src/borg/testsuite/chunker_slow.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+from binascii import unhexlify
+
+from ..chunker import Chunker
+from ..crypto.low_level import blake2b_256
+from ..constants import *  # NOQA
+from . import BaseTestCase
+
+
+class ChunkerRegressionTestCase(BaseTestCase):
+
+    def test_chunkpoints_unchanged(self):
+        def twist(size):
+            x = 1
+            a = bytearray(size)
+            for i in range(size):
+                x = (x * 1103515245 + 12345) & 0x7FFFFFFF
+                a[i] = x & 0xFF
+            return a
+
+        data = twist(100000)
+
+        runs = []
+        for winsize in (65, 129, HASH_WINDOW_SIZE, 7351):
+            for minexp in (4, 6, 7, 11, 12):
+                for maxexp in (15, 17):
+                    if minexp >= maxexp:
+                        continue
+                    for maskbits in (4, 7, 10, 12):
+                        for seed in (1849058162, 1234567653):
+                            fh = BytesIO(data)
+                            chunker = Chunker(seed, minexp, maxexp, maskbits, winsize)
+                            chunks = [blake2b_256(b'', c) for c in chunker.chunkify(fh, -1)]
+                            runs.append(blake2b_256(b'', b''.join(chunks)))
+
+        # The "correct" hash below matches the existing chunker behavior.
+        # Future chunker optimisations must not change this, or existing repos will bloat.
+        overall_hash = blake2b_256(b'', b''.join(runs))
+        self.assert_equal(overall_hash, unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3"))


### PR DESCRIPTION
I'm a bit late to the https://github.com/borgbackup/borg/issues/1021 party, buy here's a chunker speedup by rearranging the loop a bit. Testing throughput on my slow old laptop:

Before:

```(borg-env) lenovo_0$ borg-env/bin/python3  ~/borgbench
    length   count      dt throughput chunks_count
1000000000       1 5.442 183.741    120
 100000000      10 5.531 180.795     12
  10000000     100 5.225 191.399      2
   1000000    1000 2.764 361.778      1
    100000   10000 0.172 5826.037      1
     10000  100000 0.993 1006.679      1
      1000 1000000 8.999 111.122      1
       100 1000000 8.776 11.394      1
        10 1000000 8.763 1.141      1
         1 1000000 8.768 0.114      1
```

After:
```(borg-env) lenovo_0$ borg-env/bin/python3  ~/borgbench
    length   count      dt throughput chunks_count
1000000000       1 3.891 256.990    120
 100000000      10 3.989 250.687     12
  10000000     100 3.736 267.687      2
   1000000    1000 2.022 494.470      1
    100000   10000 0.172 5827.721      1
     10000  100000 0.984 1016.437      1
      1000 1000000 8.931 111.970      1
       100 1000000 8.682 11.518      1
        10 1000000 8.649 1.156      1
         1 1000000 8.677 0.115      1
```



