### PR TITLE
remove unused libc_name

### DIFF
--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -34,7 +34,6 @@ if sys.platform.startswith('linux'):
                 # 1.20.2 has been confirmed to have xattr support
                 # 1.18.2 has been confirmed not to have xattr support
                 # Versions in-between are unknown
-                libc_name = preload
                 XATTR_FAKEROOT = True
             break
 


### PR DESCRIPTION
this was a remainder from 1.1-maint, but is not used any more.