### PR TITLE
do not recurse into duplicate roots, fixes #5603 (master)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -603,6 +603,9 @@ class Archiver:
                                        exclude_caches=args.exclude_caches, exclude_if_present=args.exclude_if_present,
                                        keep_exclude_tags=args.keep_exclude_tags, skip_inodes=skip_inodes,
                                        restrict_dev=restrict_dev, read_special=args.read_special, dry_run=dry_run)
+                        # if we get back here, we've finished recursing into <path>,
+                        # we do not ever want to get back in there (even if path is given twice as recursion root)
+                        skip_inodes.add((st.st_ino, st.st_dev))
             if not dry_run:
                 if args.progress:
                     archive.stats.show_progress(final=True)

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -381,6 +381,8 @@ class ArchiverTestCaseBase(BaseTestCase):
 
 
 class ArchiverTestCase(ArchiverTestCaseBase):
+    requires_hardlinks = pytest.mark.skipif(not are_hardlinks_supported(), reason='hardlinks not supported')
+
     def test_basic_functionality(self):
         have_root = self.create_test_files()
         # fork required to test show-rc output
@@ -810,8 +812,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.cmd('create', self.repository_location + '::test', 'input')
-
-    requires_hardlinks = pytest.mark.skipif(not are_hardlinks_supported(), reason='hardlinks not supported')
 
     @requires_hardlinks
     @unittest.skipUnless(llfuse, 'llfuse not installed')


### PR DESCRIPTION
- do not archive duplicate roots (skip via inode)
- thus, it is also not extracted twice, avoiding issues