### PR TITLE
setup.cfg: setup_requires setuptools_scm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ packages = find:
 package_dir =
     =src
 python_requires = >=3.9
+setup_requires =
+   setuptools_scm[toml] >= 6.2
 install_requires =
   msgpack >=1.0.3, <=1.0.3
   packaging


### PR DESCRIPTION
readthedocs.org uses python setup.py install (not pip install).

fixes #6598.
