### PR TITLE
borg check: Handle io errors

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -5,7 +5,7 @@ import shutil
 import stat
 import struct
 import time
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 from collections import defaultdict
 from configparser import ConfigParser
 from datetime import datetime

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1526,7 +1526,15 @@ class LoggedIO:
                 size, segment, offset))
         length = size - fmt.size
         if read_data:
-            data = fd.read(length)
+            try:
+                data = fd.read(length)
+            except OSError as err:
+                if err.errno == errno.EIO:
+                    raise IntegrityError(
+                        'I/O error while reading segment file [segment {}, offset {}] : {}'
+                        .format(segment, offset, fd.name)
+                    )
+                raise err
             if len(data) != length:
                 raise IntegrityError('Segment entry data short read [segment {}, offset {}]: expected {}, got {} bytes'.format(
                     segment, offset, length, len(data)))


### PR DESCRIPTION
ciao, here's a patch that handles IOErrors when checking a repository. in my case the error is happening when checking a borg repo on a non-raid btrfs volume where's a checksum error upon reading a segment file. the patch also incorporates what my manual interventions would be: find the filepath from the inode that os reported in the kernel log, delete it, and restart the borg check.

i think there was a specific issue addressing this a few months back, but i can't find it. here's a comment where someone encountered the same exception: https://github.com/borgbackup/borg/issues/3509#issuecomment-411107848

i propose to port the patch to the 1.1 maintenance branch to make my life easier.