### PR TITLE
docs: linked recommended restrictions to ssh public keys on borg servers in faq, fixes #4946

### DIFF
--- a/docs/deployment/hosting-repositories.rst
+++ b/docs/deployment/hosting-repositories.rst
@@ -1,5 +1,6 @@
 .. include:: ../global.rst.inc
 .. highlight:: none
+.. _hosting_repositories:
 
 Hosting repositories
 ====================

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -557,6 +557,8 @@ These are your options to protect against that:
 - Mount C's filesystem on another machine and then create a backup of it.
 - Do not give C filesystem-level access to S.
 
+See :ref:`hosting_repositories` for a detailed protection guide.
+
 How can I protect against a hacked backup server?
 -------------------------------------------------
 


### PR DESCRIPTION
Article renamed to emphasize the security aspect and linked it in the FAQ.

If approved, I will backport it to 1.1-maint, too.