### PR TITLE
add pyproject.toml, fix sys.path, fixes #6466

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "pkgconfig", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     cythonize = None
 
+sys.path += [os.path.dirname(__file__)]
 import setup_checksums
 import setup_compress
 import setup_crypto


### PR DESCRIPTION
Using pyproject.toml, we can avoid people running into issues when they did not install pkgconfig and cython first.

Also:

setup.py: add parent to sys.path
When using pyproject.toml the parent of setup.py is not on sys.path by default.
See <pypa/setuptools#3134>.
