### PR TITLE
Add paragraph regarding cache security assumptions

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -352,6 +352,17 @@ to change them.
 Security
 ########
 
+Do I need to take security precautions regarding the cache?
+-----------------------------------------------------------
+
+The cache contains a lot of metadata information about the files in
+your repositories and it is not encrypted.
+
+However, the assumption is that the cache is being stored on the very
+same system which also contains the original files which are being
+backed up. So someone with access to the cache files would also have
+access the the original files anyway.
+
 How can I specify the encryption passphrase programmatically?
 -------------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -352,6 +352,8 @@ to change them.
 Security
 ########
 
+.. _cache_security:
+
 Do I need to take security precautions regarding the cache?
 -----------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -363,6 +363,9 @@ same system which also contains the original files which are being
 backed up. So someone with access to the cache files would also have
 access the the original files anyway.
 
+If you ever need to move the cache to a different location, this can
+be achieved by using the appropriate :ref:`env_vars`.
+
 How can I specify the encryption passphrase programmatically?
 -------------------------------------------------------------
 

--- a/docs/usage_general.rst.inc
+++ b/docs/usage_general.rst.inc
@@ -257,7 +257,8 @@ Directories and files:
         Default to '~/.config/borg'. This directory contains the whole config directories.
     BORG_CACHE_DIR
         Default to '~/.cache/borg'. This directory contains the local cache and might need a lot
-        of space for dealing with big repositories.
+        of space for dealing with big repositories. Make sure you're aware of the associated
+        security aspects of the cache location: :ref:`cache_security`
     BORG_SECURITY_DIR
         Default to '~/.config/borg/security'. This directory contains information borg uses to
         track its usage of NONCES ("numbers used once" - usually in encryption context) and other


### PR DESCRIPTION
I think it might be a good idea to add this information to the FAQs. While it has been answered on the mailing list, it was missing from the docs, as far as I can tell: If this assumption of "cache is at the same place as original files" is being made, it should be noted somewhere.

Could be extended further depending on #4899.