### PR TITLE
bugfix: correctly give manifest id

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -18,6 +18,7 @@ from ..helpers import get_limited_unpacker
 from ..helpers import bin_to_hex
 from ..helpers.passphrase import Passphrase, PasswordRetriesExceeded, PassphraseWrong
 from ..helpers import msgpack
+from ..helpers.manifest import Manifest
 from ..item import Key, EncryptedKey
 from ..platform import SaveFile
 
@@ -165,7 +166,7 @@ class KeyBase:
         pass
 
     def assert_id(self, id, data):
-        if id:
+        if id and id != Manifest.MANIFEST_ID:
             id_computed = self.id_hash(data)
             if not hmac.compare_digest(id_computed, id):
                 raise IntegrityError('Chunk %s: id verification failed' % bin_to_hex(id))

--- a/src/borg/helpers/manifest.py
+++ b/src/borg/helpers/manifest.py
@@ -186,7 +186,7 @@ class Manifest:
         if not key:
             key = key_factory(repository, cdata)
         manifest = cls(key, repository)
-        data = key.decrypt(None, cdata)
+        data = key.decrypt(cls.MANIFEST_ID, cdata)
         manifest_dict, manifest.tam_verified = key.unpack_and_verify_manifest(data, force_tam_not_required=force_tam_not_required)
         m = ManifestItem(internal_dict=manifest_dict)
         manifest.id = key.id_hash(data)


### PR DESCRIPTION
but do not verify chunk-id for it (does not match because the ID is fixed at all-zero).
