### PR TITLE
docs: point to borg create --list item flags in recreate usage, fixes #5165

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2564,6 +2564,7 @@ class Archiver:
         rst_plain_text_references = {
             'a_status_oddity': '"I am seeing ‘A’ (added) status for a unchanged file!?"',
             'separate_compaction': '"Separate compaction"',
+            'list_item_flags': '"Item flags"',
         }
 
         def process_epilog(epilog):
@@ -3109,6 +3110,8 @@ class Archiver:
         only include the objects specified by ``--exclude-if-present`` in your backup,
         and not include any other contents of the containing folder, this can be enabled
         through using the ``--keep-exclude-tags`` option.
+
+        .. _list_item_flags:
 
         Item flags
         ++++++++++
@@ -4113,7 +4116,7 @@ class Archiver:
         Depending on the PATHs and patterns given, recreate can be used to permanently
         delete files from archives.
         When in doubt, use ``--dry-run --verbose --list`` to see how patterns/PATHS are
-        interpreted.
+        interpreted. See :ref:`list_item_flags` in ``borg create`` for details.
 
         The archive being recreated is only removed after the operation completes. The
         archive that is built during the operation exists at the same time at


### PR DESCRIPTION
It seems that the item flags are only used in create and recreate --list, so there is no point in moving them out, and it's better to just link them in recrate.