### PR TITLE
check that borg does not require pytest for normal usage, fixes #6563

### DIFF
--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -1,3 +1,6 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 """
 Self testing module
 ===================
@@ -12,6 +15,7 @@ To assert that self test discovery works correctly the number of tests is kept i
 variable. SELFTEST_COUNT must be updated if new tests are added or removed to or from any of the tests
 used here.
 """
+
 import os
 import sys
 import time
@@ -62,6 +66,10 @@ def selftest(logger):
     result = SelfTestResult()
     test_suite = TestSuite()
     for test_case in SELFTEST_CASES:
+        module = sys.modules[test_case.__module__]
+        # a normal borg user does not have pytest installed, we must not require it in the test modules used here.
+        # note: this only detects the usual toplevel import
+        assert 'pytest' not in dir(module), "pytest must not be imported in %s" % module.__name__
         test_suite.addTest(defaultTestLoader.loadTestsFromTestCase(test_case))
     test_suite.run(result)
     result.log_results(logger)

--- a/src/borg/testsuite/chunker.py
+++ b/src/borg/testsuite/chunker.py
@@ -1,11 +1,11 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 from io import BytesIO
 
 from ..chunker import ChunkerFixed, Chunker, get_chunker, buzhash, buzhash_update
 from ..constants import *  # NOQA
 from . import BaseTestCase
-
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
 
 
 def cf(chunks):

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -1,7 +1,9 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 from binascii import hexlify
 from unittest.mock import MagicMock
 import unittest
-
 
 from ..crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_OCB, CHACHA20_POLY1305, UNENCRYPTED, IntegrityError
 from ..crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes
@@ -11,9 +13,6 @@ from ..crypto.key import KeyfileKey, RepoKey, FlexiKey
 from ..helpers import msgpack
 
 from . import BaseTestCase
-
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
 
 
 class CryptoTestCase(BaseTestCase):

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -1,3 +1,6 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 import base64
 import hashlib
 import io
@@ -9,9 +12,6 @@ from ..hashindex import NSIndex, ChunkIndex, ChunkIndexEntry
 from .. import hashindex
 from ..crypto.file_integrity import IntegrityCheckedFile, FileIntegrityError
 from . import BaseTestCase, unopened_tempfile
-
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
 
 
 def H(x):


### PR DESCRIPTION
also: move the note about this to the very top of the affected modules.
