### PR TITLE
reduce testing on travis, no macOS, no py3x-dev, see #5467

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,8 @@ matrix:
         - python: "3.8"
           os: linux
           dist: focal
-          env: TOXENV=py38-fuse2
-        - python: "3.8-dev"
-          os: linux
-          dist: focal
           env: TOXENV=py38-fuse3
-        - python: "3.9-dev"
-          os: linux
-          dist: focal
-          env: TOXENV=py39-fuse2
-        - python: "3.9-dev"
+        - python: "3.9"
           os: linux
           dist: focal
           env: TOXENV=py39-fuse3
@@ -35,16 +27,6 @@ matrix:
           os: linux
           dist: focal
           env: TOXENV=flake8
-        - language: generic
-          os: osx
-          osx_image: xcode8.3  # This is the latest working xcode image with osxfuse compatibility; later images come with an OS X version which doesn't allow kernel extensions
-          env: TOXENV=py36-fuse2
-        - language: generic
-          os: osx
-          osx_image: xcode11.3
-          env: TOXENV=py37  # No FUSE testing, because recent versions of macOS don't allow kernel extensions of osxfuse.
-    allow_failures:
-        - os: osx  # OS X builds often take too long and time out, even though tests don't actually fail
 
 before_install: # Abort installation and don't run tests for pull requests if commit only changed the docs
 - |


### PR DESCRIPTION
- kill the macOS builds, way too expensive (and problematic anyway)
- kill the builds on python development versions, can't afford any more
