### PR TITLE
fix key.decrypt calls

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1703,9 +1703,8 @@ class ArchiveChecker:
                         chunk_ids = list(reversed(chunk_ids_revd))
                         chunk_data_iter = self.repository.get_many(chunk_ids)
                 else:
-                    _chunk_id = None if chunk_id == Manifest.MANIFEST_ID else chunk_id
                     try:
-                        self.key.decrypt(_chunk_id, encrypted_data)
+                        self.key.decrypt(chunk_id, encrypted_data)
                     except IntegrityErrorBase as integrity_error:
                         self.error_found = True
                         errors += 1
@@ -1733,8 +1732,7 @@ class ArchiveChecker:
                     # from the underlying media.
                     try:
                         encrypted_data = self.repository.get(defect_chunk)
-                        _chunk_id = None if defect_chunk == Manifest.MANIFEST_ID else defect_chunk
-                        self.key.decrypt(_chunk_id, encrypted_data)
+                        self.key.decrypt(defect_chunk, encrypted_data)
                     except IntegrityErrorBase:
                         # failed twice -> get rid of this chunk
                         del self.chunks[defect_chunk]
@@ -2189,7 +2187,7 @@ class ArchiveRecreater:
         overwrite = self.recompress
         if self.recompress and not self.always_recompress and chunk_id in self.cache.chunks:
             # Check if this chunk is already compressed the way we want it
-            old_chunk = self.key.decrypt(None, self.repository.get(chunk_id), decompress=False)
+            old_chunk = self.key.decrypt(chunk_id, self.repository.get(chunk_id), decompress=False)
             if Compressor.detect(old_chunk).name == self.key.compressor.decide(data).name:
                 # Stored chunk has the same compression we wanted
                 overwrite = False

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2254,7 +2254,7 @@ class Archiver:
     def do_debug_dump_manifest(self, args, repository, manifest, key):
         """dump decoded repository manifest"""
 
-        data = key.decrypt(None, repository.get(manifest.MANIFEST_ID))
+        data = key.decrypt(manifest.MANIFEST_ID, repository.get(manifest.MANIFEST_ID))
 
         meta = prepare_dump_dict(msgpack.unpackb(data, object_hook=StableDict))
 
@@ -2269,8 +2269,7 @@ class Archiver:
 
         def decrypt_dump(i, id, cdata, tag=None, segment=None, offset=None):
             if cdata is not None:
-                give_id = id if id != Manifest.MANIFEST_ID else None
-                data = key.decrypt(give_id, cdata)
+                data = key.decrypt(id, cdata)
             else:
                 data = b''
             tag_str = '' if tag is None else '_' + tag
@@ -2360,8 +2359,7 @@ class Archiver:
             marker = result[-1]
             for id in result:
                 cdata = repository.get(id)
-                give_id = id if id != Manifest.MANIFEST_ID else None
-                data = key.decrypt(give_id, cdata)
+                data = key.decrypt(id, cdata)
 
                 # try to locate wanted sequence crossing the border of last_data and data
                 boundary_data = last_data[-(len(wanted) - 1):] + data[:len(wanted) - 1]

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3974,7 +3974,7 @@ class ManifestAuthenticationTest(ArchiverTestCaseBase):
             key.tam_required = False
             key.change_passphrase(key._passphrase)
 
-            manifest = msgpack.unpackb(key.decrypt(None, repository.get(Manifest.MANIFEST_ID)))
+            manifest = msgpack.unpackb(key.decrypt(Manifest.MANIFEST_ID, repository.get(Manifest.MANIFEST_ID)))
             del manifest[b'tam']
             repository.put(Manifest.MANIFEST_ID, key.encrypt(Manifest.MANIFEST_ID, msgpack.packb(manifest)))
             repository.commit(compact=False)


### PR DESCRIPTION
the id must now always be given correctly because
the AEAD crypto modes authenticate the chunk id.

the special case when id == MANIFEST_ID is now handled
inside assert_id, so we never need to give a None id.
