### PR TITLE
Fix typos (backport of #5597)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -124,7 +124,7 @@ Steps you should take:
 Prior versions can access and modify repositories with this measure enabled, however,
 to 1.0.9 or later their modifications are indiscernible from an attack and will
 raise an error until the below procedure is followed. We are aware that this can
-be be annoying in some circumstances, but don't see a way to fix the vulnerability
+be annoying in some circumstances, but don't see a way to fix the vulnerability
 otherwise.
 
 In case a version prior to 1.0.9 is used to modify a repository where above procedure
@@ -478,7 +478,7 @@ Version 1.1.11 (2020-03-08)
 Fixes:
 
 - fixed potential index corruption / data loss issue due to bug in hashindex_set, #4829.
-  Please read and follow the more detailled notes close to the top of this document.
+  Please read and follow the more detailed notes close to the top of this document.
 - upgrade bundled xxhash to 0.7.3, #4891.
   0.7.2 is the minimum requirement for correct operations on ARMv6 in non-fixup
   mode, where unaligned memory accesses cause bus errors.
@@ -750,7 +750,7 @@ New features:
 - init: add warning to store both key and passphrase at safe place(s)
 - BORG_HOST_ID env var to work around all-zero MAC address issue, #3985
 - borg debug dump-repo-objs --ghost (dump everything from segment files,
-  including deleted or superceded objects or commit tags)
+  including deleted or superseded objects or commit tags)
 - borg debug search-repo-objs (search in repo objects for hex bytes or strings)
 
 Other changes:
@@ -943,7 +943,7 @@ Compatibility notes:
 Fixes:
 
 - check: data corruption fix: fix for borg check --repair malfunction, #3444.
-  See the more detailled notes close to the top of this document.
+  See the more detailed notes close to the top of this document.
 - delete: also delete security dir when deleting a repo, #3427
 - prune: fix building the "borg prune" man page, #3398
 - init: use given --storage-quota for local repo, #3470
@@ -2284,8 +2284,8 @@ Bug fixes:
   Fixes a chmod/chown/chgrp/unlink/rename/... crash race between getting
   dirents and dispatching to process_symlink.
 - yes(): abort on wrong answers, saying so, #1622
-- fixed exception borg serve raised when connection was closed before reposiory
-  was openend. add an error message for this.
+- fixed exception borg serve raised when connection was closed before repository
+  was opened. Add an error message for this.
 - fix read-from-closed-FD issue, #1551
   (this seems not to get triggered in 1.0.x, but was discovered in master)
 - hashindex: fix iterators (always raise StopIteration when exhausted)
@@ -2788,7 +2788,7 @@ Bug fixes:
 - do not sleep for >60s while waiting for lock, #773
 - unpack file stats before passing to FUSE
 - fix build on illumos
-- don't try to backup doors or event ports (Solaris and derivates)
+- don't try to backup doors or event ports (Solaris and derivatives)
 - remove useless/misleading libc version display, #738
 - test suite: reset exit code of persistent archiver, #844
 - RemoteRepository: clean up pipe if remote open() fails

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -507,7 +507,7 @@ your repositories and it is not encrypted.
 However, the assumption is that the cache is being stored on the very
 same system which also contains the original files which are being
 backed up. So someone with access to the cache files would also have
-access the the original files anyway.
+access the original files anyway.
 
 The Internals section contains more details about :ref:`cache`. If you ever need to move the cache
 to a different location, this can be achieved by using the appropriate :ref:`env_vars`.
@@ -518,7 +518,7 @@ How can I specify the encryption passphrase programmatically?
 There are several ways to specify a passphrase without human intervention:
 
 Setting ``BORG_PASSPHRASE``
-  The passphrase can be specified using the ``BORG_PASSPHRASE`` enviroment variable.
+  The passphrase can be specified using the ``BORG_PASSPHRASE`` environment variable.
   This is often the simplest option, but can be insecure if the script that sets it
   is world-readable.
 
