### PR TITLE
Backport #6023: do not show archive name in error msgs referring to repository

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -152,7 +152,7 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
             if argument(args, fake) ^ invert_fake:
                 return method(self, args, repository=None, **kwargs)
             elif location.proto == 'ssh':
-                repository = RemoteRepository(location, create=create, exclusive=argument(args, exclusive),
+                repository = RemoteRepository(location.omit_archive(), create=create, exclusive=argument(args, exclusive),
                                               lock_wait=self.lock_wait, lock=lock, append_only=append_only,
                                               make_parent_dirs=make_parent_dirs, args=args)
             else:

--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -1232,6 +1232,12 @@ class Location:
             'utcnow': DatetimeWrapper(timestamp),
         })
 
+    def omit_archive(self):
+        loc = Location(self.orig)
+        loc.archive = None
+        loc.orig = loc.orig.split("::")[0]
+        return loc
+
 
 def location_validator(archive=None, proto=None):
     def validator(text):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3529,7 +3529,6 @@ class RemoteArchiverTestCase(ArchiverTestCase):
                 res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '0')
                 self.assert_true(marker not in res)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_do_not_mention_archive_if_you_can_not_find_repo(self):
         """https://github.com/borgbackup/borg/issues/6014"""
         archive = self.repository_location + '-this-repository-does-not-exist' + '::test'

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3532,7 +3532,7 @@ class RemoteArchiverTestCase(ArchiverTestCase):
     def test_do_not_mention_archive_if_you_can_not_find_repo(self):
         """https://github.com/borgbackup/borg/issues/6014"""
         archive = self.repository_location + '-this-repository-does-not-exist' + '::test'
-        output = self.cmd(*['info', archive], exit_code=2, fork=True)
+        output = self.cmd('info', archive, exit_code=2, fork=True)
         self.assert_in('this-repository-does-not-exist', output)
         self.assert_not_in('this-repository-does-not-exist::test', output)
 

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3529,6 +3529,14 @@ class RemoteArchiverTestCase(ArchiverTestCase):
                 res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '0')
                 self.assert_true(marker not in res)
 
+    @pytest.mark.xfail(raises=AssertionError, strict=True)
+    def test_do_not_mention_archive_if_you_can_not_find_repo(self):
+        """https://github.com/borgbackup/borg/issues/6014"""
+        archive = self.repository_location + '-this-repository-does-not-exist' + '::test'
+        output = self.cmd(*['info', archive], exit_code=2, fork=True)
+        self.assert_in('this-repository-does-not-exist', output)
+        self.assert_not_in('this-repository-does-not-exist::test', output)
+
 
 class ArchiverCorruptionTestCase(ArchiverTestCaseBase):
     def setUp(self):

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -231,6 +231,12 @@ class TestLocationWithoutEnv:
             # this is invalid due to the 2nd colon, correct: 'ssh://user@host/path'
             Location('ssh://user@host:/path')
 
+    def test_omit_archive(self):
+        loc = Location('ssh://user@host:1234/some/path::archive')
+        loc_without_archive = loc.omit_archive()
+        assert loc_without_archive.archive is None
+        assert loc_without_archive.orig == "ssh://user@host:1234/some/path"
+
 
 class TestLocationWithEnv:
     def test_ssh(self, monkeypatch):


### PR DESCRIPTION
Backport #6023 (do not show archive name in error msgs referring to repository)

The original PR did not have a test to prove that the bug is fixed so I took the liberty of adding one. After this is merged I'll forward port the test to master.