### PR TITLE
rephrase some warnings, fixes #5164

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -575,8 +575,8 @@ Prompts
     BORG_RELOCATED_REPO_ACCESS_IS_OK
         For "Warning: The repository at location ... was previously located at ..."
     BORG_CHECK_I_KNOW_WHAT_I_AM_DOING
-        For "This is a potentially dangerous functionality..." (check --repair)
+        For "This is a potentially dangerous function..." (check --repair)
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING
         For "You requested to completely DELETE the repository *including* all archives it contains:"
     BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING
-        For "This is a potentially dangerous functionality..." (recreate)
+        For "This is a potentially dangerous function..." (recreate)

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -578,5 +578,3 @@ Prompts
         For "This is a potentially dangerous function..." (check --repair)
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING
         For "You requested to completely DELETE the repository *including* all archives it contains:"
-    BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING
-        For "This is a potentially dangerous function..." (recreate)

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -575,8 +575,8 @@ Prompts
     BORG_RELOCATED_REPO_ACCESS_IS_OK
         For "Warning: The repository at location ... was previously located at ..."
     BORG_CHECK_I_KNOW_WHAT_I_AM_DOING
-        For "Warning: 'check --repair' is an experimental feature that might result in data loss."
+        For "This is a potentially dangerous functionality..." (check --repair)
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING
         For "You requested to completely DELETE the repository *including* all archives it contains:"
     BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING
