### PR TITLE
s/apt/apt-get/

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,8 @@ jobs:
 
     - name: Install requirements, build and install Borg
       run: |
-       sudo apt install libacl1-dev
+       sudo apt-get update
+       sudo apt-get install libacl1-dev
        pip3 install -r requirements.d/development.txt
        pip3 install -e .
 


### PR DESCRIPTION
> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.