### PR TITLE
Changing rephrase explanation

### DIFF
--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -35,9 +35,12 @@ Fully automated using environment variables:
 
 ::
 
-    $ BORG_NEW_PASSPHRASE=old borg init -e=repokey repo
+    $ export BORG_PASSPHRASE='old'
+    $ borg init -e=repokey repo
     # now "old" is the current passphrase.
-    $ BORG_PASSPHRASE=old BORG_NEW_PASSPHRASE=new borg key change-passphrase repo
+    $ export BORG_PASSPHRASE='old'
+    $ export BORG_NEW_PASSPHRASE='new' 
+    $ borg key change-passphrase repo
     # now "new" is the current passphrase.
 
 

--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -35,11 +35,10 @@ Fully automated using environment variables:
 
 ::
 
-    $ export BORG_PASSPHRASE='old'
+    $ BORG_PASSPHRASE='old'
     $ borg init -e=repokey repo
     # now "old" is the current passphrase.
-    $ export BORG_PASSPHRASE='old'
-    $ export BORG_NEW_PASSPHRASE='new' 
+    $ BORG_NEW_PASSPHRASE='new' 
     $ borg key change-passphrase repo
     # now "new" is the current passphrase.
 


### PR DESCRIPTION
Somehow, I find it more clear when the commands are on several lines (instead of one).
Also, exporting the "BORG_NEW_PASSPHRASE" to 'old' isn't very useful, rather set the BORG_PASSPHRASE to 'old' (in order to access the REPO normally)