### PR TITLE
Ignore syncfilerange.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/borg/algorithms/checksums.c
 src/borg/platform/darwin.c
 src/borg/platform/freebsd.c
 src/borg/platform/linux.c
+src/borg/platform/syncfilerange.c
 src/borg/platform/posix.c
 src/borg/platform/windows.c
 src/borg/_version.py


### PR DESCRIPTION
Add syncfilerange.c to .gitignore like all the other intermediate Cython outputs. This was missed in #4965. It could be backported to 1.1-maint like #4970 backported #4965.