### PR TITLE
chunker permutation

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -624,8 +624,9 @@ can be used to tune the chunker parameters, the default is:
 - HASH_MASK_BITS = 21 (statistical medium chunk size ~= 2^21 B = 2 MiB)
 - HASH_WINDOW_SIZE = 4095 [B] (`0xFFF`)
 
-The buzhash table is altered by XORing it with a seed randomly generated once
-for the repository, and stored encrypted in the keyfile. This is to prevent
+The buzhash table is altered by XORing it with a seed and shuffling its
+elements. The XOR seed and shuffle pattern are randomly generated once for
+the repository, and stored encrypted in the keyfile. This is to prevent
 chunk size based fingerprinting attacks on your encrypted repo contents (to
 guess what files you have based on a specific set of chunk sizes).
 
@@ -900,6 +901,9 @@ id_key
 
 chunk_seed
   the seed for the buzhash chunking table (signed 32 bit integer)
+
+chunk_permutation
+  the permutation for shuffling the buzhash table (256 bytes)
 
 These fields are packed using msgpack_. The utf-8 encoded passphrase
 is processed with PBKDF2_ (SHA256_, 100000 iterations, random 256 bit salt)

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -404,8 +404,8 @@ buzhash chunker
 +++++++++++++++
 
 The buzhash chunker chunks according to the input data, the chunker's
-parameters and the secret chunker seed (which all influence the chunk boundary
-positions).
+parameters and the secret chunker seed and permutation (which all influence the
+chunk boundary positions).
 
 Small files below some specific threshold (default: 512 KiB) result in only one
 chunk (identical content / size as the original file), bigger files result in

--- a/src/borg/_chunker.c
+++ b/src/borg/_chunker.c
@@ -68,13 +68,13 @@ static uint32_t table_base[] =
 size_t pagemask;
 
 static uint32_t *
-buzhash_init_table(uint32_t seed)
+buzhash_init_table(uint32_t seed, unsigned char *permutation)
 {
     int i;
     uint32_t *table = malloc(1024);
     for(i = 0; i < 256; i++)
     {
-        table[i] = table_base[i] ^ seed;
+        table[i] = table_base[permutation[i]] ^ seed;
     }
     return table;
 }
@@ -112,13 +112,14 @@ typedef struct {
 } Chunker;
 
 static Chunker *
-chunker_init(size_t window_size, uint32_t chunk_mask, size_t min_size, size_t max_size, uint32_t seed)
+chunker_init(size_t window_size, uint32_t chunk_mask, size_t min_size, size_t max_size, uint32_t seed,
+             unsigned char *permutation)
 {
     Chunker *c = calloc(sizeof(Chunker), 1);
     c->window_size = window_size;
     c->chunk_mask = chunk_mask;
     c->min_size = min_size;
-    c->table = buzhash_init_table(seed);
+    c->table = buzhash_init_table(seed, permutation);
     c->buf_size = max_size;
     c->data = malloc(c->buf_size);
     c->fh = -1;

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -319,7 +319,7 @@ class ChunkBuffer:
         self.packer = msgpack.Packer()
         self.chunks = []
         self.key = key
-        self.chunker = get_chunker(*chunker_params, seed=self.key.chunk_seed)
+        self.chunker = get_chunker(*chunker_params, seed=self.key.chunk_seed, permutation=self.key.chunk_permutation)
 
     def add(self, item):
         self.buffer.write(self.packer.pack(item.as_dict()))
@@ -1162,7 +1162,7 @@ class FilesystemObjectProcessors:
         self.hard_links = {}
         self.stats = Statistics()  # threading: done by cache (including progress)
         self.cwd = os.getcwd()
-        self.chunker = get_chunker(*chunker_params, seed=key.chunk_seed)
+        self.chunker = get_chunker(*chunker_params, seed=key.chunk_seed, permutation=key.chunk_permutation)
 
     @contextmanager
     def create_helper(self, path, st, status=None, hardlinkable=True):
@@ -2061,7 +2061,8 @@ class ArchiveRecreater:
             cache=self.cache, key=self.key,
             add_item=target.add_item, write_checkpoint=target.write_checkpoint,
             checkpoint_interval=self.checkpoint_interval, rechunkify=target.recreate_rechunkify).process_file_chunks
