### PR TITLE
declare "allow_cache_wipe" marker in setup.cfg to avoid pytest warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 python_files = testsuite/*.py
+markers =
+    allow_cache_wipe
 
 [flake8]
 # please note that the values are adjusted so that they do not cause failures


### PR DESCRIPTION
Undeclared markers trigger a pytest warning:

    PytestUnknownMarkWarning: Unknown pytest.mark.allow_cache_wipe - is this a typo?

Backport of #5197