### PR TITLE
Fix command & switch completion in Fish 3.3.0+

### DIFF
--- a/scripts/shell_completions/fish/borg.fish
+++ b/scripts/shell_completions/fish/borg.fish
@@ -351,7 +351,7 @@ function __fish_borg_is_dir_a_repository
     set -l config_content
     if test -f $argv[1]/README
     and test -f $argv[1]/config
-        read config_content < $argv[1]/config ^/dev/null
+        read config_content < $argv[1]/config 2>/dev/null
     end
     return (string match --quiet '[repository]' $config_content)
 end
@@ -360,7 +360,7 @@ function __fish_borg_list_repos_or_archives
     if string match --quiet --regex '.*::' '"'(commandline --current-token)'"'
         # If the current token contains "::" then list the archives:
         set -l repository_name (string replace --regex '::.*' '' (commandline --current-token))
-        borg list --format="$repository_name::{archive}{TAB}{comment}{NEWLINE}" "$repository_name" ^/dev/null
+        borg list --format="$repository_name::{archive}{TAB}{comment}{NEWLINE}" "$repository_name" 2>/dev/null
     else
         # Otherwise list the repositories, directories and user@host entries:
         set -l directories (commandline --cut-at-cursor --current-token)*/
@@ -390,7 +390,7 @@ end
 
 function __fish_borg_list_only_archives
     set -l repo_matches (string match --regex '([^ ]*)::' (commandline))
-    borg list --format="{archive}{TAB}{comment}{NEWLINE}" "$repo_matches[2]" ^/dev/null
+    borg list --format="{archive}{TAB}{comment}{NEWLINE}" "$repo_matches[2]" 2>/dev/null
 end
 
 complete -c borg -f -n __fish_borg_is_diff_second_archive -a '(__fish_borg_list_only_archives)'


### PR DESCRIPTION
Fish 3.3.0 enabled stderr-nocaret flag by default which breaks stderr redirection with "^/dev/null". A posix-like "2>/dev/null" has to be used instead.

More details:
https://github.com/fish-shell/fish-shell/pull/7907
https://github.com/fish-shell/fish-shell/issues/7105

I wasn't enable to establish where "2>..." support had been added, but looking at https://github.com/fish-shell/fish-shell/issues/4394, I believe it was "long time ago". As a result, I propose to put it also in the next 1.1.x release (if any).