### PR TITLE
test_delete_force: avoid sporadic test setup issues, fixes #5196

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1496,11 +1496,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
             archive = Archive(repository, key, manifest, 'test')
             for item in archive.iter_items():
-                if 'chunks' in item:
-                    first_chunk_id = item.chunks[0].id
-                    repository.delete(first_chunk_id)
-                    repository.commit()
+                if item.path.endswith('testsuite/archiver.py'):
+                    repository.delete(item.chunks[-1].id)
                     break
+            else:
+                assert False  # missed the file
+            repository.commit()
         output = self.cmd('delete', '--force', self.repository_location + '::test')
         self.assert_in('deleted archive was corrupted', output)
         self.cmd('check', '--repair', self.repository_location)


### PR DESCRIPTION
the old test stumbled over files with an empty chunks list,
so I guess just having some empty file in src/borg could make
that test fail.

fixed this by deleting a chunk of some specific file (we use
this file / this construction at misc. other places in the
archiver tests).