### PR TITLE
travis: python upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ matrix:
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py34
-        - language: generic
-          os: osx
-          osx_image: xcode8.3
           env: TOXENV=py35
         - language: generic
           os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py37
+        - python: 3.8
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
         - language: generic
           os: osx
           osx_image: xcode8.3
@@ -34,7 +38,7 @@ matrix:
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py36
+          env: TOXENV=py37
 
 before_install:
 - |

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,25 +4,27 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    # HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_AUTO_UPDATE=1
     export HOMEBREW_LOGS=~/brew-logs
     export HOMEBREW_TEMP=~/brew-temp
     mkdir $HOMEBREW_LOGS
     mkdir $HOMEBREW_TEMP
-    # brew update
-    if [[ "${OPENSSL}" != "0.9.8" ]]; then
-        brew outdated openssl || brew upgrade openssl
-    fi
+    brew update > /dev/null
+    brew cleanup > /dev/null  # do this here, so it won't automatically trigger in the middle of other stuff
+    brew outdated pkg-config || brew upgrade pkg-config
+    # do NOT update openssl 1.0.x, brew will also update a lot of dependent pkgs (and their dependencies) then!
+    #brew outdated openssl || brew upgrade openssl
+    export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
+    brew install readline
+    export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig:$PKG_CONFIG_PATH"
+    brew install lz4
+    brew install xz  # required for python lzma module
+    brew install Caskroom/cask/osxfuse
 
+    brew outdated pyenv || brew upgrade pyenv
     if which pyenv > /dev/null; then
         eval "$(pyenv init -)"
     fi
-
-    brew install lz4
-    brew install xz  # required for python lzma module
-    brew outdated pyenv || brew upgrade pyenv
-    brew install pkg-config
-    brew install Caskroom/cask/osxfuse
 
     case "${TOXENV}" in
         py34)

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -30,12 +30,12 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 3.4.5
             ;;
         py35)
-            pyenv install 3.5.2
-            pyenv global 3.5.2
+            pyenv install 3.5.3  # minimum for openssl 1.1.x
+            pyenv global 3.5.3
             ;;
         py36)
-            pyenv install 3.6.0
-            pyenv global 3.6.0
+            pyenv install 3.6.7  # minimum for homebrew to select openssl 1.1.x
+            pyenv global 3.6.7
             ;;
     esac
     pyenv rehash

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -31,9 +31,9 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv install 3.5.3  # minimum for openssl 1.1.x
             pyenv global 3.5.3
             ;;
-        py36)
-            pyenv install 3.6.7  # minimum for homebrew to select openssl 1.1.x
-            pyenv global 3.6.7
+        py37)
+            pyenv install 3.7.0
+            pyenv global 3.7.0
             ;;
     esac
     pyenv rehash

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,10 +27,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     fi
 
     case "${TOXENV}" in
-        py34)
-            pyenv install 3.4.5
-            pyenv global 3.4.5
-            ;;
         py35)
             pyenv install 3.5.3  # minimum for openssl 1.1.x
             pyenv global 3.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{34,35,36,37},flake8
+envlist = py{34,35,36,37,38},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
it seems that pyenv now depends on openssl 1.1, so use python versions
that work with openssl 1.1 for testing (same versions as currently
in master branch).
