### PR TITLE
suppress -Wimplicit-fallthrough warning

### DIFF
--- a/src/borg/cache_sync/unpack_template.h
+++ b/src/borg/cache_sync/unpack_template.h
@@ -196,7 +196,7 @@ static inline int unpack_execute(unpack_context* ctx, const char* data, size_t l
 
 
         _fixed_trail_again:
-            ++p;
+            ++p; // fallthrough (suppresses -Wimplicit-fallthrough)
 
         default:
             if((size_t)(pe - p) < trail) { goto _out; }


### PR DESCRIPTION
These instances of implicit switch case fallthrough appear to be
intentional. Add comments that the compiler understands to suppress
the false positive warning.
