### PR TITLE
export-tar: set tar format to GNU_FORMAT explicitly

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -933,7 +933,7 @@ class Archiver:
 
         # The | (pipe) symbol instructs tarfile to use a streaming mode of operation
         # where it never seeks on the passed fileobj.
-        tar = tarfile.open(fileobj=tarstream, mode='w|')
+        tar = tarfile.open(fileobj=tarstream, mode='w|', format=tarfile.GNU_FORMAT)
 
         self._export_tar(args, archive, tar)
 


### PR DESCRIPTION
Python 3.8 changed the default format to PAX, but GNU format is documented for Borg.

Fixes #5274