### PR TITLE
docs: fix/update cygwin package requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -315,15 +315,10 @@ Cygwin
 
 Use the Cygwin installer to install the dependencies::
 
-    python3 python3-devel libcrypt-devel python3-setuptools
-    binutils gcc-g++
-    libopenssl libssl-devel
-    git make openssh
-
-You can then install ``pip`` and ``virtualenv``::
-
-    easy_install-3.8 pip
-    pip install virtualenv
+    python38 python38-devel python38-pkgconfig
+    python38-setuptools python38-pip python38-wheel python38-virtualenv
+    libssl-devel libxxhash-devel liblz4-devel libzstd-devel
+    binutils gcc-g++ git make openssh
 
 
 .. _pip-installation:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -322,7 +322,7 @@ Use the Cygwin installer to install the dependencies::
 
 You can then install ``pip`` and ``virtualenv``::
 
-    easy_install-3.6 pip
+    easy_install-3.8 pip
     pip install virtualenv
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -317,7 +317,7 @@ Use the Cygwin installer to install the dependencies::
 
     python3 python3-devel libcrypt-devel python3-setuptools
     binutils gcc-g++
-    libopenssl openssl-devel
+    libopenssl libssl-devel
     git make openssh
 
 You can then install ``pip`` and ``virtualenv``::


### PR DESCRIPTION
Per https://cygwin.com/packages/summary/openssl-devel.html, the Cygwin package "openssl-devel" has been obsoleted by the package "libssl-devel".

Also, if you install just the basic Cygwin package "python3", it now installs Python v3.8.

(There may be other Cygwin package names that need to be changed. I wasn't able to find the package "libopenssl". However, with the list that's given there, I was ultimately able to get everything working.)