### PR TITLE
parseformat: unnecessary calls removed

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -770,10 +770,6 @@ class ItemFormatter(BaseFormatter):
     def format_item_json(self, item):
         return json.dumps(self.get_item_data(item), cls=BorgJsonEncoder) + '\n'
 
-    def add_key(self, key, callable_with_item):
-        self.call_keys[key] = callable_with_item
-        self.used_call_keys = set(self.call_keys) & self.format_keys
-
     def get_item_data(self, item):
         item_data = {}
         item_data.update(self.item_data)

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -764,7 +764,7 @@ class ItemFormatter(BaseFormatter):
             'atime': partial(self.format_time, 'atime'),
         }
         for hash_function in self.hash_algorithms:
-            self.add_key(hash_function, partial(self.hash_item, hash_function))
+            self.call_keys[hash_function] = partial(self.hash_item, hash_function)
         self.used_call_keys = set(self.call_keys) & self.format_keys
 
     def format_item_json(self, item):


### PR DESCRIPTION
Just a small cleanup to avoid unnecessary `self.used_call_keys = set(self.call_keys) & self.format_keys` calls. 

See the definition of add_keys() https://github.com/hrehfeld/borg/blob/19bfe21fa90fbcd4b2bb68c67d6f68af1ffbeaa8/src/borg/helpers/parseformat.py#L773