### PR TITLE
Backport: CI: macOS: re-enable fuse2 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             - os: ubuntu-20.04
               python-version: '3.10-dev'
               toxenv: py310
-            - os: macos-latest
+            - os: macos-10.15  # macos-latest is macos 11.6.2 and hanging at test_fuse, #6099
               # note: it seems that 3.8 and 3.9 are currently broken,
               # neverending RuntimeError crashes...
               python-version: '3.7'
@@ -117,7 +117,7 @@ jobs:
         brew install zstd || brew upgrade zstd
         brew install lz4 || brew upgrade lz4
         brew install openssl@1.1 || brew upgrade openssl@1.1
-        brew install homebrew/cask/osxfuse || brew upgrade homebrew/cask/osxfuse  # Required for Python llfuse module
+        brew install --cask macfuse || brew upgrade --cask macfuse  # Required for Python llfuse module
 
     - name: Install Python requirements
       run: |


### PR DESCRIPTION
This is a work around for #6099
This is a backport of #6125

> Downgrade to macOS 10.15 as macOS 11.x breaks fuse2 testing.
>
> On macOS 10.15, osxfuse and also macfuse works with borg's fuse2 tests.
>
> Upgrading to macOS 11.x based github CI breaks the tests, see #6099,
> even when using the more recent macfuse to provide fuse2 capability.

> Why did you switch from osxfuse to macfuse?

> strictly taken, the switch was not required, it also worked with osxfuse after the macos downgrade.
>
> but considering a later potential upgrade of macos to some more recent version again (after the hanging issue is analyzed and fixed), i wanted to switch to the more recent macfuse code to be prepared for that.
