### PR TITLE
Stop relying on `false` exiting with status code 1

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1060,8 +1060,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
     def test_create_content_from_command_with_failed_command(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         output = self.cmd('create', '--content-from-command', self.repository_location + '::test',
-                          '--', 'false', '--arg-passed-to-false', exit_code=2)
-        assert output.endswith("Command 'false' exited with status 1\n")
+                          '--', 'sh', '-c', 'exit 73;', exit_code=2)
+        assert output.endswith("Command 'sh' exited with status 73\n")
         archive_list = json.loads(self.cmd('list', '--json', self.repository_location))
         assert archive_list['archives'] == []
 


### PR DESCRIPTION
According to the manpage, `false` is only guaranteed to return with an exit code indicating an error. However, the manpage is silent on the exact code returned.

Likely fixes #5273.