### PR TITLE
Fixes BORG_CACHE_DIR crashing borg if empty

### DIFF
--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -21,7 +21,7 @@ logger = create_logger()
 py_37_plus = sys.version_info >= (3, 7)
 
 
-def ensure_dir(path, name=None, mode=0o777, pretty_deadly=True):
+def ensure_dir(path, mode=stat.S_IRWXU, pretty_deadly=True):
     """
     Ensures that the dir exists with the right permissions.
     1) Make sure the directory exists in a race-free operation
@@ -64,9 +64,8 @@ def get_keys_dir():
     """Determine where to repository keys and cache"""
 
     keys_dir = os.environ.get('BORG_KEYS_DIR', os.path.join(get_config_dir(), 'keys'))
-    if ensure_dir(keys_dir, "key directory", stat.S_IRWXU):
-        logger.debug("Created keys directory : %s" % keys_dir)
-    return keys_dir
+    if ensure_dir(keys_dir):
+        return keys_dir
 
 
 def get_security_dir(repository_id=None):
@@ -74,9 +73,8 @@ def get_security_dir(repository_id=None):
     security_dir = os.environ.get('BORG_SECURITY_DIR', os.path.join(get_config_dir(), 'security'))
     if repository_id:
         security_dir = os.path.join(security_dir, repository_id)
-    if ensure_dir(security_dir, "security directory", stat.S_IRWXU):
-        logger.debug("Created security directory : %s" % security_dir)
-    return security_dir
+    if ensure_dir(security_dir):
+        return security_dir
 
 
 def get_cache_dir():
@@ -89,16 +87,15 @@ def get_cache_dir():
     # Use BORG_CACHE_DIR if set, otherwise assemble final path from cache home path
     cache_dir = os.environ.get('BORG_CACHE_DIR', os.path.join(cache_home, 'borg'))
     # Create path if it doesn't exist yet
-    if ensure_dir(cache_dir, "cache directory", stat.S_IRWXU):
-        logger.debug("Created cache directory : %s" % cache_dir)
-    with open(os.path.join(cache_dir, CACHE_TAG_NAME), 'wb') as fd:
-        fd.write(CACHE_TAG_CONTENTS)
-        fd.write(textwrap.dedent("""
-        # This file is a cache directory tag created by Borg.
-        # For information about cache directory tags, see:
-        #       http://www.bford.info/cachedir/spec.html
-        """).encode('ascii'))
-    return cache_dir
+    if ensure_dir(cache_dir):
+        with open(os.path.join(cache_dir, CACHE_TAG_NAME), 'wb') as fd:
+            fd.write(CACHE_TAG_CONTENTS)
+            fd.write(textwrap.dedent("""
+            # This file is a cache directory tag created by Borg.
+            # For information about cache directory tags, see:
+            #       http://www.bford.info/cachedir/spec.html
+            """).encode('ascii'))
+        return cache_dir
 
 
 def get_config_dir():
@@ -111,9 +108,8 @@ def get_config_dir():
     # Use BORG_CONFIG_DIR if set, otherwise assemble final path from config home path
     config_dir = os.environ.get('BORG_CONFIG_DIR', os.path.join(config_home, 'borg'))
     # Create path if it doesn't exist yet
-    if ensure_dir(config_dir, "config directory", stat.S_IRWXU):
-        logger.debug("Created config directory : %s" % config_dir)
-    return config_dir
+    if ensure_dir(config_dir):
+        return config_dir
 
 
 def dir_is_cachedir(path):

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -38,13 +38,13 @@ def ensure_dir(path, name=None, mode=None, reraise=False):
     except FileExistsError:
         return False
     except FileNotFoundError as e:
-        print("Error : Could not create directory '%s'\n%s" % (name, e))
+        logger.error("Could not create directory '%s'\n%s" % (name, e))
         if reraise:
-            raise Error(e)
+            raise Error(e.args[1])
     except OSError as e:
-        print("Error : Could not create directory '%s'\n%s" % (name, e))
+        logger.error("Error : Could not create directory '%s'\n%s" % (name, e))
         if reraise:
-            raise Error(e)
+            raise Error(e.args[1])
     return True
 
 

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -26,10 +26,10 @@ def ensure_dir(path, mode=stat.S_IRWXU, pretty_deadly=True):
     Ensures that the dir exists with the right permissions.
     1) Make sure the directory exists in a race-free operation
     2) If mode is not None and the directory has been created, give the right
-    permissions
+    permissions to the leaf directory
     3) If pretty_deadly is True, catch exceptions, reraise them with a pretty
     message.
-    Returns True if the file has been created and has the right permissions,
+    Returns if the directory has been created and has the right permissions,
     An exception otherwise. If a deadly exception happened it is reraised.
     """
     try:
