### PR TITLE
Adding comments and explanations to Travis config and install script, improving OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,19 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - python: 3.5
+        - python: "3.5"
           os: linux
           dist: trusty
           env: TOXENV=py35
-        - python: 3.6
+        - python: "3.6"
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - python: 3.7
+        - python: "3.7"
           os: linux
           dist: xenial
           env: TOXENV=py37
-        - python: 3.8
+        - python: "3.8"
           os: linux
           dist: xenial
           env: TOXENV=py38
@@ -31,22 +31,22 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py38
-        - python: 3.5
+        - python: "3.5"
           os: linux
           dist: xenial
           env: TOXENV=flake8
         - language: generic
           os: osx
-          osx_image: xcode8.3
+          osx_image: xcode8.3  # This is the latest working xcode image with osxfuse compatibility; later images come with an OS X version which doesn't allow kernel extensions
           env: TOXENV=py35
         - language: generic
           os: osx
-          osx_image: xcode8.3
-          env: TOXENV=py37
+          osx_image: xcode11.3
+          env: TOXENV=py37 SKIPFUSE=true
     allow_failures:
-        - os: osx
+        - os: osx  # OS X builds often take too long and time out, even though tests don't actually fail
 
-before_install:
+before_install: # Abort installation and don't run tests for pull requests if commit only changed the docs
 - |
     test $TRAVIS_EVENT_TYPE != "pull_request" || {
         echo Checking whether $TRAVIS_COMMIT_RANGE changed only docs
@@ -56,15 +56,11 @@ before_install:
         }
     }
 
-install:
-    - git fetch --unshallow --tags
-    - ./.travis/install.sh
+install: ./.travis/install.sh
 
-script:
-    - ./.travis/run.sh
+script: ./.travis/run.sh
 
-after_success:
-    - ./.travis/upload_coverage.sh
+after_success: ./.travis/upload_coverage.sh
 
 notifications:
     irc:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,54 +3,73 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-    export HOMEBREW_NO_AUTO_UPDATE=1
-    export HOMEBREW_LOGS=~/brew-logs
-    export HOMEBREW_TEMP=~/brew-temp
-    mkdir $HOMEBREW_LOGS
-    mkdir $HOMEBREW_TEMP
-    brew update > /dev/null
-    brew cleanup > /dev/null  # do this here, so it won't automatically trigger in the middle of other stuff
-    brew outdated pkg-config || brew upgrade pkg-config
-    # do NOT update openssl 1.0.x, brew will also update a lot of dependent pkgs (and their dependencies) then!
-    #brew outdated openssl || brew upgrade openssl
-    export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
-    brew install readline
-    export PKG_CONFIG_PATH="/usr/local/opt/readline/lib/pkgconfig:$PKG_CONFIG_PATH"
-    brew install zstd
-    brew install lz4
-    brew install xz  # required for python lzma module
-    brew install Caskroom/cask/osxfuse
+# Travis clones with depth=50 which might be too shallow for git describe, see https://github.com/pypa/setuptools_scm/issues/93
+git fetch --unshallow --tags
 
-    brew outdated pyenv || brew upgrade pyenv
-    if which pyenv > /dev/null; then
-        eval "$(pyenv init -)"
+if [ "${TRAVIS_OS_NAME}" = "osx" ]
+then
+
+    # Update brew itself
+    export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
+    brew update
+    brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
+
+    # Install and/or upgrade dependencies
+    #brew install zstd || brew upgrade zstd  # Installation takes very long due to CMake dependency and isn't necessary for the tests as borg comes bundled with zstd anyway
+    brew install lz4 || brew upgrade lz4
+    brew install xz || brew upgrade xz  # Required for Python lzma module
+    brew install Caskroom/cask/osxfuse || brew upgrade Caskroom/cask/osxfuse  # Required for Python llfuse module
+    brew install pyenv || brew upgrade pyenv
+
+    # Configure pkg-config to use OpenSSL 1.1 from Homebrew
+    export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:${PKG_CONFIG_PATH}"
+
+    # Configure pyenv with Python version according to TOXENV
+    eval "$(pyenv init -)"
+    if [ "${TOXENV}" = "py35" ]
+    then
+        pyenv install 3.5.3  # Minimum version for OpenSSL 1.1.x
+        pyenv global 3.5.3
+    elif [ "${TOXENV}" = "py37" ]
+    then
+        pyenv install 3.7.0
+        pyenv global 3.7.0
+    else
+        printf '%s\n' "Unexpected value for TOXENV environment variable"
+        exit 1
     fi
