### PR TITLE
Complete documentation on append-only remote repos for 1.1-maint

### DIFF
--- a/docs/deployment/hosting-repositories.rst
+++ b/docs/deployment/hosting-repositories.rst
@@ -70,5 +70,15 @@ support storage quotas.
 
 Refer to :ref:`internals_storage_quota` for more details on storage quotas.
 
+**Specificities: Append-only repositories**
+
+Running ``borg init`` via a ``borg serve --append-only`` server will **not**
+create a repository that is configured to be append-only by its repository
+config.
+
+But, ``--append-only`` arguments in ``authorized_keys`` will override the
+repository config, therefore append-only mode can be enabled on a key by key
+basis.
+
 Refer to the `sshd(8) <http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man8/sshd.8>`_
 man page for more details on SSH options.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -185,6 +185,14 @@ This is not a problem anymore.
 
 For more details, see :ref:`checkpoints_parts`.
 
+How can I switch append-only mode on and off?
+-----------------------------------------------------------------------------------------------------------------------------------
+
+You could do that (via borg config REPO append_only 0/1), but using different
+ssh keys and different entries in ``authorized_keys`` is much easier and also
+maybe has less potential of things going wrong somehow.
+
+
 My machine goes to sleep causing `Broken pipe`
 ----------------------------------------------
 


### PR DESCRIPTION
Backport the documentation changes to 1.1-maint.