### PR TITLE
Fix use-after-free in `borg benchmark cpu`

### DIFF
--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -187,7 +187,7 @@ cdef class AES256_CTR_BASE:
     # Layout: HEADER + MAC 32 + IV 8 + CT (same as attic / borg < 1.2 IF HEADER = TYPE_BYTE, no AAD)
 
     cdef EVP_CIPHER_CTX *ctx
-    cdef unsigned char *enc_key
+    cdef bytes enc_key
     cdef int cipher_blk_len
     cdef int iv_len, iv_len_short
     cdef int aad_offset
@@ -360,7 +360,7 @@ cdef class AES256_CTR_BASE:
 
 
 cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
-    cdef unsigned char *mac_key
+    cdef bytes mac_key
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
         assert isinstance(mac_key, bytes) and len(mac_key) == 32
@@ -390,7 +390,7 @@ cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
 
 
 cdef class AES256_CTR_BLAKE2b(AES256_CTR_BASE):
-    cdef unsigned char *mac_key
+    cdef bytes mac_key
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
         assert isinstance(mac_key, bytes) and len(mac_key) == 128
@@ -427,7 +427,7 @@ cdef class _AEAD_BASE:
 
     cdef CIPHER cipher
     cdef EVP_CIPHER_CTX *ctx
-    cdef unsigned char *enc_key
+    cdef bytes enc_key
     cdef int cipher_blk_len
     cdef int iv_len
     cdef int aad_offset
@@ -654,7 +654,7 @@ cdef class AES:
     """A thin wrapper around the OpenSSL EVP cipher API - for legacy code, like key file encryption"""
     cdef CIPHER cipher
     cdef EVP_CIPHER_CTX *ctx
-    cdef unsigned char *enc_key
+    cdef bytes enc_key
     cdef int cipher_blk_len
     cdef int iv_len
     cdef unsigned char iv[16]


### PR DESCRIPTION
`key_256*4` goes out of scope before encrypt() is called because the cipher suite object does not own the key. 

https://github.com/borgbackup/borg/blob/3e1cfd009e9df79d286822c7dbb221bca29c92e4/src/borg/archiver.py#L601-L602

I have ran into a similar issue while working on https://github.com/borgbackup/borg/pull/6469

This PR makes all cipher suites own enc_key and mac_key.

I believe this is not a security issue. It just so happens that everywhere except for do_benchmark_cpu() and possibly out test suite the key already outlives the cipher suite.

<details>
<summary> Investigation </summary>

