### PR TITLE
declare "allow_cache_wipe" marker in pytest.ini to avoid pytest warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 python_files = testsuite/*.py
+markers =
+    allow_cache_wipe
 
 [flake8]
 # please note that the values are adjusted so that they do not cause failures


### PR DESCRIPTION
Undeclared markers trigger a pytest warning:
    PytestUnknownMarkWarning: Unknown pytest.mark.allow_cache_wipe - is this a typo?

You can see the warning in the current travis output:

    =============================== warnings summary ===============================

    .tox/py38/lib/python3.8/site-packages/borg/testsuite/archiver.py:1726

      /home/travis/build/borgbackup/borg/.tox/py38/lib/python3.8/site-packages/borg/testsuite/archiver.py:1726: PytestUnknownMarkWarning: Unknown pytest.mark.allow_cache_wipe - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

        @pytest.mark.allow_cache_wipe

    -- Docs: https://docs.pytest.org/en/latest/warnings.html
