### PR TITLE
[DOCS] Remove unnecessary/dangerous line continuation

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -189,7 +189,7 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
         /etc                            \
         /home                           \
         /root                           \
-        /var                            \
+        /var
 
     backup_exit=$?
 
@@ -206,7 +206,7 @@ backed up and that the ``prune`` command is keeping and deleting the correct bac
         --show-rc                       \
         --keep-daily    7               \
         --keep-weekly   4               \
-        --keep-monthly  6               \
+        --keep-monthly  6
 
     prune_exit=$?
 


### PR DESCRIPTION
The line continuation is unnecessary for the last line of the command.
It could even be dangerous if a user modifies the script and puts something in the line directly below the command, not realizing that it will be mashed together with the previous command.