### PR TITLE
add progress indicator for archive check

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1877,8 +1877,11 @@ class ArchiveChecker:
                 return
         num_archives = len(archive_infos)
 
+        pi = ProgressIndicatorPercent(total=num_archives, msg='Checking archives %3.1f%%', step=0.1,
+                                      msgid='check.rebuild_refcounts')
         with cache_if_remote(self.repository) as repository:
             for i, info in enumerate(archive_infos):
+                pi.show(i)
                 logger.info('Analyzing archive {} ({}/{})'.format(info.name, i + 1, num_archives))
                 archive_id = info.id
                 if archive_id not in self.chunks:
@@ -1908,6 +1911,7 @@ class ArchiveChecker:
                 cdata = self.key.encrypt(data)
                 add_reference(new_archive_id, len(data), len(cdata), cdata)
                 self.manifest.archives[info.name] = (new_archive_id, info.ts)
+            pi.finish()
 
     def orphan_chunks_check(self):
         if self.check_all:


### PR DESCRIPTION
Depending on the number of archives in a repository, the archive check part
of the check operation can take some time, so it should have a progress
indicator as well.

I do recall at least one person reporting on IRC that his `borg check --progress` "got stuck doing nothing after it completed to 100%" - completed the segment check, that was. :wink: 

Result looks like this:
```
$ borg check --progress
Checking archives 9.6%                                                                                                                            
```

For the `msgid` parameter I followed to what seems to be a `classname.callingfunctionname` convention in most places, but if it is rather supposed to be something more functionality based, I'll happily change it to something like e.g. `archive.check`.

I built and tested the change as-is on borg 1.1.16 for my own use, so happy to do a PR for 1.1-maint. :smiley: 