### PR TITLE
Adding try/finally block to make sure cleanup happens

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -456,16 +456,18 @@ class Archiver:
 
         @contextmanager
         def test_files(path, count, size, random):
-            path = os.path.join(path, 'borg-test-data')
-            os.makedirs(path)
-            z_buff = None if random else memoryview(zeros)[:size] if size <= len(zeros) else b'\0' * size
-            for i in range(count):
-                fname = os.path.join(path, 'file_%d' % i)
-                data = z_buff if not random else os.urandom(size)
-                with SyncFile(fname, binary=True) as fd:  # used for posix_fadvise's sake
-                    fd.write(data)
-            yield path
-            shutil.rmtree(path)
+            try:
+                path = os.path.join(path, 'borg-test-data')
+                os.makedirs(path)
+                z_buff = None if random else memoryview(zeros)[:size] if size <= len(zeros) else b'\0' * size
+                for i in range(count):
+                    fname = os.path.join(path, 'file_%d' % i)
+                    data = z_buff if not random else os.urandom(size)
+                    with SyncFile(fname, binary=True) as fd:  # used for posix_fadvise's sake
+                        fd.write(data)
+                yield path
+            finally:
+                shutil.rmtree(path)
 
         if '_BORG_BENCHMARK_CRUD_TEST' in os.environ:
             tests = [


### PR DESCRIPTION
In issue #5630 it was specified that when `borg benchmark` is called with wrong arguments or with permission issues, the folder `borg-test-data` is not deleted.
During tests I have also discovered that the same happens when borg receives a `keyboard interrupt` while executing the benchmark.

To solve this problem, a `try/finally` block was added in method `test_files`, to make sure the command that removes the folder will be executed (in the `finally` statement) even if the code in the `try` statement fails.

In my tests, this have solved the issue on the specified test cases and in the case of the keyboard interrupt.

This PR resolves #5630 