### PR TITLE
1.2 - Remove unused code

### DIFF
--- a/src/borg/crypto/_crypto_helpers.c
+++ b/src/borg/crypto/_crypto_helpers.c
@@ -1,6 +1,5 @@
 /* some helpers, so our code also works with OpenSSL 1.0.x */
 
-#include <string.h>
 #include <openssl/opensslv.h>
 #include <openssl/hmac.h>
 

--- a/src/borg/crypto/_crypto_helpers.h
+++ b/src/borg/crypto/_crypto_helpers.h
@@ -2,14 +2,8 @@
 
 #include <openssl/opensslv.h>
 #include <openssl/hmac.h>
-#include <openssl/evp.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 HMAC_CTX *HMAC_CTX_new(void);
 void HMAC_CTX_free(HMAC_CTX *ctx);
-#endif
-
-
-#if !defined(LIBRESSL_VERSION_NUMBER)
-#define LIBRESSL_VERSION_NUMBER 0
 #endif

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -102,13 +102,9 @@ cdef extern from "openssl/hmac.h":
 
 cdef extern from "_crypto_helpers.h":
     long OPENSSL_VERSION_NUMBER
-    long LIBRESSL_VERSION_NUMBER
 
     HMAC_CTX *HMAC_CTX_new()
     void HMAC_CTX_free(HMAC_CTX *a)
-
-
-openssl10 = OPENSSL_VERSION_NUMBER < 0x10100000 or LIBRESSL_VERSION_NUMBER
 
 
 import struct


### PR DESCRIPTION
#6473 Removed AEAD ciphers AES-OCB and CHACHA20-POLY1305 from 1.2. As a
result some additional code can be removed.

Passes regression tests.