@@ -39,7 +39,7 @@ def ensure_dir(path, mode=stat.S_IRWXU, pretty_deadly=True):
             raise Error(e.args[1])
         else:
             raise
-    return True
+    return
 
 
 def get_base_dir():
@@ -64,8 +64,8 @@ def get_keys_dir():
     """Determine where to repository keys and cache"""
 
     keys_dir = os.environ.get('BORG_KEYS_DIR', os.path.join(get_config_dir(), 'keys'))
-    if ensure_dir(keys_dir):
-        return keys_dir
+    ensure_dir(keys_dir)
+    return keys_dir
 
 
 def get_security_dir(repository_id=None):
@@ -73,8 +73,8 @@ def get_security_dir(repository_id=None):
     security_dir = os.environ.get('BORG_SECURITY_DIR', os.path.join(get_config_dir(), 'security'))
     if repository_id:
         security_dir = os.path.join(security_dir, repository_id)
-    if ensure_dir(security_dir):
-        return security_dir
+    ensure_dir(security_dir)
+    return security_dir
 
 
 def get_cache_dir():
@@ -87,15 +87,15 @@ def get_cache_dir():
     # Use BORG_CACHE_DIR if set, otherwise assemble final path from cache home path
     cache_dir = os.environ.get('BORG_CACHE_DIR', os.path.join(cache_home, 'borg'))
     # Create path if it doesn't exist yet
-    if ensure_dir(cache_dir):
-        with open(os.path.join(cache_dir, CACHE_TAG_NAME), 'wb') as fd:
-            fd.write(CACHE_TAG_CONTENTS)
-            fd.write(textwrap.dedent("""
-            # This file is a cache directory tag created by Borg.
-            # For information about cache directory tags, see:
-            #       http://www.bford.info/cachedir/spec.html
-            """).encode('ascii'))
-        return cache_dir
+    ensure_dir(cache_dir)
+    with open(os.path.join(cache_dir, CACHE_TAG_NAME), 'wb') as fd:
+        fd.write(CACHE_TAG_CONTENTS)
+        fd.write(textwrap.dedent("""
+        # This file is a cache directory tag created by Borg.
+        # For information about cache directory tags, see:
+        #       http://www.bford.info/cachedir/spec.html
+        """).encode('ascii'))
+    return cache_dir
 
 
 def get_config_dir():
@@ -108,8 +108,8 @@ def get_config_dir():
     # Use BORG_CONFIG_DIR if set, otherwise assemble final path from config home path
     config_dir = os.environ.get('BORG_CONFIG_DIR', os.path.join(config_home, 'borg'))
     # Create path if it doesn't exist yet
-    if ensure_dir(config_dir):
-        return config_dir
+    ensure_dir(config_dir)
+    return config_dir
 
 
 def dir_is_cachedir(path):

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -39,7 +39,6 @@ def ensure_dir(path, mode=stat.S_IRWXU, pretty_deadly=True):
             raise Error(e.args[1])
         else:
             raise
-    return
 
 
 def get_base_dir():

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -34,16 +34,6 @@ def ensure_dir(path, name=None, mode=0o777, pretty_deadly=True):
     """
     try:
         os.makedirs(path, mode=mode, exist_ok=True)
-    except FileExistsError:
-        if pretty_deadly:
-            raise Error(e.args[1])
-        else:
-            raise
-    except FileNotFoundError as e:
-        if pretty_deadly:
-            raise Error(e.args[1])
-        else:
-            raise
     except OSError as e:
         if pretty_deadly:
             raise Error(e.args[1])

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -27,10 +27,10 @@ def ensure_dir(path, name=None, mode=0o777, pretty_deadly=True):
     1) Make sure the directory exists in a race-free operation
     2) If mode is not None and the directory has been created, give the right
     permissions
-    3) If pretty_deadly is True, catch fatal exceptions, reraise them with a pretty
+    3) If pretty_deadly is True, catch exceptions, reraise them with a pretty
     message.
     Returns True if the file has been created and has the right permissions,
-    False otherwise. If a deadly exception happened it is reraised.
+    An exception otherwise. If a deadly exception happened it is reraised.
     """
     try:
         os.makedirs(path, mode=mode, exist_ok=True)


### PR DESCRIPTION
This patch introduces a new function that atomically checks if the given
directory exists or not, and if not, tries to fix it.
The error is reraised if necessary with a nice catching.

Fixes #5216.