### PR TITLE
create: backport implementation --stdin-mode, --stdin-user and --stdin-group, #5462

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1025,14 +1025,19 @@ Utilization of max. archive size: {csize_max:.0%}
                 for chunk in item.chunks:
                     cache.chunk_incref(chunk.id, dummy_stats, size=chunk.size)
 
-    def process_stdin(self, path, cache):
-        uid, gid = 0, 0
+    def process_stdin(self, path, cache, mode, user, group):
+        uid = user2uid(user)
+        if uid is None:
+            raise Error("no such user: %s" % user)
+        gid = group2gid(group)
+        if gid is None:
+            raise Error("no such group: %s" % group)
         t = int(time.time()) * 1000000000
         item = Item(
             path=path,
-            mode=0o100660,  # regular file, ug=rw
-            uid=uid, user=uid2user(uid),
-            gid=gid, group=gid2group(gid),
+            mode=mode & 0o107777 | 0o100000,  # forcing regular file mode
+            uid=uid, user=user,
+            gid=gid, group=group,
             mtime=t, atime=t, ctime=t,
         )
         fd = sys.stdin.buffer  # binary

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -20,6 +20,10 @@ REQUIRED_ARCHIVE_KEYS = frozenset(['version', 'name', 'items', 'cmdline', 'time'
 # default umask, overridden by --umask, defaults to read/write only for owner
 UMASK_DEFAULT = 0o077
 
+# default file mode to store stdin data, defaults to read/write for owner and group
+# forcing to 0o100XXX later
+STDIN_MODE_DEFAULT = 0o660
+
 CACHE_TAG_NAME = 'CACHEDIR.TAG'
 CACHE_TAG_CONTENTS = b'Signature: 8a477f597d28d172789f06886806bc55'
 


### PR DESCRIPTION
--stdin-mode, --stdin-user and --stdin-group options added
File mode forces to regular file with other values from the option --stdin-mode. Default mode is 0o100660.
Error occurs if given user or group do not exists. Default user and group values are taken from system uid/gid 0
