### PR TITLE
vagrant: use py 3.9.7 (incl. binary builds)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -162,7 +162,7 @@ def install_pythons(boxname)
   return <<-EOF
     . ~/.bash_profile
     pyenv install 3.10-dev  # tests, version supporting openssl 1.1
-    pyenv install 3.9.5  # tests, version supporting openssl 1.1, binary build
+    pyenv install 3.9.7  # tests, version supporting openssl 1.1, binary build
     pyenv install 3.8.0  # tests, version supporting openssl 1.1
     pyenv install 3.7.0  # tests, version supporting openssl 1.1
     pyenv rehash
@@ -182,8 +182,8 @@ def build_pyenv_venv(boxname)
     . ~/.bash_profile
     cd /vagrant/borg
     # use the latest 3.9 release
-    pyenv global 3.9.5
-    pyenv virtualenv 3.9.5 borg-env
+    pyenv global 3.9.7
+    pyenv virtualenv 3.9.7 borg-env
     ln -s ~/.pyenv/versions/borg-env .
   EOF
 end
@@ -232,8 +232,8 @@ def run_tests(boxname, skip_env)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions:
-      pyenv global 3.7.0 3.8.0 3.9.5 3.10-dev
-      pyenv local 3.7.0 3.8.0 3.9.5 3.10-dev
+      pyenv global 3.7.0 3.8.0 3.9.7 3.10-dev
+      pyenv local 3.7.0 3.8.0 3.9.7 3.10-dev
     fi
     # otherwise: just use the system python
     # some OSes can only run specific test envs, e.g. because they miss FUSE support:


### PR DESCRIPTION
note: no 1.1 backport of this (1.1 uses 3.9.0 for testing and 3.7 for binary builds)