### PR TITLE
Allow osx builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
         - $HOME/.cache/pip
 
 matrix:
+    fast_finish: true
     include:
         - python: 3.5
           os: linux
@@ -34,6 +35,15 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=flake8
+        - language: generic
+          os: osx
+          osx_image: xcode8.3
+          env: TOXENV=py35
+        - language: generic
+          os: osx
+          osx_image: xcode8.3
+          env: TOXENV=py37
+    allow_failures:
         - language: generic
           os: osx
           osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,6 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=flake8
-        - language: generic
-          os: osx
-          osx_image: xcode8.3
-          env: TOXENV=py35
-        - language: generic
-          os: osx
-          osx_image: xcode8.3
-          env: TOXENV=py37
     allow_failures:
         - language: generic
           os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=flake8
-    allow_failures:
         - language: generic
           os: osx
           osx_image: xcode8.3
@@ -44,6 +43,8 @@ matrix:
           os: osx
           osx_image: xcode8.3
           env: TOXENV=py37
+    allow_failures:
+        - os: osx
 
 before_install:
 - |


### PR DESCRIPTION
At this time, OSX builds don't seem to work well on Travis CI. This results in failed tests for each pull request or merge commit. Wouldn't it make sense to use `fast_finish` and `allow_failures` then to specifically allow those builds to fail if they're currently being ignored anyway? See https://docs.travis-ci.com/user/customizing-the-build/#jobs-that-are-allowed-to-fail for documentation. Then, if a justified failed test happens, it would show up faster and also wouldn't be disguised by the in any case failing OSX builds.