### PR TITLE
Backport docs: excluded parent dir's metadata can't restore (#6165)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2396,6 +2396,12 @@ class Archiver:
             a directory, it won't recurse into it and won't discover any potential matches for
             include rules below that directory.
 
+            .. note::
+
+                It's possible that a sub-directory/file is matched while parent directories are not.
+                In that case, parent directories are not backed up thus their user, group, permission,
+                etc. can not be restored.
+
             Note that the default pattern style for ``--pattern`` and ``--patterns-from`` is
             shell style (`sh:`), so those patterns behave similar to rsync include/exclude
             patterns. The pattern style can be set via the `P` prefix.
@@ -3582,6 +3588,10 @@ class Archiver:
 
             Currently, extract always writes into the current working directory ("."),
             so make sure you ``cd`` to the right place before calling ``borg extract``.
+
+            When parent directories are not extracted (because of using file/directory selection
+            or any other reason), borg can not restore parent directories' metadata, e.g. owner,
+            group, permission, etc.
         """)
         subparser = subparsers.add_parser('extract', parents=[common_parser], add_help=False,
                                           description=self.do_extract.__doc__,


### PR DESCRIPTION
Backport of #6165 which replaces #6062.