### PR TITLE
docs: replace deprecated function ".add_stylesheet()" for Sphinx 4 compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ def set_rst_settings(app):
 
 
 def setup(app):
-    app.add_stylesheet('css/borg.css')
+    app.add_css_file('css/borg.css')
     app.connect('builder-inited', set_rst_settings)
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
the same change was done as part of 6a1f31bf2914d167e2f5051f1d531d5d4a19f54b for master. I would like to have this in `1.1-maint` because `.add_stylesheet()` was removed in Sphinx 4 and that version will be added to Fedora rawhide (aka Fedora 35) soon.