-        target.chunker = get_chunker(*target.chunker_params, seed=self.key.chunk_seed)
+        target.chunker = get_chunker(*target.chunker_params, seed=self.key.chunk_seed,
+                                     permutation=self.key.chunk_permutation)
         return target
 
     def create_target_archive(self, name):

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -312,7 +312,8 @@ class Key(PropDict):
     If a Key shall be serialized, give as_dict() method output to msgpack packer.
     """
 
-    VALID_KEYS = {'version', 'repository_id', 'enc_key', 'enc_hmac_key', 'id_key', 'chunk_seed', 'tam_required'}  # str-typed keys
+    VALID_KEYS = {'version', 'repository_id', 'enc_key', 'enc_hmac_key', 'id_key', 'chunk_seed',
+                  'chunk_permutation', 'tam_required'}  # str-typed keys
 
     __slots__ = ("_dict", )  # avoid setting attributes not supported by properties
 
@@ -322,6 +323,7 @@ class Key(PropDict):
     enc_hmac_key = PropDict._make_property('enc_hmac_key', bytes)
     id_key = PropDict._make_property('id_key', bytes)
     chunk_seed = PropDict._make_property('chunk_seed', int)
+    chunk_permutation = PropDict._make_property('chunk_permutation', bytes)
     tam_required = PropDict._make_property('tam_required', bool)
 
 

--- a/src/borg/testsuite/chunker.py
+++ b/src/borg/testsuite/chunker.py
@@ -1,11 +1,23 @@
 from io import BytesIO
 
-from ..chunker import ChunkerFixed, Chunker, get_chunker, buzhash, buzhash_update
+from ..chunker import ChunkerFixed, Chunker, get_chunker, buzhash, buzhash_perm, buzhash_update, buzhash_update_perm
 from ..constants import *  # NOQA
 from . import BaseTestCase
 
 # Note: these tests are part of the self test, do not use or import py.test functionality here.
 #       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
+
+null_permutation = bytes(range(256))
+
+
+def permutation_invert_case():
+    perm = list(range(256))
+    for up in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+        low = up.lower()
+        perm[ord(low)] = ord(up)
+        perm[ord(up)] = ord(low)
+    return bytes(perm)
 
 
 class ChunkerFixedTestCase(BaseTestCase):
@@ -26,20 +38,21 @@ class ChunkerFixedTestCase(BaseTestCase):
 class ChunkerTestCase(BaseTestCase):
 
     def test_chunkify(self):
+        np = null_permutation
         data = b'0' * int(1.5 * (1 << CHUNK_MAX_EXP)) + b'Y'
-        parts = [bytes(c) for c in Chunker(0, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(data))]
+        parts = [bytes(c) for c in Chunker(0, np, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(data))]
         self.assert_equal(len(parts), 2)
         self.assert_equal(b''.join(parts), data)
-        self.assert_equal([bytes(c) for c in Chunker(0, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b''))], [])
-        self.assert_equal([bytes(c) for c in Chunker(0, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'fooba', b'rboobaz', b'fooba', b'rboobaz', b'fooba', b'rboobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(1, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'fo', b'obarb', b'oob', b'azf', b'oobarb', b'oob', b'azf', b'oobarb', b'oobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(2, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foob', b'ar', b'boobazfoob', b'ar', b'boobazfoob', b'ar', b'boobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(0, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz' * 3])
-        self.assert_equal([bytes(c) for c in Chunker(1, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobar', b'boobazfo', b'obar', b'boobazfo', b'obar', b'boobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(2, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foob', b'arboobaz', b'foob', b'arboobaz', b'foob', b'arboobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(0, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz' * 3])
-        self.assert_equal([bytes(c) for c in Chunker(1, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarbo', b'obazfoobar', b'boobazfo', b'obarboobaz'])
-        self.assert_equal([bytes(c) for c in Chunker(2, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz', b'foobarboobaz', b'foobarboobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(0, np, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b''))], [])
+        self.assert_equal([bytes(c) for c in Chunker(0, np, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'fooba', b'rboobaz', b'fooba', b'rboobaz', b'fooba', b'rboobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(1, np, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'fo', b'obarb', b'oob', b'azf', b'oobarb', b'oob', b'azf', b'oobarb', b'oobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(2, np, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foob', b'ar', b'boobazfoob', b'ar', b'boobazfoob', b'ar', b'boobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(0, np, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz' * 3])
+        self.assert_equal([bytes(c) for c in Chunker(1, np, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobar', b'boobazfo', b'obar', b'boobazfo', b'obar', b'boobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(2, np, 2, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foob', b'arboobaz', b'foob', b'arboobaz', b'foob', b'arboobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(0, np, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz' * 3])
+        self.assert_equal([bytes(c) for c in Chunker(1, np, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarbo', b'obazfoobar', b'boobazfo', b'obarboobaz'])
+        self.assert_equal([bytes(c) for c in Chunker(2, np, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz', b'foobarboobaz', b'foobarboobaz'])
 
     def test_buzhash(self):
         self.assert_equal(buzhash(b'abcdefghijklmnop', 0), 3795437769)
@@ -47,6 +60,21 @@ class ChunkerTestCase(BaseTestCase):
         self.assert_equal(buzhash(b'abcdefghijklmnop', 1), buzhash_update(buzhash(b'Xabcdefghijklmno', 1), ord('X'), ord('p'), 16, 1))
         # Test with more than 31 bytes to make sure our barrel_shift macro works correctly
         self.assert_equal(buzhash(b'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz', 0), 566521248)
+
+    def test_permutation(self):
+        p = permutation_invert_case()
+
+        # a non-null permutation should spoil these test cases copied from the methods above
+        self.assert_not_equal([bytes(c) for c in Chunker(2, p, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'foobarboobaz' * 3))], [b'foobarboobaz', b'foobarboobaz', b'foobarboobaz'])
+        self.assert_not_equal(buzhash_perm(b'abcdefghijklmnop', 0, p), 3795437769)
+
+        # inverting the case of the input should compensate for the permutation
+        self.assert_equal([bytes(c) for c in Chunker(0, p, 1, CHUNK_MAX_EXP, 2, 2).chunkify(BytesIO(b'FOOBARBOOBAZ' * 3))], [b'FOOBA', b'RBOOBAZ', b'FOOBA', b'RBOOBAZ', b'FOOBA', b'RBOOBAZ'])
+        self.assert_equal([bytes(c) for c in Chunker(2, p, 3, CHUNK_MAX_EXP, 2, 3).chunkify(BytesIO(b'FOOBARBOOBAZ' * 3))], [b'FOOBARBOOBAZ', b'FOOBARBOOBAZ', b'FOOBARBOOBAZ'])
+        self.assert_equal(buzhash_perm(b'ABCDEFGHIJKLMNOP', 0, p), 3795437769)
+        self.assert_equal(buzhash_perm(b'ABCDEFGHIJKLMNOP', 1, p), 3795400502)
+        self.assert_equal(buzhash_perm(b'ABCDEFGHIJKLMNOP', 1, p),
+                          buzhash_update_perm(buzhash_perm(b'xABCDEFGHIJKLMNO', 1, p), ord('x'), ord('P'), 16, 1, p))
 
     def test_small_reads(self):
         class SmallReadFile:

--- a/src/borg/testsuite/chunker_slow.py
+++ b/src/borg/testsuite/chunker_slow.py
@@ -20,20 +20,29 @@ class ChunkerRegressionTestCase(BaseTestCase):
 
         data = twist(100000)
 
-        runs = []
-        for winsize in (65, 129, HASH_WINDOW_SIZE, 7351):
-            for minexp in (4, 6, 7, 11, 12):
-                for maxexp in (15, 17):
-                    if minexp >= maxexp:
-                        continue
-                    for maskbits in (4, 7, 10, 12):
-                        for seed in (1849058162, 1234567653):
-                            fh = BytesIO(data)
-                            chunker = Chunker(seed, minexp, maxexp, maskbits, winsize)
-                            chunks = [blake2b_256(b'', c) for c in chunker.chunkify(fh, -1)]
-                            runs.append(blake2b_256(b'', b''.join(chunks)))
+        null_permutation = bytes(range(256))
+        reverse_permutation = bytes(reversed(range(256)))
 
-        # The "correct" hash below matches the existing chunker behavior.
-        # Future chunker optimisations must not change this, or existing repos will bloat.
-        overall_hash = blake2b_256(b'', b''.join(runs))
-        self.assert_equal(overall_hash, unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3"))
+        # The hashes below match the existing chunker behavior. Future chunker optimisations
+        # must not change this, or existing repos will bloat.
+        tests = ( (null_permutation,
+                   unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3")),
+                  (reverse_permutation,
+                   unhexlify("6e56c9a94c29b4564c158131914ab21b34e6897002b38e71b0843be68158c00f")))
+
+        for permutation, expected_result in tests:
+            runs = []
+            for winsize in (65, 129, HASH_WINDOW_SIZE, 7351):
+                for minexp in (4, 6, 7, 11, 12):
+                    for maxexp in (15, 17):
+                        if minexp >= maxexp:
+                            continue
+                        for maskbits in (4, 7, 10, 12):
+                            for seed in (1849058162, 1234567653):
+                                fh = BytesIO(data)
+                                chunker = Chunker(seed, permutation, minexp, maxexp, maskbits, winsize)
+                                chunks = [blake2b_256(b'', c) for c in chunker.chunkify(fh, -1)]
+                                runs.append(blake2b_256(b'', b''.join(chunks)))
+
+            overall_hash = blake2b_256(b'', b''.join(runs))
+            self.assert_equal(overall_hash, expected_result)


### PR DESCRIPTION
Make the buzhash chunker more resistant to fingerprinting by introducing a permutation of the buzhash table, as discussed at https://github.com/borgbackup/borg/issues/3687