### PR TITLE
Improve sizeof_fmt()

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -271,16 +271,13 @@ def parse_file_size(s):
 
 
 def sizeof_fmt(num, suffix='B', units=None, power=None, sep='', precision=2, sign=False):
-    prefix = '+' if sign and num > 0 else ''
-
+    sign = '+' if sign else ''
+    fmt = '{0:{1}d}{3}{4}{5}' if isinstance(num, int) else '{0:{1}.{2}f}{3}{4}{5}'
     for unit in units[:-1]:
         if abs(round(num, precision)) < power:
-            if isinstance(num, int):
-                return "{}{}{}{}{}".format(prefix, num, sep, unit, suffix)
-            else:
-                return "{}{:3.{}f}{}{}{}".format(prefix, num, precision, sep, unit, suffix)
+            return fmt.format(num, sign, precision, sep, unit, suffix)
         num /= float(power)
-    return "{}{:.{}f}{}{}{}".format(prefix, num, precision, sep, units[-1], suffix)
+    return fmt.format(num, sign, precision, sep, units[-1], suffix)
 
 
 def sizeof_fmt_iec(num, suffix='B', sep='', precision=2, sign=False):

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -272,12 +272,14 @@ def parse_file_size(s):
 
 def sizeof_fmt(num, suffix='B', units=None, power=None, sep='', precision=2, sign=False):
     sign = '+' if sign else ''
-    fmt = '{0:{1}d}{3}{4}{5}' if isinstance(num, int) else '{0:{1}.{2}f}{3}{4}{5}'
+    fmt = '{0:{1}.{2}f}{3}{4}{5}'
+    prec = 0
     for unit in units[:-1]:
         if abs(round(num, precision)) < power:
-            return fmt.format(num, sign, precision, sep, unit, suffix)
+            return fmt.format(num, sign, prec, sep, unit, suffix)
         num /= float(power)
-    return fmt.format(num, sign, precision, sep, units[-1], suffix)
+        prec = precision
+    return fmt.format(num, sign, prec, sep, units[-1], suffix)
 
 
 def sizeof_fmt_iec(num, suffix='B', sep='', precision=2, sign=False):

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -276,10 +276,12 @@ def sizeof_fmt(num, suffix='B', units=None, power=None, sep='', precision=2, sig
     prec = 0
     for unit in units[:-1]:
         if abs(round(num, precision)) < power:
-            return fmt.format(num, sign, prec, sep, unit, suffix)
+            break
         num /= float(power)
         prec = precision
-    return fmt.format(num, sign, prec, sep, units[-1], suffix)
+    else:
+        unit = units[-1]
+    return fmt.format(num, sign, prec, sep, unit, suffix)
 
 
 def sizeof_fmt_iec(num, suffix='B', sep='', precision=2, sign=False):

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -579,7 +579,7 @@ def test_file_size_precision():
 
 def test_file_size_sign():
     si_size_map = {
-        0: '0 B',
+        0: '+0 B',
         1: '+1 B',
         1234: '+1.23 kB',
         -1: '-1 B',


### PR DESCRIPTION
- Use built-in sign handling
- Format integer correctly when using biggest unit
- Use consistent format inside and outside of loop

I came here from [StackOverflow](https://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size#comment68302428_1094933) and used the opportunity to improve the code even further.