### PR TITLE
Doc: ~/.config/borg/keys is not used w/ repokey

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -514,7 +514,8 @@ The Borg config directory has content that you should take care of:
   recovered.
 
 ``keys`` subdirectory
-  In this directory all your repository keyfiles are stored. You MUST make sure to have an
+  In this directory all your repository keyfiles are stored. This does **not** apply if you
+  use the repokey mode because your key is stored alongside the the repository. You MUST make sure to have an
   independent backup of these keyfiles, otherwise you cannot access your backups anymore if you lose
   them. You also MUST keep these files secret; everyone who gains access to your repository and has
   the corresponding keyfile (and the key passphrase) can extract it.


### PR DESCRIPTION
Fixes #6107