### PR TITLE
Doc / Deployment with ansible: generic install

### DIFF
--- a/docs/deployment/central-backup-server.rst
+++ b/docs/deployment/central-backup-server.rst
@@ -120,11 +120,7 @@ Ansible
 -------
 
 Ansible takes care of all the system-specific commands to add the user, create the
-folder. Even when the configuration is changed the repository server configuration is
-satisfied and reproducible.
-
-Automate setting up an repository server with the user, group, folders and
-permissions a Ansible playbook could be used.
+folder, install and configure software.
 
 ::
 

--- a/docs/deployment/central-backup-server.rst
+++ b/docs/deployment/central-backup-server.rst
@@ -124,9 +124,7 @@ folder. Even when the configuration is changed the repository server configurati
 satisfied and reproducible.
 
 Automate setting up an repository server with the user, group, folders and
-permissions a Ansible playbook could be used. Keep in mind the playbook
-uses the Arch Linux `pacman <https://www.archlinux.org/pacman/pacman.8.html>`_
-package manager to install and keep borg up-to-date.
+permissions a Ansible playbook could be used.
 
 ::
 
@@ -144,7 +142,7 @@ package manager to install and keep borg up-to-date.
         - host: app01.clnt.local
           key: "{{ lookup('file', '/path/to/keys/app01.clnt.local.pub') }}"
     tasks:
-    - pacman: name=borg state=latest update_cache=yes
+    - package: name=borg state=present
     - group: name="{{ group }}" state=present
     - user: name="{{ user }}" shell=/bin/bash home="{{ home }}" createhome=yes group="{{ group }}" groups= state=present
     - file: path="{{ home }}" owner="{{ user }}" group="{{ group }}" mode=0700 state=directory


### PR DESCRIPTION
I replaced the [pacman module](https://docs.ansible.com/ansible/latest/collections/community/general/pacman_module.html) with the [package module](https://docs.ansible.com/ansible/2.3/package_module.html), so the snippet work for most linuxes, and not only arch.

I also switched state from `latest` to `present` : it is meant to preserve idempotency. This is a [debattable change](https://github.com/ansible/ansible-lint/issues/479).