### PR TITLE
Timestamp fixes

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -88,26 +88,6 @@ def interval(s):
     return hours
 
 
-def timestamp(s):
-    """Convert a --timestamp=s argument to a datetime object"""
-    try:
-        # is it pointing to a file / directory?
-        ts = safe_s(os.stat(s).st_mtime)
-        return datetime.utcfromtimestamp(ts)
-    except OSError:
-        # didn't work, try parsing as timestamp. UTC, no TZ, no microsecs support.
-        for format in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S+00:00',
-                       '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S',
-                       '%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M',
-                       '%Y-%m-%d', '%Y-%j',
-                       ):
-            try:
-                return datetime.strptime(s, format)
-            except ValueError:
-                continue
-        raise ValueError
-
-
 def ChunkerParams(s):
     params = s.strip().split(',')
     count = len(params)

--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -24,7 +24,7 @@ def timestamp(s):
     try:
         # is it pointing to a file / directory?
         ts = safe_s(os.stat(s).st_mtime)
-        return datetime.utcfromtimestamp(ts)
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
     except OSError:
         # didn't work, try parsing as timestamp. UTC, no TZ, no microsecs support.
         for format in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S+00:00',
@@ -33,7 +33,7 @@ def timestamp(s):
                        '%Y-%m-%d', '%Y-%j',
                        ):
             try:
-                return datetime.strptime(s, format)
+                return datetime.strptime(s, format).replace(tzinfo=timezone.utc)
             except ValueError:
                 continue
         raise ValueError

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -190,7 +190,7 @@ class TestLocationWithoutEnv:
             "Location(proto='ssh', user=None, host='host', port=None, path='/path', archive='2016-12-31@23:59:59')"
 
     def test_with_timestamp(self):
-        assert repr(Location('path::archive-{utcnow}').with_timestamp(datetime(2002, 9, 19))) == \
+        assert repr(Location('path::archive-{utcnow}').with_timestamp(datetime(2002, 9, 19, tzinfo=timezone.utc))) == \
             "Location(proto='file', user=None, host=None, port=None, path='path', archive='archive-2002-09-19T00:00:00')"
 
     def test_underspecified(self, monkeypatch):


### PR DESCRIPTION
This is a forward-port from my [back-port](https://github.com/borgbackup/borg/pull/5488) of #5472. Making the timestamp value timezone-aware makes `{now}` different from `{utcnow}`, which upon another look I think is what was [originally intended](https://github.com/borgbackup/borg/issues/5189#issuecomment-629865397).

Also, I got rid of a duplicate function that was accidentally added during a refactor.