### PR TITLE
1.2: Make switch fallthrough explicit

### DIFF
--- a/src/borg/algorithms/crc32_clmul.c
+++ b/src/borg/algorithms/crc32_clmul.c
@@ -363,8 +363,8 @@ crc32_clmul(const uint8_t *src, long len, uint32_t initial_crc)
              */
             uint32_t crc = ~initial_crc;
             switch (len) {
-                case 3: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
-                case 2: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
+                case 3: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++]; // fallthrough
+                case 2: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++]; // fallthrough
                 case 1: crc = (crc >> 8) ^ Crc32Lookup[0][(crc & 0xFF) ^ *src++];
             }
             return ~crc;


### PR DESCRIPTION
* This could be considered a forward port of https://github.com/borgbackup/borg/pull/6434
* Strictly speaking this is not a backport of  #6426 even though it serves the same purpose

Testing:
```
git clean -e /.envrc -e /.direnv -fdx \
&& CFLAGS=-Werror=implicit-fallthrough pip -v install -e .
```
