### PR TITLE
Fixed windows path parsing

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -418,7 +418,7 @@ class Location:
             m = self.win_file_re.match(text)
             if m:
                 self.proto = 'file'
-                self.path = path
+                self.path = m.group('path')
                 self.archive = m.group('archive')
                 return True
 


### PR DESCRIPTION
The parsing of windows path failed because a undefined variable
was referenced.