### PR TITLE
fix create_filter_process exception handler, fixes #6681

### DIFF
--- a/src/borg/helpers/process.py
+++ b/src/borg/helpers/process.py
@@ -332,7 +332,8 @@ def create_filter_process(cmd, stream, stream_close, inbound=True):
     except Exception:
         # something went wrong with processing the stream by borg
         logger.debug('Exception, killing the filter...')
-        proc.kill()
+        if cmd:
+            proc.kill()
         borg_succeeded = False
         raise
     else:


### PR DESCRIPTION
if cmd was falsy (e.g. None), there is no proc.
then, if "yield stream" raises an exception, the exception handler crashed at "proc.kill()".
