### PR TITLE
key export: print key if path is '-' or not given, fixes #6092

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -364,8 +364,9 @@ class Archiver:
             manager.export_paperkey(args.path)
         else:
             if not args.path:
-                self.print_error("output file to export key to expected")
-                return EXIT_ERROR
+                print("No output path provided. Printing key:")
+                manager.export_paperkey(None)
+                return EXIT_SUCCESS
             try:
                 if args.qr:
                     manager.export_qr(args.path)

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -364,8 +364,7 @@ class Archiver:
             manager.export_paperkey(args.path)
         else:
             if not args.path:
-                print("No output path provided. Printing key:")
-                manager.export_paperkey(None)
+                print(manager.get_keyfile_data())
                 return EXIT_SUCCESS
             try:
                 if args.qr:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -363,9 +363,6 @@ class Archiver:
         if args.paper:
             manager.export_paperkey(args.path)
         else:
-            if not args.path:
-                print(manager.get_keyfile_data())
-                return EXIT_SUCCESS
             try:
                 if args.qr:
                     manager.export_qr(args.path)

--- a/src/borg/crypto/keymanager.py
+++ b/src/borg/crypto/keymanager.py
@@ -75,13 +75,19 @@ class KeyManager:
         return data
 
     def store_keyfile(self, target):
-        with open(target, 'w') as fd:
+        with dash_open(target, 'w') as fd:
             fd.write(self.get_keyfile_data())
 
     def export(self, path):
+        if path is None:
+            path = '-'
+
         self.store_keyfile(path)
 
     def export_qr(self, path):
+        if path is None:
+            path = '-'
+
         with open(path, 'wb') as fd:
             key_data = self.get_keyfile_data()
             html = pkgutil.get_data('borg', 'paperkey.html')
@@ -89,6 +95,9 @@ class KeyManager:
             fd.write(html)
 
     def export_paperkey(self, path):
+        if path is None:
+            path = '-'
+
         def grouped(s):
             ret = ''
             i = 0
@@ -118,11 +127,8 @@ class KeyManager:
             export += '{0:2d}: {1} - {2}\n'.format(idx, grouped(bin_to_hex(binline)), checksum)
             binary = binary[18:]
 
-        if path:
-            with open(path, 'w') as fd:
-                fd.write(export)
-        else:
-            print(export)
+        with dash_open(path, 'w') as fd:
+            fd.write(export)
 
     def import_keyfile(self, args):
         file_id = KeyfileKey.FILE_ID

--- a/src/borg/crypto/keymanager.py
+++ b/src/borg/crypto/keymanager.py
@@ -88,7 +88,7 @@ class KeyManager:
         if path is None:
             path = '-'
 
-        with open(path, 'wb') as fd:
+        with dash_open(path, 'wb') as fd:
             key_data = self.get_keyfile_data()
             html = pkgutil.get_data('borg', 'paperkey.html')
             html = html.replace(b'</textarea>', key_data.encode() + b'</textarea>')


### PR DESCRIPTION
Implemented #6092. "borg key export [REPOSITORY]" now prints out the key
