### PR TITLE
drop support for py36, require py37+, fixes #5790

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,6 @@ jobs:
       matrix:
         include:
             - os: ubuntu-20.04
-              python-version: '3.6'
-              toxenv: py36-fuse2
-            - os: ubuntu-20.04
               python-version: '3.7'
               toxenv: py37-fuse2
             - os: ubuntu-20.04

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,7 +145,6 @@ def install_pythons(boxname)
     pyenv install 3.9.5  # tests, version supporting openssl 1.1, binary build
     pyenv install 3.8.0  # tests, version supporting openssl 1.1
     pyenv install 3.7.0  # tests, version supporting openssl 1.1
-    pyenv install 3.6.2  # tests, version supporting openssl 1.1. broken for older 3.6.x.
     pyenv rehash
   EOF
 end
@@ -174,7 +173,7 @@ def install_borg(fuse)
     . ~/.bash_profile
     cd /vagrant/borg
     . borg-env/bin/activate
-    pip install -U wheel  # upgrade wheel, too old for 3.5
+    pip install -U wheel  # upgrade wheel, might be too old
     cd borg
     pip install -r requirements.d/development.txt
     python setup.py clean
@@ -213,8 +212,8 @@ def run_tests(boxname, skip_env)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.6.2 3.7.0 3.8.0 3.9.5 3.10-dev
-      pyenv local 3.6.2 3.7.0 3.8.0 3.9.5 3.10-dev
+      pyenv global 3.7.0 3.8.0 3.9.5 3.10-dev
+      pyenv local 3.7.0 3.8.0 3.9.5 3.10-dev
     fi
     # otherwise: just use the system python
     # some OSes can only run specific test envs, e.g. because they miss FUSE support:
@@ -409,6 +408,6 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("openindiana64", ".*fuse.*")
   end
 
-  # TODO: create more VMs with python 3.6+ and openssl 1.1.
+  # TODO: create more VMs with python 3.7+ and openssl 1.1.
   # See branch 1.1-maint for a better equipped Vagrantfile (but still on py34 and openssl 1.0).
 end

--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,6 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -300,5 +299,5 @@ setup(
     setup_requires=['setuptools_scm>=1.7'],
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -4322,13 +4322,7 @@ class TestCommonOptions:
 
     @pytest.fixture
     def subparsers(self, basic_parser):
-        if sys.version_info >= (3, 7):
-            # py37 pre-release defaults to unwanted required=True, in 3.7.0+ it was fixed to =False
-            return basic_parser.add_subparsers(title='required arguments', metavar='<command>', required=False)
-        else:
-            # py36 does not support required=... argument (but behaves like required=False).
-            # note: use below call for 3.6 and 3.7 when there are no alphas/betas/RCs of 3.7.0 around any more.
-            return basic_parser.add_subparsers(title='required arguments', metavar='<command>')
+        return basic_parser.add_subparsers(title='required arguments', metavar='<command>')
 
     @pytest.fixture
     def parser(self, basic_parser):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{36,37,38,39,310}-{none,fuse2,fuse3}
+envlist = py{37,38,39,310}-{none,fuse2,fuse3}
 minversion = 3.2
 requires =
 	pkgconfig


### PR DESCRIPTION
if you do not have python >= 3.7, you can still use borg 1.1.x or 1.0.x.

another option is to use the fat binary from github releases, which
includes python and all other stuff needed.
