### PR TITLE
Enable Python3.9 env for test suite and VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ matrix:
           env: TOXENV=py36
         - language: generic
           os: osx
-          osx_image: xcode12u
-          env: TOXENV=py38 SKIPFUSE=true
+          osx_image: xcode11.3
+          env: TOXENV=py37 SKIPFUSE=true
     allow_failures:
         - os: osx  # OS X builds often take too long and time out, even though tests don't actually fail
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,58 +7,43 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - name: "Python 3.6 Trusty"
-          python: "3.6"
+        - python: "3.6"
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - name: "Python 3.7 Xenial"
-          python: "3.7"
+        - python: "3.7"
           os: linux
           dist: xenial
           env: TOXENV=py37
-        - name: "Python 3.7-dev Xenial"
-          python: "3.7-dev"
+        - python: "3.7-dev"
           os: linux
           dist: xenial
           env: TOXENV=py37
-        - name: "Python 3.8 Xenial"
-          python: "3.8"
+        - python: "3.8"
           os: linux
           dist: xenial
           env: TOXENV=py38
-        - name: "Python 3.8-dev Xenial"
-          python: "3.8-dev"
+        - python: "3.8-dev"
           os: linux
           dist: xenial
           env: TOXENV=py38
-        - name: "Python 3.9-dev Xenial"
-          python: "3.9-dev"
+        - python: "3.9-dev"
           os: linux
           dist: xenial
           env: TOXENV=py39 SKIPFUSE=true
-        - name: "Python 3.9-dev Focal Fossa"
-          python: "3.9-dev"
+        - python: "3.9-dev"
           os: linux
           dist: focal
           env: TOXENV=py39 SKIPFUSE=true
-        - name: "Python 3.6 Xenial"
-          python: "3.6"
+        - python: "3.6"
           os: linux
           dist: xenial
           env: TOXENV=flake8
-        - name: "Python 3.6 MacOs"
-          language: generic
+        - language: generic
           os: osx
           osx_image: xcode8.3  # This is the latest working xcode image with osxfuse compatibility; later images come with an OS X version which doesn't allow kernel extensions
           env: TOXENV=py36
-        - name: "Python 3.7 MacOs"
-          language: generic
-          os: osx
-          osx_image: xcode11.3
-          env: TOXENV=py37 SKIPFUSE=true
-        - name: "Python 3.8.3 MacOS"
-          language: generic
+        - language: generic
           os: osx
           osx_image: xcode12u
           env: TOXENV=py38 SKIPFUSE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,53 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - python: "3.6"
+        - name: "Python 3.6 Trusty"
+          python: "3.6"
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - python: "3.7"
-          os: linux
-          dist: xenial
-          env: TOXENV=py37
-        - python: "3.8"
-          os: linux
-          dist: xenial
-          env: TOXENV=py38
-        - python: "3.7-dev"
-          os: linux
-          dist: xenial
-          env: TOXENV=py37
-        - python: "3.8-dev"
-          os: linux
-          dist: xenial
-          env: TOXENV=py38
-        - python: "3.9-dev"
-          os: linux
-          dist: xenial
-          env: TOXENV=py39 SKIPFUSE=true
-        - python: "3.6"
+        - name: "Python 3.6 Xenial"
+          python: "3.6"
           os: linux
           dist: xenial
           env: TOXENV=flake8
