### PR TITLE
remove redundant cythonize call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,6 @@ if not on_rtd:
             # compile .pyx extensions to .c in parallel, does not work on windows
             cython_opts['nthreads'] = cpu_threads + 1
 
-        cythonize([posix_ext, linux_ext, freebsd_ext, darwin_ext, windows_ext], **cython_opts)
         ext_modules = cythonize(ext_modules, **cython_opts)
 
 


### PR DESCRIPTION
the call in the following line did basically the same thing, just better as it was built according to the platform.

also, it includes syncfilerange_ext, which was missing from the removed line.