### PR TITLE
setuptools_scm: also require it via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "pkgconfig", "Cython"]
+requires = ["setuptools", "pkgconfig", "Cython", "setuptools_scm>=1.7"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
we have this in setup_requires in setup.py, but i also added it to
pyproject.toml - so we can be sure it is installed no matter what.

**configuration** of setuptools_scm is done the old way in setup.py
here in 1.2-maint, in master we have switched that over to pyproject.toml.
