### PR TITLE
Suppress Sphinx lexer warnings in frontends.rst

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -1,5 +1,5 @@
 .. include:: ../global.rst.inc
-.. highlight:: json
+.. highlight:: none
 
 .. _json_output:
 
@@ -121,6 +121,7 @@ log_message
 See Prompts_ for the types used by prompts.
 
 .. rubric:: Examples (reformatted, each object would be on exactly one line)
+.. highlight:: json
 
 :ref:`borg_extract` progress::
 
@@ -171,6 +172,7 @@ environment variable that can be used to override the prompt. It is the same for
 messages pertaining to the same prompt.
 
 .. rubric:: Examples (reformatted, each object would be on exactly one line)
+.. highlight:: none
 
 Providing an invalid answer::
 
@@ -265,6 +267,7 @@ stats
     unique_csize
         Compressed and encrypted size of all chunks
 
+.. highlight: json
 Example *borg info* output::
 
     {


### PR DESCRIPTION
Because some of the JSON blocks in frontends.rst included non-JSON contents (user replies, etc.) the blocks didn't parse/highlight and `make html` complained:

    borg/docs/internals/frontends.rst:28: WARNING: Could not lex literal_block as "json".

There's no easy way to enable and disable highlighting just for specific lines, but individually unsetting the highlight language per block suppresses the warnings.
