### PR TITLE
properly suppress -Wimplicit-fallthrough

### DIFF
--- a/src/borg/cache_sync/unpack_template.h
+++ b/src/borg/cache_sync/unpack_template.h
@@ -196,7 +196,7 @@ static inline int unpack_execute(unpack_context* ctx, const char* data, size_t l
 
 
         _fixed_trail_again:
-            ++p; // fallthrough (suppresses -Wimplicit-fallthrough)
+            ++p; // fallthrough
 
         default:
             if((size_t)(pe - p) < trail) { goto _out; }


### PR DESCRIPTION
It turns out that explaining the comment actually breaks its
intended usage.
