### PR TITLE
docs: add note about GFS

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4283,7 +4283,9 @@ class Archiver:
         Important: Repository disk space is **not** freed until you run ``borg compact``.
 
         This command is normally used by automated backup scripts wanting to keep a
-        certain number of historic backups.
+        certain number of historic backups. This retention policy is commonly referred to
+        `GFS <https://en.wikipedia.org/wiki/Backup_rotation_scheme#Grandfather-father-son>`_
+        (Grandfather-father-son) backup rotation scheme.
 
         Also, prune automatically removes checkpoint archives (incomplete archives left
         behind by interrupted backup runs) except if the checkpoint is the latest

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4283,7 +4283,7 @@ class Archiver:
         Important: Repository disk space is **not** freed until you run ``borg compact``.
 
         This command is normally used by automated backup scripts wanting to keep a
-        certain number of historic backups. This retention policy is commonly referred to
+        certain number of historic backups. This retention policy is commonly referred to as
         `GFS <https://en.wikipedia.org/wiki/Backup_rotation_scheme#Grandfather-father-son>`_
         (Grandfather-father-son) backup rotation scheme.
 


### PR DESCRIPTION
What `borg prune` is mostly doing is also known as grandfather-father-son method (see link in code). I think it makes sense to put the words `rentention policy` and `backup rotation scheme` and most importantly, `GFS` to the docs. This increases the chance of stumbling upon borg when googling for these kinds of things. Do you agree?  For example, I was researching this a bit and found (and used) https://github.com/shello/gfs.py long before I knew borg was a thing.

This only makes sense if the change does not stay on master branch eternally. For example, the line above (`Important: Repository disk space is **not** freed until you run borg compact.`) has been commited three years ago but is still not present in the (stable, default) docs? That's a bit weird, not sure if I am misunderstanding something here.

Also, not super sure if the url syntax is right.