### PR TITLE
Fixed the Readme.rst irc webchat link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Links
 * `Offline Documentation <https://readthedocs.org/projects/borgbackup/downloads>`_
 * `GitHub <https://github.com/borgbackup/borg>`_ and
   `Issue Tracker <https://github.com/borgbackup/borg/issues>`_.
-* `Web-Chat (IRC) <https://webchat.freenode.net/?randomnick=1&channels=%23borgbackup&uio=MTY9dHJ1ZSY5PXRydWUa8>`_ and
+* `Web-Chat (IRC) <https://web.libera.chat/#borgbackup>`_ and
   `Mailing List <https://mail.python.org/mailman/listinfo/borgbackup>`_
 * `License <https://borgbackup.readthedocs.org/en/stable/authors.html#license>`_
 * `Security contact <https://borgbackup.readthedocs.io/en/latest/support.html#security-contact>`_


### PR DESCRIPTION
The irc webchat link still pointed to Freenode while the IRC channel on the main page points to libera.chat.