### PR TITLE
drop python 3.5, fixes #5344

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - python: "3.5"
-          os: linux
-          dist: trusty
-          env: TOXENV=py35
         - python: "3.6"
           os: linux
           dist: trusty
@@ -31,14 +27,14 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py38
-        - python: "3.5"
+        - python: "3.6"
           os: linux
           dist: xenial
           env: TOXENV=flake8
         - language: generic
           os: osx
           osx_image: xcode8.3  # This is the latest working xcode image with osxfuse compatibility; later images come with an OS X version which doesn't allow kernel extensions
-          env: TOXENV=py35
+          env: TOXENV=py36
         - language: generic
           os: osx
           osx_image: xcode11.3

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -26,10 +26,10 @@ then
 
     # Configure pyenv with Python version according to TOXENV
     eval "$(pyenv init -)"
-    if [ "${TOXENV}" = "py35" ]
+    if [ "${TOXENV}" = "py36" ]
     then
-        pyenv install 3.5.3  # Minimum version for OpenSSL 1.1.x
-        pyenv global 3.5.3
+        pyenv install 3.6.0
+        pyenv global 3.6.0
     elif [ "${TOXENV}" = "py37" ]
     then
         pyenv install 3.7.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,11 +103,11 @@ def packages_openindiana
   return <<-EOF
     # needs separate provisioning step + reboot:
     #pkg update
-    # already installed:
-    #pkg install python-35 virtualenv-35 pip-35 clang-40 lz4 zstd git
-    ln -sf /usr/bin/python3.5 /usr/bin/pyton3
-    ln -sf /usr/bin/virtualenv-3.5 /usr/bin/virtualenv
-    ln -sf /usr/bin/pip-3.5 /usr/bin/pip
+    pkg install python-37 clang-40 lz4 zstd git
+    ln -sf /usr/bin/python3.7 /usr/bin/python3
+    python3 -m ensurepip
+    ln -sf /usr/bin/pip3.7 /usr/bin/pip3
+    pip3 install virtualenv
   EOF
 end
 
@@ -133,7 +133,6 @@ def install_pythons(boxname)
     pyenv install 3.8.0  # tests, version supporting openssl 1.1
     pyenv install 3.7.0  # tests, version supporting openssl 1.1
     pyenv install 3.6.9  # binary build, tests, version supporting openssl 1.1
-    pyenv install 3.5.3  # tests, 3.5.3 is first to support openssl 1.1
     pyenv rehash
   EOF
 end
@@ -213,16 +212,16 @@ def run_tests(boxname)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.5.3 3.6.9 3.7.0 3.8.0
-      pyenv local 3.5.3 3.6.9 3.7.0 3.8.0
+      pyenv global 3.6.9 3.7.0 3.8.0
+      pyenv local 3.6.9 3.7.0 3.8.0
     fi
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then
       echo "Running tox WITH fakeroot -u"
-      fakeroot -u tox --skip-missing-interpreters -e py35,py36,py37,py38
+      fakeroot -u tox --skip-missing-interpreters -e py36,py37,py38
     else
       echo "Running tox WITHOUT fakeroot -u"
-      tox --skip-missing-interpreters -e py35,py36,py37,py38
+      tox --skip-missing-interpreters -e py36,py37,py38
     fi
   EOF
 end
@@ -391,6 +390,6 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("openindiana64")
   end
 
-  # TODO: create more VMs with python 3.5+ and openssl 1.1.
+  # TODO: create more VMs with python 3.6+ and openssl 1.1.
   # See branch 1.1-maint for a better equipped Vagrantfile (but still on py34 and openssl 1.0).
 end

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -182,7 +182,7 @@ Some more advanced examples::
   # verify a changed tox.ini (run this after any change to tox.ini):
   fakeroot -u tox --recreate
 
-  fakeroot -u tox -e py35  # run all tests, but only on python 3.5
+  fakeroot -u tox -e py37  # run all tests, but only on python 3.7
 
   fakeroot -u tox borg.testsuite.locking  # only run 1 test module
 
@@ -320,10 +320,7 @@ Checklist:
 - Check version number of upcoming release in ``CHANGES.rst``.
 - Render ``CHANGES.rst`` via ``make html`` and check for markup errors.
 - Verify that ``MANIFEST.in`` and ``setup.py`` are complete.
-- ``python setup.py build_usage ; python setup.py build_man`` and
-  commit (be sure to build with Python 3.5 as Python 3.6 added `more
-  guaranteed hashing algorithms
-  <https://github.com/borgbackup/borg/issues/2123>`_).
+- ``python setup.py build_usage ; python setup.py build_man`` and commit.
 - Tag the release::
 
     git tag -s -m "tagged/signed release X.Y.Z" X.Y.Z

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -141,7 +141,7 @@ Dependencies
 To install Borg from a source package (including pip), you have to install the
 following dependencies first:
 
-* `Python 3`_ >= 3.5.0, plus development headers. Even though Python 3 is not
+* `Python 3`_ >= 3.6.0, plus development headers. Even though Python 3 is not
   the default Python version on most systems, it is usually available as an
   optional install.
 * OpenSSL_ >= 1.0.0, plus development headers.
@@ -282,7 +282,7 @@ Use the Cygwin installer to install the dependencies::
 
 You can then install ``pip`` and ``virtualenv``::
 
-    easy_install-3.5 pip
+    easy_install-3.6 pip
     pip install virtualenv
 
 

--- a/setup.py
+++ b/setup.py
@@ -266,7 +266,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -294,5 +293,5 @@ setup(
     setup_requires=['setuptools_scm>=1.7'],
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
py35 is EOL.

TODO: check if the openindiana vagrant box works as expected.