### PR TITLE
Fix #4934 : The path given by borg extract --strip-components --list is not confusing anymore

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -797,7 +797,7 @@ class Archiver:
                     except BackupOSError as e:
                         self.print_warning('%s: %s', remove_surrogates(dir_item.path), e)
             if output_list:
-                logging.getLogger('borg.output.list').info(remove_surrogates(orig_path))
+                logging.getLogger('borg.output.list').info(remove_surrogates(item.path))
             try:
                 if dry_run:
                     archive.extract_item(item, dry_run=True, pi=pi)


### PR DESCRIPTION
It was due to a wrong path given in the log output of --list.