### PR TITLE
docs: borg compact --cleanup-commits also runs a normal compaction

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3424,7 +3424,8 @@ class Archiver:
 
         After upgrading borg (server) to 1.2+, you can use ``borg compact --cleanup-commits``
         to clean up the numerous 17byte commit-only segments that borg 1.1 did not clean up
-        due to a bug. It is enough to do that once per repository.
+        due to a bug. It is enough to do that once per repository. After cleaning up the
+        commits, borg will also do a normal compaction.
 
         See :ref:`separate_compaction` in Additional Notes for more details.
         """)


### PR DESCRIPTION
fixes #6324
