### PR TITLE
Introduce prune-stdio

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,6 +45,7 @@ Usage
    usage/diff
    usage/delete
    usage/prune
+   usage/prune-stdio
    usage/compact
    usage/info
    usage/mount

--- a/docs/usage/prune-stdio.rst
+++ b/docs/usage/prune-stdio.rst
@@ -1,0 +1,60 @@
+.. include:: prune-stdio.rst.inc
+
+Examples
+~~~~~~~~
+
+A session using ``prune-stdio`` might look as follows:
+
+::
+
+    # Lines borg outputs on stdout are prefixed with >
+    # Lines input to borg on stdin are prefixed with <
+    # Lines without prefix are output on stderr
+    $ borg prune-stdio --json --list /tmp/tmp.ncyjKaLKtk
+    > {
+    >     "archives": [
+    >         {
+    >             "archive": "archive_3",
+    >             "barchive": "archive_3",
+    >             "id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0",
+    >             "name": "archive_3",
+    >             "start": "2022-02-13T11:44:49.000000",
+    >             "time": "2022-02-13T11:44:49.000000"
+    >         },
+    >         {
+    >             "archive": "archive_2",
+    >             "barchive": "archive_2",
+    >             "id": "abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9",
+    >             "name": "archive_2",
+    >             "start": "2022-02-13T11:44:44.000000",
+    >             "time": "2022-02-13T11:44:44.000000"
+    >         },
+    >         {
+    >             "archive": "archive_1",
+    >             "barchive": "archive_1",
+    >             "id": "4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4",
+    >             "name": "archive_1",
+    >             "start": "2022-02-13T11:44:37.000000",
+    >             "time": "2022-02-13T11:44:37.000000"
+    >         }
+    >     ],
+    >     "encryption": {
+    >         "mode": "none"
+    >     },
+    >     "repository": {
+    >         "id": "4a5a24f317ac4d9bdcf3ac277fba6c506fd17f1afb1cdb01ac98108dd5d6f34c",
+    >         "last_modified": "2022-02-13T11:44:51.000000",
+    >         "location": "/tmp/tmp.ncyjKaLKtk"
+    >     }
+    > }
+    < [
+    <   {"id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0"},
+    <   {"barchive": "archive_1"}
+    < ]
+    Keeping archive (rule: stdio #1):        archive_3                            Sun, 2022-02-13 11:44:49 [e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0]
+    Pruning archive (1/2):                   archive_2                            Sun, 2022-02-13 11:44:44 [abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9]
+    Keeping archive (rule: stdio #2):        archive_1                            Sun, 2022-02-13 11:44:37 [4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4]
+    Pruning archive (2/2):                   archive_1.checkpoint                 Sun, 2022-02-13 11:44:17 [92662ffd369b20c00168bf9eff821a6c00efe6e622cf1e7bce13e6f20fda5643]
+
+It is up to the user to generate the stdin from borgs output.
+Usually `borg prune-stdio` would be run as a subprocess from a custom script.

--- a/docs/usage/prune.rst
+++ b/docs/usage/prune.rst
@@ -34,62 +34,6 @@ first so you will see what it would do without it actually doing anything.
     # and an end of month archive for every month:
     $ borg prune -v --list --keep-within=10d --keep-weekly=4 --keep-monthly=-1 /path/to/repo
 
-A session using ``--keep-stdio`` might look as follows:
-
-::
-
-    # Lines borg outputs on stdout are prefixed with >
-    # Lines input to borg on stdin are prefixed with <
-    # Lines without prefix are output on stderr
-    $ borg prune --keep-stdio --list
-    > {
-    >     "archives": [
-    >         {
-    >             "archive": "archive_3",
-    >             "barchive": "archive_3",
-    >             "id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0",
-    >             "name": "archive_3",
-    >             "start": "2022-02-13T11:44:49.000000",
-    >             "time": "2022-02-13T11:44:49.000000"
-    >         },
-    >         {
-    >             "archive": "archive_2",
-    >             "barchive": "archive_2",
-    >             "id": "abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9",
-    >             "name": "archive_2",
-    >             "start": "2022-02-13T11:44:44.000000",
-    >             "time": "2022-02-13T11:44:44.000000"
-    >         },
-    >         {
-    >             "archive": "archive_1",
-    >             "barchive": "archive_1",
-    >             "id": "4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4",
-    >             "name": "archive_1",
-    >             "start": "2022-02-13T11:44:37.000000",
-    >             "time": "2022-02-13T11:44:37.000000"
-    >         }
-    >     ],
-    >     "encryption": {
-    >         "mode": "none"
-    >     },
-    >     "repository": {
-    >         "id": "4a5a24f317ac4d9bdcf3ac277fba6c506fd17f1afb1cdb01ac98108dd5d6f34c",
-    >         "last_modified": "2022-02-13T11:44:51.000000",
-    >         "location": "/tmp/tmp.ncyjKaLKtk"
-    >     }
-    > }
-    < [
-    <   {"id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0"},
-    <   {"barchive": "archive_1"}
-    < ]
-    Keeping archive (rule: stdio #1):        archive_3                            Sun, 2022-02-13 11:44:49 [e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0]
-    Pruning archive (1/2):                   archive_2                            Sun, 2022-02-13 11:44:44 [abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9]
-    Keeping archive (rule: stdio #2):        archive_1                            Sun, 2022-02-13 11:44:37 [4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4]
-    Pruning archive (2/2):                   archive_1.checkpoint                 Sun, 2022-02-13 11:44:17 [92662ffd369b20c00168bf9eff821a6c00efe6e622cf1e7bce13e6f20fda5643]
-
-It is up to the user to generate the stdin from borgs output.
-Usually `borg prune --keep-stdio` would be run as a subprocess from a custom script.
-
 There is also a visualized prune example in ``docs/misc/prune-example.txt``:
 
 .. highlight:: none

--- a/docs/usage/prune.rst
+++ b/docs/usage/prune.rst
@@ -34,6 +34,62 @@ first so you will see what it would do without it actually doing anything.
     # and an end of month archive for every month:
     $ borg prune -v --list --keep-within=10d --keep-weekly=4 --keep-monthly=-1 /path/to/repo
 
+A session using ``--keep-stdio`` might look as follows:
+
+::
+
+    # Lines borg outputs on stdout are prefixed with >
+    # Lines input to borg on stdin are prefixed with <
+    # Lines without prefix are output on stderr
+    $ borg prune --keep-stdio --list
+    > {
+    >     "archives": [
+    >         {
+    >             "archive": "archive_3",
+    >             "barchive": "archive_3",
+    >             "id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0",
+    >             "name": "archive_3",
+    >             "start": "2022-02-13T11:44:49.000000",
+    >             "time": "2022-02-13T11:44:49.000000"
+    >         },
+    >         {
+    >             "archive": "archive_2",
+    >             "barchive": "archive_2",
+    >             "id": "abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9",
+    >             "name": "archive_2",
+    >             "start": "2022-02-13T11:44:44.000000",
+    >             "time": "2022-02-13T11:44:44.000000"
+    >         },
+    >         {
+    >             "archive": "archive_1",
+    >             "barchive": "archive_1",
+    >             "id": "4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4",
+    >             "name": "archive_1",
+    >             "start": "2022-02-13T11:44:37.000000",
+    >             "time": "2022-02-13T11:44:37.000000"
+    >         }
+    >     ],
+    >     "encryption": {
+    >         "mode": "none"
+    >     },
+    >     "repository": {
+    >         "id": "4a5a24f317ac4d9bdcf3ac277fba6c506fd17f1afb1cdb01ac98108dd5d6f34c",
+    >         "last_modified": "2022-02-13T11:44:51.000000",
+    >         "location": "/tmp/tmp.ncyjKaLKtk"
+    >     }
+    > }
+    < [
+    <   {"id": "e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0"},
+    <   {"barchive": "archive_1"}
+    < ]
+    Keeping archive (rule: stdio #1):        archive_3                            Sun, 2022-02-13 11:44:49 [e6e08836ae5e15b11b528ead254d0f46cd5172b6b3d4311a73275b5182d9a4c0]
+    Pruning archive (1/2):                   archive_2                            Sun, 2022-02-13 11:44:44 [abcca3c8808b703b87ac25d3a329e275bf13a7d0d1108f83881ff4bb4c389cc9]
+    Keeping archive (rule: stdio #2):        archive_1                            Sun, 2022-02-13 11:44:37 [4ed9fa060f7a37bde7408c3cc1c32f1371afaf49c478379c46ca13d3e0b86db4]
+    Pruning archive (2/2):                   archive_1.checkpoint                 Sun, 2022-02-13 11:44:17 [92662ffd369b20c00168bf9eff821a6c00efe6e622cf1e7bce13e6f20fda5643]
+
+It is up to the user to generate the stdin from borgs output.
+Usually `borg prune --keep-stdio` would be run as a subprocess from a custom script.
+
 There is also a visualized prune example in ``docs/misc/prune-example.txt``:
 
 .. highlight:: none

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -52,7 +52,7 @@ try:
     from .helpers import PrefixSpec, GlobSpec, CommentSpec, SortBySpec, FilesCacheMode
     from .helpers import BaseFormatter, ItemFormatter, ArchiveFormatter
     from .helpers import format_timedelta, format_file_size, parse_file_size, format_archive
-    from .helpers import safe_encode, remove_surrogates, bin_to_hex, prepare_dump_dict, eval_escapes
+    from .helpers import safe_encode, remove_surrogates, bin_to_hex, hex_to_bin, prepare_dump_dict, eval_escapes
     from .helpers import interval, prune_within, prune_split, PRUNING_PATTERNS
     from .helpers import timestamp
     from .helpers import get_cache_dir, os_stat
@@ -1529,16 +1529,6 @@ class Archiver:
                 output_data.append(formatter.get_item_data(archive))
             json_print(basic_json_data(manifest, extra={'archives': output_data}))
 
-            def hex_to_bin(d):
-                bin_id = None
-                try:
-                    bin_id = unhexlify(d)
-                except:
-                    raise ValueError('Invalid value, must be 64 hex digits') from None
-                if len(bin_id) != 32:
-                    raise ValueError('Invalid value, must be 64 hex digits')
-                return bin_id
-
             archives_by_id = {archive.id: archive for archive in archives}
             archives_by_name = {archive.name: archive for archive in archives}
 
@@ -1547,7 +1537,7 @@ class Archiver:
                 for keep_item in json.load(sys.stdin):
                     archive = None
                     if 'id' in keep_item:
-                        bin_id = hex_to_bin(keep_item['id'])
+                        bin_id = hex_to_bin(keep_item['id'], blen=32)
                         if bin_id in archives_by_id:
                             archive = archives_by_id[bin_id]
                     elif 'barchive' in keep_item:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1481,7 +1481,7 @@ class Archiver:
         """Prune repository archives according to specified rules"""
         if not any((args.secondly, args.minutely, args.hourly, args.daily,
                     args.weekly, args.monthly, args.yearly, args.within)):
-            self.print_error('At least one of the "keep-within", "keep-last",'
+            self.print_error('At least one of the "keep-within", "keep-last", '
                              '"keep-secondly", "keep-minutely", "keep-hourly", "keep-daily", '
                              '"keep-weekly", "keep-monthly" or "keep-yearly" settings must be specified.')
             return self.exit_code

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1478,12 +1478,12 @@ class Archiver:
     def do_prune(self, args, repository, manifest, key):
         """Prune repository archives according to specified rules"""
         if not any((args.secondly, args.minutely, args.hourly, args.daily,
-                    args.weekly, args.monthly, args.yearly, args.within, args.filter_stdio)):
+                    args.weekly, args.monthly, args.yearly, args.within, args.keep_stdio)):
             self.print_error('At least one of the "keep-within", "keep-last", "keep-stdio",'
                              '"keep-secondly", "keep-minutely", "keep-hourly", "keep-daily", '
                              '"keep-weekly", "keep-monthly" or "keep-yearly" settings must be specified.')
             return self.exit_code
-        if args.filter_stdio and any((args.secondly, args.minutely, args.hourly, args.daily,
+        if args.keep_stdio and any((args.secondly, args.minutely, args.hourly, args.daily,
                     args.weekly, args.monthly, args.yearly, args.within)):
             self.print_error('"keep-stdio" is mutually exclusive with other keep options')
             return self.exit_code
@@ -1521,7 +1521,7 @@ class Archiver:
             if num is not None:
                 keep += prune_split(archives, rule, num, kept_because)
 
-        if args.filter_stdio:
+        if args.keep_stdio:
             format = "{archive:<36} {time} [{id}]{NL}"
             formatter = ArchiveFormatter(format, repository, manifest, key, json=True, iec=args.iec)
             output_data = []
@@ -4519,7 +4519,7 @@ class Archiver:
                                help='number of monthly archives to keep')
         subparser.add_argument('-y', '--keep-yearly', dest='yearly', type=int, default=0,
                                help='number of yearly archives to keep')
-        subparser.add_argument('--keep-stdio', dest='filter_stdio', action='store_true',
+        subparser.add_argument('--keep-stdio', action='store_true',
                                help='filter archives to keep by json interaction on stdin/stdout instead')
         define_archive_filters_group(subparser, sort_by=False, first_last=False)
         subparser.add_argument('--save-space', dest='save_space', action='store_true',

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1544,11 +1544,7 @@ class Archiver:
 
             kept_counter = 0
             try:
-                input = sys.stdin.read()
-                input_data = []
-                if input:
-                    input_data = json.loads(input)
-                for keep_item in input_data:
+                for keep_item in json.load(sys.stdin):
                     archive = None
                     if 'id' in keep_item:
                         bin_id = hex_to_bin(keep_item['id'])
@@ -4481,7 +4477,6 @@ class Archiver:
         Each element of the list is expected to be an object containing at least
         one of the keys ``id`` or ``barchive``, as in the output.
         Only archives given on stdin will be kept.
-        Empty stdin will be treated like ``[]``.
 
         When using ``--stats``, you will get some statistics about how much data was
         deleted - the "Deleted data" deduplicated size there is most interesting as

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1544,11 +1544,10 @@ class Archiver:
                 archive = None
                 if 'id' in keep_item:
                     bin_id = hex_to_bin(keep_item['id'], blen=32)
-                    if bin_id in archives_by_id:
-                        archive = archives_by_id[bin_id]
+                    archive = archives_by_id.get(bin_id)
                 elif 'barchive' in keep_item:
-                    if keep_item['barchive'] in archives_by_name:
-                        archive = archives_by_name[keep_item['barchive']]
+                    bname = keep_item['barchive']
+                    archive = archives_by_name.get(bname)
                 if archive is None:
                     self.print_error(f'Could not identify archive from json list element: {json.dumps(keep_item)}')
                     return self.exit_code

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -30,6 +30,7 @@ from ..platformflags import is_win32
 def bin_to_hex(binary):
     return hexlify(binary).decode('ascii')
 
+
 def hex_to_bin(hexadecimal, blen=None):
     binary = None
     try:

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -8,7 +8,8 @@ import shlex
 import socket
 import stat
 import uuid
-from binascii import hexlify
+from binascii import hexlify, unhexlify
+import binascii
 from collections import Counter, OrderedDict
 from datetime import datetime, timezone
 from functools import partial
@@ -28,6 +29,16 @@ from ..platformflags import is_win32
 
 def bin_to_hex(binary):
     return hexlify(binary).decode('ascii')
+
+def hex_to_bin(hexadecimal, blen=None):
+    binary = None
+    try:
+        binary = unhexlify(hexadecimal)
+    except binascii.Error as e:
+        raise ValueError(f'Invalid hexadecimal value "{hexadecimal}": {str(e)}')
+    if blen is not None and len(binary) != blen:
+        raise ValueError(f'Invalid hexadecimal value "{hexadecimal}", expected value of length {blen} ({blen * 2} hex digits)')
+    return binary
 
 
 def safe_decode(s, coding='utf-8', errors='surrogateescape'):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2270,7 +2270,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('create', self.repository_location + '::2015-08-12-20:00-foo', src_dir)
         self.cmd('create', self.repository_location + '::2015-08-12-10:00-bar', src_dir)
         self.cmd('create', self.repository_location + '::2015-08-12-20:00-bar', src_dir)
-        output = self.cmd('prune', '--dry-run', '--keep-stdio', self.repository_location)
+        output = self.cmd('prune', '--dry-run', '--keep-stdio', self.repository_location, input=b'[]')
         self.assert_not_in('2015-08-12-10:00-foo.checkpoint', output)
         list_data = json.loads(output)
         input_data = []


### PR DESCRIPTION
This pull request introduces `--keep-stdio` to `borg prune`.  
Instead of considering the other `--keep-*` options this mode outputs all archives (excluding checkpoints) on stdout and keeps exactly those archives returned on stdin.

Fixes #6266 