### PR TITLE
if ensure_dir() fails, give more informative error message, fixes #5952

### DIFF
--- a/src/borg/helpers.py
+++ b/src/borg/helpers.py
@@ -528,7 +528,7 @@ def ensure_dir(path, mode=stat.S_IRWXU, pretty_deadly=True):
         os.makedirs(path, mode=mode, exist_ok=True)
     except OSError as e:
         if pretty_deadly:
-            raise Error(e.args[1])
+            raise Error(str(e))
         else:
             raise
 


### PR DESCRIPTION
previously, it just said PermissionDenied with giving the filename/path.
