### PR TITLE
docs: Clarify on-disk order and size of log entry fields

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -96,11 +96,11 @@ files manually.
 A segment starts with a magic number (``BORG_SEG`` as an eight byte ASCII string),
 followed by a number of log entries. Each log entry consists of: (in this order)
 
-* First, unsigned 32-bit number, the CRC32 of the entire entry excluding the CRC32 field
+* First, unsigned 32-bit number, the CRC32 of the entire entry (for a PUT including the DATA) excluding the CRC32 field
 * Second, unsigned 32-bit size of the entry (including the whole header)
-* Thrird, unsigned 8-bit entry tag: PUT(1), DELETE(2) or COMMIT(3)
+* Third, unsigned 8-bit entry tag: PUT(1), DELETE(2) or COMMIT(3)
 * Fourth, on PUT or DELETE, 32 byte key
-* Fifth, PUT only, (size - 41) bytes of data (length = size - sizeof(CRC32) - sizeof(size) - sizeof(entry key) - sizeof(key))
+* Fifth, PUT only, (size - 41) bytes of data (length = size - sizeof(CRC32) - sizeof(size) - sizeof(entry tag) - sizeof(key))
 
 Those files are strictly append-only and modified only once.
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -94,13 +94,13 @@ this value in a non-empty repository, you may also need to relocate the segment
 files manually.
 
 A segment starts with a magic number (``BORG_SEG`` as an eight byte ASCII string),
-followed by a number of log entries. Each log entry consists of:
+followed by a number of log entries. Each log entry consists of: (in this order)
 
-* 32-bit size of the entry
-* CRC32 of the entire entry (for a PUT this includes the data)
-* entry tag: PUT, DELETE or COMMIT
-* PUT and DELETE follow this with the 32 byte key
-* PUT follow the key with the data
+* First, unsigned 32-bit number, the CRC32 of the entire entry excluding the CRC32 field
+* Second, unsigned 32-bit size of the entry (including the whole header)
+* Thrird, unsigned 8-bit entry tag: PUT(1), DELETE(2) or COMMIT(3)
+* Fourth, on PUT or DELETE, 32 byte key
+* Fifth, PUT only, (size - 41) bytes of data, only on PUT entries (size - sizeof(CRC32) - sizeof(size) - sizeof(entry key) - sizeof(key))
 
 Those files are strictly append-only and modified only once.
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -100,7 +100,7 @@ followed by a number of log entries. Each log entry consists of: (in this order)
 * Second, unsigned 32-bit size of the entry (including the whole header)
 * Thrird, unsigned 8-bit entry tag: PUT(1), DELETE(2) or COMMIT(3)
 * Fourth, on PUT or DELETE, 32 byte key
-* Fifth, PUT only, (size - 41) bytes of data, only on PUT entries (size - sizeof(CRC32) - sizeof(size) - sizeof(entry key) - sizeof(key))
+* Fifth, PUT only, (size - 41) bytes of data (length = size - sizeof(CRC32) - sizeof(size) - sizeof(entry key) - sizeof(key))
 
 Those files are strictly append-only and modified only once.
 


### PR DESCRIPTION
This PR only contains a small patch to the internals docs.

The order of the fields of a log entry on disk is CRC32 first, the docs had the size first.

I tried to make this list similar to the HashIndex struct description.