@@ -641,7 +641,7 @@ C to delete all backups residing on S.
 These are your options to protect against that:
 
 - Do not allow to permanently delete data from the repo, see :ref:`append_only_mode`.
-- Use a pull-mode setup using ``ssh -R``, see :ref:`pull_backup` for more informations.
+- Use a pull-mode setup using ``ssh -R``, see :ref:`pull_backup` for more information.
 - Mount C's filesystem on another machine and then create a backup of it.
 - Do not give C filesystem-level access to S.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -252,7 +252,7 @@ messages such as::
 
     /Users/you/Pictures/Photos Library.photoslibrary: scandir: [Errno 1] Operation not permitted:
 
-To fix this problem, you should grant full disk acccess to cron, and to your
+To fix this problem, you should grant full disk access to cron, and to your
 Terminal application. More information `can be found here
 <https://osxdaily.com/2020/04/27/fix-cron-permissions-macos-full-disk-access/>`__.
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -55,7 +55,7 @@ time for the purposes of the log.
 Config file
 ~~~~~~~~~~~
 
-Each repository has a ``config`` file which which is a ``INI``-style file
+Each repository has a ``config`` file which is a ``INI``-style file
 and looks like this::
 
     [repository]

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -109,7 +109,7 @@ the tampering.
 
 Note that when using BORG_PASSPHRASE the attacker cannot swap the *entire*
 repository against a new repository with e.g. repokey mode and no passphrase,
-because Borg will abort access when BORG_PASSPRHASE is incorrect.
+because Borg will abort access when BORG_PASSPHRASE is incorrect.
 
 However, interactively a user might not notice this kind of attack
 immediately, if she assumes that the reason for the absent passphrase

--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -68,7 +68,7 @@ You can use this to not query and store (or not extract and set) bsdflags -
 in case you don't need them or if they are broken somehow for your fs.
 
 On Linux, dealing with the bsflags needs some additional syscalls.
-Especially when dealing with lots of small files, this causes a noticable
+Especially when dealing with lots of small files, this causes a noticeable
 overhead, so you can use this option also for speeding up operations.
 
 ``--umask``

--- a/scripts/shell_completions/fish/borg.fish
+++ b/scripts/shell_completions/fish/borg.fish
@@ -113,7 +113,7 @@ complete -c borg         -l 'exclude-if-present'    -d 'Exclude directories that
 complete -c borg -f      -l 'keep-exclude-tags'     -d 'Keep tag files of excluded directories'     -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'keep-tag-files'        -d 'Keep tag files of excluded directories'     -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'exclude-nodump'        -d 'Exclude files flagged NODUMP'               -n "__fish_seen_subcommand_from create"
-# Filesytem options
+# Filesystem options
 complete -c borg -f -s x -l 'one-file-system'       -d 'Stay in the same file system'               -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'numeric-owner'         -d 'Only store numeric user:group identifiers'  -n "__fish_seen_subcommand_from create"
 complete -c borg -f      -l 'noatime'               -d 'Do not store atime'                         -n "__fish_seen_subcommand_from create"

