### PR TITLE
fix crash when upgrading erroneous hints file, fixes #4922

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -883,10 +883,19 @@ class Repository:
 
     def _rebuild_sparse(self, segment):
         """Rebuild sparse bytes count for a single segment relative to the current index."""
-        self.compact[segment] = 0
-        if self.segments[segment] == 0:
-            self.compact[segment] += self.io.segment_size(segment)
+        try:
+            segment_size = self.io.segment_size(segment)
+        except FileNotFoundError:
+            # segment does not exist any more, remove it from the mappings
+            # note: no need to self.compact.pop(segment), as we start from empty mapping.
+            self.segments.pop(segment)
             return
+
+        if self.segments[segment] == 0:
+            self.compact[segment] = segment_size
+            return
+
+        self.compact[segment] = 0
         for tag, key, offset, size in self.io.iter_objects(segment, read_data=False):
             if tag == TAG_PUT:
                 if self.index.get(key, (-1, -1)) != (segment, offset):


### PR DESCRIPTION
if an old hints file gets converted to the new format and it
has entries referring to non-existent segment files, a crash
occurred.

with this code, the crash is avoided and the erroneous hints
entry is removed.