### PR TITLE
[DOCS] #3428 –  Borg repo restore instructions needed

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -202,9 +202,10 @@ the working repository to the same location:
 A plain delete command would remove the security info in
 ``~/.config/borg/security``, including the nonce value. In BorgBackup
 :ref:`security_encryption` is AES-CTR, where the nonce is a counter. When the
-working repo was used later for creating new archives, Borg would initialize a
-fresh nonce, which would be bad for security reasons. To prevent this, the
-``keep-security-info`` option is applied so that the nonce counter is kept.
+working repo was used later for creating new archives, Borg would re-use nonce
+values due to starting from a lower counter value given by the older copy of the
+repository. To prevent this, the ``keep-security-info`` option is applied so
+that the client-side nonce counter is kept.
 
 Can Borg add redundancy to the backup data to deal with hardware malfunction?
 -----------------------------------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -187,6 +187,38 @@ all the part files and manually concatenate them together.
 
 For more details, see :ref:`checkpoints_parts`.
 
+My repository is corrupt, how can I restore from an older but working repository?
+---------------------------------------------------------------------------------
+
+If the working repo has the same ID as the corrupt one, the recommended method
+is to delete the corrupted repository, and then copy the working repository to
+the same location. The delete command will completely remove the corrupt repo
+and delete the corresponding cache and security subdirectory in
+``~/.config/borg/security``, including the nonce value (if encryption is used).
+When the working repo is used later for creating new archives, Borg would
+initialize a fresh nonce, which would be bad for security reasons (nonce values
+should never be reused). To prevent this, the security subdirectory should be
+saved before deleting, and later moved back into place.
+
+Example:
+
+::
+
+    # Get the repo ID from repo config.
+    REPO_ID=$(borg config /path/to/repo-good id)
+
+    # Rename the repo security dir so Borg won't delete it.
+    cd ~/.config/borg/security
+    mv $REPO_ID $REPO_ID.backup
+
+    # Now delete and rename the security dir back.
+    borg delete /path/to/repo
+    mv $REPO_ID.backup $REPO_ID
+
+    # Finally copy the good repo to the original place.
+    rsync -avH /path/to/repo-good /path/to/repo
+
+
 Can Borg add redundancy to the backup data to deal with hardware malfunction?
 -----------------------------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -187,37 +187,24 @@ all the part files and manually concatenate them together.
 
 For more details, see :ref:`checkpoints_parts`.
 
-My repository is corrupt, how can I restore from an older but working repository?
----------------------------------------------------------------------------------
+My repository is corrupt, how can I restore from an older copy of it?
+---------------------------------------------------------------------
 
-If the working repo has the same ID as the corrupt one, the recommended method
-is to delete the corrupted repository, and then copy the working repository to
-the same location. The delete command will completely remove the corrupt repo
-and delete the corresponding cache and security subdirectory in
-``~/.config/borg/security``, including the nonce value (if encryption is used).
-When the working repo is used later for creating new archives, Borg would
-initialize a fresh nonce, which would be bad for security reasons (nonce values
-should never be reused). To prevent this, the security subdirectory should be
-saved before deleting, and later moved back into place.
-
-Example:
+If your repositories are encrypted and have the same ID, the recommended method
+is to delete the corrupted repository, but keep its security info, and then copy
+the working repository to the same location:
 
 ::
 
-    # Get the repo ID from repo config.
-    REPO_ID=$(borg config /path/to/repo-good id)
+    borg delete --keep-security-info /path/to/repo
+    rsync -aH /path/to/repo-working/ /path/to/repo  # Note the trailing slash.
 
