### PR TITLE
make constants for files cache mode more clear

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3799,8 +3799,8 @@ class Archiver:
         fs_group.add_argument('--sparse', dest='sparse', action='store_true',
                                help='detect sparse holes in input (supported only by fixed chunker)')
         fs_group.add_argument('--files-cache', metavar='MODE', dest='files_cache_mode', action=Highlander,
-                              type=FilesCacheMode, default=DEFAULT_FILES_CACHE_MODE_UI,
-                              help='operate files cache in MODE. default: %s' % DEFAULT_FILES_CACHE_MODE_UI)
+                              type=FilesCacheMode, default=FILES_CACHE_MODE_UI_DEFAULT,
+                              help='operate files cache in MODE. default: %s' % FILES_CACHE_MODE_UI_DEFAULT)
         fs_group.add_argument('--read-special', dest='read_special', action='store_true',
                               help='open and read block and char device files as well as FIFOs as if they were '
                                    'regular files. Also follows symlinks pointing to these kinds of files.')

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -196,7 +196,7 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
                 if cache:
                     with Cache(repository, kwargs['key'], kwargs['manifest'],
                                progress=getattr(args, 'progress', False), lock_wait=self.lock_wait,
-                               cache_mode=getattr(args, 'files_cache_mode', DEFAULT_FILES_CACHE_MODE),
+                               cache_mode=getattr(args, 'files_cache_mode', FILES_CACHE_MODE_DISABLED),
                                consider_part_files=getattr(args, 'consider_part_files', False),
                                iec=getattr(args, 'iec', False)) as cache_:
                         return method(self, args, repository=repository, cache=cache_, **kwargs)
@@ -240,7 +240,7 @@ def with_other_repository(manifest=False, key=False, cache=False, compatibility=
                 if cache:
                     with Cache(repository, key_, manifest_,
                                progress=False, lock_wait=self.lock_wait,
-                               cache_mode=getattr(args, 'files_cache_mode', DEFAULT_FILES_CACHE_MODE),
+                               cache_mode=getattr(args, 'files_cache_mode', FILES_CACHE_MODE_DISABLED),
                                consider_part_files=getattr(args, 'consider_part_files', False),
                                iec=getattr(args, 'iec', False)) as cache_:
                         kwargs['other_cache'] = cache_

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -13,7 +13,7 @@ logger = create_logger()
 
 files_cache_logger = create_logger('borg.debug.files_cache')
 
-from .constants import CACHE_README, DEFAULT_FILES_CACHE_MODE
+from .constants import CACHE_README, FILES_CACHE_MODE_DISABLED
 from .hashindex import ChunkIndex, ChunkIndexEntry, CacheSynchronizer
 from .helpers import Location
 from .helpers import Error
@@ -371,7 +371,7 @@ class Cache:
             shutil.rmtree(path)
 
     def __new__(cls, repository, key, manifest, path=None, sync=True, warn_if_unencrypted=True,
-                progress=False, lock_wait=None, permit_adhoc_cache=False, cache_mode=DEFAULT_FILES_CACHE_MODE,
+                progress=False, lock_wait=None, permit_adhoc_cache=False, cache_mode=FILES_CACHE_MODE_DISABLED,
                 consider_part_files=False, iec=False):
 
         def local():
@@ -457,7 +457,7 @@ class LocalCache(CacheStatsMixin):
     """
 
     def __init__(self, repository, key, manifest, path=None, sync=True, warn_if_unencrypted=True,
-                 progress=False, lock_wait=None, cache_mode=DEFAULT_FILES_CACHE_MODE, consider_part_files=False,
+                 progress=False, lock_wait=None, cache_mode=FILES_CACHE_MODE_DISABLED, consider_part_files=False,
                  iec=False):
         """
         :param warn_if_unencrypted: print warning if accessing unknown unencrypted repository

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -85,7 +85,7 @@ CH_DATA, CH_ALLOC, CH_HOLE = 0, 1, 2
 
 # operating mode of the files cache (for fast skipping of unchanged files)
 DEFAULT_FILES_CACHE_MODE_UI = 'ctime,size,inode'  # default for "borg create" command (CLI UI)
-DEFAULT_FILES_CACHE_MODE = 'd'  # most borg commands do not use the files cache at all (disable)
+FILES_CACHE_MODE_DISABLED = 'd'  # most borg commands do not use the files cache at all (disable)
 
 # return codes returned by borg command
 # when borg is killed by signal N, rc = 128 + N

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -84,7 +84,7 @@ ITEMS_CHUNKER_PARAMS = (CH_BUZHASH, 15, 19, 17, HASH_WINDOW_SIZE)
 CH_DATA, CH_ALLOC, CH_HOLE = 0, 1, 2
 
 # operating mode of the files cache (for fast skipping of unchanged files)
-DEFAULT_FILES_CACHE_MODE_UI = 'ctime,size,inode'  # default for "borg create" command (CLI UI)
+FILES_CACHE_MODE_UI_DEFAULT = 'ctime,size,inode'  # default for "borg create" command (CLI UI)
 FILES_CACHE_MODE_DISABLED = 'd'  # most borg commands do not use the files cache at all (disable)
 
 # return codes returned by borg command


### PR DESCRIPTION
Traditionally, DEFAULT_FILES_CACHE_MODE_UI and DEFAULT_FILES_CACHE_MODE
were - as the naming scheme implies - the same setting, one being the UI
representation as given to the --files-cache command line option and the
other being the same default value in the internal representation.

It happended that the actual value used in borg create always comes from
DEFAULT_FILES_CACHE_MODE_UI (because that does have the --files-cache
option) whereas for all other commands (that do not use the files cache) it
comes from DEFAULT_FILES_CACHE_MODE.

PR #5777 then abused this fact to implement the optimisation to skip loading
of the files cache in those other commands by changing the value of
DEFAULT_FILES_CACHE_MODE to disabled.
This however also changes the meaning of that variable and thus redesignates
it to something not matching the original naming anymore.

Anyone not aware of this change and the intention behind it looking at the
code would have a hard time figuring this out and be easily mislead.

This does away with the confusion making the code more maintainable by
renaming DEFAULT_FILES_CACHE_MODE to FILES_CACHE_MODE_DISABLED, making the
new intention of that internal default clear.

Thank you for contributing code to Borg, your help is appreciated!

Please, before you submit a pull request, make sure it complies with the
guidelines given in our documentation:

https://borgbackup.readthedocs.io/en/latest/development.html#contributions

**Please remove all above text before submitting your pull request.**
