### PR TITLE
add progress indicator for archive check

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1615,8 +1615,11 @@ class ArchiveChecker:
                 return
         num_archives = len(archive_infos)
 
+        pi = ProgressIndicatorPercent(total=num_archives, msg='Checking archives %3.1f%%', step=0.1,
+                                      msgid='check.rebuild_refcounts')
         with cache_if_remote(self.repository) as repository:
             for i, info in enumerate(archive_infos):
+                pi.show(i)
                 logger.info('Analyzing archive {} ({}/{})'.format(info.name, i + 1, num_archives))
                 archive_id = info.id
                 if archive_id not in self.chunks:
@@ -1646,6 +1649,7 @@ class ArchiveChecker:
                 cdata = self.key.encrypt(data)
                 add_reference(new_archive_id, len(data), len(cdata), cdata)
                 self.manifest.archives[info.name] = (new_archive_id, info.ts)
+            pi.finish()
 
     def orphan_chunks_check(self):
         if self.check_all:


### PR DESCRIPTION
Depending on the number of archives in a repository, the archive check part
of the check operation can take some time, so it should have a progress
indicator as well.

1.1.x version of #5809, no changes needed.