### PR TITLE
create: backport implementation --stdin-mode, --stdin-user and --stdin-group, #5333

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1025,14 +1025,19 @@ Utilization of max. archive size: {csize_max:.0%}
                 for chunk in item.chunks:
                     cache.chunk_incref(chunk.id, dummy_stats, size=chunk.size)
 
-    def process_stdin(self, path, cache):
-        uid, gid = 0, 0
+    def process_stdin(self, path, cache, mode, user, group):
+        uid = user2uid(user)
+        if uid is None:
+            raise Error("no such user: %s" % user)
+        gid = group2gid(group)
+        if gid is None:
+            raise Error("no such group: %s" % group)
         t = int(time.time()) * 1000000000
         item = Item(
             path=path,
-            mode=0o100660,  # regular file, ug=rw
-            uid=uid, user=uid2user(uid),
-            gid=gid, group=gid2group(gid),
+            mode=mode & 0o107777 | 0o100000,  # forcing regular file mode
+            uid=uid, user=user,
+            gid=gid, group=group,
             mtime=t, atime=t, ctime=t,
         )
         fd = sys.stdin.buffer  # binary

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -76,6 +76,7 @@ try:
     from .patterns import PatternMatcher
     from .item import Item
     from .platform import get_flags, get_process_id, SyncFile
+    from .platform import uid2user, gid2group
     from .remote import RepositoryServer, RemoteRepository, cache_if_remote
     from .repository import Repository, LIST_SCAN_LIMIT, TAG_PUT, TAG_DELETE, TAG_COMMIT
     from .selftest import selftest
@@ -524,9 +525,12 @@ class Archiver:
             for path in args.paths:
                 if path == '-':  # stdin
                     path = args.stdin_name
+                    mode = args.stdin_mode
+                    user = args.stdin_user
+                    group = args.stdin_group
                     if not dry_run:
                         try:
-                            status = archive.process_stdin(path, cache)
+                            status = archive.process_stdin(path, cache, mode, user, group)
                         except BackupOSError as e:
                             status = 'E'
                             self.print_warning('%s: %s', path, e)
@@ -3408,6 +3412,12 @@ class Archiver:
                                help='do not load/update the file metadata cache used to detect unchanged files')
         subparser.add_argument('--stdin-name', metavar='NAME', dest='stdin_name', default='stdin',
                                help='use NAME in archive for stdin data (default: "stdin")')
+        subparser.add_argument('--stdin-user', metavar='USER', dest='stdin_user', default=uid2user(0),
+                                help='set user USER in archive for stdin data (default: %(default)r)')
+        subparser.add_argument('--stdin-group', metavar='GROUP', dest='stdin_group', default=gid2group(0),
+                                help='set group GROUP in archive for stdin data (default: %(default)r)')
+        subparser.add_argument('--stdin-mode', metavar='M', dest='stdin_mode', type=lambda s: int(s, 8), default=STDIN_MODE_DEFAULT,
+                                help='set mode to M in archive for stdin data (default: %(default)04o)')
 
         exclude_group = define_exclusion_group(subparser, tag_files=True)
         exclude_group.add_argument('--exclude-nodump', dest='exclude_nodump', action='store_true',

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -20,6 +20,10 @@ REQUIRED_ARCHIVE_KEYS = frozenset(['version', 'name', 'items', 'cmdline', 'time'
 # default umask, overridden by --umask, defaults to read/write only for owner
 UMASK_DEFAULT = 0o077
 
+# default file mode to store stdin data, defaults to read/write for owner and group
+# forcing to 0o100XXX later
+STDIN_MODE_DEFAULT = 0o660
+
 CACHE_TAG_NAME = 'CACHEDIR.TAG'
 CACHE_TAG_CONTENTS = b'Signature: 8a477f597d28d172789f06886806bc55'
 


### PR DESCRIPTION
--stdin-mode, --stdin-user and --stdin-group options added
File mode forces to regular file with other values from the option --stdin-mode. Default mode is 0o100660.
Error occurs if given user or group do not exists. Default user and group values are taken from system uid/gid 0