-
-    case "${TOXENV}" in
-        py35)
-            pyenv install 3.5.3  # minimum for openssl 1.1.x
-            pyenv global 3.5.3
-            ;;
-        py37)
-            pyenv install 3.7.0
-            pyenv global 3.7.0
-            ;;
-    esac
     pyenv rehash
-    python -m pip install --user virtualenv
-else
-    pip install virtualenv
+
+elif [ "${TRAVIS_OS_NAME}" = "linux" ]
+then
+
+    # Install dependencies
     sudo apt-get update
     sudo apt-get install -y pkg-config fakeroot
-    #sudo apt-get install -y liblz4-dev  # too old on trusty and xenial
-    #sudo apt-get install -y libzstd-dev  # too old on trusty and xenial
+    #sudo apt-get install -y liblz4-dev  # Too old on trusty and xenial, but might be useful in future versions
+    #sudo apt-get install -y libzstd-dev  # Too old on trusty and xenial, but might be useful in future versions
     sudo apt-get install -y libacl1-dev
-    sudo apt-get install -y libfuse-dev fuse  # optional, for FUSE support
+    sudo apt-get install -y libfuse-dev fuse  # Required for Python llfuse module
+
+else
+
+    printf '%s\n' "Unexpected value for TRAVIS_OS_NAME environment variable"
+    exit 1
+
 fi
 
+# Setup and activate virtual environment
+python -m pip install virtualenv
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
+
+# Recent versions of OS X don't allow kernel extensions which makes the osxfuse tests fail; those versions are marked with SKIPFUSE=true in .travis.yml
+if [ "${SKIPFUSE}" = "true" ]
+then
+    truncate -s 0 requirements.d/fuse.txt
+fi
+
+# Install requirements
 pip install -r requirements.d/development.txt
 pip install codecov
 python setup.py --version


### PR DESCRIPTION
As suggested on IRC, simply going ahead and posting this as a pull request to make it easier to discuss possible improvements.

Intrigued by the exceeding timeouts of OS X builds and wanting to learn a little bit more about the build process, I've been playing around with the CI setup and made a few changes to `.travis.yml` and `.travis/install.sh`. Mostly tidying up, writing comments on what I learned, keeping it POSIX-compliant and verified with [ShellCheck](https://www.shellcheck.net/).

Turns out, OS X builds now consistently pass (within about half an hour), meeting the Travis CI maximum build time and not timing out. :tada:  (I hope I didn't break something without noticing.)

Possibly, the reasons for the previous timeouts have been some time-consuming remnants from using xcode6.4 which didn't get removed when switching to xcode8.3 with https://github.com/borgbackup/borg/commit/c7503f651853ba1eac577338a0999fdee390b9dd. I'm not sure though. 🤷

However, using images later than xcode8.3 results in tests regarding FUSE simplify freezing (`testsuite/archiver.py::ArchiverTestCase::test_fuse`, for example) and the checks fail with 10 minutes of no output received. This happens due to `osxfuse` being a kernel extension and therefore requiring explicit activation due to SIP (System Integrity Protection) in recent versions of OS X - affected versions being used for image > xcode8.3. Travis CI seems to be aware of this issue, but no changes have been made, yet. Here is one of the most recent posts: https://travis-ci.community/t/allow-disabling-sip-on-macos-10-13/3253 (But you'll find many more.)

This means, at the moment, if you want to run the full test suite on OS X, you need to use xcode8.3. Excluding FUSE tests by disabling the installation of FUSE requirements with pip (namely `llfuse`) via `SKIPFUSE=true` is a way around this and shows that everything else works just fine.