### PR TITLE
[1.2-maint] src/borg/compress.pyx: fix compiler warning, closes #6365

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -286,7 +286,7 @@ class ZSTD(DecidingCompressor):
         if not isinstance(idata, bytes):
             idata = bytes(idata)  # code below does not work with memoryview
         cdef int isize = len(idata)
-        cdef size_t osize
+        cdef int osize
         cdef char *source = idata
         cdef char *dest
         cdef int level = self.level


### PR DESCRIPTION
This resolves a compiler warning from the generated code that
resulted from a comparison of two local variables of different
signedness. The issue is resolved by changing the type of both
to int since this seems like the safest choice available.
