### PR TITLE
Add proof of concept for pull mechanism

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -157,10 +157,11 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
             make_parent_dirs = getattr(args, 'make_parent_dirs', False)
             if argument(args, fake) ^ invert_fake:
                 return method(self, args, repository=None, **kwargs)
-            elif location.proto == 'ssh':
+
+            elif location.proto == 'ssh' or location.proto == 'serve':
                 repository = RemoteRepository(location.omit_archive(), create=create, exclusive=argument(args, exclusive),
                                               lock_wait=self.lock_wait, lock=lock, append_only=append_only,
-                                              make_parent_dirs=make_parent_dirs, args=args)
+                                              make_parent_dirs=make_parent_dirs, args=args, serve=(location.proto == 'serve'))
             else:
                 repository = Repository(location.path, create=create, exclusive=argument(args, exclusive),
                                         lock_wait=self.lock_wait, lock=lock, append_only=append_only,
@@ -269,6 +270,7 @@ class Archiver:
             restrict_to_repositories=args.restrict_to_repositories,
             append_only=args.append_only,
             storage_quota=args.storage_quota,
+            pull_command=args.pull_command
         ).serve()
         return EXIT_SUCCESS
 
@@ -4629,6 +4631,9 @@ class Archiver:
                                help='Override storage quota of the repository (e.g. 5G, 1.5T). '
                                     'When a new repository is initialized, sets the storage quota on the new '
                                     'repository as well. Default: no quota.')
+
+        subparser.add_argument('--pull-command', metavar='cmd', dest='pull_command',
+                               help='command to use for pulling from a borg server started in serve:// mode')
 
         # borg umount
         umount_epilog = process_epilog("""

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -348,6 +348,10 @@ class Location:
         (?P<host>([^:/]+|\[[0-9a-fA-F:.]+\]))(?::(?P<port>\d+))?  # host or host:port or [ipv6] or [ipv6]:port
         """ + abs_path_re + optional_archive_re, re.VERBOSE)  # path or path::archive
 
+    serve_re = re.compile(r"""
+        (?P<proto>serve)://                                   # serve://
+        """ + abs_path_re + optional_archive_re, re.VERBOSE)  # path or path::archive
+
     file_re = re.compile(r"""
         (?P<proto>file)://                                  # file://
         """ + file_path_re + optional_archive_re, re.VERBOSE)  # servername/path, path or path::archive
@@ -424,6 +428,12 @@ class Location:
             self.user = m.group('user')
             self._host = m.group('host')
             self.port = m.group('port') and int(m.group('port')) or None
+            self.path = normpath_special(m.group('path'))
+            self.archive = m.group('archive')
+            return True
+        m = self.serve_re.match(text)
+        if m:
+            self.proto = m.group('proto')
             self.path = normpath_special(m.group('path'))
             self.archive = m.group('archive')
             return True


### PR DESCRIPTION
Hi there :wave: 

first of all: This is not a real pull request. It is basically a proof of concept for an operation that I would love to see being implemented, but that is far to complex to implement it by myself. The operation itself is quite simple (as demonstrated by this PR), however, it probably requires changes in many other locations of this project.

So what is this PR about? It implements a simple proof of concept for a **Pull Operation**. Currently, the recommended way to perform a backup in pull mode is using sshfs, which has several drawbacks as outlined in the documentation. After looking into how push backups are implemented, I did not understand why pull backups are not implemented in the same way. Since the remote backup mechanism simply utilizes stdin and stdout of an ssh connection, it is basically invertible and it is possible to create a pull mechanism in the same way.

When applying the patch contained within this PR, the `borg create` command allows a new protocol type to use `serve://<repo>`. When using this protocol type, *borg* behaves basically the same as during a push operation, but outputs all RPC commands to stdout and obtains input from stdin. Therefore, `borg create` with the `serve://` protocol is expected to run on the server side where the update is pulled from.

On the other side, on the local backup server, the `borg serve` operation got a new option `--pull-command`. This option expects the command to use for a connection to the serving *borg* server in pull mode.

And that's basically everything. So let's look at a short demonstration: On the server side we write the following in our authorized-keys file:

```
command="BORG_PASSPHRASE=example123 borg create serve:///opt/backup::'{now}' /etc /opt",restrict ssh-ed25519 AAAA...
```

On the client side we create a new repo and attempt a backup in pull mode:

```console
[user@host opt]$ borg init --encryption repokey backup
Enter new passphrase: example123
[user@host opt]$ borg list /opt/backup/
Enter passphrase for key /opt/backup: example123
[user@host opt]$ borg serve --pull "ssh -i ./id_rsa root@172.17.0.2"
[user@host opt]$ borg list /opt/backup/
Enter passphrase for key /opt/backup: example123
2022-02-10T22:07:54                  Thu, 2022-02-10 23:07:54 [1713f6df6648055c3de2574e014ec45c91c8bf464cca4b27e72ef095d6820a94]
```

This example demonstrates that everything works like expected. That being said, this was obviously an easy example and there are many edge cases. One example is e.g. when unencrypted repositories are used. In this case `borg create` asks for user confirmation, which obviously breaks the pull backup. Furthermore, the whole approach is not very flexible. It would be nice if clients could specify additional parameters that are used during the backup on the server side.

So like I said, there is a lot of work to be done. However, this PR demonstrates that creating updates in pull mode is basically possible by recycling already existing mechanisms. Feel free to close this PR and to use the code snippets from it during your development process. I thought is would be easier to monitor my changes than creating an issue, but I'm aware that this PR should not be merged in it's current state.

