### PR TITLE
Fix compilation warnings: ‘PyUnicode_AsUnicode’ is deprecated

### DIFF
--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -6,8 +6,17 @@ from functools import lru_cache
 
 from libc.errno cimport errno as c_errno
 
+from cpython.mem cimport PyMem_Free
+from libc.stddef cimport wchar_t
+
 cdef extern from "wchar.h":
-    cdef int wcswidth(const Py_UNICODE *str, size_t n)
+    # https://www.man7.org/linux/man-pages/man3/wcswidth.3.html
+    cdef int wcswidth(const wchar_t *s, size_t n)
+
+
+cdef extern from "Python.h":
+    # https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsWideCharString
+    wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t*) except NULL
 
 
 def get_errno():
@@ -15,12 +24,14 @@ def get_errno():
 
 
 def swidth(s):
-    str_len = len(s)
-    terminal_width = wcswidth(s, str_len)
+    cdef Py_ssize_t size
+    cdef wchar_t *as_wchar = PyUnicode_AsWideCharString(s, &size)
+    terminal_width = wcswidth(as_wchar, <size_t>size)
+    PyMem_Free(as_wchar)
     if terminal_width >= 0:
         return terminal_width
     else:
-        return str_len
+        return len(s)
 
 
 def process_alive(host, pid, thread):


### PR DESCRIPTION
Fix compilation warnings:
```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/opt/hostedtoolcache/Python/3.9.10/x64/include/python3.9 -c src/borg/platform/posix.c -o build/temp.linux-x86_64-3.9/src/borg/platform/posix.o
src/borg/platform/posix.c: In function ‘__pyx_pf_4borg_8platform_5posix_2swidth’:
src/borg/platform/posix.c:1572:3: warning: ‘PyUnicode_AsUnicode’ is deprecated [-Wdeprecated-declarations]
 1572 |   __pyx_t_2 = __Pyx_PyUnicode_AsUnicode(__pyx_v_s); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) __PYX_ERR(0, 19, __pyx_L1_error)
      |   ^~~~~~~~~
In file included from /opt/hostedtoolcache/Python/3.9.10/x64/include/python3.9/unicodeobject.h:1026,
                 from /opt/hostedtoolcache/Python/3.9.10/x64/include/python3.9/Python.h:93,
                 from src/borg/platform/posix.c:19:
/opt/hostedtoolcache/Python/3.9.10/x64/include/python3.9/cpython/unicodeobject.h:580:45: note: declared here
  580 | Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
      |                                             ^~~~~~~~~~~~~~~~~~~
```

Ref: https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUnicode

Note: the warning also shows up in 1.1 and 1.2 builds and I plan to backport this patch after it is merged.