### PR TITLE
msgpack: drop support for old buffer protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
             - os: ubuntu-20.04
               python-version: 3.9
               toxenv: py39
+            - os: ubuntu-20.04
+              python-version: 3.10
+              toxenv: py310
             - os: macos-latest
               # note: it seems that 3.8 and 3.9 are currently broken,
               # neverending RuntimeError crashes...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,27 +52,27 @@ jobs:
       matrix:
         include:
             - os: ubuntu-20.04
-              python-version: 3.5
+              python-version: '3.5'
               toxenv: py35
             - os: ubuntu-20.04
-              python-version: 3.6
+              python-version: '3.6'
               toxenv: py36
             - os: ubuntu-20.04
-              python-version: 3.7
+              python-version: '3.7'
               toxenv: py37
             - os: ubuntu-20.04
-              python-version: 3.8
+              python-version: '3.8'
               toxenv: py38
             - os: ubuntu-20.04
-              python-version: 3.9
+              python-version: '3.9'
               toxenv: py39
             - os: ubuntu-20.04
-              python-version: 3.10
+              python-version: '3.10'
               toxenv: py310
             - os: macos-latest
               # note: it seems that 3.8 and 3.9 are currently broken,
               # neverending RuntimeError crashes...
-              python-version: 3.7
+              python-version: '3.7'
               toxenv: py37
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
               python-version: '3.9'
               toxenv: py39
             - os: ubuntu-20.04
-              python-version: '3.10'
+              python-version: '3.10-dev'
               toxenv: py310
             - os: macos-latest
               # note: it seems that 3.8 and 3.9 are currently broken,

--- a/setup.py
+++ b/setup.py
@@ -875,6 +875,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Security :: Cryptography',
         'Topic :: System :: Archiving :: Backup',
     ],

--- a/src/borg/algorithms/msgpack/_version.py
+++ b/src/borg/algorithms/msgpack/_version.py
@@ -1,1 +1,6 @@
-version = (0, 5, 6)
+# This is a bundled msgpack 0.5.6 with local modifications.
+# Changes:
+# +borg1: drop support for old buffer protocol to be compatible with py310
+#         (backport of commit 9ae43709e42092c7f6a4e990d696d9005fa1623d)
+version = (0, 5, 6, '+borg1')
+

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1359,8 +1359,9 @@ def is_slow_msgpack():
 
 def is_supported_msgpack():
     # DO NOT CHANGE OR REMOVE! See also requirements and comments in setup.py.
-    return (0, 4, 6) <= msgpack.version <= (0, 5, 6) and \
-           msgpack.version not in [(0, 5, 0), (0, 5, 2), (0, 5, 3), (0, 5, 5)]
+    v = msgpack.version[:3]
+    return (0, 4, 6) <= v <= (0, 5, 6) and \
+           v not in [(0, 5, 0), (0, 5, 2), (0, 5, 3), (0, 5, 5)]
 
 
 FALSISH = ('No', 'NO', 'no', 'N', 'n', '0', )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{35,36,37,38,39}
+envlist = py{35,36,37,38,39,310}
 
 [testenv]
 deps =


### PR DESCRIPTION
This is my attempt to solve #5683.

We should also update the msgpack version as [requested by @ThomasWaldmann](https://github.com/borgbackup/borg/issues/5683#issuecomment-777781315) and [@RonnyPfannschmidt](https://github.com/borgbackup/borg/issues/5683#issuecomment-777794854). The version is currently `version = (0, 5, 6)`.

Updating to 0.5.7 is easy though I also like the idea of using a more descriptive version number. As far as I can see nothing in borg uses the msgpack version number so we could also change to `version = (0, 5, 6, '+borg')` easily. Comments?

----
Commit message

The old buffer protocol was deprecated since Python 3.0 and will be removed entirely in Python 3.10.

This is a backport of

    commit 9ae43709e42092c7f6a4e990d696d9005fa1623d
    Author: Inada Naoki <songofacandy@gmail.com>
    Date:   Thu Dec 5 20:20:53 2019 +0900

        Drop old buffer protocol support (#383)

Backporting by me, any errors are likely due to backporting.
