### PR TITLE
docs: explain the difference between a path that ends with or without a slash

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2234,6 +2234,11 @@ class Archiver:
         /path/to/repo /home/user`` will store all files as
         `home/user/.../file.ext`.
 
+        A folder exclusion pattern can end either with or without a slash ('/').
+        If it ends with a slash, such as `some/path/`, the directory will be
+        included but not its content. If it does not end with a slash, such as
+        `some/path`, both the directory and content will be excluded.
+
         File patterns support these styles: fnmatch, shell, regular expressions,
         path prefixes and path full-matches. By default, fnmatch is used for
         ``--exclude`` patterns and shell-style is used for the ``--pattern``

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2234,10 +2234,10 @@ class Archiver:
         /path/to/repo /home/user`` will store all files as
         `home/user/.../file.ext`.
 
-        A folder exclusion pattern can end either with or without a slash ('/').
-        If it ends with a slash, such as `some/path/`, the directory will be
-        included but not its content. If it does not end with a slash, such as
-        `some/path`, both the directory and content will be excluded.
+        A directory exclusion pattern can end either with or without a slash
+        ('/'). If it ends with a slash, such as `some/path/`, the directory will
+        be included but not its content. If it does not end with a slash, such
+        as `some/path`, both the directory and content will be excluded.
 
         File patterns support these styles: fnmatch, shell, regular expressions,
         path prefixes and path full-matches. By default, fnmatch is used for

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2234,10 +2234,10 @@ class Archiver:
         /path/to/repo /home/user`` will store all files as
         `home/user/.../file.ext`.
 
-        A directory exclusion pattern can end either with or without a slash
-        ('/'). If it ends with a slash, such as `some/path/`, the directory will
-        be included but not its content. If it does not end with a slash, such
-        as `some/path`, both the directory and content will be excluded.
+        A directory exclusion pattern can end either with or without a slash ('/').
+        If it ends with a slash, such as `some/path/`, the directory will be
+        included but not its content. If it does not end with a slash, such as
+        `some/path`, both the directory and content will be excluded.
 
         File patterns support these styles: fnmatch, shell, regular expressions,
         path prefixes and path full-matches. By default, fnmatch is used for


### PR DESCRIPTION
Resolves #6258: explains the difference between a path that ends with or without a slash.

In the doc I specifically mentioned the difference when used as an exclusion pattern, because if I'm not mistaken there's no difference for inclusion patterns (`some/path/` and `some/path` would result in the same backup set). But let me know if I should tweak this.