### PR TITLE
travis: macOS: test on py35 and py37, linux: test on py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py37
-        - python: "3.6-dev"
+        - python: 3.8
           os: linux
-          dist: trusty
-          env: TOXENV=py36
+          dist: xenial
+          env: TOXENV=py38
         - python: "3.7-dev"
           os: linux
           dist: xenial
@@ -41,7 +41,7 @@ matrix:
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py36
+          env: TOXENV=py37
 
 before_install:
 - |

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -32,9 +32,9 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv install 3.5.3  # minimum for openssl 1.1.x
             pyenv global 3.5.3
             ;;
-        py36)
-            pyenv install 3.6.7  # minimum for homebrew to select openssl 1.1.x
-            pyenv global 3.6.7
+        py37)
+            pyenv install 3.7.0
+            pyenv global 3.7.0
             ;;
     esac
     pyenv rehash


### PR DESCRIPTION
macOS: to cover some rather old and some rather new python
(not 3.8 though, but 3.8.0 is tested on linux).

linux: to test on 3.7 releases also. stop testing 3.6-dev.
