### PR TITLE
[DOCS] Add note about patterns and stored paths, #4160

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2198,17 +2198,26 @@ class Archiver:
         when invoking borg and these can be either relative or absolute paths.
 
         So, when you give `relative/` as root, the paths going into the matcher
-        will look like `relative/.../file.ext`. When you give `/absolute/` as root,
-        they will look like `/absolute/.../file.ext`. This is meant when we talk
-        about "full path" below.
+        will look like `relative/.../file.ext`. When you give `/absolute/` as
+        root, they will look like `/absolute/.../file.ext`. This is meant when
+        we talk about "full path" below.
+
+        File paths in Borg archives are always stored normalized and relative.
+        This means that e.g. ``borg create /path/to/repo ../some/path`` will
+        store all files as `some/path/.../file.ext` and ``borg create
+        /path/to/repo /home/user`` will store all files as
+        `home/user/.../file.ext`. Therefore, always use relative paths in your
+        patterns when matching archive content in commands like ``extract`` or
+        ``mount``. Starting with Borg 1.2 this behaviour will be changed to
+        accept both absolute and relative paths.
 
         File patterns support these styles: fnmatch, shell, regular expressions,
         path prefixes and path full-matches. By default, fnmatch is used for
-        ``--exclude`` patterns and shell-style is used for the experimental ``--pattern``
-        option.
+        ``--exclude`` patterns and shell-style is used for the experimental
+        ``--pattern`` option.
 
-        If followed by a colon (':') the first two characters of a pattern are used as a
-        style selector. Explicit style selection is necessary when a
+        If followed by a colon (':') the first two characters of a pattern are
+        used as a style selector. Explicit style selection is necessary when a
         non-default style is desired or when the desired pattern starts with
         two alphanumeric characters followed by a colon (i.e. `aa:something/*`).
 


### PR DESCRIPTION
Add a section that explains why to use relative patterns and how this is changed in Borg 1.2.

This change is for the 1.1 branch. For the master branch I plan to add a different section.