### PR TITLE
create: implement --paths-from-stdin and --paths-from-command

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -546,7 +546,7 @@ class Archiver:
                     pipe_bin = proc.stdout
                 else:  # args.paths_from_stdin == True
                     pipe_bin = sys.stdin.buffer
-                pipe = TextIOWrapper(pipe_bin, encoding='utf-8', errors='surrogateescape')
+                pipe = TextIOWrapper(pipe_bin, errors='surrogateescape')
                 for path in iter_separated(pipe, paths_sep):
                     try:
                         with backup_io('stat'):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3312,10 +3312,9 @@ class Archiver:
                                     ' stdin below.')
         subparser.add_argument('--paths-from-stdin', action='store_true',
                                help='read DELIM-separated list of paths to backup from stdin. Will not '
-                                    'recurse in directories')
+                                    'recurse into directories.')
         subparser.add_argument('--paths-from-command', action='store_true',
-                               help='interpret PATH as command and treat its output as ``--paths-from-stdin``'
-                                    'recurse in directories')
+                               help='interpret PATH as command and treat its output as ``--paths-from-stdin``')
         subparser.add_argument('--paths-delimiter', metavar='DELIM',
                                help='set path delimiter for ``--paths-from-stdin`` and ``--paths-from-command`` (default: \\n) ')
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -27,6 +27,7 @@ try:
     from binascii import unhexlify
     from contextlib import contextmanager
     from datetime import datetime, timedelta
+    from io import TextIOWrapper
 
     from .logger import create_logger, setup_logging
 
@@ -73,6 +74,7 @@ try:
     from .helpers import flags_root, flags_dir, flags_special_follow, flags_special
     from .helpers import msgpack
     from .helpers import sig_int
+    from .helpers import iter_separated
     from .nanorst import rst_to_terminal
     from .patterns import ArgparsePatternAction, ArgparseExcludeFileAction, ArgparsePatternFileAction, parse_exclude_pattern
     from .patterns import PatternMatcher
@@ -541,9 +543,10 @@ class Archiver:
                     except (FileNotFoundError, PermissionError) as e:
                         self.print_error('Failed to execute command: %s', e)
                         return self.exit_code
-                    pipe = proc.stdout
+                    pipe_bin = proc.stdout
                 else:  # args.paths_from_stdin == True
-                    pipe = sys.stdin
+                    pipe_bin = sys.stdin.buffer
+                pipe = TextIOWrapper(pipe_bin, encoding='utf-8', errors='surrogateescape')
                 for path in iter_separated(pipe, paths_sep):
                     try:
                         with backup_io('stat'):

--- a/src/borg/helpers/misc.py
+++ b/src/borg/helpers/misc.py
@@ -215,15 +215,12 @@ class ErrorIgnoringTextIOWrapper(io.TextIOWrapper):
         return len(s)
 
 
-def iter_separated(fd, sep=None, read_size=1024):
+def iter_separated(fd, sep=None, read_size=4096):
     """Iter over chunks of open file ``fd`` delimited by ``sep``. Doesn't trim."""
     buf = fd.read(read_size)
-    if type(buf) is str:
-        part = ''
-        sep = sep or '\n'
-    else:
-        part = b''
-        sep = sep or b'\n'
+    is_str = isinstance(buf, str)
+    part = '' if is_str else b''
+    sep = sep or ('\n' if is_str else b'\n')
     while len(buf) > 0:
         part2, *items = buf.split(sep)
         *full, part = (part + part2, *items)

--- a/src/borg/helpers/misc.py
+++ b/src/borg/helpers/misc.py
@@ -213,3 +213,17 @@ class ErrorIgnoringTextIOWrapper(io.TextIOWrapper):
                 except OSError:
                     pass
         return len(s)
+
+
+def iter_separated(fd, sep='\n', read_size=1024):
+    """Iter over chunks of open file ``fd`` delimited by ``sep``. Doesn't trim."""
+    part = ''
+    buf = fd.read(read_size)
+    while len(buf) > 0:
+        part2, *items = buf.split(sep)
+        *full, part = (part + part2, *items)
+        yield from full
+    # won't yield an empty part if stream ended with `sep`
+    # or if there was no data before EOF
+    if len(part) > 0:
+        yield part

--- a/src/borg/helpers/misc.py
+++ b/src/borg/helpers/misc.py
@@ -215,10 +215,15 @@ class ErrorIgnoringTextIOWrapper(io.TextIOWrapper):
         return len(s)
 
 
-def iter_separated(fd, sep='\n', read_size=1024):
+def iter_separated(fd, sep=None, read_size=1024):
     """Iter over chunks of open file ``fd`` delimited by ``sep``. Doesn't trim."""
-    part = ''
     buf = fd.read(read_size)
+    if type(buf) is str:
+        part = ''
+        sep = sep or '\n'
+    else:
+        part = b''
+        sep = sep or b'\n'
     while len(buf) > 0:
         part2, *items = buf.split(sep)
         *full, part = (part + part2, *items)

--- a/src/borg/helpers/misc.py
+++ b/src/borg/helpers/misc.py
@@ -223,6 +223,7 @@ def iter_separated(fd, sep='\n', read_size=1024):
         part2, *items = buf.split(sep)
         *full, part = (part + part2, *items)
         yield from full
