### PR TITLE
Forward port #6064: avoid expanding path into LHS of formatting operation

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3460,7 +3460,6 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
             assert 'Attic repository detected.' in output
 
     # derived from test_extract_xattrs_errors()
-    @pytest.mark.xfail(raises=ValueError, strict=True)
     @pytest.mark.skipif(not xattr.XATTR_FAKEROOT, reason='xattr not supported on this system or on this version of'
                                                          'fakeroot')
     def test_do_not_fail_when_percent_is_in_xattr_name(self):
@@ -3477,7 +3476,6 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
                 self.cmd('extract', self.repository_location + '::test', exit_code=EXIT_WARNING)
 
     # derived from test_extract_xattrs_errors()
-    @pytest.mark.xfail(raises=ValueError, strict=True)
     @pytest.mark.skipif(not xattr.XATTR_FAKEROOT, reason='xattr not supported on this system or on this version of'
                                                          'fakeroot')
     def test_do_not_fail_when_percent_is_in_file_name(self):

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -132,7 +132,6 @@ def set_all(path, xattrs, follow_symlinks=False):
                 path_str = '<FD %d>' % path
             else:
                 path_str = os.fsdecode(path)
-            msg_format = '%s: when setting extended attribute %s: %%s' % (path_str, k_str)
             if e.errno == errno.E2BIG:
                 err_str = 'too big for this filesystem'
             elif e.errno == errno.ENOTSUP:
@@ -146,5 +145,5 @@ def set_all(path, xattrs, follow_symlinks=False):
                 # EACCES: permission denied to set this specific xattr (this may happen related to security.* keys)
                 # EPERM: operation not permitted
                 err_str = os.strerror(e.errno)
-            logger.warning(msg_format % err_str)
+            logger.warning('%s: when setting extended attribute %s: %s', path_str, k_str, err_str)
     return warning


### PR DESCRIPTION
Fixes #6063 (xattrs not supported warning during extract fails due to % in filename)
Forward port #6064 (avoid expanding path into LHS of formatting operation)

I took the liberty of adding tests that the original PR neglected. Once this is merged I'll backport the tests