### PR TITLE
load_key: no key is same as empty key, fixes #6441

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -617,11 +617,11 @@ class FlexiKey:
             raise KeyfileNotFoundError(self.repository._location.canonical_path(), get_keys_dir())
         elif self.STORAGE == KeyBlobStorage.REPO:
             loc = self.repository._location.canonical_path()
-            try:
-                self.repository.load_key()
-                return loc
-            except configparser.NoOptionError:
+            key = self.repository.load_key()
+            if not key:
+                # if we got an empty key, it means there is no key.
                 raise RepoKeyNotFoundError(loc) from None
+            return loc
         else:
             raise TypeError('Unsupported borg key storage type')
 
@@ -681,6 +681,10 @@ class FlexiKey:
             # what we get in target is just a repo location, but we already have the repo obj:
             target = self.repository
             key_data = target.load_key()
+            if not key_data:
+                # if we got an empty key, it means there is no key.
+                loc = target._location.canonical_path()
+                raise RepoKeyNotFoundError(loc) from None
             key_data = key_data.decode('utf-8')  # remote repo: msgpack issue #99, getting bytes
         else:
             raise TypeError('Unsupported borg key storage type')

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -343,7 +343,7 @@ class Repository:
         self.save_config(self.path, self.config)
 
     def load_key(self):
-        keydata = self.config.get('repository', 'key')
+        keydata = self.config.get('repository', 'key', fallback='').strip()
         # note: if we return an empty string, it means there is no repo key
         return keydata.encode('utf-8')  # remote repo: msgpack issue #99, returning bytes
 


### PR DESCRIPTION
when migrating from repokey to keyfile, we just store an empty key into the repo config,
because we do not have a "delete key" RPC api. thus, empty key means "there is no key".

here we fix load_key, so that it does not behave differently for no key and empty key:
in both cases, it just returns an empty value.

additionally, we strip the value we get from the config, so whitespace does not matter.

All callers now check for the repokey not being empty, otherwise RepoKeyNotFoundError
is raised.
