### PR TITLE
Backport check that borg does not require pytest for normal usage (#6670, 1.1)

### DIFF
--- a/src/borg/selftest.py
+++ b/src/borg/selftest.py
@@ -1,3 +1,6 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 """
 Self testing module
 ===================
@@ -12,6 +15,7 @@ To assert that self test discovery works correctly the number of tests is kept i
 variable. SELFTEST_COUNT must be updated if new tests are added or removed to or from any of the tests
 used here.
 """
+
 import os
 import sys
 import time
@@ -62,6 +66,10 @@ def selftest(logger):
     result = SelfTestResult()
     test_suite = TestSuite()
     for test_case in SELFTEST_CASES:
+        module = sys.modules[test_case.__module__]
+        # a normal borg user does not have pytest installed, we must not require it in the test modules used here.
+        # note: this only detects the usual toplevel import
+        assert 'pytest' not in dir(module), "pytest must not be imported in %s" % module.__name__
         test_suite.addTest(defaultTestLoader.loadTestsFromTestCase(test_case))
     test_suite.run(result)
     result.log_results(logger)

--- a/src/borg/testsuite/chunker.py
+++ b/src/borg/testsuite/chunker.py
@@ -1,11 +1,11 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 from io import BytesIO
 
 from ..chunker import Chunker, buzhash, buzhash_update
 from ..constants import *  # NOQA
 from . import BaseTestCase
-
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
 
 
 class ChunkerTestCase(BaseTestCase):

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -5,9 +5,6 @@ from ..crypto.low_level import increment_iv, bytes16_to_int, int_to_bytes16
 from ..crypto.low_level import hkdf_hmac_sha512
 from . import BaseTestCase
 
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
-
 
 class CryptoTestCase(BaseTestCase):
 

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -1,3 +1,6 @@
+# Note: these tests are part of the self test, do not use or import pytest functionality here.
+#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
+
 import base64
 import hashlib
 import io
@@ -9,9 +12,6 @@ from ..hashindex import NSIndex, ChunkIndex, ChunkIndexEntry
 from .. import hashindex
 from ..crypto.file_integrity import IntegrityCheckedFile, FileIntegrityError
 from . import BaseTestCase
-
-# Note: these tests are part of the self test, do not use or import py.test functionality here.
-#       See borg.selftest for details. If you add/remove test methods, update SELFTEST_COUNT
 
 
 def H(x):


### PR DESCRIPTION
Backport of #6670 to 1.1-maint