### PR TITLE
Expose hash over ChunkListEntry data to borg list --format {chunk_ids_$HASH}

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -834,13 +834,16 @@ class ItemFormatter(BaseFormatter):
         # note: does not support hardlink slaves, they will be csize 0
         return item.get_size(compressed=True)
 
-    def hash_item(self, hash_function, item):
-        if 'chunks' not in item:
-            return ""
+    def prepare_hash_function(self, hash_function):
         if hash_function in hashlib.algorithms_guaranteed:
             hash = hashlib.new(hash_function)
         elif hash_function == 'xxh64':
             hash = self.xxh64()
+        return hash
+    def hash_item(self, hash_function, item):
+        if 'chunks' not in item:
+            return ""
+        hash = self.prepare_hash_function(hash_function)
         for data in self.archive.pipeline.fetch_many([c.id for c in item.chunks]):
             hash.update(data)
         return hash.hexdigest()


### PR DESCRIPTION
- First time messing with the code -- No test yet, can somebody help writing one?
- Existing tests and flake give no warnings
- Not sure about the format key naming, suggestions?

Rationale: because checksums are so slow, and `borg diff` is much faster, I tried to expose  to `borg list` a hash over the data that `borg diff` seems to use to compare items