```sh
# Latest master
git describe | sed -r 's/^/# /'
# 1.2.0-120-g3e1cfd00
# Dangerous pattern
egrep -B5 'cdef unsigned char.*key' src/borg/crypto/low_level.pyx | sed -r 's/^/# /'
# 
# cdef class AES256_CTR_BASE:
#     # Layout: HEADER + MAC 32 + IV 8 + CT (same as attic / borg < 1.2 IF HEADER = TYPE_BYTE, no AAD)
# 
#     cdef EVP_CIPHER_CTX *ctx
#     cdef unsigned char *enc_key
# --
#         offset = self.header_len + self.mac_len
#         return bytes_to_long(envelope[offset:offset+self.iv_len_short])
# 
# 
# cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
#     cdef unsigned char *mac_key
# --
#         if CRYPTO_memcmp(mac_buf, mac_wanted, self.mac_len):
#             raise IntegrityError('MAC Authentication failed')
# 
# 
# cdef class AES256_CTR_BLAKE2b(AES256_CTR_BASE):
#     cdef unsigned char *mac_key
# --
# cdef class _AEAD_BASE:
#     # Layout: HEADER + MAC 16 + IV 12 + CT
# 
#     cdef CIPHER cipher
#     cdef EVP_CIPHER_CTX *ctx
#     cdef unsigned char *enc_key
# --
# 
# cdef class AES:
#     """A thin wrapper around the OpenSSL EVP cipher API - for legacy code, like key file encryption"""
#     cdef CIPHER cipher
#     cdef EVP_CIPHER_CTX *ctx
#     cdef unsigned char *enc_key

# AES256_CTR_BASE, _AEAD_BASE, _AES_BASE and _CHACHA_BASE are only used as base classes
egrep -r 'AES256_CTR_BASE|_AEAD_BASE|_AES_BASE|_CHACHA_BASE' src/ | sed -r 's/^/# /'
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_BASE:
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_BLAKE2b(AES256_CTR_BASE):
# src/borg/crypto/low_level.pyx:cdef class _AEAD_BASE:
# src/borg/crypto/low_level.pyx:cdef class _AES_BASE(_AEAD_BASE):
# src/borg/crypto/low_level.pyx:cdef class _CHACHA_BASE(_AEAD_BASE):
# src/borg/crypto/low_level.pyx:cdef class AES256_OCB(_AES_BASE):
# src/borg/crypto/low_level.pyx:cdef class CHACHA20_POLY1305(_CHACHA_BASE):

# Safe: `key` outlives `AES()`
fgrep -B2 -r 'AES(' src/ | sed -r 's/^/# /'
# src/borg/crypto/key.py-        assert enc_key.algorithm == 'sha256'
# src/borg/crypto/key.py-        key = passphrase.kdf(enc_key.salt, enc_key.iterations, 32)
# src/borg/crypto/key.py:        data = AES(key, b'\0'*16).decrypt(enc_key.data)
# --
# src/borg/crypto/key.py-        key = passphrase.kdf(salt, iterations, 32)
# src/borg/crypto/key.py-        hash = hmac_sha256(key, data)
# src/borg/crypto/key.py:        cdata = AES(key, b'\0'*16).encrypt(data)

# AES256_OCB and CHACHA20_POLY1305 are
# used in src/borg/testsuite/crypto.py and src/borg/archiver.py:
egrep -r 'AES256_OCB|CHACHA20_POLY1305' src/ | sed -r 's/^/# /'
# src/borg/testsuite/crypto.py:from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_OCB, CHACHA20_POLY1305, UNENCRYPTED, \
# src/borg/testsuite/crypto.py:                (AES256_OCB,
# src/borg/testsuite/crypto.py:                (CHACHA20_POLY1305,
# src/borg/testsuite/crypto.py:                (AES256_OCB,
# src/borg/testsuite/crypto.py:                (CHACHA20_POLY1305,
# src/borg/archiver.py:        from borg.crypto.low_level import AES256_OCB, CHACHA20_POLY1305
# src/borg/archiver.py:                ("aes-256-ocb", lambda: AES256_OCB(
# src/borg/archiver.py:                ("chacha20-poly1305", lambda: CHACHA20_POLY1305(
# src/borg/crypto/low_level.pyx:cdef class AES256_OCB(_AES_BASE):
# src/borg/crypto/low_level.pyx:cdef class CHACHA20_POLY1305(_CHACHA_BASE):

# Safe: `key_256` outlives `tests`
egrep -B53 -A31 'AES256_OCB|CHACHA20_POLY1305' src/borg/archiver.py | sed -r 's/^/# /'
#     def do_benchmark_cpu(self, args):
#         """Benchmark CPU bound operations."""
#         from timeit import timeit
#         random_10M = os.urandom(10*1000*1000)
#         key_256 = os.urandom(32)
#         key_128 = os.urandom(16)
#         key_96 = os.urandom(12)
# 
#         import io
#         from borg.chunker import get_chunker
#         print("Chunkers =======================================================")
#         size = "1GB"
# 
#         def chunkit(chunker_name, *args, **kwargs):
#             with io.BytesIO(random_10M) as data_file:
#                 ch = get_chunker(chunker_name, *args, **kwargs)
#                 for _ in ch.chunkify(fd=data_file):
#                     pass
# 
#         for spec, func in [
#             ("buzhash,19,23,21,4095", lambda: chunkit("buzhash", 19, 23, 21, 4095, seed=0)),
#             ("fixed,1048576", lambda: chunkit("fixed", 1048576, sparse=False)),
#         ]:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         import zlib
#         from borg.checksums import crc32, deflate_crc32, xxh64
#         print("Non-cryptographic checksums / hashes ===========================")
#         size = "1GB"
#         tests = [
#             ("xxh64", lambda: xxh64(random_10M)),
#         ]
#         if crc32 is zlib.crc32:
#             tests.insert(0, ("crc32 (zlib, used)", lambda: crc32(random_10M)))
#             tests.insert(1, ("crc32 (libdeflate)", lambda: deflate_crc32(random_10M)))
#         elif crc32 is deflate_crc32:
#             tests.insert(0, ("crc32 (libdeflate, used)", lambda: crc32(random_10M)))
#             tests.insert(1, ("crc32 (zlib)", lambda: zlib.crc32(random_10M)))
#         else:
#             raise Error("crc32 benchmarking code missing")
#         for spec, func in tests:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         from borg.crypto.low_level import hmac_sha256, blake2b_256
#         print("Cryptographic hashes / MACs ====================================")
#         size = "1GB"
#         for spec, func in [
#             ("hmac-sha256", lambda: hmac_sha256(key_256, random_10M)),
#             ("blake2b-256", lambda: blake2b_256(key_256, random_10M)),
#         ]:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         from borg.crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
#         from borg.crypto.low_level import AES256_OCB, CHACHA20_POLY1305
#         from borg.crypto.low_level import is_libressl
#         print("Encryption =====================================================")
#         size = "1GB"
# 
#         tests = [
#             ("aes-256-ctr-hmac-sha256", lambda: AES256_CTR_HMAC_SHA256(
#                 key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
#             ("aes-256-ctr-blake2b", lambda: AES256_CTR_BLAKE2b(
#                 key_256*4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
#         ]
#         if not is_libressl:
#             tests.extend([
#                 ("aes-256-ocb", lambda: AES256_OCB(
#                     None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
#                 ("chacha20-poly1305", lambda: CHACHA20_POLY1305(
#                     None, key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
#             ])
#         for spec, func in tests:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         from borg.compress import CompressionSpec
#         print("Compression ====================================================")
#         for spec in [
#             'lz4',
#             'zstd,1',
#             'zstd,3',
#             'zstd,22',
#             'zlib,0',
#             'zlib,6',
#             'zlib,9',
#             'lzma,0',
#             'lzma,6',
#             'lzma,9',
#         ]:
#             compressor = CompressionSpec(spec).compressor
#             size = "0.1GB"
#             print(f"{spec:<12} {size:<10} {timeit(lambda: compressor.compress(random_10M), number=10):.3f}s")
# 
#         print("msgpack ========================================================")
#         item = Item(path="/foo/bar/baz", mode=660, mtime=1234567)
#         items = [item.as_dict(), ] * 1000
#         size = "100k Items"
#         spec = "msgpack"
#         print(f"{spec:<12} {size:<10} {timeit(lambda: msgpack.packb(items), number=100):.3f}s")
# 
#         return 0

# AES256_CTR_HMAC_SHA256 and AES256_CTR_BLAKE2b are
# used in src/borg/testsuite/crypto.py src/borg/archiver.py and src/borg/crypto/key.py
egrep -r 'AES256_CTR' src/borg | sed -r 's/^/# /'
# src/borg/testsuite/crypto.py:from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_OCB, CHACHA20_POLY1305, UNENCRYPTED, \
# src/borg/testsuite/crypto.py:    def test_AES256_CTR_HMAC_SHA256(self):
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, iv, header_len=1, aad_offset=1)
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, header_len=len(header), aad_offset=1)
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, header_len=len(header), aad_offset=1)
# src/borg/testsuite/crypto.py:    def test_AES256_CTR_HMAC_SHA256_aad(self):
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, iv, header_len=3, aad_offset=1)
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, header_len=len(header), aad_offset=1)
# src/borg/testsuite/crypto.py:        cs = AES256_CTR_HMAC_SHA256(mac_key, enc_key, header_len=len(header), aad_offset=1)
# src/borg/archiver.py:        from borg.crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
# src/borg/archiver.py:            ("aes-256-ctr-hmac-sha256", lambda: AES256_CTR_HMAC_SHA256(
# src/borg/archiver.py:            ("aes-256-ctr-blake2b", lambda: AES256_CTR_BLAKE2b(
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_BASE:
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
# src/borg/crypto/low_level.pyx:cdef class AES256_CTR_BLAKE2b(AES256_CTR_BASE):
# src/borg/crypto/key.py:from .low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b
# src/borg/crypto/key.py:    CIPHERSUITE = AES256_CTR_HMAC_SHA256
# src/borg/crypto/key.py:    CIPHERSUITE = AES256_CTR_BLAKE2b

## src/borg/crypto/key.py
egrep -C2 'CIPHERSUITE' src/borg/crypto/key.py | sed -r 's/^/# /'
#     PAYLOAD_OVERHEAD = 1 + 32 + 8  # TYPE + HMAC + NONCE
# 
#     CIPHERSUITE = AES256_CTR_HMAC_SHA256
# 
#     logically_encrypted = True
# --
# 
#     def init_ciphers(self, manifest_data=None):
#         self.cipher = self.CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key, header_len=1, aad_offset=1)
#         if manifest_data is None:
#             nonce = 0
# --
# class Blake2FlexiKey(ID_BLAKE2b_256, FlexiKey):
#     TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
#     CIPHERSUITE = AES256_CTR_BLAKE2b
# 
# 
### self.cipher does not outlive self and
### is reset by init_ciphers()
egrep -C2 'self.cipher' src/borg/crypto/key.py | sed -r 's/^/# /'
#     def encrypt(self, chunk):
#         data = self.compressor.compress(chunk)
#         next_iv = self.nonce_manager.ensure_reservation(self.cipher.next_iv(),
#                                                         self.cipher.block_count(len(data)))
#         return self.cipher.encrypt(data, header=self.TYPE_STR, iv=next_iv)
# 
#     def decrypt(self, id, data, decompress=True):
#         self.assert_type(data[0], id)
#         try:
#             payload = self.cipher.decrypt(data)
#         except IntegrityError as e:
#             raise IntegrityError(f"Chunk {bin_to_hex(id)}: Could not decrypt [{str(e)}]")
# --
# 
#     def init_ciphers(self, manifest_data=None):
#         self.cipher = self.CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key, header_len=1, aad_offset=1)
#         if manifest_data is None:
#             nonce = 0
# --
#             # be a bit too high, but that does not matter.
#             manifest_blocks = num_cipher_blocks(len(manifest_data))
#             nonce = self.cipher.extract_iv(manifest_data) + manifest_blocks
#         self.cipher.set_iv(nonce)
#         self.nonce_manager = NonceManager(self.repository, nonce)
# 
### self.enc_key and self.enc_hmac_key may
### in theory be deallocated by _load() and init_from_random_data()
egrep -C10 'self.enc_key|self.enc_hmac_key' src/borg/crypto/key.py | sed -r 's/^/# /'
#             if not hmac.compare_digest(id_computed, id):
#                 raise IntegrityError('Chunk %s: id verification failed' % bin_to_hex(id))
# 
#     def assert_type(self, type_byte, id=None):
#         if type_byte not in self.TYPES_ACCEPTABLE:
#             id_str = bin_to_hex(id) if id is not None else '(unknown)'
#             raise IntegrityError(f'Chunk {id_str}: Invalid encryption envelope')
# 
#     def _tam_key(self, salt, context):
#         return hkdf_hmac_sha512(
#             ikm=self.id_key + self.enc_key + self.enc_hmac_key,
#             salt=salt,
#             info=b'borg-metadata-authentication-' + context,
#             output_length=64
#         )
# 
#     def pack_and_authenticate_metadata(self, metadata_dict, context=b'manifest'):
#         metadata_dict = StableDict(metadata_dict)
#         tam = metadata_dict['tam'] = StableDict({
#             'type': 'HKDF_HMAC_SHA512',
#             'hmac': bytes(64),
# --
#     Key mix-in class for using BLAKE2b-256 for the id key.
# 
#     The id_key length must be 32 bytes.
#     """
# 
#     def id_hash(self, data):
#         return blake2b_256(self.id_key, data)
# 
#     def init_from_random_data(self):
#         super().init_from_random_data()
#         self.enc_hmac_key = random_blake2b_256_key()
#         self.id_key = random_blake2b_256_key()
# 
# 
# class ID_HMAC_SHA_256:
#     """
#     Key mix-in class for using HMAC-SHA-256 for the id key.
# 
#     The id_key length must be 32 bytes.
#     """
# 
# --
#         except IntegrityError as e:
#             raise IntegrityError(f"Chunk {bin_to_hex(id)}: Could not decrypt [{str(e)}]")
#         if not decompress:
#             return payload
#         data = self.decompress(payload)
#         self.assert_id(id, data)
#         return data
# 
#     def init_from_random_data(self):
#         data = os.urandom(100)
#         self.enc_key = data[0:32]
#         self.enc_hmac_key = data[32:64]
#         self.id_key = data[64:96]
#         self.chunk_seed = bytes_to_int(data[96:100])
#         # Convert to signed int32
#         if self.chunk_seed & 0x80000000:
#             self.chunk_seed = self.chunk_seed - 0xffffffff - 1
# 
#     def init_ciphers(self, manifest_data=None):
#         self.cipher = self.CIPHERSUITE(mac_key=self.enc_hmac_key, enc_key=self.enc_key, header_len=1, aad_offset=1)
#         if manifest_data is None:
#             nonce = 0
#         else:
#             self.assert_type(manifest_data[0])
#             # manifest_blocks is a safe upper bound on the amount of cipher blocks needed
#             # to encrypt the manifest. depending on the ciphersuite and overhead, it might
#             # be a bit too high, but that does not matter.
#             manifest_blocks = num_cipher_blocks(len(manifest_data))
#             nonce = self.cipher.extract_iv(manifest_data) + manifest_blocks
#         self.cipher.set_iv(nonce)
# --
# 
#     def _load(self, key_data, passphrase):
#         cdata = a2b_base64(key_data)
#         data = self.decrypt_key_file(cdata, passphrase)
#         if data:
#             data = msgpack.unpackb(data)
#             key = Key(internal_dict=data)
#             if key.version != 1:
#                 raise IntegrityError('Invalid key file header')
#             self.repository_id = key.repository_id
#             self.enc_key = key.enc_key
#             self.enc_hmac_key = key.enc_hmac_key
#             self.id_key = key.id_key
#             self.chunk_seed = key.chunk_seed
#             self.tam_required = key.get('tam_required', tam_required(self.repository))
#             return True
#         return False
# 
#     def decrypt_key_file(self, data, passphrase):
#         unpacker = get_limited_unpacker('key')
#         unpacker.feed(data)
#         data = unpacker.unpack()
# --
#             algorithm='sha256',
#             hash=hash,
#             data=cdata,
#         )
#         return msgpack.packb(enc_key.as_dict())
# 
#     def _save(self, passphrase):
#         key = Key(
#             version=1,
#             repository_id=self.repository_id,
#             enc_key=self.enc_key,
#             enc_hmac_key=self.enc_hmac_key,
#             id_key=self.id_key,
#             chunk_seed=self.chunk_seed,
#             tam_required=self.tam_required,
#         )
#         data = self.encrypt_key_file(msgpack.packb(key.as_dict()), passphrase)
#         key_data = '\n'.join(textwrap.wrap(b2a_base64(data).decode('ascii')))
#         return key_data
# 
#     def change_passphrase(self, passphrase=None):
#         if passphrase is None:
### Safe: init_from_random_data() is never called after init_ciphers()
egrep -r -C10 'init_from_random_data' src/borg/ | sed -r 's/^/# /'
# src/borg/crypto/key.py-class ID_BLAKE2b_256:
# src/borg/crypto/key.py-    """
# src/borg/crypto/key.py-    Key mix-in class for using BLAKE2b-256 for the id key.
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    The id_key length must be 32 bytes.
# src/borg/crypto/key.py-    """
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    def id_hash(self, data):
# src/borg/crypto/key.py-        return blake2b_256(self.id_key, data)
# src/borg/crypto/key.py-
# src/borg/crypto/key.py:    def init_from_random_data(self):
# src/borg/crypto/key.py:        super().init_from_random_data()
# src/borg/crypto/key.py-        self.enc_hmac_key = random_blake2b_256_key()
# src/borg/crypto/key.py-        self.id_key = random_blake2b_256_key()
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-class ID_HMAC_SHA_256:
# src/borg/crypto/key.py-    """
# src/borg/crypto/key.py-    Key mix-in class for using HMAC-SHA-256 for the id key.
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    The id_key length must be 32 bytes.
# src/borg/crypto/key.py-    """
# --
# src/borg/crypto/key.py-        try:
# src/borg/crypto/key.py-            payload = self.cipher.decrypt(data)
# src/borg/crypto/key.py-        except IntegrityError as e:
# src/borg/crypto/key.py-            raise IntegrityError(f"Chunk {bin_to_hex(id)}: Could not decrypt [{str(e)}]")
# src/borg/crypto/key.py-        if not decompress:
# src/borg/crypto/key.py-            return payload
# src/borg/crypto/key.py-        data = self.decompress(payload)
# src/borg/crypto/key.py-        self.assert_id(id, data)
# src/borg/crypto/key.py-        return data
# src/borg/crypto/key.py-
# src/borg/crypto/key.py:    def init_from_random_data(self):
# src/borg/crypto/key.py-        data = os.urandom(100)
# src/borg/crypto/key.py-        self.enc_key = data[0:32]
# src/borg/crypto/key.py-        self.enc_hmac_key = data[32:64]
# src/borg/crypto/key.py-        self.id_key = data[64:96]
# src/borg/crypto/key.py-        self.chunk_seed = bytes_to_int(data[96:100])
# src/borg/crypto/key.py-        # Convert to signed int32
# src/borg/crypto/key.py-        if self.chunk_seed & 0x80000000:
# src/borg/crypto/key.py-            self.chunk_seed = self.chunk_seed - 0xffffffff - 1
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    def init_ciphers(self, manifest_data=None):
# --
# src/borg/crypto/key.py-    def change_passphrase(self, passphrase=None):
# src/borg/crypto/key.py-        if passphrase is None:
# src/borg/crypto/key.py-            passphrase = Passphrase.new(allow_empty=True)
# src/borg/crypto/key.py-        self.save(self.target, passphrase)
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    @classmethod
# src/borg/crypto/key.py-    def create(cls, repository, args):
# src/borg/crypto/key.py-        passphrase = Passphrase.new(allow_empty=True)
# src/borg/crypto/key.py-        key = cls(repository)
# src/borg/crypto/key.py-        key.repository_id = repository.id
# src/borg/crypto/key.py:        key.init_from_random_data()
# src/borg/crypto/key.py-        key.init_ciphers()
# src/borg/crypto/key.py-        target = key.get_new_target(args)
# src/borg/crypto/key.py-        key.save(target, passphrase, create=True)
# src/borg/crypto/key.py-        logger.info('Key in "%s" created.' % target)
# src/borg/crypto/key.py-        logger.info('Keep this key safe. Your data will be inaccessible without it.')
# src/borg/crypto/key.py-        return key
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    def save(self, target, passphrase, create=False):
# src/borg/crypto/key.py-        raise NotImplementedError
# src/borg/crypto/key.py-
### _load() is called by load()
egrep -r -C20 '[.]_load[(]' src/borg/ | sed -r 's/^/# /'
# src/borg/crypto/key.py-        while os.path.exists(path):
# src/borg/crypto/key.py-            i += 1
# src/borg/crypto/key.py-            path = filename + '.%d' % i
# src/borg/crypto/key.py-        return path
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    def load(self, target, passphrase):
# src/borg/crypto/key.py-        if self.STORAGE == KeyBlobStorage.KEYFILE:
# src/borg/crypto/key.py-            with open(target) as fd:
# src/borg/crypto/key.py-                key_data = ''.join(fd.readlines()[1:])
# src/borg/crypto/key.py-        elif self.STORAGE == KeyBlobStorage.REPO:
# src/borg/crypto/key.py-            # While the repository is encrypted, we consider a repokey repository with a blank
# src/borg/crypto/key.py-            # passphrase an unencrypted repository.
# src/borg/crypto/key.py-            self.logically_encrypted = passphrase != ''
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-            # what we get in target is just a repo location, but we already have the repo obj:
# src/borg/crypto/key.py-            target = self.repository
# src/borg/crypto/key.py-            key_data = target.load_key()
# src/borg/crypto/key.py-            key_data = key_data.decode('utf-8')  # remote repo: msgpack issue #99, getting bytes
# src/borg/crypto/key.py-        else:
# src/borg/crypto/key.py-            raise TypeError('Unsupported borg key storage type')
# src/borg/crypto/key.py:        success = self._load(key_data, passphrase)
# src/borg/crypto/key.py-        if success:
# src/borg/crypto/key.py-            self.target = target
# src/borg/crypto/key.py-        return success
# src/borg/crypto/key.py-
# src/borg/crypto/key.py-    def save(self, target, passphrase, create=False):
# src/borg/crypto/key.py-        key_data = self._save(passphrase)
# src/borg/crypto/key.py-        if self.STORAGE == KeyBlobStorage.KEYFILE:
# src/borg/crypto/key.py-            if create and os.path.isfile(target):
# src/borg/crypto/key.py-                # if a new keyfile key repository is created, ensure that an existing keyfile of another
# src/borg/crypto/key.py-                # keyfile key repo is not accidentally overwritten by careless use of the BORG_KEY_FILE env var.
# src/borg/crypto/key.py-                # see issue #6036
# src/borg/crypto/key.py-                raise Error('Aborting because key in "%s" already exists.' % target)
# src/borg/crypto/key.py-            with SaveFile(target) as fd:
# src/borg/crypto/key.py-                fd.write(f'{self.FILE_ID} {bin_to_hex(self.repository_id)}\n')
# src/borg/crypto/key.py-                fd.write(key_data)
# src/borg/crypto/key.py-                fd.write('\n')
# src/borg/crypto/key.py-        elif self.STORAGE == KeyBlobStorage.REPO:
# src/borg/crypto/key.py-            self.logically_encrypted = passphrase != ''
# src/borg/crypto/key.py-            key_data = key_data.encode('utf-8')  # remote repo: msgpack issue #99, giving bytes
# src/borg/crypto/key.py-            target.save_key(key_data)
### load() is not called from outside src/borg/crypto/key.py
egrep -r '[.]load[(]' src/borg/ | sed -r 's/^/# /'
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:                assert_data = pickle.load(_in)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            repo_key.load(None, Passphrase.env_passphrase())
# src/borg/testsuite/archiver.py:        backup_key.load(export_file, Passphrase.env_passphrase())
# src/borg/testsuite/archiver.py:            repo_key2.load(None, Passphrase.env_passphrase())
# src/borg/testsuite/archiver.py:            result = json.load(f)
# src/borg/testsuite/archiver.py:            result = json.load(f)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            _, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/archiver.py:            _, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/testsuite/locking.py:        empty = roster.load()
# src/borg/testsuite/cache.py:        return Manifest.load(repository, key=key, operations=Manifest.NO_OPERATION_CHECK)[0]
# src/borg/archiver.py:                    kwargs['manifest'], kwargs['key'] = Manifest.load(repository, compatibility)
# src/borg/archiver.py:        manifest, key = Manifest.load(repository, (Manifest.Operation.DELETE,))
# src/borg/archiver.py:                    manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
# src/borg/archiver.py:            manifest, key = Manifest.load(repository, (Manifest.Operation.CHECK,), force_tam_not_required=args.force)
# src/borg/archiver.py:            manifest, key = Manifest.load(repository, Manifest.NO_OPERATION_CHECK, force_tam_not_required=True)
# src/borg/archiver.py:            manifest, key = Manifest.load(repository, (Manifest.Operation.WRITE,))
# src/borg/archiver.py:                cache.cache_config.load()
# src/borg/crypto/key.py:            if not key.load(target, passphrase):
# src/borg/crypto/key.py:                    if key.load(target, passphrase):
# src/borg/crypto/key.py:            if not key.load(target, passphrase):
# src/borg/crypto/key.py:        success = super().load(target, passphrase)
# src/borg/locking.py:                data = json.load(f)
# src/borg/locking.py:        roster = self.load()
# src/borg/locking.py:        roster = self.load()
# src/borg/archive.py:            self.load(info.id)
# src/borg/archive.py:                self.manifest, _ = Manifest.load(repository, (Manifest.Operation.CHECK,), key=self.key)
# src/borg/cache.py:        self.load()
# src/borg/cache.py:        self.cache_config.load()
# src/borg/cache.py:                self.pre12_meta = json.load(fd)
### Safe: load() is never called after init_ciphers()
egrep -C10 -r '[.]load[(]' src/borg/crypto/key.py | sed -r 's/^/# /'
# 
# class FlexiKeyBase(AESKeyBase):
#     @classmethod
#     def detect(cls, repository, manifest_data):
#         key = cls(repository)
#         target = key.find_key()
#         prompt = 'Enter passphrase for key %s: ' % target
#         passphrase = Passphrase.env_passphrase()
#         if passphrase is None:
#             passphrase = Passphrase()
#             if not key.load(target, passphrase):
#                 for retry in range(0, 3):
#                     passphrase = Passphrase.getpass(prompt)
#                     if key.load(target, passphrase):
#                         break
#                 else:
#                     raise PasswordRetriesExceeded
#         else:
#             if not key.load(target, passphrase):
#                 raise PassphraseWrong
#         key.init_ciphers(manifest_data)
#         key._passphrase = passphrase
#         return key
# 
#     def find_key(self):
#         raise NotImplementedError
# 
#     def load(self, target, passphrase):
#         raise NotImplementedError
# --
#     STORAGE = KeyBlobStorage.REPO
# 
# 
# class AuthenticatedKeyBase(FlexiKey):
#     STORAGE = KeyBlobStorage.REPO
# 
#     # It's only authenticated, not encrypted.
#     logically_encrypted = False
# 
#     def load(self, target, passphrase):
#         success = super().load(target, passphrase)
#         self.logically_encrypted = False
#         return success
# 
#     def save(self, target, passphrase, create=False):
#         super().save(target, passphrase, create=create)
#         self.logically_encrypted = False
# 
#     def init_ciphers(self, manifest_data=None):
#         if manifest_data is not None:
#             self.assert_type(manifest_data[0])

## src/borg/archiver.py
## !!! Use after free in do_benchmark_cpu():
## `key_256*4` does not outlive `AES256_CTR_BLAKE2b()`
egrep -B60 'AES256_CTR' src/borg/archiver.py | sed -r 's/^/# /'
#             fmt = '%s-%-10s %9.2f MB/s (%d * %s %s files: %.2fs)'
#             print(fmt % ('C', msg, total_size_MB / dt_create, count, file_size_formatted, content, dt_create))
#             print(fmt % ('R', msg, total_size_MB / dt_extract, count, file_size_formatted, content, dt_extract))
#             print(fmt % ('U', msg, total_size_MB / dt_update, count, file_size_formatted, content, dt_update))
#             print(fmt % ('D', msg, total_size_MB / dt_delete, count, file_size_formatted, content, dt_delete))
# 
#         return 0
# 
#     def do_benchmark_cpu(self, args):
#         """Benchmark CPU bound operations."""
#         from timeit import timeit
#         random_10M = os.urandom(10*1000*1000)
#         key_256 = os.urandom(32)
#         key_128 = os.urandom(16)
#         key_96 = os.urandom(12)
# 
#         import io
#         from borg.chunker import get_chunker
#         print("Chunkers =======================================================")
#         size = "1GB"
# 
#         def chunkit(chunker_name, *args, **kwargs):
#             with io.BytesIO(random_10M) as data_file:
#                 ch = get_chunker(chunker_name, *args, **kwargs)
#                 for _ in ch.chunkify(fd=data_file):
#                     pass
# 
#         for spec, func in [
#             ("buzhash,19,23,21,4095", lambda: chunkit("buzhash", 19, 23, 21, 4095, seed=0)),
#             ("fixed,1048576", lambda: chunkit("fixed", 1048576, sparse=False)),
#         ]:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         import zlib
#         from borg.checksums import crc32, deflate_crc32, xxh64
#         print("Non-cryptographic checksums / hashes ===========================")
#         size = "1GB"
#         tests = [
#             ("xxh64", lambda: xxh64(random_10M)),
#         ]
#         if crc32 is zlib.crc32:
#             tests.insert(0, ("crc32 (zlib, used)", lambda: crc32(random_10M)))
#             tests.insert(1, ("crc32 (libdeflate)", lambda: deflate_crc32(random_10M)))
#         elif crc32 is deflate_crc32:
#             tests.insert(0, ("crc32 (libdeflate, used)", lambda: crc32(random_10M)))
#             tests.insert(1, ("crc32 (zlib)", lambda: zlib.crc32(random_10M)))
#         else:
#             raise Error("crc32 benchmarking code missing")
#         for spec, func in tests:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         from borg.crypto.low_level import hmac_sha256, blake2b_256
#         print("Cryptographic hashes / MACs ====================================")
#         size = "1GB"
#         for spec, func in [
#             ("hmac-sha256", lambda: hmac_sha256(key_256, random_10M)),
#             ("blake2b-256", lambda: blake2b_256(key_256, random_10M)),
#         ]:
#             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
# 
#         from borg.crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
#         from borg.crypto.low_level import AES256_OCB, CHACHA20_POLY1305
#         from borg.crypto.low_level import is_libressl
#         print("Encryption =====================================================")
#         size = "1GB"
# 
#         tests = [
#             ("aes-256-ctr-hmac-sha256", lambda: AES256_CTR_HMAC_SHA256(
#                 key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(random_10M, header=b'X')),
#             ("aes-256-ctr-blake2b", lambda: AES256_CTR_BLAKE2b(
```

</details>