### PR TITLE
Fix tests of read-only repos for non-root users

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -262,9 +262,10 @@ class BaseTestCase(unittest.TestCase):
     def read_only(self, path):
         """Some paths need to be made read-only for testing
 
-        Using chmod to remove write permissions is not enough due to
-        the tests running with root privileges. Instead, the folder is
-        rendered immutable with chattr or chflags, respectively.
+        To simulate operations on read-only repositories, writing
+        permissions are simply being withdrawn. However, if the tests
+        are being run with root privileges, this is not enough and
+        the folder has to be rendered immutable, additionally.
         """
         if sys.platform.startswith('linux'):
             cmd_immutable = 'chattr +i "%s"' % path
@@ -279,11 +280,13 @@ class BaseTestCase(unittest.TestCase):
             message = 'Testing read-only repos is not supported on platform %s' % sys.platform
             self.skipTest(message)
         try:
+            os.system('chmod -R ugo-w "%s"' % path)
             os.system(cmd_immutable)
             yield
         finally:
             # Restore permissions to ensure clean-up doesn't fail
             os.system(cmd_mutable)
+            os.system('chmod -R ugo+w "%s"' % path)
 
 
 class changedir:


### PR DESCRIPTION
To simulate read-only repos, the repo folder was being rendered immutable. This doesn't work when running the tests as non-root users. See #5111 