### PR TITLE
Remove Python3.5 from tox.ini as it is not supported anymore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36,37,38,39},flake8
+envlist = py{36,37,38,39},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
tox.ini still had py35 in it's configuration while the setup.py [specifies](https://github.com/borgbackup/borg/blob/master/setup.py#L297) that the minimum supported version is py36.
This commits fixes this issue.

Fixes #5426 