### PR TITLE
vagrant: use py37 for binary creation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,10 +132,10 @@ end
 def install_pythons(boxname)
   return <<-EOF
     . ~/.bash_profile
-    pyenv install 3.9.0rc2  # tests, version supporting openssl 1.1
+    pyenv install 3.9.0  # tests, version supporting openssl 1.1
     pyenv install 3.8.0  # tests, version supporting openssl 1.1
-    pyenv install 3.7.0  # tests, version supporting openssl 1.1
-    pyenv install 3.6.10  # binary build, tests, version supporting openssl 1.1
+    pyenv install 3.7.9  # binary build, tests, version supporting openssl 1.1
+    pyenv install 3.6.1  # tests, version supporting openssl 1.1. coverage-py is broken on 3.6.0.
     pyenv rehash
   EOF
 end
@@ -152,9 +152,9 @@ def build_pyenv_venv(boxname)
   return <<-EOF
     . ~/.bash_profile
     cd /vagrant/borg
-    # use the latest 3.6 release
-    pyenv global 3.6.10
-    pyenv virtualenv 3.6.10 borg-env
+    # use the latest 3.7 release
+    pyenv global 3.7.9
+    pyenv virtualenv 3.7.9 borg-env
     ln -s ~/.pyenv/versions/borg-env .
   EOF
 end
@@ -215,8 +215,8 @@ def run_tests(boxname)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.6.10 3.7.0 3.8.0 3.9.0rc2
-      pyenv local 3.6.10 3.7.0 3.8.0 3.9.0rc2
+      pyenv global 3.6.1 3.7.9 3.8.0 3.9.0
+      pyenv local 3.6.1 3.7.9 3.8.0 3.9.0
     fi
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then


### PR DESCRIPTION
python 3.7 is the latest python release with good support by pyinstaller
4.0, so use latest 3.7.x to build the binary.

for testing borg on py36, use 3.6.1 because 3.6.0 breaks coverage-py.

also: upgrade 3.9.0rc2 to 3.9.0.

**no backport to 1.1-maint yet, maybe after 1.1.14 release**