### PR TITLE
fix intermediate commits, shall be at end of segment

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1634,7 +1634,7 @@ class LoggedIO:
     def write_commit(self, intermediate=False):
         # Intermediate commits go directly into the current segment - this makes checking their validity more
         # expensive, but is faster and reduces clobber. Final commits go into a new segment.
-        fd = self.get_write_fd(want_new=not intermediate)
+        fd = self.get_write_fd(want_new=not intermediate, no_new=intermediate)
         if intermediate:
             fd.sync()
         header = self.header_no_crc_fmt.pack(self.header_fmt.size, TAG_COMMIT)


### PR DESCRIPTION
compact_segments produced separate 17b files for intermediate commits, although they were intended to be end-of-segment-file commits.

this is because when the intermediate commit is triggered, we are already at an offset beyond the limit.
 thus needed to add the no_new flag to indicate that we do not want a new segment file just for the commit IF it is an intermediate commit.