--- a/scripts/shell_completions/zsh/_borg
+++ b/scripts/shell_completions/zsh/_borg
@@ -1135,7 +1135,7 @@ __borg_complete_keys() {
   compset -S '[^A-Za-z]##*'
 
   [[ -n $ISUFFIX ]] && compstate[to_end]=''
-  # NOTE: `[[ -n $ISUFFIX ]]` is a workarond for a bug that causes cursor movement to the right further than it should
+  # NOTE: `[[ -n $ISUFFIX ]]` is a workaround for a bug that causes cursor movement to the right further than it should
   # NOTE: the _oldlist completer doesn't respect compstate[to_end]=''
 
   local ipref suf

--- a/src/borg/__init__.py
+++ b/src/borg/__init__.py
@@ -1,7 +1,7 @@
 from packaging.version import parse as parse_version
 
 # IMPORTANT keep imports from borg here to a minimum because our testsuite depends on
-# beeing able to import borg.constants and then monkey patching borg.constants.PBKDF2_ITERATIONS
+# being able to import borg.constants and then monkey patching borg.constants.PBKDF2_ITERATIONS
 from ._version import version as __version__
 
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2037,7 +2037,7 @@ class Archiver:
                 fd.write(data)
 
         if args.ghost:
-            # dump ghosty stuff from segment files: not yet committed objects, deleted / superceded objects, commit tags
+            # dump ghosty stuff from segment files: not yet committed objects, deleted / superseded objects, commit tags
 
             # set up the key without depending on a manifest obj
             for id, cdata, tag, segment, offset in repository.scan_low_level():
@@ -2128,7 +2128,7 @@ class Archiver:
                 # try to locate wanted sequence in data
                 count = data.count(wanted)
                 if count:
-                    offset = data.find(wanted)  # only determine first occurance's offset
+                    offset = data.find(wanted)  # only determine first occurrence's offset
                     info = "%d %s #%d" % (i, id.hex(), count)
                     print_finding(info, wanted, data, offset)
 
@@ -2387,7 +2387,7 @@ class Archiver:
 
                 Via ``--pattern`` or ``--patterns-from`` you can define BOTH inclusion and exclusion
                 of files using pattern prefixes ``+`` and ``-``. With ``--exclude`` and
-                ``--exlude-from`` ONLY excludes are defined.
+                ``--exclude-from`` ONLY excludes are defined.
 
             Inclusion patterns are useful to include paths that are contained in an excluded
             path. The first matching pattern is used so if an include pattern matches before
@@ -4510,7 +4510,7 @@ class Archiver:
                     value = getattr(client_result, attr_name, not_present)
                     if value is not not_present:
                         # note: it is not possible to specify a allowlisted option via a forced command,
-                        # it always gets overridden by the value specified (or defaulted to) by the client commmand.
+                        # it always gets overridden by the value specified (or defaulted to) by the client command.
                         setattr(result, attr_name, value)
 
         return result

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -112,7 +112,7 @@ class Error(Exception):
     """Error: {}"""
     # Error base class
 
-    # if we raise such an Error and it is only catched by the uppermost
+    # if we raise such an Error and it is only caught by the uppermost
     # exception handler (that exits short after with the given exit_code),
     # it is always a (fatal and abrupt) EXIT_ERROR, never just a warning.
     exit_code = EXIT_ERROR
@@ -1640,7 +1640,7 @@ class ProgressIndicatorPercent(ProgressIndicatorBase):
             # truncate the last argument, if no space is available
             if info is not None:
                 if not self.json:
-                    # no need to truncate if we're not outputing to a terminal
+                    # no need to truncate if we're not outputting to a terminal
                     terminal_space = get_terminal_size(fallback=(-1, -1))[0]
                     if terminal_space != -1:
                         space = terminal_space - len(self.msg % tuple([pct] + info[:-1] + ['']))

--- a/src/borg/locking.py
+++ b/src/borg/locking.py
@@ -315,7 +315,7 @@ class Lock:
     """
     A Lock for a resource that can be accessed in a shared or exclusive way.
     Typically, write access to a resource needs an exclusive lock (1 writer,
-    noone is allowed reading) and read access to a resource needs a shared
+    no one is allowed reading) and read access to a resource needs a shared
     lock (multiple readers are allowed).
 
     If possible, try to use the contextmanager here like::

--- a/src/borg/logger.py
+++ b/src/borg/logger.py
@@ -117,7 +117,7 @@ def setup_logging(stream=None, conf_fname=None, env_var='BORG_LOGGING_CONF', lev
 
 
 def find_parent_module():
-    """find the name of a the first module calling this module
+    """find the name of the first module calling this module
 
     if we cannot find it, we return the current module's name
     (__name__) instead.

--- a/src/borg/paperkey.html
+++ b/src/borg/paperkey.html
@@ -2012,7 +2012,7 @@ Sha256.Maj = function(x, y, z) { return (x & y) ^ (x & z) ^ (y & z); };
  * @private
  */
 Sha256.toHexStr = function(n) {
-    // note can't use toString(16) as it is implementation-dependant,
+    // note can't use toString(16) as it is implementation-dependent,
     // and in IE returns signed numbers when used on full words
     var s="", v;
     for (var i=7; i>=0; i--) { v = (n>>>(i*4)) & 0xf; s += v.toString(16); }

--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -372,7 +372,7 @@ def parse_inclexcl_command(cmd_line_str, fallback=ShellPattern):
 
     cmd = cmd_prefix_map.get(cmd_line_str[0])
     if cmd is None:
-        raise argparse.ArgumentTypeError("A pattern/command must start with any one of: %s" %
+        raise argparse.ArgumentTypeError("A pattern/command must start with anyone of: %s" %
                                          ', '.join(cmd_prefix_map))
 
     # remaining text on command-line following the command character

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1030,7 +1030,7 @@ class Repository:
         """Very low level scan over all segment file entries.
 
         It does NOT care about what's committed and what not.
-        It does NOT care whether an object might be deleted or superceded later.
+        It does NOT care whether an object might be deleted or superseded later.
         It just yields anything it finds in the segment files.
 
         This is intended as a last-resort way to get access to all repo contents of damaged repos,

--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -235,7 +235,7 @@ class BaseTestCase(unittest.TestCase):
             # the borg mount daemon to work properly or the tests
             # will just freeze. Therefore, if argument `fork` is not
             # specified, the default value is `True`, regardless of
-            # `FORK_DEFAULT`. However, leaving the possibilty to run
+            # `FORK_DEFAULT`. However, leaving the possibility to run
             # the command with `fork = False` is still necessary for
             # testing for mount failures, for example attempting to
             # mount a read-only repo.

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1956,12 +1956,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in('file1', output)
 
     def test_create_read_special_broken_symlink(self):
-        os.symlink('somewhere doesnt exist', os.path.join(self.input_path, 'link'))
+        os.symlink('somewhere does not exist', os.path.join(self.input_path, 'link'))
         self.cmd('init', '--encryption=repokey', self.repository_location)
         archive = self.repository_location + '::test'
         self.cmd('create', '--read-special', archive, 'input')
         output = self.cmd('list', archive)
-        assert 'input/link -> somewhere doesnt exist' in output
+        assert 'input/link -> somewhere does not exist' in output
 
     # def test_cmdline_compatibility(self):
     #    self.create_regular_file('file1', size=1024 * 80)

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -192,7 +192,7 @@ class HashIndexRefcountingTestCase(BaseTestCase):
         idx = ChunkIndex()
         idx[H(1)] = ChunkIndex.MAX_VALUE - 1, 1, 2
 
-        # 5 is arbitray, any number of incref/decrefs shouldn't move it once it's limited
+        # 5 is arbitrary, any number of incref/decrefs shouldn't move it once it's limited
         for i in range(5):
             # first incref to move it to the limit
             refcount, *_ = idx.incref(H(1))


### PR DESCRIPTION
This is a back-port attempt of #5597. It is intended to be part of issue #5837.

Note this is a manual revamp of the original merge commit due to the sheer number of differences. Notably some didn't apply because they were not present in this older version and some files were not present or were shuffled around.

`README_WINDOWS.rst` doesn't exist in this older release and appears to not exist anywhere else either.
`src/borg/compress.pyx` had no relevant typos in this release.
`src/borg/helpers/errors.py` and `src/borg/helpers/progress.py` didn't exist but their typos exist in this version under `src/borg/helpers.py`.