-        - language: generic
+        - name: "Python 3.7 Xenial"
+          python: "3.7"
+          os: linux
+          dist: xenial
+          env: TOXENV=py37
+        - name: "Python 3.7-dev Xenial"
+          python: "3.7-dev"
+          os: linux
+          dist: xenial
+          env: TOXENV=py37
+        - name: "Python 3.8 Xenial"
+          python: "3.8"
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
+        - name: "Python 3.8-dev Xenial"
+          python: "3.8-dev"
+          os: linux
+          dist: xenial
+          env: TOXENV=py38
+        - name: "Python 3.9-dev Xenial"
+          python: "3.9-dev"
+          os: linux
+          dist: xenial
+          env: TOXENV=py39 SKIPFUSE=true
+        - name: "Python 3.9 Focal Fossa"
+          python: "3.9-dev"
+          os: linux
+          dist: focal
+          env: TOXENV=py39 SKIPFUSE=true
+        - name: "Python 3.6 MacOs"
+          language: generic
           os: osx
           osx_image: xcode8.3  # This is the latest working xcode image with osxfuse compatibility; later images come with an OS X version which doesn't allow kernel extensions
           env: TOXENV=py36
-        - language: generic
+        - name: "Python 3.7 MacOs"
+          language: generic
           os: osx
           osx_image: xcode11.3
           env: TOXENV=py37 SKIPFUSE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ matrix:
           os: linux
           dist: trusty
           env: TOXENV=py36
-        - name: "Python 3.6 Xenial"
-          python: "3.6"
-          os: linux
-          dist: xenial
-          env: TOXENV=flake8
         - name: "Python 3.7 Xenial"
           python: "3.7"
           os: linux
@@ -42,11 +37,16 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py39 SKIPFUSE=true
-        - name: "Python 3.9 Focal Fossa"
+        - name: "Python 3.9-dev Focal Fossa"
           python: "3.9-dev"
           os: linux
           dist: focal
           env: TOXENV=py39 SKIPFUSE=true
+        - name: "Python 3.6 Xenial"
+          python: "3.6"
+          os: linux
+          dist: xenial
+          env: TOXENV=flake8
         - name: "Python 3.6 MacOs"
           language: generic
           os: osx
@@ -57,6 +57,11 @@ matrix:
           os: osx
           osx_image: xcode11.3
           env: TOXENV=py37 SKIPFUSE=true
+        - name: "Python 3.8.3 MacOS"
+          language: generic
+          os: osx
+          osx_image: xcode12u
+          env: TOXENV=py38 SKIPFUSE=true
     allow_failures:
         - os: osx  # OS X builds often take too long and time out, even though tests don't actually fail
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py38
+        - python: "3.9-dev"
+          os: linux
+          dist: xenial
+          env: TOXENV=py39
         - python: "3.6"
           os: linux
           dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - python: "3.9-dev"
           os: linux
           dist: xenial
-          env: TOXENV=py39
+          env: TOXENV=py39 SKIPFUSE=true
         - python: "3.6"
           os: linux
           dist: xenial

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -11,7 +11,6 @@ then
 
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
-    brew update > /dev/null
     brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
 
     # Install and/or upgrade dependencies

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -12,7 +12,7 @@ then
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
     brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
-
+    brew update > /dev/null
     # Install and/or upgrade dependencies
     #brew install zstd || brew upgrade zstd  # Installation takes very long due to CMake dependency and isn't necessary for the tests as borg comes bundled with zstd anyway
     brew install lz4 || brew upgrade lz4

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -12,7 +12,7 @@ then
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
     brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
-    brew update
+
     # Install and/or upgrade dependencies
     #brew install zstd || brew upgrade zstd  # Installation takes very long due to CMake dependency and isn't necessary for the tests as borg comes bundled with zstd anyway
     brew install lz4 || brew upgrade lz4

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -12,7 +12,7 @@ then
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
     brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
-
+    brew update
     # Install and/or upgrade dependencies
     #brew install zstd || brew upgrade zstd  # Installation takes very long due to CMake dependency and isn't necessary for the tests as borg comes bundled with zstd anyway
     brew install lz4 || brew upgrade lz4
@@ -29,10 +29,10 @@ then
     then
         pyenv install 3.6.0
         pyenv global 3.6.0
-    elif [ "${TOXENV}" = "py38" ]
+    elif [ "${TOXENV}" = "py37" ]
     then
