### PR TITLE
Backport: info: emit repo info even if repo has 0 archives

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1530,8 +1530,6 @@ class Archiver:
             archive_names = (args.location.archive,)
         else:
             archive_names = tuple(x.name for x in manifest.archives.list_considering(args))
-            if not archive_names:
-                return self.exit_code
 
         output_data = []
 

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1476,7 +1476,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         assert datetime.strptime(archive['start'], ISO_FORMAT)
         assert datetime.strptime(archive['end'], ISO_FORMAT)
 
-    @pytest.mark.xfail(strict=True)
     def test_info_json_of_empty_archive(self):
         """See https://github.com/borgbackup/borg/issues/6120"""
         self.cmd('init', '--encryption=repokey', self.repository_location)

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1476,6 +1476,15 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         assert datetime.strptime(archive['start'], ISO_FORMAT)
         assert datetime.strptime(archive['end'], ISO_FORMAT)
 
+    @pytest.mark.xfail(strict=True)
+    def test_info_json_of_empty_archive(self):
+        """See https://github.com/borgbackup/borg/issues/6120"""
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        info_repo = json.loads(self.cmd('info', '--json', '--first=1', self.repository_location))
+        assert info_repo["archives"] == []
+        info_repo = json.loads(self.cmd('info', '--json', '--last=1', self.repository_location))
+        assert info_repo["archives"] == []
+
     def test_comment(self):
         self.create_regular_file('file1', size=1024 * 80)
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
Fixes #6120

This is a backport of https://github.com/borgbackup/borg/pull/6152
This also includes a backport of https://github.com/borgbackup/borg/pull/6155