### PR TITLE
mark myself as retired

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,6 @@ Borg authors ("The Borg Collective")
 ------------------------------------
 
 - Thomas Waldmann <tw@waldmann-edv.de>
-- Antoine Beaupré <anarcat@debian.org>
 - Radek Podgorny <radek@podgorny.cz>
 - Yuri D'Elia
 - Michael Hanselmann <public@hansmi.ch>
@@ -12,6 +11,11 @@ Borg authors ("The Borg Collective")
 - Daniel Reichelt <hacking@nachtgeist.net>
 - Lauri Niskanen <ape@ape3000.com>
 - Abdel-Rahman A. (Abogical)
+
+Retired
+```````
+
+- Antoine Beaupré <anarcat@debian.org>
 
 Borg is a fork of Attic.
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,8 @@
+E-mail addresses listed here are not intended for support, please see
+the `support section`_ instead.
+
+.. support section: https://borgbackup.readthedocs.io/en/stable/support.html
+
 Borg authors ("The Borg Collective")
 ------------------------------------
 


### PR DESCRIPTION
I retired from this project in 2016, yet I still regularly get support requests by email. I rarely have time to answer those requests, which are better served by community infrastructure anyways.

I suspect other members of the borg "collective" are retired as well, but I do not want to make any claims in that regard.