### PR TITLE
repository: quota computation fixes for delayed compaction

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -930,7 +930,7 @@ class Repository:
                 else:
                     report(msg)
         if self.segments[segment] == 0:
-            self.compact[segment] += self.io.segment_size(segment)
+            self.compact[segment] = self.io.segment_size(segment)
 
     def _rebuild_sparse(self, segment):
         """Rebuild sparse bytes count for a single segment relative to the current index."""

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -463,13 +463,16 @@ class QuotaTestCase(RepositoryTestCaseBase):
         self.repository.put(H(2), bytes(5678))
         assert self.repository.storage_quota_use == 1234 + 5678 + 2 * 41
         self.repository.delete(H(1))
-        assert self.repository.storage_quota_use == 5678 + 41
+        assert self.repository.storage_quota_use == 1234 + 5678 + 2 * 41  # we have not compacted yet
         self.repository.commit(compact=False)
+        assert self.repository.storage_quota_use == 1234 + 5678 + 2 * 41  # we have not compacted yet
         self.reopen()
         with self.repository:
             # Open new transaction; hints and thus quota data is not loaded unless needed.
             self.repository.put(H(3), b'')
             self.repository.delete(H(3))
+            assert self.repository.storage_quota_use == 1234 + 5678 + 3 * 41  # we have not compacted yet
+            self.repository.commit(compact=True)
             assert self.repository.storage_quota_use == 5678 + 41
 
     def test_exceed_quota(self):
@@ -486,10 +489,12 @@ class QuotaTestCase(RepositoryTestCaseBase):
         assert self.repository.storage_quota_use == 82
         self.reopen()
         with self.repository:
-            self.repository.storage_quota = 50
+            self.repository.storage_quota = 100
             # Open new transaction; hints and thus quota data is not loaded unless needed.
             self.repository.put(H(1), b'')
-            assert self.repository.storage_quota_use == 41
+            assert self.repository.storage_quota_use == 82  # we have 2 puts for H(1) here and not yet compacted.
+            self.repository.commit(compact=True)
+            assert self.repository.storage_quota_use == 41  # now we have compacted.
 
 
 class NonceReservation(RepositoryTestCaseBase):


### PR DESCRIPTION
see commit comments.

for master branch, these fixes are required, because we have delayed compaction (separate `borg compact` command).

for 1.1-maint, they could be also applied, but are not that important because compact_segments is always called after writing.