-        pyenv install 3.8.0
-        pyenv global 3.8.0
+        pyenv install 3.7.0
+        pyenv global 3.7.0
     else
         printf '%s\n' "Unexpected value for TOXENV environment variable"
         exit 1

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -34,6 +34,10 @@ then
     then
         pyenv install 3.7.0
         pyenv global 3.7.0
+    elif [ "${TOXENV}" = "py39" ]
+    then
+        pyenv install 3.9
+        pyenv global 3.9
     else
         printf '%s\n' "Unexpected value for TOXENV environment variable"
         exit 1

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -67,14 +67,17 @@ python -m pip install virtualenv
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
 
-# Recent versions of OS X don't allow kernel extensions which makes the osxfuse tests fail; those versions are marked with SKIPFUSE=true in .travis.yml
-if [ "${SKIPFUSE}" = "true" ]
-then
-    truncate -s 0 requirements.d/fuse.txt
-fi
-
 # Install requirements
 pip install -r requirements.d/development.txt
 pip install codecov
 python setup.py --version
-pip install -e .[fuse]
+
+# Recent versions of OS X don't allow kernel extensions which makes the osxfuse tests fail; those versions are marked with SKIPFUSE=true in .travis.yml
+if [ "${SKIPFUSE}" = "true" ]
+then
+    truncate -s 0 requirements.d/fuse.txt
+    pip install -e .
+else
+    pip install -e .[fuse]
+fi
+

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -34,6 +34,10 @@ then
     then
         pyenv install 3.7.0
         pyenv global 3.7.0
+    elif [ "${TOXENV}" = "py38" ]
+    then
+        pyenv install 3.8.0
+        pyenv global 3.8.0
     elif [ "${TOXENV}" = "py39" ]
     then
         pyenv install 3.9

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -11,7 +11,7 @@ then
 
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
-    brew update
+    brew update > /dev/null
     brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
 
     # Install and/or upgrade dependencies
@@ -30,18 +30,10 @@ then
     then
         pyenv install 3.6.0
         pyenv global 3.6.0
-    elif [ "${TOXENV}" = "py37" ]
-    then
-        pyenv install 3.7.0
-        pyenv global 3.7.0
     elif [ "${TOXENV}" = "py38" ]
     then
         pyenv install 3.8.0
         pyenv global 3.8.0
-    elif [ "${TOXENV}" = "py39" ]
-    then
-        pyenv install 3.9
-        pyenv global 3.9
     else
         printf '%s\n' "Unexpected value for TOXENV environment variable"
         exit 1

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -11,8 +11,8 @@ then
 
     # Update brew itself
     export HOMEBREW_NO_AUTO_UPDATE=1  # Auto-updating everything would take too much time
-    brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
     brew update > /dev/null
+    brew cleanup  # Preempt possible scheduled clean-up so it doesn't clutter the log later
     # Install and/or upgrade dependencies
     #brew install zstd || brew upgrade zstd  # Installation takes very long due to CMake dependency and isn't necessary for the tests as borg comes bundled with zstd anyway
     brew install lz4 || brew upgrade lz4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -220,10 +220,10 @@ def run_tests(boxname)
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then
       echo "Running tox WITH fakeroot -u"
-      fakeroot -u tox --skip-missing-interpreters -e py36,py37,py38
+      fakeroot -u tox --skip-missing-interpreters -e py36,py37,py38,py39
     else
       echo "Running tox WITHOUT fakeroot -u"
-      tox --skip-missing-interpreters -e py36,py37,py38
+      tox --skip-missing-interpreters -e py36,py37,py38,py39
     fi
   EOF
 end

--- a/setup.py
+++ b/setup.py
@@ -269,6 +269,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Security :: Cryptography',
         'Topic :: System :: Archiving :: Backup',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36,37,38},flake8
+envlist = py{35,36,37,38,39},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Add python 3.9 support in `tox.ini`, `.travis.yml`, `Vagrantfile` and metadata in `setup.py`
