### PR TITLE
Skip corrupt chunks fast

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1487,7 +1487,9 @@ class LoggedIO:
         """
         Returns a tuple of chunk data (or None) and length of bytes to skip forward
 
-        If try_next_chunk is True, then when the CRC mismatches, it will seek past the purported size and check the CRC of the next chunk. If that is correct, or exactly EOF, it will be returned with a length of both the corrupt chunk and the next one being returned.
+        If try_next_chunk is True, then when the CRC mismatches, it will seek past the purported size and check
+        the CRC of the next chunk. If that is correct, or exactly EOF, it will be returned with a length of both
+        the corrupt chunk and the next one being returned.
         If pedantic is True (always for the next-chunk check), chunk will only be accepted if the tag is valid.
         """
         crc, size, tag = self.header_fmt.unpack(d[:self.header_fmt.size])

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1524,12 +1524,16 @@ class LoggedIO:
                     data = memoryview(mm)
                     d = data
                     chunk = None
+                    alignment_normal = True
                     try:
                         dst_fd.write(MAGIC)
                         while len(d) >= self.header_fmt.size:
-                            chunk, size = self.recover_segment_chunk(d)
+                            chunk, size = self.recover_segment_chunk(d, try_next_chunk=alignment_normal)
                             d = d[size:]
-                            if chunk is not None:
+                            if chunk is None:
+                                alignment_normal = False
+                            else:
+                                alignment_normal = True
                                 dst_fd.write(chunk)
                     finally:
                         del chunk


### PR DESCRIPTION
When recovery encounters a chunk that the CRC fails on, check if the size is correct by looking at the subsequent chunk offset by that size.

If the next chunk validates, assume the size was correct for the corrupt chunk, and avoid iterating through it byte-by-byte looking for a valid chunk.

Possible drawbacks:
- If it happens to have a corrupt size that coincidentally hits a valid chunk, we might fail to recover valid chunks in between.
- Each time the size is corrupt, we verify the CRC of more data than we needed to, which could significantly slow down cases where the size was corrupt. ~~Since the fallback is iterating byte-by-byte, we effectively double the already-slow process.~~ (Edit: No longer doing that)