### PR TITLE
Move sync_file_range to its own extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ item_source = 'src/borg/item.pyx'
 checksums_source = 'src/borg/algorithms/checksums.pyx'
 platform_posix_source = 'src/borg/platform/posix.pyx'
 platform_linux_source = 'src/borg/platform/linux.pyx'
+platform_syncfilerange_source = 'src/borg/platform/syncfilerange.pyx'
 platform_darwin_source = 'src/borg/platform/darwin.pyx'
 platform_freebsd_source = 'src/borg/platform/freebsd.pyx'
 platform_windows_source = 'src/borg/platform/windows.pyx'
@@ -112,6 +113,7 @@ cython_sources = [
 
     platform_posix_source,
     platform_linux_source,
+    platform_syncfilerange_source,
     platform_freebsd_source,
     platform_darwin_source,
     platform_windows_source,
@@ -202,6 +204,7 @@ if not on_rtd:
 
     posix_ext = Extension('borg.platform.posix', [platform_posix_source])
     linux_ext = Extension('borg.platform.linux', [platform_linux_source], libraries=['acl'])
+    syncfilerange_ext = Extension('borg.platform.syncfilerange', [platform_syncfilerange_source])
     freebsd_ext = Extension('borg.platform.freebsd', [platform_freebsd_source])
     darwin_ext = Extension('borg.platform.darwin', [platform_darwin_source])
     windows_ext = Extension('borg.platform.windows', [platform_windows_source])
@@ -212,6 +215,7 @@ if not on_rtd:
         ext_modules.append(windows_ext)
     if sys.platform == 'linux':
         ext_modules.append(linux_ext)
+        ext_modules.append(syncfilerange_ext)
     elif sys.platform.startswith('freebsd'):
         ext_modules.append(freebsd_ext)
     elif sys.platform == 'darwin':

--- a/src/borg/platform/syncfilerange.pyx
+++ b/src/borg/platform/syncfilerange.pyx
@@ -1,0 +1,13 @@
+from libc.stdint cimport int64_t
+
+
+# Some Linux systems (like Termux on Android 7 or earlier) do not have access
+# to sync_file_range. By isolating the access to sync_file_range in this
+# separate extension, it can be imported dynamically from linux.pyx only when
+# available and systems without support can otherwise use the rest of
+# linux.pyx.
+cdef extern from "fcntl.h":
+    int sync_file_range(int fd, int64_t offset, int64_t nbytes, unsigned int flags)
+    unsigned int SYNC_FILE_RANGE_WRITE
+    unsigned int SYNC_FILE_RANGE_WAIT_BEFORE
+    unsigned int SYNC_FILE_RANGE_WAIT_AFTER


### PR DESCRIPTION
Here is one way of addressing #4905. I moved the `cdef extern` import of `sync_file_range` into its own extension and imported it in a try block. If the import fails, borg falls back to using the BaseSyncFile class like it does with BORG_WORKAROUNDS=basesyncfile. This way BORG_WORKAROUNDS is not required when there is no sync_file_range support. An alternative would be to still require BORG_WORKAROUNDS.
