### PR TITLE
fix bug in hashindex_set on resize, fixes #4829

### DIFF
--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -586,6 +586,16 @@ hashindex_set(HashIndex *index, const unsigned char *key, const unsigned char *v
                 if(!hashindex_resize(index, index->num_buckets)) {
                     return 0;
                 }
+                /* we have just built a fresh hashtable and removed all tombstones,
+                 * so we only have EMPTY or USED buckets, but no DELETED ones any more.
+                 */
+                idx = start_idx = hashindex_index(index, key);
+                while(!BUCKET_IS_EMPTY(index, idx)) {
+                    idx++;
+                    if (idx >= index->num_buckets){
+                        idx -= index->num_buckets;
+                    }
+                }
             }
         }
         ptr = BUCKET_ADDR(index, idx);


### PR DESCRIPTION
the problem was that after a resize that was triggered by too few
empty buckets, the rebuilt new hash table had entries at different
positions than before, but the idx where to SET the entry was not
recomputed afterwards.