### PR TITLE
--umask is for the local borg process only, fixes #4947

### DIFF
--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -84,12 +84,19 @@ use this option also for speeding up operations.
 ``--umask``
 ~~~~~~~~~~~
 
-If you use ``--umask``, make sure that all repository-modifying borg commands
-(create, delete, prune) that access the repository in question use the same
-``--umask`` value.
+borg uses a safe default umask of 077 (that means the files borg creates have
+only permissions for owner, but no permissions for group and others) - so there
+should rarely be a need to change the default behaviour.
 
-If multiple machines access the same repository, this should hold true for all
-of them.
+This option only affects the process to which it is given. Thus, when you run
+borg in client/server mode and you want to change the behaviour on the server
+side, you need to use ``borg serve --umask=XXX ...`` as a ssh forced command
+in ``authorized_keys``. The ``--umask`` value given on the client side is
+**not** transferred to the server side.
+
+Also, if you choose to use the ``--umask`` option, always be consistent and use
+the same umask value so you do not create a mixup of permissions in a borg
+repository or with other files borg creates.
 
 ``--read-special``
 ~~~~~~~~~~~~~~~~~~

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2617,7 +2617,7 @@ class Archiver:
             add_common_option('--show-rc', dest='show_rc', action='store_true',
                               help='show/log the return code (rc)')
             add_common_option('--umask', metavar='M', dest='umask', type=lambda s: int(s, 8), default=UMASK_DEFAULT,
-                              help='set umask to M (local and remote, default: %(default)04o)')
+                              help='set umask to M (local only, default: %(default)04o)')
             add_common_option('--remote-path', metavar='PATH', dest='remote_path',
                               help='use PATH as borg executable on the remote (default: "borg")')
             add_common_option('--remote-ratelimit', metavar='RATE', dest='remote_ratelimit', type=int,
@@ -4413,12 +4413,12 @@ class Archiver:
                     'restrict_to_repositories',
                     'append_only',
                     'storage_quota',
+                    'umask',
                 }
                 whitelist = {
                     'debug_topics',
                     'lock_wait',
                     'log_level',
-                    'umask',
                 }
                 not_present = object()
                 for attr_name in whitelist:

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -647,7 +647,6 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
         # give some args/options to 'borg serve' process as they were given to us
         opts = []
         if args is not None:
-            opts.append('--umask=%03o' % args.umask)
             root_logger = logging.getLogger()
             if root_logger.isEnabledFor(logging.DEBUG):
                 opts.append('--debug')

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3799,8 +3799,8 @@ def test_get_args():
     # everything normal:
     # first param is argv as produced by ssh forced command,
     # second param is like from SSH_ORIGINAL_COMMAND env variable
-    args = archiver.get_args(['borg', 'serve', '--restrict-to-path=/p1', '--restrict-to-path=/p2', ],
-                             'borg serve --info --umask=0027')
+    args = archiver.get_args(['borg', 'serve', '--umask=0027', '--restrict-to-path=/p1', '--restrict-to-path=/p2', ],
+                             'borg serve --info')
     assert args.func == archiver.do_serve
     assert args.restrict_to_paths == ['/p1', '/p2']
     assert args.umask == 0o027

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -885,17 +885,17 @@ class RemoteRepositoryTestCase(RepositoryTestCase):
         # XXX without next line we get spurious test fails when using pytest-xdist, root cause unknown:
         logging.getLogger().setLevel(logging.INFO)
         # note: test logger is on info log level, so --info gets added automagically
-        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--umask=077', '--info']
+        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--info']
         args.remote_path = 'borg-0.28.2'
-        assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--umask=077', '--info']
+        assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--info']
         args.debug_topics = ['something_client_side', 'repository_compaction']
-        assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--umask=077', '--info',
+        assert self.repository.borg_cmd(args, testing=False) == ['borg-0.28.2', 'serve', '--info',
                                                                  '--debug-topic=borg.debug.repository_compaction']
         args = self._get_mock_args()
         args.storage_quota = 0
-        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--umask=077', '--info']
+        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--info']
         args.storage_quota = 314159265
-        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--umask=077', '--info',
+        assert self.repository.borg_cmd(args, testing=False) == ['borg', 'serve', '--info',
                                                                  '--storage-quota=314159265']
         args.rsh = 'ssh -i foo'
         self.repository._args = args


### PR DESCRIPTION
The umask value is NOT transmitted from client to server any more,
so the borg client can not influence the borg server umask any more.

If one wants to have a specific umask on the server side, one needs to
use a ssh forced command in .ssh/authorized_keys file.

OTOH, as the default value is 077 (in general, for client as well as for
the server) and the server does not take the value from the client any more,
there usually should be no need to give it on the server side, IF you are
happy with the default value.
