### PR TITLE
[BUGFIX] Borg commands accept absolute pathes, #4029

### DIFF
--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -143,7 +143,7 @@ class PatternMatcher:
         in self.fallback is returned (defaults to None).
 
         """
-        path = normalize_path(path)
+        path = normalize_path(path).lstrip(os.path.sep)
         # do a fast lookup for full path matches (note: we do not count such matches):
         non_existent = object()
         value = self._path_full_patterns.get(path, non_existent)


### PR DESCRIPTION
Strip leading path separator before trying to match a path.

I just found that I forgot this. In my tests I only checked if ``borg create ::archive relative/path`` works, but not with ``/absolute/path``.