### PR TITLE
support platforms with no os.link (port to master)

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -79,6 +79,10 @@ def are_symlinks_supported():
 
 @functools.lru_cache()
 def are_hardlinks_supported():
+    if not hasattr(os, 'link'):
+        # some pythons do not have os.link
+        return False
+
     with unopened_tempfile() as file1path, unopened_tempfile() as file2path:
         open(file1path, 'w').close()
         try:

--- a/src/borg/testsuite/upgrader.py
+++ b/src/borg/testsuite/upgrader.py
@@ -141,6 +141,7 @@ def test_keys(attic_repo, attic_key_file):
     assert key_valid(keyfile_path)
 
 
+@pytest.mark.skipif(not are_hardlinks_supported(), reason='hardlinks not supported')
 def test_convert_all(attic_repo, attic_key_file, inplace):
     """test all conversion steps
 
@@ -166,7 +167,7 @@ def test_convert_all(attic_repo, attic_key_file, inplace):
     with AtticRepositoryUpgrader(repo_path, create=False) as repository:
         # replicate command dispatch, partly
         os.umask(UMASK_DEFAULT)
-        backup = repository.upgrade(dryrun=False, inplace=inplace)
+        backup = repository.upgrade(dryrun=False, inplace=inplace)  # note: uses hardlinks internally
         if inplace:
             assert backup is None
             assert first_inode(repository.path) == orig_inode


### PR DESCRIPTION
This is a port of #4903 addressing #4901 for the master branch. This cherry-picked cleanly from 1.1-maint except for a minor conflict with importing has_link into archiver.py.