### PR TITLE
remove leftovers of BORG_HOSTNAME_IS_UNIQUE from docs

### DIFF
--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -35,10 +35,6 @@ General:
         Main usecase for this is to fully automate ``borg change-passphrase``.
     BORG_DISPLAY_PASSPHRASE
         When set, use the value to answer the "display the passphrase for verification" question when defining a new passphrase for encrypted repositories.
-    BORG_HOSTNAME_IS_UNIQUE=no
-        Borg assumes that it can derive a unique hostname / identity (see ``borg debug info``).
-        If this is not the case or you do not want Borg to automatically remove stale locks,
-        set this to *no*.
     BORG_HOST_ID
         Borg usually computes a host id from the FQDN plus the results of ``uuid.getnode()`` (which usually returns
         a unique id based on the MAC address of the network interface. Except if that MAC happens to be all-zero - in


### PR DESCRIPTION
thanks to @snsmac for the hint: there is no code implementing this any more. it was replaced by
BORG_HOST_ID (if needed).
