### PR TITLE
avoid expanding path into LHS of formatting operation, see #6063

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -792,7 +792,7 @@ Utilization of max. archive size: {csize_max:.0%}
                         # EACCES: permission denied to set this specific xattr (this may happen related to security.* keys)
                         # EPERM: operation not permitted
                         err_str = os.strerror(e.errno)
-                    logger.warning('%s: when setting extended attribute %s: %s' % (path, k.decode(), err_str))
+                    logger.warning('%s: when setting extended attribute %s: %s', path, k.decode(), err_str)
                     set_ec(EXIT_WARNING)
         # bsdflags include the immutable flag and need to be set last:
         if not self.nobsdflags and 'bsdflags' in item:

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -778,7 +778,6 @@ Utilization of max. archive size: {csize_max:.0%}
                 try:
                     xattr.setxattr(fd or path, k, v, follow_symlinks=False)
                 except OSError as e:
-                    msg_format = '%s: when setting extended attribute %s: %%s' % (path, k.decode())
                     if e.errno == errno.E2BIG:
                         err_str = 'too big for this filesystem'
                     elif e.errno == errno.ENOTSUP:
@@ -793,7 +792,7 @@ Utilization of max. archive size: {csize_max:.0%}
                         # EACCES: permission denied to set this specific xattr (this may happen related to security.* keys)
                         # EPERM: operation not permitted
                         err_str = os.strerror(e.errno)
-                    logger.warning(msg_format % err_str)
+                    logger.warning('%s: when setting extended attribute %s: %s' % (path, k.decode(), err_str))
                     set_ec(EXIT_WARNING)
         # bsdflags include the immutable flag and need to be set last:
         if not self.nobsdflags and 'bsdflags' in item:


### PR DESCRIPTION
Submitted on `1.1-maint` because the code in question has been moved, removed, or refactored on `master`.