### PR TITLE
Fix exceptions thrown by `setup.py build_man`

### DIFF
--- a/docs/usage/import-tar.rst
+++ b/docs/usage/import-tar.rst
@@ -1,0 +1,1 @@
+.. include:: import-tar.rst.inc

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1656,6 +1656,7 @@ class Archiver:
 
     @with_repository(cache=True, exclusive=True, compatibility=(Manifest.Operation.WRITE,))
     def do_import_tar(self, args, repository, manifest, key, cache):
+        """Create a backup archive from a tarball"""
         self.output_filter = args.output_filter
         self.output_list = args.output_list
 


### PR DESCRIPTION
While doing some doc updates I needed a way to test them - to build
the documentation and inspect the output. I ran into an issue:
running python setup.py build_man was throwing exceptions:

1. The import-tar parser had a None description causing:

    File "/home/user/borg/setup_docs.py", line 451, in write_heading
      write(char * len(header))
    TypeError: object of type 'NoneType' has no len()

2. There was no docs/usage/import-tar.rst causing an exception too