### PR TITLE
Update docs for dev environment installation instructions

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -156,7 +156,7 @@ controlled by that flag.  See ``_setup_implied_logging()`` in
 Building a development environment
 ----------------------------------
 
-First, just install borg into a virtual env as described before.
+First, just install borg into a virtual env :ref:`as described before <git-installation>`.
 
 To install some additional packages needed for running the tests, activate your
 virtual env and run::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -86,7 +86,7 @@ github to followup on packaging efforts.
 .. start-badges
 
 |Packaging status|
- 
+
 .. |Packaging status| image:: https://repology.org/badge/vertical-allrepos/borgbackup.svg
         :alt: Packaging status
         :target: https://repology.org/project/borgbackup/versions
@@ -377,9 +377,9 @@ While we try not to break master, there are no guarantees on anything.
     or
     pip install -e .[llfuse]   # in-place editable mode, use llfuse
 
-    # optional: run all the tests, on all supported Python versions
+    # optional: run all the tests, on all installed Python versions
     # requires fakeroot, available through your package manager
-    fakeroot -u tox
+    fakeroot -u tox --skip-missing-interpreters
 
 By default the system installation of python will be used.
 If you need to use a different version of Python you can install this using ``pyenv``:


### PR DESCRIPTION
See #5504 for motivation. The current installation instructions are confusing and result in failing tests on a typical setup, this adds a link back to an earlier section that's mentioned in the dev environment setup and changes the installation instructions to recommend only running the tests for installed versions of python. 