### PR TITLE
s/apt/apt-get/ (1.2)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,8 @@ jobs:
 
     - name: Install requirements, build and install Borg
       run: |
-       sudo apt install libacl1-dev
+       sudo apt-get update
+       sudo apt-get install libacl1-dev
        pip3 install -r requirements.d/development.txt
        pip3 install -e .
 


### PR DESCRIPTION
This is a backport of #6356

> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.