### PR TITLE
diff: reduce memory consumption, fix is_hardlink_master

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -990,7 +990,7 @@ Utilization of max. archive size: {csize_max:.0%}
             return 'source' not in item or not hardlinkable(item.mode) or item.source in hardlink_masters
 
         def is_hardlink_master(item):
-            return item.get('hardlink_master', True) and 'source' not in item
+            return item.get('hardlink_master', True) and 'source' not in item and hardlinkable(item.mode)
 
         def update_hardlink_masters(item1, item2):
             if is_hardlink_master(item1) or is_hardlink_master(item2):


### PR DESCRIPTION
I was trying the `diff` command with somewhat big archives (60 GB of a Linux root filesystem) but with little differences (the second backup created right after the first one), and it used a lot of memory compared to `export-tar`.

Adding some prints in the code, I figured that `hardlink_masters` grew up to 300k items (the partition has only 10k hardlinks), but most of them were directories.

Compared to the other implementation of [item_is_hardlink_master](https://github.com/borgbackup/borg/blob/master/src/borg/archive.py#L2055), I conclude that storing the directories is a bug.

Comparing version 1.1.17 to `1.1-maint` with this change, it decreases the memory used (measured with `/usr/bin/time -f %M`) from 1.1 GB to 110 MB for the diff between the archives of the Linux partition.