### PR TITLE
import-tar: fix empty user/group name in TarInfo, fixes #5853

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1410,7 +1410,7 @@ class TarfileObjectProcessors:
     @contextmanager
     def create_helper(self, tarinfo, status=None, type=None):
         item = Item(path=make_path_safe(tarinfo.name), mode=tarinfo.mode | type,
-                    uid=tarinfo.uid, gid=tarinfo.gid, user=tarinfo.uname, group=tarinfo.gname,
+                    uid=tarinfo.uid, gid=tarinfo.gid, user=tarinfo.uname or None, group=tarinfo.gname or None,
                     mtime=tarinfo.mtime * 1000**3)
         yield item, status
         # if we get here, "with"-block worked ok without error/exception, the item was processed ok...


### PR DESCRIPTION
if the tar has no information about user/group name (empty string),
we must assign None to Item.user/group (not the empty string).

Fixup for #5650.