### PR TITLE
Elaborate on "Calculating size"

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -778,7 +778,7 @@ class Archiver:
         filter = self.build_filter(matcher, peek_and_store_hardlink_masters, strip_components)
         if progress:
             pi = ProgressIndicatorPercent(msg='%5.1f%% Extracting: %s', step=0.1, msgid='extract')
-            pi.output('Calculating total archive size for the progress indicator (might take long if it\'s a large one)')
+            pi.output('Calculating total archive size for the progress indicator (might take long for large archives)')
             extracted_size = sum(item.get_size(hardlink_masters) for item in archive.iter_items(filter))
             pi.total = extracted_size
         else:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -778,7 +778,7 @@ class Archiver:
         filter = self.build_filter(matcher, peek_and_store_hardlink_masters, strip_components)
         if progress:
             pi = ProgressIndicatorPercent(msg='%5.1f%% Extracting: %s', step=0.1, msgid='extract')
-            pi.output('Calculating size')
+            pi.output('Calculating total archive size for the progress indicator (might take long if it\'s a large one)')
             extracted_size = sum(item.get_size(hardlink_masters) for item in archive.iter_items(filter))
             pi.total = extracted_size
         else:


### PR DESCRIPTION
It actually took me several days to figure out that `--progress` was the culprit to Borg constantly being SIGKILL'd by the kernel, because Borg ate all of the memory, and because I enabled progress option. This elaborates on what's the calculation for.

This is not intended to be a "garbage" PR, but if you think this is useless you can close this.