### PR TITLE
fuse: remove unneeded version check and compat code

### DIFF
--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -8,7 +8,6 @@ import tempfile
 import time
 from collections import defaultdict
 from signal import SIGINT
-from distutils.version import LooseVersion
 
 import llfuse
 
@@ -32,14 +31,10 @@ have_fuse_xtime_ns = hasattr(llfuse.EntryAttributes, 'st_mtime_ns')
 have_fuse_birthtime = hasattr(llfuse.EntryAttributes, 'st_birthtime')  # never?
 have_fuse_birthtime_ns = hasattr(llfuse.EntryAttributes, 'st_birthtime_ns')  # since llfuse 1.3
 
-fuse_version = LooseVersion(getattr(llfuse, '__version__', '0.1'))
-if fuse_version >= '0.42':
-    def fuse_main():
-        return llfuse.main(workers=1)
-else:
-    def fuse_main():
-        llfuse.main(single=True)
-        return None
+
+def fuse_main():
+    return llfuse.main(workers=1)
+
 
 # size of some LRUCaches (1 element per simultaneously open file)
 # note: _inode_cache might have rather large elements - Item.chunks can be large!


### PR DESCRIPTION
we require >= 1.3 now anyway, see setup.py.

Looks like this was forgotten to backport to 1.1-maint and also was a remainder still requiring distutils.

Thanks to @LocutusOfBorg for pointing to the right changeset in master.