### PR TITLE
WIP: Support copying objects between repos

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -170,6 +170,10 @@ class KeyBase:
     # was supplied, and if an empty passphrase works, then Borg won't ask for one.
     logically_encrypted = False
 
+    # skip the check for valid IDs.
+    # This is required after loading data from a repo with an alternative key.
+    skip_assert_id = False
+
     def __init__(self, repository):
         self.TYPE_STR = bytes([self.TYPE])
         self.repository = repository
@@ -191,6 +195,9 @@ class KeyBase:
         pass
 
     def assert_id(self, id, data):
+        if self.skip_assert_id:
+            return
+
         if id:
             id_computed = self.id_hash(data)
             if not compare_digest(id_computed, id):


### PR DESCRIPTION
This implements dump and load commands that allow directly copying objects between repos, like requested in #4337. It works but I wanted to get a little feedback before adding docs, tests and so forth.

- The **dump** command outputs a msgpack stream of decrypted objects (id/data pairs) from the repo.
- The **load** command takes objects from stdin, encrypts them and stores them in the repo, except the manifest. It adds any archives it encounters to the existing manifest.
- The **recreate** command gets a new option, `--new-ids` which forces rechunking while ignoring invalid IDs, because the new objects won't match the new encryption key.

I was thinking that a cleaner way to handle this would be to allow multiple keys for one repo. So you could move the old key along with the data and the recryption and **recreate** steps would be optional.

I also would like to make the **dump** command recognize the archives, so **load** doesn't need to guess.

Thoughts?