### PR TITLE
`borg benchmark cpu` fails with libressl

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -591,19 +591,24 @@ class Archiver:
 
         from borg.crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
         from borg.crypto.low_level import AES256_OCB, CHACHA20_POLY1305
+        from borg.crypto.low_level import is_libressl
         print("Encryption =====================================================")
         size = "1GB"
 
-        for spec, func in [
+        tests = [
             ("aes-256-ctr-hmac-sha256", lambda: AES256_CTR_HMAC_SHA256(
                 key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
             ("aes-256-ctr-blake2b", lambda: AES256_CTR_BLAKE2b(
                 key_256*4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
-            ("aes-256-ocb", lambda: AES256_OCB(
-                None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
-            ("chacha20-poly1305", lambda: CHACHA20_POLY1305(
-                None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
-        ]:
+        ]
+        if not is_libressl:
+            tests.extend([
+                ("aes-256-ocb", lambda: AES256_OCB(
+                    None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
+                ("chacha20-poly1305", lambda: CHACHA20_POLY1305(
+                    None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
+            ])
+        for spec, func in tests:
             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
 
         from borg.compress import CompressionSpec


### PR DESCRIPTION
`borg benchmark cpu` fails on OpenBSD with the error below, which is
caused by LibreSSL currently not supporting AES256_OCB and
CHACHA20_POLY1305.

Work around this by checking if borg is used with LibreSSL. Tested on
OpenBSD.

```
Chunkers =======================================================
buzhash,19,23,21,4095    1GB        14.294s
fixed,1048576            1GB        0.244s
Non-cryptographic checksums / hashes ===========================
crc32 (libdeflate, used) 1GB        0.724s
crc32 (zlib)             1GB        1.953s
xxh64                    1GB        0.361s
Cryptographic hashes / MACs ====================================
hmac-sha256              1GB        7.039s
blake2b-256              1GB        9.845s
Encryption =====================================================
aes-256-ctr-hmac-sha256  1GB        18.312s
aes-256-ctr-blake2b      1GB        21.213s
Local Exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/borg/archiver.py", line 5241, in main
    exit_code = archiver.run(args)
  File "/usr/local/lib/python3.9/site-packages/borg/archiver.py", line 5172, in run
    return set_ec(func(args))
  File "/usr/local/lib/python3.9/site-packages/borg/archiver.py", line 607, in do_benchmark_cpu
    print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
  File "/usr/local/lib/python3.9/timeit.py", line 233, in timeit
    return Timer(stmt, setup, timer, globals).timeit(number)
  File "/usr/local/lib/python3.9/timeit.py", line 177, in timeit
    timing = self.inner(it, self.timer)
  File "<timeit-src>", line 6, in inner
  File "/usr/local/lib/python3.9/site-packages/borg/archiver.py", line 602, in <lambda>
    ("aes-256-ocb", lambda: AES256_OCB(
  File "src/borg/crypto/low_level.pyx", line 636, in borg.crypto.low_level.AES256_OCB.__init__
  File "src/borg/crypto/low_level.pyx", line 633, in borg.crypto.low_level.AES256_OCB.requirements_check
ValueError: AES OCB is not implemented by LibreSSL (yet?).

Platform: OpenBSD gateway.lan 7.1 GENERIC.MP#418 amd64
Borg: 1.2.1.dev98+gebaf0c32  Python: CPython 3.9.10 msgpack: 1.0.3 fuse: None [pyfuse3,llfuse]
PID: 38614  CWD: /storage/8899fc1454db04de.a/home/code/git/ports/sysutils/borg
sys.argv: ['/usr/local/bin/borg', 'benchmark', 'cpu']
SSH_ORIGINAL_COMMAND: None
```