### PR TITLE
Option to bypass locking to use sensible borg commands with read-only repositories

### DIFF
--- a/docs/usage/general.rst
+++ b/docs/usage/general.rst
@@ -31,6 +31,20 @@ All Borg commands share these options:
 
 .. include:: common-options.rst.inc
 
+Option ``--bypass-lock`` allows you to access the repository while bypassing
+borg's locking mechanism. This is necessary if your repository is on a read-only
+storage where you don't have write permissions or capabilities and therefore
+cannot create a lock. Examples are repositories stored on a Bluray disc or a
+read-only network storage. Avoid this option if you are able to use locks as
+that is the safer way; see the warning below.
+
+.. warning::
+
+    If you do use ``--bypass-lock``, you are responsible to ensure that no other
+    borg instances have write access to the repository. Otherwise, you might
+    experience errors and read broken data if changes to that repository are
+    being made at the same time.
+
 Examples
 ~~~~~~~~
 ::

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -134,9 +134,19 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
         if create:
             compatibility = Manifest.NO_OPERATION_CHECK
 
+    # To process the `--bypass-lock` option if specified, we need to
+    # modify `lock` inside `wrapper`. Therefore we cannot use the
+    # `nonlocal` statement to access `lock` as modifications would also
+    # affect the scope outside of `wrapper`. Subsequent calls would
+    # only see the overwritten value of `lock`, not the original one.
+    # The solution is to define a place holder variable `_lock` to
+    # propagate the value into `wrapper`.
+    _lock = lock
+
     def decorator(method):
         @functools.wraps(method)
         def wrapper(self, args, **kwargs):
+            lock = getattr(args, 'lock', _lock)
             location = args.location  # note: 'location' must be always present in args
             append_only = getattr(args, 'append_only', False)
             storage_quota = getattr(args, 'storage_quota', None)
@@ -2554,6 +2564,9 @@ class Archiver:
                               help='Output one JSON object per log line instead of formatted text.')
             add_common_option('--lock-wait', metavar='SECONDS', dest='lock_wait', type=int, default=1,
                               help='wait at most SECONDS for acquiring a repository/cache lock (default: %(default)d).')
+            add_common_option('--bypass-lock', dest='lock', action='store_false',
+                              default=argparse.SUPPRESS,  # only create args attribute if option is specified
+                              help='Bypass locking mechanism')
             add_common_option('--show-version', dest='show_version', action='store_true',
                               help='show/log the borg version')
             add_common_option('--show-rc', dest='show_rc', action='store_true',
@@ -4328,6 +4341,12 @@ class Archiver:
         if func == self.do_create and not args.paths:
             # need at least 1 path but args.paths may also be populated from patterns
             parser.error('Need at least one PATH argument.')
+        if not getattr(args, 'lock', True):  # Option --bypass-lock sets args.lock = False
+            bypass_allowed = {self.do_check, self.do_config, self.do_diff,
+                              self.do_export_tar, self.do_extract, self.do_info,
+                              self.do_list, self.do_mount, self.do_umount}
+            if func not in bypass_allowed:
+                raise Error('Not allowed to bypass locking mechanism for chosen command')
         return args
 
     def prerun_checks(self, logger, is_serve):


### PR DESCRIPTION
Linked to #1035. It makes sense wanting to mount read-only repos - and alternative solutions like copying to temp first or an overlay mount are unnecessarily tedious or complex.

Suggested explanation in the docs for `--bypass-lock`:

> Option ``--bypass-lock`` allows you to access the repository while bypassing borg's locking mechanism. This is necessary if your repository is on a read-only storage where you don't have write permissions or capabilities and therefore cannot acquire a lock. Examples are repositories stored on a Bluray disc or a read-only network storage. Avoid this option if you are able to use locks as it's the safer way; see the warning below.
> 
> **Note:** If you do use ``--bypass-lock``, you are responsible to ensure that no other borg instances have write access to the repository. Otherwise, you might experience errors and read broken data if changes to that repository are being made at the same time.