### PR TITLE
delete: add repository id and location to prompt

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1392,23 +1392,38 @@ class Archiver:
 
         if not args.cache_only:
             if args.forced == 0:  # without --force, we let the user see the archives list and confirm.
+                id = bin_to_hex(repository.id)
+                location = repository._location.canonical_path()
                 msg = []
                 try:
                     manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
+                    n_archives = len(manifest.archives)
+                    msg.append(f"You requested to completely DELETE the following repository "
+                               f"*including* {n_archives} archives it contains:")
                 except NoManifestError:
-                    msg.append("You requested to completely DELETE the repository *including* all archives it may "
-                               "contain.")
-                    msg.append("This repository seems to have no manifest, so we can't tell anything about its "
-                               "contents.")
-                else:
-                    if self.output_list:
-                        msg.append("You requested to completely DELETE the repository *including* all archives it "
-                                   "contains:")
-                        for archive_info in manifest.archives.list(sort_by=['ts']):
-                            msg.append(format_archive(archive_info))
+                    n_archives = None
+                    msg.append("You requested to completely DELETE the following repository "
+                               "*including* all archives it may contain:")
+
+                msg.append(DASHES)
+                msg.append(f"Repository ID: {id}")
+                msg.append(f"Location: {location}")
+
+                if self.output_list:
+                    msg.append("")
+                    msg.append("Archives:")
+
+                    if n_archives is not None:
+                        if n_archives > 0:
+                            for archive_info in manifest.archives.list(sort_by=['ts']):
+                                msg.append(format_archive(archive_info))
+                        else:
+                            msg.append("This repository seems to not have any archives.")
                     else:
-                        msg.append("You requested to completely DELETE the repository *including* %d archives it contains."
-                                   % len(manifest.archives))
+                        msg.append("This repository seems to have no manifest, so we can't "
+                                   "tell anything about its contents.")
+
+                msg.append(DASHES)
                 msg.append("Type 'YES' if you understand this and want to continue: ")
                 msg = '\n'.join(msg)
                 if not yes(msg, false_msg="Aborting.", invalid_msg='Invalid answer, aborting.', truish=('YES',),


### PR DESCRIPTION
This commit will change prompt of `borg delete` command from
```
# borg delete
You requested to completely DELETE the repository *including* all archives it contains:
host1.example.net-2022-03-14T14:55:31 Mon, 2022-03-14 15:55:31 [ecb4e323c38e5d560452192456073f284aa3acaf59b53e24f584ae33e3025519]
Type 'YES' if you understand this and want to continue: YES
```
to
```
# borg delete
You requested to completely DELETE the repository with ID 2c91b9eee2c718f766dcec336fa4c25af0568714110df36b5972b24a551a2310 located in ssh://username@borgbackup.example.net/path/to/repo *including* all archives it contains:
host1.example.net-2022-03-14T14:55:31 Mon, 2022-03-14 15:55:31 [ecb4e323c38e5d560452192456073f284aa3acaf59b53e24f584ae33e3025519]
Type 'YES' if you understand this and want to continue: 
```
