### PR TITLE
export-tar --tar-format=BORG_C / import-tar: support chunked tar content

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -942,7 +942,7 @@ class LocalCache(CacheStatsMixin):
     def add_chunk(self, id, chunk, stats, overwrite=False, wait=True):
         if not self.txn_active:
             self.begin_txn()
-        size = len(chunk)
+        size = len(chunk) if chunk is not None else None
         refcount = self.seen_chunk(id, size)
         if refcount and not overwrite:
             return self.chunk_incref(id, stats)


### PR DESCRIPTION
while the BORG format uses a full, raw content byte stream,
the BORG_C format uses a sequence of chunk packs.

each pack is:
- 32bit size (signed)
- 256bit chunk id
- SIZE bytes data (optional, only present if size != -1)

for simplicity, a pack is generated for each entry in item.chunks,
but only still missing chunks have data.

packs with no data (size == -1) must already exist in the target repository.

for simplicity / for now:
- export-tar decrypts and decompresses, but chunks and chunk ids are kept
- import-tar does not recompute chunk ids, accepts missing chunks "as is"
  (but recompresses / re-encrypts) and increfs already present chunks.
- no preload via archive.iter_items for chunked mode
- have_chunks is initialised to the empty set, thus only inner duplication
  in the exported archive is considered.
