### PR TITLE
Argon2 fourth part: borg benchmark cpu: use ARGON2_ARGS

### DIFF
--- a/src/borg/__init__.py
+++ b/src/borg/__init__.py
@@ -1,7 +1,5 @@
 from packaging.version import parse as parse_version
 
-# IMPORTANT keep imports from borg here to a minimum because our testsuite depends on
-# being able to import borg.constants and then monkey patching borg.constants.PBKDF2_ITERATIONS
 from ._version import version as __version__
 
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -626,7 +626,7 @@ class Archiver:
         count = 5
         for spec, func in [
             ("pbkdf2", lambda: Passphrase('mypassphrase').kdf(b'salt'*8, PBKDF2_ITERATIONS, 32)),
-            ("argon2", lambda: Passphrase('mypassphrase').argon2(32, b'salt'*8, 3, 65536, 1, 'id')),
+            ("argon2", lambda: Passphrase('mypassphrase').argon2(64, b'S' * ARGON2_SALT_BYTES, **ARGON2_ARGS)),
         ]:
             print(f"{spec:<24} {count:<10} {timeit(func, number=count):.3f}s")
 


### PR DESCRIPTION
I have updated the cpu benchmark to use the same argon2 configuration as we use normally.

After this is merged I'll work on the last PR of #747 - the changelog and documentation updates