### PR TITLE
remove AEAD ciphers AES-OCB and CHACHA20-POLY1305, fixes #6472

### DIFF
--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -23,14 +23,3 @@ void HMAC_CTX_free(HMAC_CTX *ctx)
     }
 }
 #endif
-
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-const EVP_CIPHER *EVP_aes_256_ocb(void){  /* dummy, so that code compiles */
-    return NULL;
-}
-
-const EVP_CIPHER *EVP_chacha20_poly1305(void){  /* dummy, so that code compiles */
-    return NULL;
-}
-#endif

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -10,12 +10,6 @@ void HMAC_CTX_free(HMAC_CTX *ctx);
 #endif
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-const EVP_CIPHER *EVP_aes_256_ocb(void);  /* dummy, so that code compiles */
-const EVP_CIPHER *EVP_chacha20_poly1305(void);  /* dummy, so that code compiles */
-#endif
-
-
 #if !defined(LIBRESSL_VERSION_NUMBER)
 #define LIBRESSL_VERSION_NUMBER 0
 #endif

--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -29,7 +29,7 @@ SELFTEST_CASES = [
     ChunkerTestCase,
 ]
 
-SELFTEST_COUNT = 35
+SELFTEST_COUNT = 33
 
 
 class SelfTestResult(TestResult):


### PR DESCRIPTION
not used in 1.2.x, we'll start using them in 1.3.
