### PR TITLE
Remove BORG_LIBC completion

### DIFF
--- a/scripts/shell_completions/zsh/_borg
+++ b/scripts/shell_completions/zsh/_borg
@@ -794,10 +794,6 @@ _borg_parameters() {
     _description values expl 'value'
     compadd "$expl[@]" YES NO && ret=0
     ;;
-  (LIBC)
-    _wanted libraries expl 'library' \
-      compadd - ${^=LD_LIBRARY_PATH:-/usr/lib /usr/local/lib}/lib*.(a|so*)(:t:fr:s/lib//) && ret=0
-    ;;
   (SELFTEST)
     _description values expl 'value'
     compadd "$expl[@]" disabled && ret=0


### PR DESCRIPTION
BORG_LIBC was added in a4f7e69 to allow borg to work on systems where 
ctypes.util,find_library() fails. Since 9914968 borg no longer uses 
find_library(). This removes the need to forward port #6008