-    # Rename the repo security dir so Borg won't delete it.
-    cd ~/.config/borg/security
-    mv $REPO_ID $REPO_ID.backup
-
-    # Now delete and rename the security dir back.
-    borg delete /path/to/repo
-    mv $REPO_ID.backup $REPO_ID
-
-    # Finally copy the good repo to the original place.
-    rsync -avH /path/to/repo-good /path/to/repo
-
+A plain delete command would remove the security info in
+``~/.config/borg/security``, including the nonce value. In BorgBackup
+:ref:`security_encryption` is AES-CTR, where the nonce is a counter. When the
+working repo was used later for creating new archives, Borg would initialize a
+fresh nonce, which would be bad for security reasons. To prevent this, the
+``keep-security-info`` option is applied so that the nonce counter is kept.
 
 Can Borg add redundancy to the backup data to deal with hardware malfunction?
 -----------------------------------------------------------------------------

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -118,6 +118,8 @@ prompt is a set BORG_PASSPHRASE. See issue :issue:`2169` for details.
        manifest this way, while a changed layout would have broken
        compatibility.
 
+.. _security_encryption:
+
 Encryption
 ----------
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1183,6 +1183,7 @@ class Archiver:
     def _delete_repository(self, args, repository):
         """Delete a repository"""
         dry_run = args.dry_run
+        keep_security_info = args.keep_security_info
 
         if not args.cache_only:
             msg = []
@@ -1207,9 +1208,14 @@ class Archiver:
             if not dry_run:
                 repository.destroy()
                 logger.info("Repository deleted.")
-                SecurityManager.destroy(repository)
+                if not keep_security_info:
+                    SecurityManager.destroy(repository)
             else:
                 logger.info("Would delete repository.")
+                if keep_security_info:
+                    logger.info("Would keep security info.")
+                else:
+                    logger.info("Would delete security info.")
         if not dry_run:
             Cache.destroy(repository)
             logger.info("Cache deleted.")
@@ -3352,9 +3358,10 @@ class Archiver:
         Important: When deleting archives, repository disk space is **not** freed until
         you run ``borg compact``.
 
-        If you delete the complete repository, the local cache for it (if any) is
-        also deleted. Alternatively, you can delete just the local cache with the
-        ``--cache-only`` option.
+        When you delete a complete repository, the security info and local cache for it
+        (if any) is also deleted. Alternatively, you can delete just the local cache
+        with the ``--cache-only`` option, or keep the security info with the
+        ``--keep-security-info`` option.
 
         When using ``--stats``, you will get some statistics about how much data was
         deleted - the "Deleted data" deduplicated size there is most interesting as
@@ -3383,10 +3390,11 @@ class Archiver:
                                help='print statistics for the deleted archive')
         subparser.add_argument('--cache-only', dest='cache_only', action='store_true',
                                help='delete only the local cache for the given repository')
-        subparser.add_argument('--force', dest='forced',
-                               action='count', default=0,
+        subparser.add_argument('--force', dest='forced', action='count', default=0,
                                help='force deletion of corrupted archives, '
                                     'use ``--force --force`` in case ``--force`` does not work.')
+        subparser.add_argument('--keep-security-info', dest='keep_security_info', action='store_true',
+                               help='keep the local security info when deleting a repository')
         subparser.add_argument('--save-space', dest='save_space', action='store_true',
                                help='work slower, but using less space')
         subparser.add_argument('location', metavar='REPOSITORY_OR_ARCHIVE', nargs='?', default='',

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1212,10 +1212,7 @@ class Archiver:
                     SecurityManager.destroy(repository)
             else:
                 logger.info("Would delete repository.")
-                if keep_security_info:
-                    logger.info("Would keep security info.")
-                else:
-                    logger.info("Would delete security info.")
+                logger.info("Would %s security info." % ("keep" if keep_security_info else "delete"))
         if not dry_run:
             Cache.destroy(repository)
             logger.info("Cache deleted.")
@@ -3359,7 +3356,7 @@ class Archiver:
         you run ``borg compact``.
 
         When you delete a complete repository, the security info and local cache for it
-        (if any) is also deleted. Alternatively, you can delete just the local cache
+        (if any) are also deleted. Alternatively, you can delete just the local cache
         with the ``--cache-only`` option, or keep the security info with the
         ``--keep-security-info`` option.
 


### PR DESCRIPTION
Add new FAQ: A repo is corrupt and must be replaced with an older repo.