### PR TITLE
Add a hint on sleeping computer in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -183,6 +183,12 @@ This is not a problem anymore.
 
 For more details, see :ref:`checkpoints_parts`.
 
+My machine goes to sleep causing `Broken pipe`
+----------------------------------------------
+
+When backing up your data over the network, your machine should not go to sleep.
+On macOS you can use `caffeinate` to avoid that.
+
 How can I restore huge file(s) over an unstable connection?
 -----------------------------------------------------------
 


### PR DESCRIPTION
Now the FAQ warns that a sleeping computer can lead to a broken pipe
when backing up over ssh.

Fixes #5301 