### PR TITLE
[BUGFIX] Borg config --list does not show last_segment_checked, #5159

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1659,7 +1659,7 @@ class Archiver:
         def repo_validate(section, name, value=None, check_value=True):
             if section not in ['repository', ]:
                 raise ValueError('Invalid section')
-            if name in ['segments_per_dir', 'max_segment_size', 'storage_quota', ]:
+            if name in ['segments_per_dir', 'max_segment_size', 'storage_quota', 'last_segment_checked', ]:
                 if check_value:
                     try:
                         int(value)
@@ -1715,6 +1715,11 @@ class Archiver:
                     value = default_values.get(key)
                     if value is None:
                         raise Error('The repository config is missing the %s key which has no default value' % key)
+                print('%s = %s' % (key, value))
+            for key in ['last_segment_checked', ]:
+                value = config.get('repository', key, fallback=None)
+                if value is None:
+                    continue
                 print('%s = %s' % (key, value))
 
         if not args.list:

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2991,6 +2991,17 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
         self.assert_in('append_only', output)
         self.assert_in('additional_free_space', output)
         self.assert_in('id', output)
+        self.assert_not_in('last_segment_checked', output)
+
+        output = self.cmd('config', self.repository_location, 'last_segment_checked', exit_code=1)
+        self.assert_in('No option ', output)
+        self.cmd('config', self.repository_location, 'last_segment_checked', '123')
+        output = self.cmd('config', self.repository_location, 'last_segment_checked')
+        assert output == '123' + '\n'
+        output = self.cmd('config', '--list', self.repository_location)
+        self.assert_in('last_segment_checked', output)
+        self.cmd('config', '--delete', self.repository_location, 'last_segment_checked')
+
         for cfg_key, cfg_value in [
             ('additional_free_space', '2G'),
             ('repository.append_only', '1'),
@@ -3002,6 +3013,7 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
             assert output == cfg_value + '\n'
             self.cmd('config', '--delete', self.repository_location, cfg_key)
             self.cmd('config', self.repository_location, cfg_key, exit_code=1)
+
         self.cmd('config', '--list', '--delete', self.repository_location, exit_code=2)
         self.cmd('config', self.repository_location, exit_code=2)
         self.cmd('config', self.repository_location, 'invalid-option', exit_code=1)


### PR DESCRIPTION
Add a for loop for "dynamic" config keys like last_segment_checked, skip printing if they are not found in the config.

Also allow last_segment_checked to be set with a int value.

Added tests.

fixes #5159