### PR TITLE
1.1-cleanup code style checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,16 +15,15 @@ if hasattr(pytest, 'register_assert_rewrite'):
     pytest.register_assert_rewrite('borg.testsuite')
 
 
-import borg.cache
-from borg.logger import setup_logging
+import borg.cache  # noqa: E402
+from borg.logger import setup_logging  # noqa: E402
 
 # Ensure that the loggers exist for all tests
 setup_logging()
 
-from borg.testsuite import has_lchflags, has_llfuse
-from borg.testsuite import are_symlinks_supported, are_hardlinks_supported, is_utime_fully_supported
-from borg.testsuite.platform import fakeroot_detected, are_acls_working
-from borg import xattr
+from borg.testsuite import has_lchflags, has_llfuse  # noqa: E402
+from borg.testsuite import are_symlinks_supported, are_hardlinks_supported, is_utime_fully_supported  # noqa: E402
+from borg.testsuite.platform import fakeroot_detected  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +64,8 @@ class DefaultPatches:
         self.org_cache_wipe_cache = borg.cache.LocalCache.wipe_cache
 
         def wipe_should_not_be_called(*a, **kw):
-            raise AssertionError("Cache wipe was triggered, if this is part of the test add @pytest.mark.allow_cache_wipe")
+            raise AssertionError("Cache wipe was triggered, if this is part of the test add "
+                                 "@pytest.mark.allow_cache_wipe")
         if 'allow_cache_wipe' not in request.keywords:
             borg.cache.LocalCache.wipe_cache = wipe_should_not_be_called
         request.addfinalizer(self.undo)

--- a/scripts/errorlist.py
+++ b/scripts/errorlist.py
@@ -2,7 +2,7 @@
 
 from textwrap import indent
 
-import borg.archiver
+import borg.archiver  # noqa: F401 - need import to get Error and ErrorWithTraceback subclasses.
 from borg.helpers import Error, ErrorWithTraceback
 
 classes = Error.__subclasses__() + ErrorWithTraceback.__subclasses__()

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ ignore = E226, W503
 # flake8 failures that appear with your change.
 per_file_ignores =
     docs/conf.py:E121,E126,E265,E305,E401,E402,
-    scripts/errorlist.py:F401
     src/borg/archive.py:E122,E125,E127,E402,E501,F401,F405,W504
     src/borg/archiver.py:E126,E127,E128,E501,E722,E731,E741,F401,F405,W504
     src/borg/cache.py:E127,E128,E402,E501,E722,W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,13 +4,80 @@ markers =
     allow_cache_wipe
 
 [flake8]
+# for reference ...
+#   E121 continuation line under-indented for hanging indent
+#   E122 continuation line missing indentation or outdented
+#   E123 closing bracket does not match indentation of opening bracket's line
+#   E125 continuation line with same indent as next logical line
+#   E126 continuation line over-indented for hanging indent
+#   E127 continuation line over-indented for visual indent
+#   E128 continuation line under-indented for visual indent
+#   E221 multiple spaces before operator
+#   E226 missing whitespace around arithmetic operator
+#   E261 at least two spaces before inline comment
+#   E265 block comment should start with '# '
+#   E301 expected 1 blank line
+#   E305 expected 2 blank lines after class or function definition
+#   E401 multiple imports on one line
+#   E402 module level import not at top
+#   E501 line too long
+#   E722 do not use bare except
+#   E731 do not assign a lambda expression, use def
+#   E741 ambiguous variable name
+#   F401 import unsused
+#   F403 from ... import * used, unable to detect undefined names
+#   F405 undefined or defined from star imports
+#   F811 redef of unused var
+#   F821 undefined name
+#   W391 blank line at end of file
+#   #### Pick either W503, or W504 - latest recommendation from pep8 is to ignore W503
+#   W503 line break before binary operator
+#   W504 line break after binary operator
+
+# borg code style guidelines:
+ignore = E226, W503
+
+# Code style violation exceptions:
 # please note that the values are adjusted so that they do not cause failures
 # with existing code. if you want to change them, you should first fix all
 # flake8 failures that appear with your change.
-ignore = E122,E123,E125,E126,E127,E128,E226,E402,E722,E731,E741,
-         F401,F405,F811,
-         W504
-# line length long term target: 120
-max-line-length = 255
-exclude = build,dist,.git,.idea,.cache,.tox,docs/conf.py,src/borg/algorithms/msgpack
+per_file_ignores =
+    conftest.py:E402,E501,F401
+    docs/conf.py:E121,E126,E265,E305,E401,E402,
+    scripts/errorlist.py:F401
+    src/borg/archive.py:E122,E125,E127,E402,E501,F401,F405,W504
+    src/borg/archiver.py:E126,E127,E128,E501,E722,E731,E741,F401,F405,W504
+    src/borg/cache.py:E127,E128,E402,E501,E722,W504
+    src/borg/fuse.py:E402,E501,E722,W504
+    src/borg/helpers.py:E127,E402,E501,E722,E741,F401,F405
+    src/borg/locking.py:E501,E722
+    src/borg/remote.py:E128,E501,F405
+    src/borg/repository.py:E126,E501,F401,F405,W504
+    src/borg/shellpattern.py:E501
+    src/borg/upgrader.py:E501
+    src/borg/algorithms/msgpack/*.py:E127,E221,E261,E301,E402,E722,E731,F401,F403,F821,W391
+    src/borg/crypto/key.py:E125,E128,E402,E501,F405,W504
+    src/borg/crypto/keymanager.py:E126,E128,E501,F401
+    src/borg/crypto/nonces.py:E501
+    src/borg/platform/__init__.py:F401,F811
+    src/borg/testsuite/__init__.py:E501,F401
+    src/borg/testsuite/archive.py:E128,W504
+    src/borg/testsuite/archiver.py:E128,E501,E722,F401,F405,F811
+    src/borg/testsuite/benchmark.py:F401,F811
+    src/borg/testsuite/chunker.py:E501,F405
+    src/borg/testsuite/compress.py:F401
+    src/borg/testsuite/crypto.py:E126,E501,E741
+    src/borg/testsuite/file_integrity.py:F401
+    src/borg/testsuite/hashindex.py:F401
+    src/borg/testsuite/helpers.py:E126,E127,E501,F401
+    src/borg/testsuite/key.py:E501
+    src/borg/testsuite/locking.py:E126,E722,F401
+    src/borg/testsuite/patterns.py:E123
+    src/borg/testsuite/platform.py:E501,F401,F811
+    src/borg/testsuite/repository.py:E501,F401
+    src/borg/testsuite/shellpattern.py:E123
+    src/borg/testsuite/upgrader.py:F405
+
+max_line_length = 120
+exclude = build,dist,.git,.idea,.cache,.tox
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ ignore = E226, W503
 # with existing code. if you want to change them, you should first fix all
 # flake8 failures that appear with your change.
 per_file_ignores =
-    conftest.py:E402,E501,F401
     docs/conf.py:E121,E126,E265,E305,E401,E402,
     scripts/errorlist.py:F401
     src/borg/archive.py:E122,E125,E127,E402,E501,F401,F405,W504


### PR DESCRIPTION
@ThomasWaldmann, how about I start with this to grandfather in specific files that violate some checks. This will make sure that all other files meet the requirements and allow us to fix smaller sets of files, reducing conflicts for active PRs.
