### PR TITLE
mount: implement --numeric-owner (default: False!)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2822,6 +2822,8 @@ class Archiver:
                                 help='stay in foreground, do not daemonize')
             parser.add_argument('-o', dest='options', type=str,
                                 help='Extra mount options')
+            parser.add_argument('--numeric-owner', dest='numeric_owner', action='store_true',
+                                  help='use numeric user and group identifiers from archive(s)')
             define_archive_filters_group(parser)
             parser.add_argument('paths', metavar='PATH', nargs='*', type=str,
                                    help='paths to extract; patterns are supported')


### PR DESCRIPTION
this is different default behaviour than in borg < 1.2:

default (numeric_owner=False) is to use the user/group name from the archive,
look up the local uid / gid and then use that for the FUSE fs.

when --numeric-owner is given (numeric_owner=True), then the uid/gid
from the archive is directly used (as it was the default behaviour in
borg < 1.2).

this was implemented like this (changing the default behaviour) to make
borg mount and borg extract behave more similar considering usage of
user/group numeric archived ids or archived names mapped to corresponding
numeric local system ids.

also, both now use the same function to get the uid/gid from the item.

fixes #2377