### PR TITLE
docs: excluded parent dir's metadata can't restore.

### DIFF
--- a/docs/usage/extract.rst.inc
+++ b/docs/usage/extract.rst.inc
@@ -121,5 +121,5 @@ pass over the archive metadata.
     so make sure you ``cd`` to the right place before calling ``borg extract``.
 
     When parent directories are not extracted (because of using file/directory selection
-    or any other reasons), borg can not restore those directories' metadata, e.g. owner,
+    or any other reason), borg can not restore parent directories' metadata, e.g. owner,
     group, permission, etc.

--- a/docs/usage/extract.rst.inc
+++ b/docs/usage/extract.rst.inc
@@ -119,3 +119,7 @@ pass over the archive metadata.
 
     Currently, extract always writes into the current working directory ("."),
     so make sure you ``cd`` to the right place before calling ``borg extract``.
+
+    When using file and directory selection, if the parent directories of selected
+    targets are not selected, borg can not restore those directories' metadata, e.g.
+    owner, group, permission, etc.

--- a/docs/usage/extract.rst.inc
+++ b/docs/usage/extract.rst.inc
@@ -120,6 +120,6 @@ pass over the archive metadata.
     Currently, extract always writes into the current working directory ("."),
     so make sure you ``cd`` to the right place before calling ``borg extract``.
 
-    When using file and directory selection, if the parent directories of selected
-    targets are not selected, borg can not restore those directories' metadata, e.g.
-    owner, group, permission, etc.
+    When parent directories are not extracted (because of using file/directory selection
+    or any other reasons), borg can not restore those directories' metadata, e.g. owner,
+    group, permission, etc.

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -170,7 +170,7 @@ Examples::
     .. note::
 
         It's possible that a sub-directory/file is matched while parent directories are not.
-        In that case, parent directories are not backed up thus their user, group, permission,=
+        In that case, parent directories are not backed up thus their user, group, permission,
         etc. can not be restored.
 
         For example, with `--pattern=+/home/user/subdir --pattern=-/home/user/*`,

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -173,10 +173,6 @@ Examples::
         In that case, parent directories are not backed up thus their user, group, permission,
         etc. can not be restored.
 
-        For example, with `--pattern=+/home/user/subdir --pattern=-/home/user/*`,
-        `/home/user/subdir` can be restored with correct metadata, while `\home`and
-        `/home/user` can not.
-
     Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
     shell style (`sh:`), so those patterns behave similar to rsync include/exclude
     patterns. The pattern style can be set via the `P` prefix.

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -167,6 +167,16 @@ Examples::
     a directory, it won't recurse into it and won't discover any potential matches for
     include rules below that directory.
 
+    .. note::
+
+        It's possible that a sub-directory/file is matched while parent directories are not.
+        In that case, parent directories are not backed up thus their user, group, permission,=
+        etc. can not be restored.
+
+        For example, with `--pattern=+/home/user/subdir --pattern=-/home/user/*`,
+        `/home/user/subdir` can be restored with correct metadata, while `\home`and
+        `/home/user` can not.
+
     Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
     shell style (`sh:`), so those patterns behave similar to rsync include/exclude
     patterns. The pattern style can be set via the `P` prefix.


### PR DESCRIPTION
Refer to discussion in #5680.