### PR TITLE
Remove the flake8 test for Vagrant VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -228,10 +228,10 @@ def run_tests(boxname)
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then
       echo "Running tox WITH fakeroot -u"
-      fakeroot -u tox --skip-missing-interpreters
+      fakeroot -u tox --skip-missing-interpreters -e py35,py36,py37,py38
     else
       echo "Running tox WITHOUT fakeroot -u"
-      tox --skip-missing-interpreters
+      tox --skip-missing-interpreters -e py35,py36,py37,py38
     fi
   EOF
 end


### PR DESCRIPTION
This is tested after each commit so this test is quite useless on the
Vagrant VMs.

Fix #5020 .