### PR TITLE
upgrade FreeBSD VM to 11.4, pyinstaller to v4.2, fixes #5688

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -276,7 +276,7 @@ def install_pyinstaller()
     . borg-env/bin/activate
     git clone https://github.com/thomaswaldmann/pyinstaller.git
     cd pyinstaller
-    git checkout v4.0-maint
+    git checkout v4.2-maint
     python setup.py install
   EOF
 end
@@ -448,7 +448,7 @@ Vagrant.configure(2) do |config|
 
   # BSD
   config.vm.define "freebsd64" do |b|
-    b.vm.box = "freebsd64"  # custom FreeBSD 10.3 box. official ones are broken, #3022.
+    b.vm.box = "freebsd/FreeBSD-11.4-STABLE"
     b.vm.provider :virtualbox do |v|
       v.memory = 1024 + $wmem
     end


### PR DESCRIPTION
FreeBSD 10.x is not supported any more, the pkg sources are not
available any more, so our VM needed an upgrade.

so, we'll build borg 1.1.x binaries on FBSD 11.4 in future.

additionally, pyinstaller had some regression that is fixed by v4.2.
in v4.2-maint branch i added the FBSD bootloaders, which were missing
as usual.