### PR TITLE
docs: excluded parent dir's metadata can't restore

### DIFF
--- a/docs/usage/extract.rst.inc
+++ b/docs/usage/extract.rst.inc
@@ -119,7 +119,3 @@ pass over the archive metadata.
 
     Currently, extract always writes into the current working directory ("."),
     so make sure you ``cd`` to the right place before calling ``borg extract``.
-
-    When parent directories are not extracted (because of using file/directory selection
-    or any other reason), borg can not restore parent directories' metadata, e.g. owner,
-    group, permission, etc.

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -167,12 +167,6 @@ Examples::
     a directory, it won't recurse into it and won't discover any potential matches for
     include rules below that directory.
 
-    .. note::
-
-        It's possible that a sub-directory/file is matched while parent directories are not.
-        In that case, parent directories are not backed up thus their user, group, permission,
-        etc. can not be restored.
-
     Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
     shell style (`sh:`), so those patterns behave similar to rsync include/exclude
     patterns. The pattern style can be set via the `P` prefix.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2369,6 +2369,12 @@ class Archiver:
             a directory, it won't recurse into it and won't discover any potential matches for
             include rules below that directory.
 
+            .. note::
+
+                It's possible that a sub-directory/file is matched while parent directories are not.
+                In that case, parent directories are not backed up thus their user, group, permission,
+                etc. can not be restored.
+
             Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
             shell style (`sh:`), so those patterns behave similar to rsync include/exclude
             patterns. The pattern style can be set via the `P` prefix.
@@ -3878,6 +3884,10 @@ class Archiver:
 
             Currently, extract always writes into the current working directory ("."),
             so make sure you ``cd`` to the right place before calling ``borg extract``.
+
+            When parent directories are not extracted (because of using file/directory selection
+            or any other reason), borg can not restore parent directories' metadata, e.g. owner,
+            group, permission, etc.
         """)
         subparser = subparsers.add_parser('extract', parents=[common_parser], add_help=False,
                                           description=self.do_extract.__doc__,


### PR DESCRIPTION
The PR #6062 made a mistake: it updated the generated files instead of the source. This is the fix

Refer to discussion in #5680.