### PR TITLE
Fix manifest-timestamp path

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -115,7 +115,7 @@ you could delete the manifest-timestamp and the local cache:
 ::
 
   borg config repo id   # shows the REPO_ID
-  rm ~/.config/borg/REPO_ID/manifest-timestamp
+  rm ~/.config/borg/security/REPO_ID/manifest-timestamp
   borg delete --cache-only REPO
 
 This is an unsafe and unsupported way to use borg, you have been warned.


### PR DESCRIPTION
This is a backport of PR #6016 to the 1.1-maint branch.