### PR TITLE
Fix build with LibreSSL

### DIFF
--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -7,4 +7,8 @@
 const EVP_CIPHER *EVP_aes_256_ocb(void){  /* dummy, so that code compiles */
     return NULL;
 }
+
+const EVP_CIPHER *EVP_chacha20_poly1305(void){  /* dummy, so that code compiles */
+    return NULL;
+}
 #endif

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -5,6 +5,7 @@
 
 #if defined(LIBRESSL_VERSION_NUMBER)
 const EVP_CIPHER *EVP_aes_256_ocb(void);  /* dummy, so that code compiles */
+const EVP_CIPHER *EVP_chacha20_poly1305(void);  /* dummy, so that code compiles */
 #endif
 
 #if !defined(LIBRESSL_VERSION_NUMBER)

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -97,6 +97,7 @@ cdef extern from "_crypto_helpers.h":
     long LIBRESSL_VERSION_NUMBER
 
     const EVP_CIPHER *EVP_aes_256_ocb()  # dummy
+    const EVP_CIPHER *EVP_chacha20_poly1305()  # dummy
 
 
 is_libressl = bool(LIBRESSL_VERSION_NUMBER)
@@ -640,7 +641,8 @@ cdef class AES256_OCB(_AES_BASE):
 cdef class CHACHA20_POLY1305(_CHACHA_BASE):
     @classmethod
     def requirements_check(cls):
-        pass
+        if is_libressl:
+            raise ValueError('CHACHA20-POLY1305 is not implemented by LibreSSL (yet?).')
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
         self.requirements_check()

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -98,15 +98,15 @@ class CryptoTestCase(BaseTestCase):
         header = b'\x23'
         tests = [
             # (ciphersuite class, exp_mac, exp_cdata)
-            (CHACHA20_POLY1305,
-             b'fd08594796e0706cde1e8b461e3e0555',
-             b'a093e4b0387526f085d3c40cca84a35230a5c0dd766453b77ba38bcff775',)
         ]
         if not is_libressl:
             tests += [
                 (AES256_OCB,
                  b'b6909c23c9aaebd9abbe1ff42097652d',
                  b'877ce46d2f62dee54699cebc3ba41d9ab613f7c486778c1b3636664b1493', ),
+                (CHACHA20_POLY1305,
+                 b'fd08594796e0706cde1e8b461e3e0555',
+                 b'a093e4b0387526f085d3c40cca84a35230a5c0dd766453b77ba38bcff775', )
             ]
         for cs_cls, exp_mac, exp_cdata in tests:
             # print(repr(cs_cls))
@@ -142,15 +142,15 @@ class CryptoTestCase(BaseTestCase):
         header = b'\x12\x34\x56'
         tests = [
             # (ciphersuite class, exp_mac, exp_cdata)
-            (CHACHA20_POLY1305,
-             b'b7e7c9a79f2404e14f9aad156bf091dd',
-             b'a093e4b0387526f085d3c40cca84a35230a5c0dd766453b77ba38bcff775',)
         ]
         if not is_libressl:
             tests += [
                 (AES256_OCB,
                  b'f2748c412af1c7ead81863a18c2c1893',
                  b'877ce46d2f62dee54699cebc3ba41d9ab613f7c486778c1b3636664b1493', ),
+                (CHACHA20_POLY1305,
+                 b'b7e7c9a79f2404e14f9aad156bf091dd',
+                 b'a093e4b0387526f085d3c40cca84a35230a5c0dd766453b77ba38bcff775', )
             ]
         for cs_cls, exp_mac, exp_cdata in tests:
             # print(repr(cs_cls))


### PR DESCRIPTION
#6338 introduces regression when building with LibreSSL (3.5.0).

```
cc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -g -fPIC -O2 -pipe -g -O2 -pipe -g -O2 -pipe -fPIC -Isrc/borg/crypto -I/usr/local/include/python3.9 -c src/borg/crypto/low_level.c -o /tmp/ports/pobj/borgbackup-1.2.1/borg-eec359cf228caf00d9c72bde07bf939872e9d3fa/temp.openbsd-7.1-amd64-3.9/src/borg/crypto/low_level.o
src/borg/crypto/low_level.c:12439:48: error: use of undeclared identifier 'EVP_chacha20_poly1305'; did you mean 'EVP_aead_chacha20_poly1305'?
  __pyx_v_self->__pyx_base.__pyx_base.cipher = EVP_chacha20_poly1305;
                                               ^~~~~~~~~~~~~~~~~~~~~
                                               EVP_aead_chacha20_poly1305
/usr/include/openssl/evp.h:1161:17: note: 'EVP_aead_chacha20_poly1305' declared here
const EVP_AEAD *EVP_aead_chacha20_poly1305(void);
                ^
1 error generated.
```

Unfortunately `EVP_aead_chacha20_poly1305`, offered by LibreSSL, is not
a drop in replacement for `EVP_chacha20_poly1305`. More info on the
first can be found at https://man.openbsd.org/EVP_AEAD_CTX_init.3.