### PR TITLE
Backport upgrade pythons (#6116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
               python-version: '3.9'
               toxenv: py39
             - os: ubuntu-20.04
-              python-version: '3.10-dev'
+              python-version: '3.10'
               toxenv: py310
             - os: macos-10.15  # macos-latest is macos 11.6.2 and hanging at test_fuse, #6099
               # note: it seems that 3.8 and 3.9 are currently broken,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -220,7 +220,7 @@ def install_pythons(boxname)
     pyenv install 3.7.11  # binary build, use latest 3.7.x release
     pyenv install 3.8.0  # tests
     pyenv install 3.9.0  # tests
-    pyenv install 3.10-dev  # tests
+    pyenv install 3.10.0  # tests
     pyenv rehash
   EOF
 end
@@ -300,9 +300,9 @@ def run_tests(boxname)
     . ../borg-env/bin/activate
     if which pyenv 2> /dev/null; then
       # for testing, use the earliest point releases of the supported python versions.
-      # on some dists, 3.10-dev does not compile, so if pyenv fails due to this, try without 3.10.
-      pyenv global 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0 3.10-dev || pyenv global 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0
-      pyenv local 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0 3.10-dev || pyenv local 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0
+      # on some dists, 3.10 does not compile, so if pyenv fails due to this, try without 3.10.
+      pyenv global 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0 3.10.0 || pyenv global 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0
+      pyenv local 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0 3.10.0 || pyenv local 3.5.3 3.6.2 3.7.11 3.8.0 3.9.0
     fi
     # otherwise: just use the system python
     if which fakeroot 2> /dev/null; then


### PR DESCRIPTION
Backport of #6116.

I did not port the lines from
https://github.com/borgbackup/borg/pull/6116/files#diff-1ea02434f746b6d1522cdef3d4a56e57cf2d5a72c5273927746a71eaf06d74fdR182-R183
because this branch still uses 3.7