### PR TITLE
create: fix passing device nodes and symlinks to --paths-from-stdin

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -39,6 +39,7 @@ from .helpers import bin_to_hex
 from .helpers import safe_ns
 from .helpers import ellipsis_truncate, ProgressIndicatorPercent, log_multi
 from .helpers import os_open, flags_normal, flags_dir
+from .helpers import os_stat
 from .helpers import msgpack
 from .helpers import sig_int
 from .lrucache import LRUCache
@@ -1284,7 +1285,7 @@ class FilesystemObjectProcessors:
         with self.create_helper(path, st, dev_type) as (item, status, hardlinked, hardlink_master):  # char/block device
             # looks like we can not work fd-based here without causing issues when trying to open/close the device
             with backup_io('stat'):
-                st = stat_update_check(st, os.stat(name, dir_fd=parent_fd, follow_symlinks=False))
+                st = stat_update_check(st, os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False))
             item.rdev = st.st_rdev
             item.update(self.metadata_collector.stat_attrs(st, path))
             return status

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -681,7 +681,7 @@ class Archiver:
                 return fso.process_symlink(path=path, parent_fd=parent_fd, name=name, st=st)
             else:
                 try:
-                    st_target = os.stat(name, dir_fd=parent_fd, follow_symlinks=True)
+                    st_target = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=True)
                 except OSError:
                     special = False
                 else:


### PR DESCRIPTION
Paths that come from --paths-from-stdin or --paths-from-command don't
have a parent_fd or name, so we need to use the os_stat helper that
falls back on the full path if those are missing.

Fixes borgbackup/borg#6009