### PR TITLE
Refactor: remove assert_true (1.1)

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -169,7 +169,7 @@ class BaseTestCase(unittest.TestCase):
     def assert_creates_file(self, path):
         assert not os.path.exists(path), '{} should not exist'.format(path)
         yield
-        assert not os.path.exists(path), '{} should not exist'.format(path)
+        assert os.path.exists(path), '{} should exist'.format(path)
 
     def assert_dirs_equal(self, dir1, dir2, **kwargs):
         diff = filecmp.dircmp(dir1, dir2)

--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -159,7 +159,6 @@ class BaseTestCase(unittest.TestCase):
     assert_not_in = unittest.TestCase.assertNotIn
     assert_equal = unittest.TestCase.assertEqual
     assert_not_equal = unittest.TestCase.assertNotEqual
-    assert_true = unittest.TestCase.assertTrue
 
     if raises:
         assert_raises = staticmethod(raises)
@@ -168,9 +167,9 @@ class BaseTestCase(unittest.TestCase):
 
     @contextmanager
     def assert_creates_file(self, path):
-        self.assert_true(not os.path.exists(path), '{} should not exist'.format(path))
+        assert not os.path.exists(path), '{} should not exist'.format(path)
         yield
-        self.assert_true(os.path.exists(path), '{} should exist'.format(path))
+        assert not os.path.exists(path), '{} should not exist'.format(path)
 
     def assert_dirs_equal(self, dir1, dir2, **kwargs):
         diff = filecmp.dircmp(dir1, dir2)

--- a/src/borg/testsuite/archive.py
+++ b/src/borg/testsuite/archive.py
@@ -124,11 +124,11 @@ class ChunkBufferTestCase(BaseTestCase):
         chunks.flush(flush=False)
         # the code is expected to leave the last partial chunk in the buffer
         self.assert_equal(len(chunks.chunks), 3)
-        self.assert_true(chunks.buffer.tell() > 0)
+        assert chunks.buffer.tell() > 0
         # now really flush
         chunks.flush(flush=True)
         self.assert_equal(len(chunks.chunks), 4)
-        self.assert_true(chunks.buffer.tell() == 0)
+        assert chunks.buffer.tell() == 0
         unpacker = msgpack.Unpacker()
         for id in chunks.chunks:
             unpacker.feed(cache.objects[id])

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -629,7 +629,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 self.assert_equal(fd.read(hole_size), b'\0' * hole_size)
                 self.assert_equal(fd.read(len(content)), content)
                 self.assert_equal(fd.read(hole_size), b'\0' * hole_size)
-            self.assert_true(is_sparse(filename, total_size, hole_size))
+            assert is_sparse(filename, total_size, hole_size)
 
     def test_unusual_filenames(self):
         filenames = ['normal', 'with some blanks', '(with_parens)', ]
@@ -788,7 +788,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('create', self.repository_location + '::test', 'input')
         with changedir('output'):
             self.cmd('extract', self.repository_location + '::test', '--strip-components', '3')
-            self.assert_true(not os.path.exists('file'))
+            assert not os.path.exists('file')
             with self.assert_creates_file('file'):
                 self.cmd('extract', self.repository_location + '::test', '--strip-components', '2')
             with self.assert_creates_file('dir/file'):
@@ -3558,16 +3558,16 @@ class RemoteArchiverTestCase(ArchiverTestCase):
         marker = 'cached responses left in RemoteRepository'
         with changedir('output'):
             res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '3')
-            self.assert_true(marker not in res)
+            assert marker not in res
             with self.assert_creates_file('file'):
                 res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '2')
-                self.assert_true(marker not in res)
+                assert marker not in res
             with self.assert_creates_file('dir/file'):
                 res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '1')
-                self.assert_true(marker not in res)
+                assert marker not in res
             with self.assert_creates_file('input/dir/file'):
                 res = self.cmd('extract', "--debug", self.repository_location + '::test', '--strip-components', '0')
-                self.assert_true(marker not in res)
+                assert marker not in res
 
     def test_do_not_mention_archive_if_you_can_not_find_repo(self):
         """https://github.com/borgbackup/borg/issues/6014"""

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -89,7 +89,7 @@ class HashIndexTestCase(BaseTestCase):
         for x in range(n):
             idx[H(x)] = x, x
         idx.write(idx_name.name)
-        self.assert_true(initial_size < os.path.getsize(idx_name.name))
+        assert initial_size < os.path.getsize(idx_name.name)
         for x in range(n):
             del idx[H(x)]
         self.assert_equal(len(idx), 0)

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -815,7 +815,7 @@ class RepositoryHintsTestCase(RepositoryTestCaseBase):
     def test_hints_behaviour(self):
         self.repository.put(H(0), b'data')
         self.assert_equal(self.repository.shadow_index, {})
-        self.assert_true(len(self.repository.compact) == 0)
+        assert len(self.repository.compact) == 0
         self.repository.delete(H(0))
         self.repository.commit()
         # this is to make the previous delete "stable", see delete_is_not_stable:

--- a/src/borg/testsuite/xattr.py
+++ b/src/borg/testsuite/xattr.py
@@ -50,7 +50,7 @@ class XattrTestCase(BaseTestCase):
             setxattr(self.tmpfile.name, key, b'x')
         got_keys = listxattr(self.tmpfile.name)
         self.assert_equal_se(got_keys, keys)
-        self.assert_true(len(buffer) > 64)
+        assert len(buffer) > 64
 
     def test_getxattr_buffer_growth(self):
         # make it work even with ext4, which imposes rather low limits


### PR DESCRIPTION
Work toward #28

This PR removes the usage of assert_true in the 1.1 branch