### PR TITLE
clarify who starts the remote agent

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,11 +13,11 @@ What is the difference between a repo on an external hard drive vs. repo on a se
 
 If Borg is running in client/server mode, the client uses SSH as a transport to
 talk to the remote agent, which is another Borg process (Borg is installed on
-the server, too). The Borg server is doing storage-related low-level repo
-operations (get, put, commit, check, compact), while the Borg client does the
-high-level stuff: deduplication, encryption, compression, dealing with
-archives, backups, restores, etc., which reduces the amount of data that goes
-over the network.
+the server, too) started automatically by the client. The Borg server is doing
+storage-related low-level repo operations (get, put, commit, check, compact),
+while the Borg client does the high-level stuff: deduplication, encryption,
+compression, dealing with archives, backups, restores, etc., which reduces the
+amount of data that goes over the network.
 
 When Borg is writing to a repo on a locally mounted remote file system, e.g.
 SSHFS, the Borg client only can do file system operations and has no agent


### PR DESCRIPTION
It was unclear that the user _only_ needs to have borg installed on a remote system to use client/server mode. Hopefully this change makes it apparent that the user doesn't start anything on the remote system themselves.
If the language is awkward or even more unclear, I'm happy to make changes
