### PR TITLE
drop lru cache for noop id transformation functions of windows

### DIFF
--- a/src/borg/platform/windows.pyx
+++ b/src/borg/platform/windows.pyx
@@ -1,6 +1,5 @@
 import os
 import platform
-from functools import lru_cache
 
 
 cdef extern from 'windows.h':
@@ -14,22 +13,18 @@ cdef extern from 'windows.h':
     cdef extern int PROCESS_QUERY_INFORMATION
 
 
-@lru_cache(maxsize=None)
 def uid2user(uid, default=None):
     return default
 
 
-@lru_cache(maxsize=None)
 def user2uid(user, default=None):
     return default
 
 
-@lru_cache(maxsize=None)
 def gid2group(gid, default=None):
     return default
     
 
-@lru_cache(maxsize=None)
 def group2gid(group, default=None):
     return default
     


### PR DESCRIPTION

this just takes out something i felt is redundant