### PR TITLE
fix new xattr tests for binary test runs

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3527,6 +3527,14 @@ class ArchiverTestCaseBinary(ArchiverTestCase):
         else:
             super().test_fuse()
 
+    @unittest.skip('patches objects')
+    def test_do_not_fail_when_percent_is_in_xattr_name(self):
+        pass
+
+    @unittest.skip('patches objects')
+    def test_do_not_fail_when_percent_is_in_file_name(self):
+        pass
+
 
 class ArchiverCheckTestCase(ArchiverTestCaseBase):
 


### PR DESCRIPTION
the tests do object patching, this does not work when we call the external binary "borg.exe".

this made these tests fail IF the borg.exe was available (like in the debian stretch vagrant VM).
