### PR TITLE
Remove --list-format from borg list

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4245,7 +4245,7 @@ class Archiver:
                 help='Show checkpoint archives in the repository contents list (default: hidden).')
         subparser.add_argument('--short', dest='short', action='store_true',
                                help='only print file/directory names, nothing else')
-        subparser.add_argument('--format', '--list-format', metavar='FORMAT', dest='format',
+        subparser.add_argument('--format', metavar='FORMAT', dest='format',
                                help='specify format for file listing '
                                     '(default: "{mode} {user:6} {group:6} {size:8d} {mtime} {path}{extra}{NL}")')
         subparser.add_argument('--json', action='store_true',


### PR DESCRIPTION
While reading the docs I noticed that in `borg list` the options --list-format and --format do the same thing. Using `git log -S` I have uncovered that --list-format used to be deprecated and was supposed to be removed in c87393cab736d30a3c138f5f694c8cc0c8ca6ccc, but you overlooked it and undeprecated it instead. *What should we do now? Just remove it or deprecate it again?*