### PR TITLE
Backport: setuptools 60.7.0 is breaks pyinstaller

### DIFF
--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-setuptools!=60.6.0
+setuptools !=60.6.0, !=60.7.0
 setuptools_scm
 pip
 virtualenv


### PR DESCRIPTION
This is a backport of https://github.com/borgbackup/borg/pull/6246