### PR TITLE
docs: remove /var/cache exclusion in example commands

### DIFF
--- a/docs/deployment/automated-local.rst
+++ b/docs/deployment/automated-local.rst
@@ -137,7 +137,6 @@ modify it to suit your needs (e.g. more backup sets, dumping databases etc.).
     # This is just an example, change it however you see fit
     borg create $BORG_OPTS \
       --exclude /root/.cache \
-      --exclude /var/cache \
       --exclude /var/lib/docker/devicemapper \
       $TARGET::$DATE-$$-system \
       / /boot

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -191,7 +191,6 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
         --compression lz4               \
         --exclude-caches                \
         --exclude '/home/*/.cache/*'    \
-        --exclude '/var/cache/*'        \
         --exclude '/var/tmp/*'          \
                                         \
         ::'{hostname}-{now}'            \


### PR DESCRIPTION
This is generally a poor idea and shouldn't be promoted through examples.

Fixes #5625
