### PR TITLE
docs: add unsafe workaround to use an old repo copy, fixes #5722

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -118,6 +118,31 @@ you could delete the manifest-timestamp and the local cache:
 
 This is an unsafe and unsupported way to use borg, you have been warned.
 
+"this is either an attack or unsafe" warning
+--------------------------------------------
+
+About the warning:
+
+  Cache, or information obtained from the security directory is newer than
+  repository - this is either an attack or unsafe (multiple repos with same ID)
+
+"unsafe": If not following the advice from the previous section, you can easily
+run into this by yourself by restoring an older copy of your repository.
+
+"attack": maybe an attacker has replaced your repo by an older copy, trying to
+trick you into AES counter reuse, trying to break your repo encryption.
+
+If you'ld decide to ignore this and accept unsafe operation for this repository,
+you could delete the manifest-timestamp and the local cache:
+
+::
+
+  borg config repo id   # shows the REPO_ID
+  rm ~/.config/borg/REPO_ID/manifest-timestamp
+  borg delete --cache-only REPO
+
+This is an unsafe and unsupported way to use borg, you have been warned.
+
 Which file types, attributes, etc. are *not* preserved?
 -------------------------------------------------------
 


### PR DESCRIPTION
This is a forward-port attempt of #5732. It is intended to be part of issue #5838.