### PR TITLE
Fix MacOS build for 1.0-maint

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,10 +9,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     export HOMEBREW_TEMP=~/brew-temp
     mkdir $HOMEBREW_LOGS
     mkdir $HOMEBREW_TEMP
-    # brew update
-    if [[ "${OPENSSL}" != "0.9.8" ]]; then
-        brew outdated openssl || brew upgrade openssl
-    fi
+
+    brew install rbenv/tap/openssl@1.0
 
     if which pyenv > /dev/null; then
         eval "$(pyenv init -)"
@@ -25,11 +23,11 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     case "${TOXENV}" in
         py34)
-            pyenv install 3.4.5
+            PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA=openssl@1.0 pyenv install 3.4.5
             pyenv global 3.4.5
             ;;
         py35)
-            pyenv install 3.5.2
+            PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA=openssl@1.0 pyenv install 3.5.2
             pyenv global 3.5.2
             ;;
         py36)

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,6 +10,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     mkdir $HOMEBREW_LOGS
     mkdir $HOMEBREW_TEMP
 
+    # Brew removed openssl@1.0 end of 2019 https://brew.sh/2019/11/27/homebrew-2.2.0/
+    # Use rbenv's formula fork https://github.com/rbenv/homebrew-tap/blob/master/Formula/openssl%401.0.rb
     brew install rbenv/tap/openssl@1.0
 
     if which pyenv > /dev/null; then


### PR DESCRIPTION
Fixes https://github.com/borgbackup/borg/issues/4982

Homebrew updated default openssl to 1.1 but not all versions of Python support that version (i.e. older versions of Python). It looks like the pyenv code assumes `openssl` formula is 1.0 and `openssl@1.1` is 1.1 when in fact they're now the same. This instructs pyenv to use `openssl@1.0` formula from rbenv tap