### PR TITLE
add examples for --paths-from-stdin, --paths-from-command, --paths-separator

### DIFF
--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -81,7 +81,7 @@ Examples
     # Use --paths-from-command with find to only backup files from a given user
     $ borg create --paths-from-command -- /path/to/repo::joes-files find ~ -user joe
     # Use --paths-from-stdin with --paths-delimiter to backup files listed in a csv file
-    $ cat ~files-to-backup.csv | borg create \
+    $ cat ~/files-to-backup.csv | borg create \
         --paths-from-stdin \
         --paths-delimiter "," \
         /path/to/repo::csv-specified-files

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -80,8 +80,8 @@ Examples
     $ find ~ -size -1000k | borg create --paths-from-stdin /path/to/repo::small-files-only
     # Use --paths-from-command with find to only backup files from a given user
     $ borg create --paths-from-command -- /path/to/repo::joes-files find ~ -user joe
-    # Use --paths-from-stdin with --paths-delimiter to backup files listed in a csv file
-    $ cat ~/files-to-backup.csv | borg create \
+    # Use --paths-from-stdin with --paths-delimiter (for example, for files with newlines in them)
+    $ find ~ -size -1000k -print0 | borg create \
         --paths-from-stdin \
-        --paths-delimiter "," \
-        /path/to/repo::csv-specified-files
+        --paths-delimiter "\0" \
+        /path/to/repo::smallfiles-handle-newline

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -79,7 +79,7 @@ Examples
     # Use --paths-from-stdin with find to only backup files less than 1MB in size
     $ find ~ -size -1000k | borg create --paths-from-stdin /path/to/repo::small-files-only
     # Use --paths-from-command with find to only backup files from a given user
-    $ borg create --paths-from-command -- /path/to/repo::joes-files find ~ -user joe
+    $ borg create --paths-from-command /path/to/repo::joes-files -- find /srv/samba/shared -user joe
     # Use --paths-from-stdin with --paths-delimiter (for example, for files with newlines in them)
     $ find ~ -size -1000k -print0 | borg create \
         --paths-from-stdin \

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -74,3 +74,14 @@ Examples
     $ cd /home/user/Documents
     # The root directory of the archive will be "projectA"
     $ borg create /path/to/repo::daily-projectA-{now:%Y-%m-%d} projectA
+
+    # Use external command to determine files to archive
+    # Use --paths-from-stdin with find to only backup files less than 1MB in size
+    $ find ~ -size -1000k | borg create --paths-from-stdin /path/to/repo::small-files-only
+    # Use --paths-from-command with find to only backup files from a given user
+    $ borg create --paths-from-command -- /path/to/repo::joes-files find ~ -user joe
+    # Use --paths-from-stdin with --paths-separator to backup files listed in a csv file
+    $ echo files-to-backup.csv | borg create \
+        --paths-from-stdin \
+        --paths-separator "," \
+        /path/to/repo::csv-specified-files

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -80,7 +80,7 @@ Examples
     $ find ~ -size -1000k | borg create --paths-from-stdin /path/to/repo::small-files-only
     # Use --paths-from-command with find to only backup files from a given user
     $ borg create --paths-from-command /path/to/repo::joes-files -- find /srv/samba/shared -user joe
-    # Use --paths-from-stdin with --paths-delimiter (for example, for files with newlines in them)
+    # Use --paths-from-stdin with --paths-delimiter (for example, for filenames with newlines in them)
     $ find ~ -size -1000k -print0 | borg create \
         --paths-from-stdin \
         --paths-delimiter "\0" \

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -80,8 +80,8 @@ Examples
     $ find ~ -size -1000k | borg create --paths-from-stdin /path/to/repo::small-files-only
     # Use --paths-from-command with find to only backup files from a given user
     $ borg create --paths-from-command -- /path/to/repo::joes-files find ~ -user joe
-    # Use --paths-from-stdin with --paths-separator to backup files listed in a csv file
-    $ echo files-to-backup.csv | borg create \
+    # Use --paths-from-stdin with --paths-delimiter to backup files listed in a csv file
+    $ cat ~files-to-backup.csv | borg create \
         --paths-from-stdin \
-        --paths-separator "," \
+        --paths-delimiter "," \
         /path/to/repo::csv-specified-files


### PR DESCRIPTION
Closes #5551
Added some examples for these options to the `borg create` documentation, one that showcases each of them.