### PR TITLE
Doc: borg key export: add examples

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4131,6 +4131,13 @@ class Archiver:
         repository in the config file. A backup is thus not strictly needed,
         but guards against the repository becoming inaccessible if the file
         is damaged for some reason.
+
+        Examples::
+
+            borg key export /path/to/repo > encrypted-key-backup
+            borg key export /path/to/repo --paper > encrypted-key-backup.txt
+            borg key export /path/to/repo --qr-html > encrypted-key-backup.html
+
         """)
         subparser = key_parsers.add_parser('export', parents=[common_parser], add_help=False,
                                           description=self.do_key_export.__doc__,

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4135,8 +4135,12 @@ class Archiver:
         Examples::
 
             borg key export /path/to/repo > encrypted-key-backup
-            borg key export /path/to/repo --paper > encrypted-key-backup.txt
-            borg key export /path/to/repo --qr-html > encrypted-key-backup.html
+            borg key export --paper /path/to/repo > encrypted-key-backup.txt
+            borg key export --qr-html /path/to/repo > encrypted-key-backup.html
+            # Or pass the output file as an argument instead of redirecting stdout:
+            borg key export /path/to/repo encrypted-key-backup
+            borg key export --paper /path/to/repo encrypted-key-backup.txt
+            borg key export --qr-html /path/to/repo encrypted-key-backup.html
 
 
         """)

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4138,6 +4138,7 @@ class Archiver:
             borg key export /path/to/repo --paper > encrypted-key-backup.txt
             borg key export /path/to/repo --qr-html > encrypted-key-backup.html
 
+
         """)
         subparser = key_parsers.add_parser('export', parents=[common_parser], add_help=False,
                                           description=self.do_key_export.__doc__,


### PR DESCRIPTION
https://github.com/borgbackup/borg/issues/6204#issuecomment-1027150308

The examples I provided should work in the next 1.2 release and
the next 1.1 release (see #6092 and #6177). Alternatively I could give
the following example that should work today:
```sh
borg key export --qr-html /path/to/repo encrypted-key-backup.html
```

@ThomasWaldmann, you have added "documentation" label after a comment by https://github.com/rolandu. Is this the fix you wanted/expected?