### PR TITLE
Backport: Disallow overwriting of existing keyfiles on init

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -687,7 +687,7 @@ class KeyfileKeyBase(AESKeyBase):
         key.init_from_random_data()
         key.init_ciphers()
         target = key.get_new_target(args)
-        key.save(target, passphrase)
+        key.save(target, passphrase, create=True)
         logger.info('Key in "%s" created.' % target)
         logger.info('Keep this key safe. Your data will be inaccessible without it.')
         return key

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -692,7 +692,7 @@ class KeyfileKeyBase(AESKeyBase):
         logger.info('Keep this key safe. Your data will be inaccessible without it.')
         return key
 
-    def save(self, target, passphrase):
+    def save(self, target, passphrase, create=False):
         raise NotImplementedError
 
     def get_new_target(self, args):
@@ -753,7 +753,12 @@ class KeyfileKey(ID_HMAC_SHA_256, KeyfileKeyBase):
             self.target = target
         return success
 
-    def save(self, target, passphrase):
+    def save(self, target, passphrase, create=False):
+        if create and os.path.isfile(target):
+            # if a new keyfile key repository is created, ensure that an existing keyfile of another
+            # keyfile key repo is not accidentally overwritten by careless use of the BORG_KEY_FILE env var.
+            # see issue #6036
+            raise Error('Aborting because key in "%s" already exists.' % target)
         key_data = self._save(passphrase)
         with SaveFile(target) as fd:
             fd.write('%s %s\n' % (self.FILE_ID, bin_to_hex(self.repository_id)))
@@ -793,7 +798,7 @@ class RepoKey(ID_HMAC_SHA_256, KeyfileKeyBase):
             self.target = target
         return success
 
-    def save(self, target, passphrase):
+    def save(self, target, passphrase, create=False):
         self.logically_encrypted = passphrase != ''
         key_data = self._save(passphrase)
         key_data = key_data.encode('utf-8')  # remote repo: msgpack issue #99, giving bytes
@@ -831,8 +836,8 @@ class AuthenticatedKeyBase(RepoKey):
         self.logically_encrypted = False
         return success
 
-    def save(self, target, passphrase):
-        super().save(target, passphrase)
+    def save(self, target, passphrase, create=False):
+        super().save(target, passphrase, create=create)
         self.logically_encrypted = False
 
     def extract_nonce(self, payload):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2582,8 +2582,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             self.cmd('init', '--encryption=keyfile', self.repository_location + '0')
             with open(keyfile) as file:
                 before = file.read()
-            with pytest.raises(borg.helpers.Error):
-                self.cmd('init', '--encryption=keyfile', self.repository_location + '1')
+            arg = ('init', '--encryption=keyfile', self.repository_location + '1')
+            if self.FORK_DEFAULT:
+                self.cmd(*arg, exit_code=2)
+            else:
+                with pytest.raises(borg.helpers.Error):
+                    self.cmd(*arg)
             with open(keyfile) as file:
                 after = file.read()
             assert before == after

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 import borg
-import borg.helpers.errors
+import borg.helpers
 from .. import xattr, helpers, platform
 from ..archive import Archive, ChunkBuffer, flags_noatime, flags_normal
 from ..archiver import Archiver, parse_storage_quota, PURE_PYTHON_MSGPACK_WARNING
@@ -2582,7 +2582,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             self.cmd('init', '--encryption=keyfile', self.repository_location + '0')
             with open(keyfile) as file:
                 before = file.read()
-            with pytest.raises(borg.helpers.errors.Error):
+            with pytest.raises(borg.helpers.Error):
                 self.cmd('init', '--encryption=keyfile', self.repository_location + '1')
             with open(keyfile) as file:
                 after = file.read()

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -32,6 +32,7 @@ except ImportError:
     pass
 
 import borg
+import borg.helpers.errors
 from .. import xattr, helpers, platform
 from ..archive import Archive, ChunkBuffer, flags_noatime, flags_normal
 from ..archiver import Archiver, parse_storage_quota, PURE_PYTHON_MSGPACK_WARNING
@@ -2571,6 +2572,21 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         else:
             with pytest.raises(Repository.AlreadyExists):
                 self.cmd('init', '--encryption=repokey', self.repository_location + '/nested')
+
+    def test_init_refuse_to_overwrite_keyfile(self):
+        """BORG_KEY_FILE=something borg init should quit if "something" already exists.
+
+        See https://github.com/borgbackup/borg/pull/6046"""
+        keyfile = os.path.join(self.tmpdir, 'keyfile')
+        with environment_variable(BORG_KEY_FILE=keyfile):
+            self.cmd('init', '--encryption=keyfile', self.repository_location + '0')
+            with open(keyfile) as file:
+                before = file.read()
+            with pytest.raises(borg.helpers.errors.Error):
+                self.cmd('init', '--encryption=keyfile', self.repository_location + '1')
+            with open(keyfile) as file:
+                after = file.read()
+            assert before == after
 
     def check_cache(self):
         # First run a regular borg check


### PR DESCRIPTION
This is a backport of #6046 and #6243