### PR TITLE
fuse: set f_namemax in statfs result, fixes #2684

### DIFF
--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -540,6 +540,7 @@ class FuseOperations(llfuse.Operations, FuseBackend):
         stat_.f_files = 0
         stat_.f_ffree = 0
         stat_.f_favail = 0
+        stat_.f_namemax = 255  # == NAME_MAX (depends on archive source OS / FS)
         return stat_
 
     def getattr(self, inode, ctx=None):


### PR DESCRIPTION
setting it to 255 for now (as seen on Linux / ext4), better than the default 0.

the attribute is present since llfuse 1.3.0, which is the minimum requirement currently anyway.
