### PR TITLE
move chunk_equals to module level and modernize tox.ini

### DIFF
--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -517,36 +517,36 @@ class ItemDiff:
             return self._item1.chunks == self._item2.chunks
         if self._item1.get_size() != self._item2.get_size():
             return False
-        return ItemDiff._chunk_content_equal(chunk_iterator1, chunk_iterator2)
+        return chunks_contents_equal(chunk_iterator1, chunk_iterator2)
 
-    @staticmethod
-    def _chunk_content_equal(chunks1, chunks2):
-        """
-        Compare chunk content and return True if they are identical.
 
-        The chunks must be given as chunk iterators (like returned by :meth:`.DownloadPipeline.fetch_many`).
-        """
+def chunks_contents_equal(chunks1, chunks2):
+    """
+    Compare chunk content and return True if they are identical.
 
-        end = object()
-        alen = ai = 0
-        blen = bi = 0
-        while True:
-            if not alen - ai:
-                a = next(chunks1, end)
-                if a is end:
-                    return not blen - bi and next(chunks2, end) is end
-                a = memoryview(a)
-                alen = len(a)
-                ai = 0
-            if not blen - bi:
-                b = next(chunks2, end)
-                if b is end:
-                    return not alen - ai and next(chunks1, end) is end
-                b = memoryview(b)
-                blen = len(b)
-                bi = 0
-            slicelen = min(alen - ai, blen - bi)
-            if a[ai:ai + slicelen] != b[bi:bi + slicelen]:
-                return False
-            ai += slicelen
-            bi += slicelen
+    The chunks must be given as chunk iterators (like returned by :meth:`.DownloadPipeline.fetch_many`).
+    """
+
+    end = object()
+    alen = ai = 0
+    blen = bi = 0
+    while True:
+        if not alen - ai:
+            a = next(chunks1, end)
+            if a is end:
+                return not blen - bi and next(chunks2, end) is end
+            a = memoryview(a)
+            alen = len(a)
+            ai = 0
+        if not blen - bi:
+            b = next(chunks2, end)
+            if b is end:
+                return not alen - ai and next(chunks1, end) is end
+            b = memoryview(b)
+            blen = len(b)
+            bi = 0
+        slicelen = min(alen - ai, blen - bi)
+        if a[ai:ai + slicelen] != b[bi:bi + slicelen]:
+            return False
+        ai += slicelen
+        bi += slicelen

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -47,7 +47,7 @@ from ..helpers import msgpack
 from ..helpers import flags_noatime, flags_normal
 from ..nanorst import RstToTextLazy, rst_to_terminal
 from ..patterns import IECommand, PatternMatcher, parse_pattern
-from ..item import Item, ItemDiff
+from ..item import Item, ItemDiff, chunks_contents_equal
 from ..locking import LockFailed
 from ..logger import setup_logging
 from ..remote import RemoteRepository, PathNotAllowed
@@ -4218,8 +4218,8 @@ def test_chunk_content_equal():
     def ccc(a, b):
         chunks_a = [data for data in a]
         chunks_b = [data for data in b]
-        compare1 = ItemDiff._chunk_content_equal(iter(chunks_a), iter(chunks_b))
-        compare2 = ItemDiff._chunk_content_equal(iter(chunks_b), iter(chunks_a))
+        compare1 = chunks_contents_equal(iter(chunks_a), iter(chunks_b))
+        compare2 = chunks_contents_equal(iter(chunks_b), iter(chunks_a))
         assert compare1 == compare2
         return compare1
     assert ccc([

--- a/tox.ini
+++ b/tox.ini
@@ -3,31 +3,29 @@
 
 [tox]
 envlist = py{36,37,38,39,310}-{none,fuse2,fuse3}
-
+minversion = 3.2
+requires =
+	pkgconfig
+	cython
+	wheel
+	setuptools_scm
 [testenv]
+setenv =
+   fuse2: BORG_FUSE_IMPL=llfuse
+   fuse3: BORG_FUSE_IMPL=pyfuse3
 deps =
+    fuse2: llfuse
+    fuse3: pyfuse3
     -rrequirements.d/development.txt
 commands = py.test -v -n {env:XDISTN:1} -rs --cov=borg --cov-config=.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:
 passenv = *
 
-[testenv:py{36,37,38,39}-fuse2]
-setenv =
-    BORG_FUSE_IMPL=llfuse
-deps =
-    llfuse
-    {[testenv]deps}
-
-[testenv:py{36,37,38,39}-fuse3]
-setenv =
-    BORG_FUSE_IMPL=pyfuse3
-deps =
-    pyfuse3
-    {[testenv]deps}
 
 [testenv:flake8]
+skip_sdist=true
+skip_install=true
 changedir =
 deps =
     flake8
-    pkgconfig
 commands = flake8 src scripts conftest.py


### PR DESCRIPTION
the move of the function supports easier building of microbenchmarks against #5763 
the changes in tox.ini enabled running the tox command even when the system python is not ready,
it may be advisable to use pyproject.toml in future
