### PR TITLE
Backport: exclude buggy current setuptools release

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-setuptools
+setuptools!=60.6.0
 setuptools_scm
 pip
 virtualenv


### PR DESCRIPTION
setuptools>45 was added in 0e9befb53953af1ad4f8bd957dfc834fd1daebbe.
This constrint was never backported to 1.1.
My backport honors that.

This is a backport of #6223

Original commit message:
> see there: https://github.com/pypa/setuptools/issues/3063