### PR TITLE
check: do not stumble over invalid item key, fixes #4845

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1527,7 +1527,7 @@ class ArchiveChecker:
                 logger.error(msg)
 
             def list_keys_safe(keys):
-                return ', '.join((k.decode() if isinstance(k, bytes) else str(k) for k in keys))
+                return ', '.join((k.decode(errors='replace') if isinstance(k, bytes) else str(k) for k in keys))
 
             def valid_item(obj):
                 if not isinstance(obj, StableDict):


### PR DESCRIPTION
The code used for error reporting crashes due to an invalid utf-8
sequence. Use errors='replace' to never crash there. Errors
are expected in input data when borg check is run.
