### PR TITLE
avoid losing the key (old crypto)

### DIFF
--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -191,7 +191,7 @@ cdef class AES256_CTR_BASE:
     # Layout: HEADER + MAC 32 + IV 8 + CT (same as attic / borg < 1.2 IF HEADER = TYPE_BYTE, no AAD)
 
     cdef EVP_CIPHER_CTX *ctx
-    cdef unsigned char *enc_key
+    cdef unsigned char enc_key[32]
     cdef int cipher_blk_len
     cdef int iv_len, iv_len_short
     cdef int aad_offset
@@ -340,8 +340,7 @@ cdef class AES256_CTR_BASE:
         if isinstance(iv, int):
             iv = iv.to_bytes(self.iv_len, byteorder='big')
         assert isinstance(iv, bytes) and len(iv) == self.iv_len
-        for i in range(self.iv_len):
-            self.iv[i] = iv[i]
+        self.iv = iv
         self.blocks = 0  # how many AES blocks got encrypted with this IV?
 
     def next_iv(self):
@@ -366,7 +365,7 @@ cdef class AES256_CTR_BASE:
 
 cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
     cdef HMAC_CTX *hmac_ctx
-    cdef unsigned char *mac_key
+    cdef unsigned char mac_key[32]
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
         assert isinstance(mac_key, bytes) and len(mac_key) == 32
@@ -400,7 +399,7 @@ cdef class AES256_CTR_HMAC_SHA256(AES256_CTR_BASE):
 
 
 cdef class AES256_CTR_BLAKE2b(AES256_CTR_BASE):
-    cdef unsigned char *mac_key
+    cdef unsigned char mac_key[128]
 
     def __init__(self, mac_key, enc_key, iv=None, header_len=1, aad_offset=1):
         assert isinstance(mac_key, bytes) and len(mac_key) == 128
@@ -436,7 +435,7 @@ cdef class AES:
     """A thin wrapper around the OpenSSL EVP cipher API - for legacy code, like key file encryption"""
     cdef CIPHER cipher
     cdef EVP_CIPHER_CTX *ctx
-    cdef unsigned char *enc_key
+    cdef unsigned char enc_key[32]
     cdef int cipher_blk_len
     cdef int iv_len
     cdef unsigned char iv[16]
@@ -524,8 +523,7 @@ cdef class AES:
         if isinstance(iv, int):
             iv = iv.to_bytes(self.iv_len, byteorder='big')
         assert isinstance(iv, bytes) and len(iv) == self.iv_len
-        for i in range(self.iv_len):
-            self.iv[i] = iv[i]
+        self.iv = iv
         self.blocks = 0  # number of cipher blocks encrypted with this IV
 
     def next_iv(self):


### PR DESCRIPTION
if we just have a pointer to a bytes object which might go out of scope, we can lose it.

also: cython can directly assign a bytes object into a same-size char array.
