### PR TITLE
Allow EIO with warning when trying to hardlink

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -301,7 +301,7 @@ class Repository:
             try:
                 os.link(config_path, old_config_path)
             except OSError as e:
-                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM, errno.EACCES, errno.ENOTSUP):
+                if e.errno in (errno.EMLINK, errno.ENOSYS, errno.EPERM, errno.EACCES, errno.ENOTSUP, errno.EIO):
                     logger.warning(link_error_msg)
                 else:
                     raise


### PR DESCRIPTION
Hello! Thanks for Borg, it's great!

I ran into an `[Errno 5] Input/output error` when doing `borg init`. It occurs when Borg tries to hardlink `config` to `config.old`. Since the code already ignores (with warning) a few errors from `os.link`, I just added `EIO` (errno 5).

For some more context, I'm running Borg in Docker on Mac. Docker for Mac recently changed the default bind mount filesystem from `osxfs` to `gRPC-FUSE`. It's `gRPC-FUSE` that has this hardlink error. I can workaround by switching Docker back to `osxfs`, but that's slower. So it seems preferable to be able to run Borg on the newer filesystem.