### PR TITLE
add paragraph added in #5855 to utility documentation source

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3042,6 +3042,11 @@ class Archiver:
         check --repair is a potentially dangerous function and might lead to data loss
         (for kinds of corruption it is not capable of dealing with). BE VERY CAREFUL!
 
+        Pursuant to the previous warning it is also highly recommended to test the
+        reliability of the hardware running this software with stress testing software
+        such as memory testers. Unreliable hardware can also lead to data loss especially
+        when this command is run in repair mode.
+
         First, the underlying repository data files are checked:
 
         - For all segments, the segment magic header is checked.


### PR DESCRIPTION
I noticed the changes I did were to the generated files and not the original source. This should correct that.