### PR TITLE
Doc: borg init: explain the encryption modes better

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2733,7 +2733,7 @@ class Archiver:
             'a_status_oddity': '"I am seeing ‘A’ (added) status for a unchanged file!?"',
             'separate_compaction': '"Separate compaction"',
             'list_item_flags': '"Item flags"',
-            'key_files': 'Internals -> Data structures and file formats -> Key files in the online documentation',
+            'key_files': 'Internals -> Data structures and file formats -> Key files',
             'borg_key_export': 'borg key export --help'
         }
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3987,7 +3987,7 @@ class Archiver:
         Borg will:
 
         1. Ask you to come up with a passphrase.
-        2. Generate a random key (3 keys to be more precise. See :ref:`key_files`).
+        2. Create a borg key (which contains 3 random secrets. See :ref:`key_files`).
         3. Encrypt the key with your passphrase.
         4. Store the encrypted key alongside the repository in ``/path/to/repo``.
            This is why it is essential to use a secure passphrase.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3999,7 +3999,7 @@ class Archiver:
            never sees your passphrase, your unencrypted key or your unencrypted files.
            Chunking and id generation are also based on your key to improve
            your privacy (See https://github.com/borgbackup/borg/pull/6184#issuecomment-1028105848).
-        6. Use the key when extracting files to verify that the contents of
+        6. Use the key when extracting files to decrypt them and to verify that the contents of
            the backups have not been accidentally or maliciously altered.
 
         Picking a passphrase

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3976,12 +3976,16 @@ class Archiver:
         you can neither configure it on a per-archive basis nor change the
         encryption mode of an existing repository.
 
-        Use::
+        Use ``repokey``::
 
             borg init --encryption repokey /path/to/repo
 
+        Or ``repokey-blake2`` depending on which is faster on your client machines (see below)::
+
+            borg init --encryption repokey-blake2 /path/to/repo
+
         Borg will:
-        
+
         1. Ask you to come up with a passphrase.
         2. Generate a random key (3 keys to be more precise. See :ref:`key_files`).
         3. Encrypt the key with your passphrase.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3990,7 +3990,7 @@ class Archiver:
         2. Generate a random key (3 keys to be more precise. See :ref:`key_files`).
         3. Encrypt the key with your passphrase.
         4. Store the encrypted key alongside the repository in ``/path/to/repo``.
-           This is why it is vital to use a secure passphrase.
+           This is why it is essential to use a secure passphrase.
         5. Encrypt your backups to prevent anyone from reading them unless they
            have the key and know the passphrase. Make sure to keep a backup of
            your key **outside** the repository - do not lock yourself out by

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3994,7 +3994,7 @@ class Archiver:
            For remote backups the encryption is done locally - the remote machine
            never sees your passphrase, your unencrypted key or your unencrypted files.
            Chunking and id generation are also based on your key to improve
-           your privacy (See ).
+           your privacy (See https://github.com/borgbackup/borg/pull/6184#issuecomment-1028105848).
         6. Use the key when extracting files to verify that the contents of
            the backups have not been accidentally or maliciously altered.
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3998,7 +3998,7 @@ class Archiver:
            For remote backups the encryption is done locally - the remote machine
            never sees your passphrase, your unencrypted key or your unencrypted files.
            Chunking and id generation are also based on your key to improve
-           your privacy (See https://github.com/borgbackup/borg/pull/6184#issuecomment-1028105848).
+           your privacy.
         6. Use the key when extracting files to decrypt them and to verify that the contents of
            the backups have not been accidentally or maliciously altered.
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3993,6 +3993,8 @@ class Archiver:
            "leaving your keys inside your car" (see :ref:`borg_key_export`).
            For remote backups the encryption is done locally - the remote machine
            never sees your passphrase, your unencrypted key or your unencrypted files.
+           Chunking and id generation are also based on your key to improve
+           your privacy (See ).
         6. Use the key when extracting files to verify that the contents of
            the backups have not been accidentally or maliciously altered.
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2734,7 +2734,7 @@ class Archiver:
             'separate_compaction': '"Separate compaction"',
             'list_item_flags': '"Item flags"',
             'key_files': 'Internals -> Data structures and file formats -> Key files',
-            'borg_key_export': 'borg key export --help'
+            'borg_key_export': 'borg key export --help',
         }
 
         def process_epilog(epilog):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2733,7 +2733,7 @@ class Archiver:
             'a_status_oddity': '"I am seeing ‘A’ (added) status for a unchanged file!?"',
             'separate_compaction': '"Separate compaction"',
             'list_item_flags': '"Item flags"',
-            'key_files': 'https://borgbackup.readthedocs.io/en/master/internals/data-structures.html#key-files',
+            'key_files': 'Internals -> Data structures and file formats -> Key files in the online documentation',
             'borg_key_export': 'borg key export --help'
         }
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4036,8 +4036,9 @@ class Archiver:
         If you do **not** want to encrypt the contents of your backups, but still
         want to detect malicious tampering use ``--encryption authenticated``.
 
-        If you prefer ``BLAKE2b`` to ``SHA-256``, use ``--encryption authenticated-blake2``,
-        ``--encryption repokey-blake2`` or ``--encryption keyfile-blake2``.
+        If ``BLAKE2b`` is faster than ``SHA-256`` on your hardware, use ``--encryption authenticated-blake2``,
+        ``--encryption repokey-blake2`` or ``--encryption keyfile-blake2``. Note: for remote backups
+        the hashing is done on your local machine.
 
         .. nanorst: inline-fill
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3989,7 +3989,7 @@ class Archiver:
         1. Ask you to come up with a passphrase.
         2. Create a borg key (which contains 3 random secrets. See :ref:`key_files`).
         3. Encrypt the key with your passphrase.
-        4. Store the encrypted key alongside the repository in ``/path/to/repo``.
+        4. Store the encrypted borg key inside the repository directory (in the repo config).
            This is why it is essential to use a secure passphrase.
         5. Encrypt your backups to prevent anyone from reading them unless they
            have the key and know the passphrase. Make sure to keep a backup of

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3991,7 +3991,7 @@ class Archiver:
         3. Encrypt the key with your passphrase.
         4. Store the encrypted borg key inside the repository directory (in the repo config).
            This is why it is essential to use a secure passphrase.
-        5. Encrypt your backups to prevent anyone from reading them unless they
+        5. Encrypt sign your backups to prevent anyone from reading or forging them unless they
            have the key and know the passphrase. Make sure to keep a backup of
            your key **outside** the repository - do not lock yourself out by
            "leaving your keys inside your car" (see :ref:`borg_key_export`).

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4032,7 +4032,6 @@ class Archiver:
 
         If you want "passphrase and having-the-key" security, use ``--encryption keyfile``.
         The key will be stored in your home directory (in ``~/.config/borg/keys``).
-        TODO: where is the key stored on Windows?
 
         If you do **not** want to encrypt the contents of your backups, but still
         want to detect malicious tampering use ``--encryption authenticated``.

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3991,7 +3991,7 @@ class Archiver:
         3. Encrypt the key with your passphrase.
         4. Store the encrypted borg key inside the repository directory (in the repo config).
            This is why it is essential to use a secure passphrase.
-        5. Encrypt sign your backups to prevent anyone from reading or forging them unless they
+        5. Encrypt and sign your backups to prevent anyone from reading or forging them unless they
            have the key and know the passphrase. Make sure to keep a backup of
            your key **outside** the repository - do not lock yourself out by
            "leaving your keys inside your car" (see :ref:`borg_key_export`).


### PR DESCRIPTION
The documentation for borg init was not structured logically:
1. The topic is switched from the general discussion of `borg init`
   to the discussion of encryption modes without a title.
2. Obscure technical details (chunking, id generation etc) were
   above the high-level overview and other key information.