### PR TITLE
Use --timestamp in placeholders if given

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4496,6 +4496,8 @@ class Archiver:
                               self.do_list, self.do_mount, self.do_umount}
             if func not in bypass_allowed:
                 raise Error('Not allowed to bypass locking mechanism for chosen command')
+        if getattr(args, 'timestamp', None):
+            args.location = args.location.with_timestamp(args.timestamp)
         return args
 
     def prerun_checks(self, logger, is_serve):

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -189,6 +189,10 @@ class TestLocationWithoutEnv:
         assert repr(Location('ssh://host/path::2016-12-31@23:59:59')) == \
             "Location(proto='ssh', user=None, host='host', port=None, path='/path', archive='2016-12-31@23:59:59')"
 
+    def test_with_timestamp(self):
+        assert repr(Location('path::archive-{utcnow}').with_timestamp(datetime(2002, 9, 19))) == \
+            "Location(proto='file', user=None, host=None, port=None, path='path', archive='archive-2002-09-19T00:00:00')"
+
     def test_underspecified(self, monkeypatch):
         monkeypatch.delenv('BORG_REPO', raising=False)
         with pytest.raises(ValueError):
@@ -933,6 +937,10 @@ def test_replace_placeholders():
     now = datetime.now()
     assert " " not in replace_placeholders('{now}')
     assert int(replace_placeholders('{now:%Y}')) == now.year
+
+
+def test_override_placeholders():
+    assert replace_placeholders('{uuid4}', overrides={'uuid4': "overridden"}) == "overridden"
 
 
 def working_swidth():


### PR DESCRIPTION
Fixes #5189. `{now}` and `{utcnow}` will take the value of `--timestamp` if given. I also added a test for this functionality.