### PR TITLE
fix "useless trailing comma" cython warnings

### DIFF
--- a/src/borg/algorithms/checksums.pyx
+++ b/src/borg/algorithms/checksums.pyx
@@ -25,16 +25,16 @@ cdef extern from "xxhash.h":
         XXH_OK,
         XXH_ERROR
 
-    XXH64_state_t* XXH64_createState();
-    XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr);
-    XXH64_hash_t XXH64(const void* input, size_t length, unsigned long long seed);
+    XXH64_state_t* XXH64_createState()
+    XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+    XXH64_hash_t XXH64(const void* input, size_t length, unsigned long long seed)
 
-    XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed);
-    XXH_errorcode XXH64_update(XXH64_state_t* statePtr, const void* input, size_t length);
-    XXH64_hash_t XXH64_digest(const XXH64_state_t* statePtr);
+    XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed)
+    XXH_errorcode XXH64_update(XXH64_state_t* statePtr, const void* input, size_t length)
+    XXH64_hash_t XXH64_digest(const XXH64_state_t* statePtr)
 
-    void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash);
-    XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src);
+    void XXH64_canonicalFromHash(XXH64_canonical_t* dst, XXH64_hash_t hash)
+    XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src)
 
 
 cdef Py_buffer ro_buffer(object data) except *:


### PR DESCRIPTION
fixes #6420.