### PR TITLE
implement more standard hashindex.setdefault behaviour

### DIFF
--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -129,6 +129,7 @@ cdef class IndexBase:
     def setdefault(self, key, value):
         if not key in self:
             self[key] = value
+        return self[key]
 
     def __delitem__(self, key):
         assert len(key) == self.key_size

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -70,6 +70,21 @@ class HashIndexTestCase(BaseTestCase):
             idx.write(filepath)
             del idx
             self.assert_equal(len(cls.read(filepath)), 0)
+        idx = cls()
+        # Test setdefault - set non-existing key
+        idx.setdefault(H(0), make_value(42))
+        assert H(0) in idx
+        assert idx[H(0)] == make_value(42)
+        # Test setdefault - do not set existing key
+        idx.setdefault(H(0), make_value(23))
+        assert H(0) in idx
+        assert idx[H(0)] == make_value(42)
+        # Test setdefault - get-like return value, key not present
+        assert idx.setdefault(H(1), make_value(23)) == make_value(23)
+        # Test setdefault - get-like return value, key present
+        assert idx.setdefault(H(0), make_value(23)) == make_value(42)
+        # clean up setdefault test
+        del idx
 
     def test_nsindex(self):
         self._generic_test(NSIndex, lambda x: (x, x),


### PR DESCRIPTION
the .get() like behaviour (== returning the value) was missing.

it's still not 100% like dict.setdefault, because there is no
default value None. but None doesn't make sense here, because we
usually need a N-tuple matching the hash table's value format.

note: this "bug" (or unusual implementation) was without consequences,
      because hashindex.setdefault is not used anywhere in borg, so
      it was also not used in a wrong way anywhere.

https://docs.python.org/3/library/stdtypes.html#dict.setdefault