### PR TITLE
fuse: set f_namemax in statfs result, fixes #2684

### DIFF
--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -518,6 +518,8 @@ class FuseOperations(llfuse.Operations):
         stat_.f_files = 0
         stat_.f_ffree = 0
         stat_.f_favail = 0
+        if hasattr(stat_, 'f_namemax'):  # since llfuse 1.3.0
+            stat_.f_namemax = 255  # == NAME_MAX (depends on archive source OS / FS)
         return stat_
 
     def get_item(self, inode):


### PR DESCRIPTION
setting it to 255 for now (as seen on Linux / ext4), better than the default 0.

the attribute is only present since llfuse 1.3.0.

backport of #5108.