+        buf = fd.read(read_size)
     # won't yield an empty part if stream ended with `sep`
     # or if there was no data before EOF
     if len(part) > 0:

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -48,6 +48,11 @@ def remove_surrogates(s, errors='replace'):
     return s.encode('utf-8', errors).decode('utf-8')
 
 
+def eval_escapes(s):
+    """Evaluate literal escape sequences in a string (eg `\\n` -> `\n`)."""
+    return s.encode('ascii', 'backslashreplace').decode('unicode-escape')
+
+
 def decode_dict(d, keys, encoding='utf-8', errors='surrogateescape'):
     for key in keys:
         if isinstance(d.get(key), bytes):

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from argparse import ArgumentTypeError
 from datetime import datetime, timezone, timedelta
-from io import StringIO
+from io import StringIO, BytesIO
 from time import sleep
 
 import pytest
@@ -1031,14 +1031,15 @@ def test_iter_separated():
     # newline and utf-8
     fd = StringIO('foo\nbar/baz\n나윤a선나윤선나윤선나윤선나윤선\n')
     assert list(iter_separated(fd)) == ['foo', 'bar/baz', '나윤a선나윤선나윤선나윤선나윤선']
-
     # null
     fd = StringIO('foo/bar\0baz\0spam')
     assert list(iter_separated(fd, sep='\0')) == ['foo/bar', 'baz', 'spam']
-
     # multichar
     fd = StringIO('foo/barSEPbazSEPspam')
     assert list(iter_separated(fd, sep='SEP')) == ['foo/bar', 'baz', 'spam']
+    # bytes
+    fd = BytesIO(b'foo\nblop\t\n')
+    assert list(iter_separated(fd, sep=b'\n')) == [b'foo', b'blop\t']
 
 
 def test_eval_escapes():

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -1029,17 +1029,21 @@ def test_dash_open():
 
 def test_iter_separated():
     # newline and utf-8
-    fd = StringIO('foo\nbar/baz\n나윤a선나윤선나윤선나윤선나윤선\n')
-    assert list(iter_separated(fd)) == ['foo', 'bar/baz', '나윤a선나윤선나윤선나윤선나윤선']
-    # null
-    fd = StringIO('foo/bar\0baz\0spam')
-    assert list(iter_separated(fd, sep='\0')) == ['foo/bar', 'baz', 'spam']
+    sep, items = '\n', ['foo', 'bar/baz', '나윤a선나윤선나윤선나윤선나윤선']
+    fd = StringIO(sep.join(items))
+    assert list(iter_separated(fd)) == items
+    # null and bogus ending
+    sep, items = '\0', ['foo/bar', 'baz', 'spam']
+    fd = StringIO(sep.join(items) + '\0')
+    assert list(iter_separated(fd, sep=sep)) == ['foo/bar', 'baz', 'spam']
     # multichar
-    fd = StringIO('foo/barSEPbazSEPspam')
-    assert list(iter_separated(fd, sep='SEP')) == ['foo/bar', 'baz', 'spam']
+    sep, items = 'SEP', ['foo/bar', 'baz', 'spam']
+    fd = StringIO(sep.join(items))
+    assert list(iter_separated(fd, sep=sep)) == items
     # bytes
-    fd = BytesIO(b'foo\nblop\t\n')
-    assert list(iter_separated(fd, sep=b'\n')) == [b'foo', b'blop\t']
+    sep, items = b'\n', [b'foo', b'blop\t', b'gr\xe4ezi']
+    fd = BytesIO(sep.join(items))
+    assert list(iter_separated(fd)) == items
 
 
 def test_eval_escapes():

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -1049,4 +1049,3 @@ def test_iter_separated():
 def test_eval_escapes():
     assert eval_escapes('\\n\\0\\x23') == '\n\0#'
     assert eval_escapes('äç\\n') == 'äç\n'
-    assert eval_escapes('aoeu\u1234') == 'aoeu\u1234'

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -1029,7 +1029,7 @@ def test_dash_open():
 
 def test_iter_separated():
     # newline and utf-8
-    sep, items = '\n', ['foo', 'bar/baz', '나윤a선나윤선나윤선나윤선나윤선']
+    sep, items = '\n', ['foo', 'bar/baz', 'αáčő']
     fd = StringIO(sep.join(items))
     assert list(iter_separated(fd)) == items
     # null and bogus ending
@@ -1048,5 +1048,5 @@ def test_iter_separated():
 
 def test_eval_escapes():
     assert eval_escapes('\\n\\0\\x23') == '\n\0#'
-    assert eval_escapes('ä捃\\n') == 'ä捃\n'
+    assert eval_escapes('äç\\n') == 'äç\n'
     assert eval_escapes('aoeu\u1234') == 'aoeu\u1234'


### PR DESCRIPTION
WIP. Follow-up of #5492. Implement two switches which shortcut the filesystem-walking logic completely: borg will read the paths and backup without doing any recursion (directories can --and should-- be passed). Should honor any relevant option (common options and all filesystem option but --one-file-system).

Slight change from my earlier proposal: now if either `--paths-from-stdin` or `--paths-from-command` are given, then it won't process any normal path from `args.path`. In `--path-from-command` it wouldn't make sense anyway since `args.path` is being used for the command. Technically, for `--paths-from-stdin` we could still handle `args.path` as usual but it's probably safe to assume that a user don't want to mix both things. Besides it simplifies the code and the top-level behavior of `create`.

WIP: Just wrote, didn't execute! :) I should verify if it works correctly and add unit tests to the PR.