### PR TITLE
1.1: Make switch fallthrough explicit

### DIFF
--- a/src/borg/algorithms/crc32_clmul.c
+++ b/src/borg/algorithms/crc32_clmul.c
@@ -363,8 +363,8 @@ crc32_clmul(const uint8_t *src, long len, uint32_t initial_crc)
              */
             uint32_t crc = ~initial_crc;
             switch (len) {
-                case 3: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
-                case 2: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
+                case 3: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++]; // fallthrough
+                case 2: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++]; // fallthrough
                 case 1: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
             }
             return ~crc;

--- a/src/borg/algorithms/msgpack/unpack_template.h
+++ b/src/borg/algorithms/msgpack/unpack_template.h
@@ -245,7 +245,7 @@ static inline int unpack_execute(unpack_context* ctx, const char* data, Py_ssize
 
 
         _fixed_trail_again:
-            ++p;
+            ++p; // fallthrough
 
         default:
             if((size_t)(pe - p) < trail) { goto _out; }

--- a/src/borg/cache_sync/unpack_template.h
+++ b/src/borg/cache_sync/unpack_template.h
@@ -196,7 +196,7 @@ static inline int unpack_execute(unpack_context* ctx, const char* data, size_t l
 
 
         _fixed_trail_again:
-            ++p;
+            ++p; // fallthrough
 
         default:
             if((size_t)(pe - p) < trail) { goto _out; }


### PR DESCRIPTION
This includes a backport of https://github.com/borgbackup/borg/pull/6426

Testing:
```
git clean -e /.envrc -e /.direnv -fdx \
&& CFLAGS=-Werror=implicit-fallthrough pip -v install -e .
```

* This reduces compilation warnings introduced by https://github.com/borgbackup/borg/pull/6433