### PR TITLE
Backport: fix new xattr tests for binary test runs

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3176,6 +3176,14 @@ class ArchiverTestCaseBinary(ArchiverTestCase):
         else:
             super().test_fuse()
 
+    @unittest.skip('patches objects')
+    def test_do_not_fail_when_percent_is_in_xattr_name(self):
+        pass
+
+    @unittest.skip('patches objects')
+    def test_do_not_fail_when_percent_is_in_file_name(self):
+        pass
+
 
 class ArchiverCheckTestCase(ArchiverTestCaseBase):
 


### PR DESCRIPTION
This is a backport of #6115