### PR TITLE
Chunk size obfuscating "compressor"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ Main features
     All data can be protected using 256-bit AES encryption, data integrity and
     authenticity is verified using HMAC-SHA256. Data is encrypted clientside.
 
+**Obfuscation**
+    Optionally, borg can actively obfuscate e.g. the size of files / chunks to
+    make fingerprinting attacks more difficult.
+
 **Compression**
     All data can be optionally compressed:
 

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -426,6 +426,27 @@ he assumes that the victim also possesses (and backups into the repository)
 could try a brute force fingerprinting attack based on the chunk sizes in the
 repository to prove his assumption.
 
+To make this more difficult, borg has an ``obfuscate`` pseudo compressor, that
+will take the output of the normal compression step and tries to obfuscate
+the size of that output. Of course, it can only **add** to the size, not reduce
+it. Thus, the optional usage of this mechanism comes at a cost: it will make
+your repository larger (ranging from a few percent larger [cheap] to ridiculously
+larger [expensive], depending on the algorithm/params you wisely choose).
+
+The output of the compressed-size obfuscation step will then be encrypted and
+authenticated, as usual. Of course, using that obfuscation would not make any
+sense without encryption. Thus, the additional data added by the obfuscator
+are just 0x00 bytes, which is good enough because after encryption it will
+look like random anyway.
+
+To summarize, this is making size-based fingerprinting difficult:
+
+- user-selectable chunker algorithm (and parametrization)
+- for the buzhash chunker: secret, random per-repo chunker seed
+- user-selectable compression algorithm (and level)
+- optional ``obfuscate`` pseudo compressor with different choices
+  of algorithm and parameters
+
 Stored chunk proximity
 ----------------------
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2392,6 +2392,32 @@ class Archiver:
             For compressible data, it uses the given C[,L] compression - with C[,L]
             being any valid compression specifier.
 
+        obfuscate,SPEC,C[,L]
+            Use compressed-size obfuscation to make fingerprinting attacks based on
+            the observable stored chunk size more difficult.
+            Note:
+            - you must combine this with encryption or it won't make any sense.
+            - your repo size will be bigger, of course.
+
+            The SPEC value will determine how the size obfuscation will work:
+
+            Relative random reciprocal size variation:
+            Size will increase by a factor, relative to the compressed data size.
+            Smaller factors are often used, larger factors rarely.
+            1: factor 0.01 .. 100.0
+            2: factor 0.1 .. 1000.0
+            3: factor 1.0 .. 10000.0
+            4: factor 10.0 .. 100000.0
+            5: factor 100.0 .. 1000000.0
+            6: factor 1000.0 .. 10000000.0
+
+            Add a randomly sized padding up to the given size:
+            110: 1kiB
+            ...
+            120: 1MiB
+            ...
+            123: 8MiB (max.)
+
         Examples::
 
             borg create --compression lz4 REPO::ARCHIVE data
@@ -2400,7 +2426,10 @@ class Archiver:
             borg create --compression zlib REPO::ARCHIVE data
             borg create --compression zlib,1 REPO::ARCHIVE data
             borg create --compression auto,lzma,6 REPO::ARCHIVE data
-            borg create --compression auto,lzma ...\n\n''')
+            borg create --compression auto,lzma ...
+            borg create --compression obfuscate,3,none ...
+            borg create --compression obfuscate,3,auto,zstd,10 ...
+            borg create --compression obfuscate,2,zstd,6 ...\n\n''')
 
     def do_help(self, parser, commands, args):
         if not args.topic:

--- a/src/borg/helpers/checks.py
+++ b/src/borg/helpers/checks.py
@@ -29,7 +29,7 @@ def check_extension_modules():
         raise ExtensionModuleError
     if chunker.API_VERSION != '1.2_01':
         raise ExtensionModuleError
-    if compress.API_VERSION != '1.2_01':
+    if compress.API_VERSION != '1.2_02':
         raise ExtensionModuleError
     if borg.crypto.low_level.API_VERSION != '1.2_01':
         raise ExtensionModuleError


### PR DESCRIPTION
See #3687 for the problem discussion.

This PR would make a borg repo harder to attack using a known set of small file sizes fingerprinting attack.

Notes:
- borg client side will still store the real size (and overall csize) into client-side indexes
- borg server side segment files will only store overall csize (result of compression + obfuscation)
- plaintext size information in archive metadata is encrypted, attacker on repo side can't see it
- attacker does not know exact amount of obfuscation and can also only guess compression algo/level
- no problem adding just a random amount of zero bytes because encryption will make them look random
- but it is important to not compress these, because compressor could reduce a lot of zeros to just a few bytes e.g. due to run-length encoding (RLE), thus resulting in only little real size variation.