-        For "recreate is an experimental feature."
+        For "This is a potentially dangerous functionality..." (recreate)

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -83,11 +83,11 @@ Some automatic "answerers" (if set, they automatically answer confirmation quest
     BORG_RELOCATED_REPO_ACCESS_IS_OK=no (or =yes)
         For "Warning: The repository at location ... was previously located at ..."
     BORG_CHECK_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
-        For "Warning: 'check --repair' is an experimental feature that might result in data loss."
+        For "This is a potentially dangerous function..." (check --repair)
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
         For "You requested to completely DELETE the repository *including* all archives it contains:"
     BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
-        For "recreate is an experimental feature."
+        For "This is a potentially dangerous function..." (recreate)
 
     Note: answers are case sensitive. setting an invalid answer value might either give the default
     answer or ask you interactively, depending on whether retries are allowed (they by default are

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -86,8 +86,6 @@ Some automatic "answerers" (if set, they automatically answer confirmation quest
         For "This is a potentially dangerous function..." (check --repair)
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
         For "You requested to completely DELETE the repository *including* all archives it contains:"
-    BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
-        For "This is a potentially dangerous function..." (recreate)
 
     Note: answers are case sensitive. setting an invalid answer value might either give the default
     answer or ask you interactively, depending on whether retries are allowed (they by default are

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -307,9 +307,8 @@ class Archiver:
         """Check repository consistency"""
         if args.repair:
             msg = ("This is a potentially dangerous function.\n"
-                   "check --repair might lead to data loss (in case of bugs or for kinds of\n"
-                   "corruption it is not capable of dealing with).\n"
-                   "BE VERY CAREFUL!\n"
+                   "check --repair might lead to data loss (for kinds of corruption it is not\n"
+                   "capable of dealing with). BE VERY CAREFUL!\n"
                    "\n"
                    "Type 'YES' if you understand this and want to continue: ")
             if not yes(msg, false_msg="Aborting.", invalid_msg="Invalid answer, aborting.",
@@ -1591,8 +1590,7 @@ class Archiver:
     def do_recreate(self, args, repository, manifest, key, cache):
         """Re-create archives"""
         msg = ("This is a potentially dangerous function.\n"
-               "recreate might lead to data loss (if used wrongly or in case of bugs).\n"
-               "BE VERY CAREFUL!\n"
+               "recreate might lead to data loss (if used wrongly). BE VERY CAREFUL!\n"
                "\n"
                "Type 'YES' if you understand this and want to continue: ")
         if not yes(msg, false_msg="Aborting.", truish=('YES',),
@@ -2868,8 +2866,7 @@ class Archiver:
         The check command verifies the consistency of a repository and the corresponding archives.
 
         check --repair is a potentially dangerous function and might lead to data loss
-        (in case of bugs or for kinds of corruption it is not capable of dealing with).
-        BE VERY CAREFUL!
+        (for kinds of corruption it is not capable of dealing with). BE VERY CAREFUL!
 
         First, the underlying repository data files are checked:
 
@@ -4099,8 +4096,7 @@ class Archiver:
         Recreate the contents of existing archives.
 
         recreate is a potentially dangerous function and might lead to data loss
-        (if used wrongly or in case of bugs).
-        BE VERY CAREFUL!
+        (if used wrongly). BE VERY CAREFUL!
 
         Important: Repository disk space is **not** freed until you run ``borg compact``.
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -306,7 +306,7 @@ class Archiver:
     def do_check(self, args, repository):
         """Check repository consistency"""
         if args.repair:
-            msg = ("This is a potentially dangerous functionality.\n"
+            msg = ("This is a potentially dangerous function.\n"
                    "check --repair might lead to data loss (in case of bugs or for kinds of\n"
                    "corruption it is not capable of dealing with).\n"
                    "BE VERY CAREFUL!\n"
@@ -1590,7 +1590,7 @@ class Archiver:
     @with_repository(cache=True, exclusive=True, compatibility=(Manifest.Operation.CHECK,))
     def do_recreate(self, args, repository, manifest, key, cache):
         """Re-create archives"""
-        msg = ("This is a potentially dangerous functionality.\n"
+        msg = ("This is a potentially dangerous function.\n"
                "recreate might lead to data loss (if used wrongly or in case of bugs).\n"
                "BE VERY CAREFUL!\n"
                "\n"
@@ -2867,7 +2867,7 @@ class Archiver:
         check_epilog = process_epilog("""
         The check command verifies the consistency of a repository and the corresponding archives.
 
-        check --repair is a potentially dangerous functionality and might lead to data loss
+        check --repair is a potentially dangerous function and might lead to data loss
         (in case of bugs or for kinds of corruption it is not capable of dealing with).
         BE VERY CAREFUL!
 
@@ -4098,7 +4098,7 @@ class Archiver:
         recreate_epilog = process_epilog("""
         Recreate the contents of existing archives.
 
-        recreate is a potentially dangerous functionality and might lead to data loss
+        recreate is a potentially dangerous function and might lead to data loss
         (if used wrongly or in case of bugs).
         BE VERY CAREFUL!
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1589,14 +1589,6 @@ class Archiver:
     @with_repository(cache=True, exclusive=True, compatibility=(Manifest.Operation.CHECK,))
     def do_recreate(self, args, repository, manifest, key, cache):
         """Re-create archives"""
-        msg = ("This is a potentially dangerous function.\n"
-               "recreate might lead to data loss (if used wrongly). BE VERY CAREFUL!\n"
-               "\n"
-               "Type 'YES' if you understand this and want to continue: ")
-        if not yes(msg, false_msg="Aborting.", truish=('YES',),
-                   env_var_override='BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING'):
-            return EXIT_ERROR
-
         matcher = self.build_matcher(args.patterns, args.paths)
         self.output_list = args.output_list
         self.output_filter = args.output_filter

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -306,8 +306,11 @@ class Archiver:
     def do_check(self, args, repository):
         """Check repository consistency"""
         if args.repair:
-            msg = ("'check --repair' is an experimental feature that might result in data loss." +
-                   "\n" +
+            msg = ("This is a potentially dangerous functionality.\n"
+                   "check --repair might lead to data loss (in case of bugs or for kinds of\n"
+                   "corruption it is not capable of dealing with).\n"
+                   "BE VERY CAREFUL!\n"
+                   "\n"
                    "Type 'YES' if you understand this and want to continue: ")
             if not yes(msg, false_msg="Aborting.", invalid_msg="Invalid answer, aborting.",
                        truish=('YES', ), retry=False,
@@ -1587,7 +1590,10 @@ class Archiver:
     @with_repository(cache=True, exclusive=True, compatibility=(Manifest.Operation.CHECK,))
     def do_recreate(self, args, repository, manifest, key, cache):
         """Re-create archives"""
-        msg = ("recreate is an experimental feature.\n"
+        msg = ("This is a potentially dangerous functionality.\n"
+               "recreate might lead to data loss (if used wrongly or in case of bugs).\n"
+               "BE VERY CAREFUL!\n"
+               "\n"
                "Type 'YES' if you understand this and want to continue: ")
         if not yes(msg, false_msg="Aborting.", truish=('YES',),
                    env_var_override='BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING'):
@@ -2861,6 +2867,10 @@ class Archiver:
         check_epilog = process_epilog("""
         The check command verifies the consistency of a repository and the corresponding archives.
 
+        check --repair is a potentially dangerous functionality and might lead to data loss
+        (in case of bugs or for kinds of corruption it is not capable of dealing with).
+        BE VERY CAREFUL!
+
         First, the underlying repository data files are checked:
 
         - For all segments, the segment magic header is checked.
@@ -4088,7 +4098,9 @@ class Archiver:
         recreate_epilog = process_epilog("""
         Recreate the contents of existing archives.
 
-        This is an *experimental* feature. Do *not* use this on your only backup.
+        recreate is a potentially dangerous functionality and might lead to data loss
+        (if used wrongly or in case of bugs).
+        BE VERY CAREFUL!
 
         Important: Repository disk space is **not** freed until you run ``borg compact``.
 

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -251,7 +251,6 @@ class ArchiverTestCaseBase(BaseTestCase):
     def setUp(self):
         os.environ['BORG_CHECK_I_KNOW_WHAT_I_AM_DOING'] = 'YES'
         os.environ['BORG_DELETE_I_KNOW_WHAT_I_AM_DOING'] = 'YES'
-        os.environ['BORG_RECREATE_I_KNOW_WHAT_I_AM_DOING'] = 'YES'
         os.environ['BORG_PASSPHRASE'] = 'waytooeasyonlyfortests'
         self.archiver = not self.FORK_DEFAULT and Archiver() or None
         self.tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
borg check --repair and borg recreate are now present in the code
since rather long, so they are not experimental any more.

but, both bear some risk of data loss:
- there could be an undiscovered bug in the code
- the user might use them wrong (e.g. accidentally excluding everything /
  not matching anything when recreating an archive)
- there might be kinds of corruption borg check --repair can not fix
  and it might make things even worse while trying to fix.

so, if your repo / archive(s) are important, be careful.
