### PR TITLE
Pass args.log_json to FilesystemObjectProcessors

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1200,7 +1200,8 @@ class FilesystemObjectProcessors:
 
     def __init__(self, *, metadata_collector, cache, key,
                  add_item, process_file_chunks,
-                 chunker_params, show_progress, sparse):
+                 chunker_params, show_progress, sparse,
+                 log_json):
         self.metadata_collector = metadata_collector
         self.cache = cache
         self.key = key
@@ -1209,7 +1210,7 @@ class FilesystemObjectProcessors:
         self.show_progress = show_progress
 
         self.hard_links = {}
-        self.stats = Statistics()  # threading: done by cache (including progress)
+        self.stats = Statistics(output_json=log_json)  # threading: done by cache (including progress)
         self.cwd = os.getcwd()
         self.chunker = get_chunker(*chunker_params, seed=key.chunk_seed, sparse=sparse)
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -657,7 +657,8 @@ class Archiver:
                     checkpoint_interval=args.checkpoint_interval, rechunkify=False)
                 fso = FilesystemObjectProcessors(metadata_collector=metadata_collector, cache=cache, key=key,
                     process_file_chunks=cp.process_file_chunks, add_item=archive.add_item,
-                    chunker_params=args.chunker_params, show_progress=args.progress, sparse=args.sparse)
+                    chunker_params=args.chunker_params, show_progress=args.progress, sparse=args.sparse,
+                    log_json=args.log_json)
                 create_inner(archive, cache, fso)
         else:
             create_inner(None, None, None)


### PR DESCRIPTION
Ensure `Statistics()` instance used by `FilesystemObjectProcessors()` obeys `--log-json` argument. (needed for Vorta status logs)

See comment https://github.com/borgbackup/borg/issues/4360#issuecomment-774580052