### PR TITLE
correctly calculate compression ratio, taking header size into accoun…

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -311,7 +311,8 @@ class Auto(CompressorBase):
         *lz4_data* is the LZ4 result if *compressor* is LZ4 as well, otherwise it is None.
         """
         lz4_data = LZ4_COMPRESSOR.compress(data)
-        ratio = len(lz4_data) / len(data)
+        # lz4_data includes the compression type header, while data does not yet
+        ratio = len(lz4_data) / (len(data) + 2)
         if ratio < 0.97:
             return self.compressor, lz4_data
         elif ratio < 1:


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/borgbackup/borg/pull/4683#issuecomment-608095574) to PR#4683, the calculation of compression ratio done by the decide method is not entirely correct.
This PR fixes this issue, which is present in the existing code base and not related to PR#4683.
