### PR TITLE
Use relative imports

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -622,7 +622,7 @@ class Archiver:
         key_96 = os.urandom(12)
 
         import io
-        from borg.chunker import get_chunker
+        from .chunker import get_chunker
         print("Chunkers =======================================================")
         size = "1GB"
 
@@ -639,7 +639,7 @@ class Archiver:
             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
 
         import zlib
-        from borg.checksums import crc32, deflate_crc32, xxh64
+        from .checksums import crc32, deflate_crc32, xxh64
         print("Non-cryptographic checksums / hashes ===========================")
         size = "1GB"
         tests = [
@@ -656,7 +656,7 @@ class Archiver:
         for spec, func in tests:
             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
 
-        from borg.crypto.low_level import hmac_sha256, blake2b_256
+        from .crypto.low_level import hmac_sha256, blake2b_256
         print("Cryptographic hashes / MACs ====================================")
         size = "1GB"
         for spec, func in [
@@ -665,8 +665,8 @@ class Archiver:
         ]:
             print(f"{spec:<24} {size:<10} {timeit(func, number=100):.3f}s")
 
-        from borg.crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
-        from borg.crypto.low_level import AES256_OCB, CHACHA20_POLY1305
+        from .crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
+        from .crypto.low_level import AES256_OCB, CHACHA20_POLY1305
         print("Encryption =====================================================")
         size = "1GB"
 
@@ -691,7 +691,7 @@ class Archiver:
         ]:
             print(f"{spec:<24} {count:<10} {timeit(func, number=count):.3f}s")
 
-        from borg.compress import CompressionSpec
+        from .compress import CompressionSpec
         print("Compression ====================================================")
         for spec in [
             'lz4',

--- a/src/borg/helpers/checks.py
+++ b/src/borg/helpers/checks.py
@@ -23,15 +23,14 @@ class ExtensionModuleError(Error):
 
 
 def check_extension_modules():
-    import borg.crypto.low_level
-    from .. import platform, compress, item, chunker, hashindex
+    from .. import platform, compress, crypto, item, chunker, hashindex
     if hashindex.API_VERSION != '1.2_01':
         raise ExtensionModuleError
     if chunker.API_VERSION != '1.2_01':
         raise ExtensionModuleError
     if compress.API_VERSION != '1.2_02':
         raise ExtensionModuleError
-    if borg.crypto.low_level.API_VERSION != '1.3_01':
+    if crypto.low_level.API_VERSION != '1.3_01':
         raise ExtensionModuleError
     if item.API_VERSION != '1.2_01':
         raise ExtensionModuleError

--- a/src/borg/helpers/errors.py
+++ b/src/borg/helpers/errors.py
@@ -1,6 +1,6 @@
 from ..constants import *  # NOQA
 
-import borg.crypto.low_level
+from ..crypto.low_level import IntegrityError as IntegrityErrorBase
 
 
 class Error(Exception):
@@ -30,7 +30,7 @@ class ErrorWithTraceback(Error):
     traceback = True
 
 
-class IntegrityError(ErrorWithTraceback, borg.crypto.low_level.IntegrityError):
+class IntegrityError(ErrorWithTraceback, IntegrityErrorBase):
     """Data integrity error: {}"""
 
 

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -4,9 +4,9 @@ import socket
 import tempfile
 import uuid
 
-from borg.constants import UMASK_DEFAULT
-from borg.helpers import safe_unlink
-from borg.platformflags import is_win32
+from ..constants import UMASK_DEFAULT
+from ..helpers import safe_unlink
+from ..platformflags import is_win32
 
 """
 platform base module

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -245,7 +245,7 @@ class TestLocationWithoutEnv:
             Location('ssh://user@host:/path')
 
     def test_omit_archive(self):
-        from borg.platform import hostname
+        from ..platform import hostname
         loc = Location('ssh://user@host:1234/repos/{hostname}::archive')
         loc_without_archive = loc.omit_archive()
         assert loc_without_archive.archive is None
@@ -264,7 +264,7 @@ class TestLocationWithEnv:
                "Location(proto='ssh', user='user', host='host', port=1234, path='/some/path', archive=None)"
 
     def test_ssh_placeholder(self, monkeypatch):
-        from borg.platform import hostname
+        from ..platform import hostname
         monkeypatch.setenv('BORG_REPO', 'ssh://user@host:1234/{hostname}')
         assert repr(Location('::archive')) == \
             f"Location(proto='ssh', user='user', host='host', port=1234, path='/{hostname}', archive='archive')"


### PR DESCRIPTION
Make unnecessary absolute imports relative instead, both to make code style more consistent and reduce the code parts a potential future module rename, e.g. for a breaking borg2, would have to touch.