### PR TITLE
Backport: docs: explain the difference between a path that ends with or without a slash

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2260,6 +2260,11 @@ class Archiver:
         ``mount``. Starting with Borg 1.2 this behaviour will be changed to
         accept both absolute and relative paths.
 
+        A directory exclusion pattern can end either with or without a slash ('/').
+        If it ends with a slash, such as `some/path/`, the directory will be
+        included but not its content. If it does not end with a slash, such as
+        `some/path`, both the directory and content will be excluded.
+
         File patterns support these styles: fnmatch, shell, regular expressions,
         path prefixes and path full-matches. By default, fnmatch is used for
         ``--exclude`` patterns and shell-style is used for the ``--pattern`` option.


### PR DESCRIPTION
This is a backport of https://github.com/borgbackup/borg/pull/6297