### PR TITLE
borg2: there is no csize

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -269,12 +269,8 @@ stats
         Number of unique chunks
     total_size
         Total uncompressed size of all chunks multiplied with their reference counts
-    total_csize
-        Total compressed and encrypted size of all chunks multiplied with their reference counts
     unique_size
         Uncompressed size of all chunks
-    unique_csize
-        Compressed and encrypted size of all chunks
 
 .. highlight: json
 
@@ -285,10 +281,8 @@ Example *borg info* output::
             "path": "/home/user/.cache/borg/0cbe6166b46627fd26b97f8831e2ca97584280a46714ef84d2b668daf8271a23",
             "stats": {
                 "total_chunks": 511533,
-                "total_csize": 17948017540,
                 "total_size": 22635749792,
                 "total_unique_chunks": 54892,
-                "unique_csize": 1920405405,
                 "unique_size": 2449675468
             }
         },
@@ -424,10 +418,8 @@ The same archive with more information (``borg info --last 1 --json``)::
             "path": "/home/user/.cache/borg/0cbe6166b46627fd26b97f8831e2ca97584280a46714ef84d2b668daf8271a23",
             "stats": {
                 "total_chunks": 511533,
-                "total_csize": 17948017540,
                 "total_size": 22635749792,
                 "total_unique_chunks": 54892,
-                "unique_csize": 1920405405,
                 "unique_size": 2449675468
             }
         },
@@ -495,26 +487,26 @@ added:
 
 removed:
     See **added** property.
-    
+
 old_mode:
     If **type** == '*mode*', then **old_mode** and **new_mode** provide the mode and permissions changes.
 
 new_mode:
     See **old_mode** property.
- 
+
 old_user:
     If **type** == '*owner*', then **old_user**, **new_user**, **old_group** and **new_group** provide the user
     and group ownership changes.
 
 old_group:
     See **old_user** property.
- 
+
 new_user:
     See **old_user** property.
- 
+
 new_group:
     See **old_user** property.
-    
+
 
 Example (excerpt) of ``borg diff --json-lines``::
 

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -58,60 +58,46 @@ class Statistics:
     def __init__(self, output_json=False, iec=False):
         self.output_json = output_json
         self.iec = iec
-        self.osize = self.csize = self.usize = self.nfiles = 0
-        self.osize_parts = self.csize_parts = self.usize_parts = self.nfiles_parts = 0
+        self.osize = self.nfiles = 0
+        self.osize_parts = self.nfiles_parts = 0
         self.last_progress = 0  # timestamp when last progress was shown
 
-    def update(self, size, csize, unique, part=False):
+    def update(self, size, part=False):
         if not part:
             self.osize += size
-            self.csize += csize
-            if unique:
-                self.usize += csize
         else:
             self.osize_parts += size
-            self.csize_parts += csize
-            if unique:
-                self.usize_parts += csize
 
     def __add__(self, other):
         if not isinstance(other, Statistics):
             raise TypeError('can only add Statistics objects')
         stats = Statistics(self.output_json, self.iec)
         stats.osize = self.osize + other.osize
-        stats.csize = self.csize + other.csize
-        stats.usize = self.usize + other.usize
         stats.nfiles = self.nfiles + other.nfiles
         stats.osize_parts = self.osize_parts + other.osize_parts
-        stats.csize_parts = self.csize_parts + other.csize_parts
-        stats.usize_parts = self.usize_parts + other.usize_parts
         stats.nfiles_parts = self.nfiles_parts + other.nfiles_parts
         return stats
 
-    summary = "{label:15} {stats.osize_fmt:>20s} {stats.csize_fmt:>20s} {stats.usize_fmt:>20s}"
+    summary = "{label:15} {stats.osize_fmt:>20s}"
 
     def __str__(self):
         return self.summary.format(stats=self, label='This archive:')
 
     def __repr__(self):
-        return "<{cls} object at {hash:#x} ({self.osize}, {self.csize}, {self.usize})>".format(
+        return "<{cls} object at {hash:#x} ({self.osize})>".format(
             cls=type(self).__name__, hash=id(self), self=self)
 
     def as_dict(self):
         return {
             'original_size': FileSize(self.osize, iec=self.iec),
-            'compressed_size': FileSize(self.csize, iec=self.iec),
-            'deduplicated_size': FileSize(self.usize, iec=self.iec),
             'nfiles': self.nfiles,
         }
 
     def as_raw_dict(self):
         return {
             'size': self.osize,
-            'csize': self.csize,
             'nfiles': self.nfiles,
             'size_parts': self.osize_parts,
-            'csize_parts': self.csize_parts,
             'nfiles_parts': self.nfiles_parts,
         }
 
@@ -119,24 +105,14 @@ class Statistics:
     def from_raw_dict(cls, **kw):
         self = cls()
         self.osize = kw['size']
-        self.csize = kw['csize']
         self.nfiles = kw['nfiles']
         self.osize_parts = kw['size_parts']
-        self.csize_parts = kw['csize_parts']
         self.nfiles_parts = kw['nfiles_parts']
         return self
 
     @property
     def osize_fmt(self):
         return format_file_size(self.osize, iec=self.iec)
-
-    @property
-    def usize_fmt(self):
-        return format_file_size(self.usize, iec=self.iec)
-
-    @property
-    def csize_fmt(self):
-        return format_file_size(self.csize, iec=self.iec)
 
     def show_progress(self, item=None, final=False, stream=None, dt=None):
         now = time.monotonic()
@@ -158,7 +134,7 @@ class Statistics:
             else:
                 columns, lines = get_terminal_size()
                 if not final:
-                    msg = '{0.osize_fmt} O {0.csize_fmt} C {0.usize_fmt} D {0.nfiles} N '.format(self)
+                    msg = '{0.osize_fmt} O {0.nfiles} N '.format(self)
                     path = remove_surrogates(item.path) if item else ''
                     space = columns - swidth(msg)
                     if space < 12:
@@ -614,10 +590,8 @@ Utilization of max. archive size: {csize_max:.0%}
         if stats is not None:
             metadata.update({
                 'size': stats.osize,
-                'csize': stats.csize,
                 'nfiles': stats.nfiles,
                 'size_parts': stats.osize_parts,
-                'csize_parts': stats.csize_parts,
                 'nfiles_parts': stats.nfiles_parts})
         metadata.update(additional_metadata or {})
         metadata = ArchiveItem(metadata)
@@ -651,51 +625,12 @@ Utilization of max. archive size: {csize_max:.0%}
         return stats
 
     def _calc_stats(self, cache, want_unique=True):
-        have_borg12_meta = self.metadata.get('nfiles') is not None
-
-        if have_borg12_meta and not want_unique:
-            unique_csize = 0
-        else:
-            def add(id):
-                entry = cache.chunks[id]
-                archive_index.add(id, 1, entry.size, entry.csize)
-
-            archive_index = ChunkIndex()
-            sync = CacheSynchronizer(archive_index)
-            add(self.id)
-            # we must escape any % char in the archive name, because we use it in a format string, see #6500
-            arch_name_escd = self.name.replace('%', '%%')
-            pi = ProgressIndicatorPercent(total=len(self.metadata.items),
-                                          msg='Calculating statistics for archive %s ... %%3.0f%%%%' % arch_name_escd,
-                                          msgid='archive.calc_stats')
-            for id, chunk in zip(self.metadata.items, self.repository.get_many(self.metadata.items)):
-                pi.show(increase=1)
-                add(id)
-                data = self.key.decrypt(id, chunk)
-                sync.feed(data)
-            unique_csize = archive_index.stats_against(cache.chunks)[3]
-            pi.finish()
-
         stats = Statistics(iec=self.iec)
-        stats.usize = unique_csize  # the part files use same chunks as the full file
-        if not have_borg12_meta:
-            if self.consider_part_files:
-                stats.nfiles = sync.num_files_totals
-                stats.osize = sync.size_totals
-                stats.csize = sync.csize_totals
-            else:
-                stats.nfiles = sync.num_files_totals - sync.num_files_parts
-                stats.osize = sync.size_totals - sync.size_parts
-                stats.csize = sync.csize_totals - sync.csize_parts
-        else:
-            if self.consider_part_files:
-                stats.nfiles = self.metadata.nfiles_parts + self.metadata.nfiles
-                stats.osize = self.metadata.size_parts + self.metadata.size
-                stats.csize = self.metadata.csize_parts + self.metadata.csize
-            else:
-                stats.nfiles = self.metadata.nfiles
-                stats.osize = self.metadata.size
-                stats.csize = self.metadata.csize
+        stats.nfiles = self.metadata.nfiles
+        stats.osize = self.metadata.size
+        if self.consider_part_files:
+            stats.nfiles += self.metadata.nfiles_parts
+            stats.osize += self.metadata.size_parts
         return stats
 
     @contextmanager
@@ -986,7 +921,7 @@ Utilization of max. archive size: {csize_max:.0%}
                         item = Item(internal_dict=item)
                         if 'chunks' in item:
                             part = not self.consider_part_files and 'part' in item
-                            for chunk_id, size, csize in item.chunks:
+                            for chunk_id, size, _ in item.chunks:
                                 chunk_decref(chunk_id, stats, part=part)
                 except (TypeError, ValueError):
                     # if items metadata spans multiple chunks and one chunk got dropped somehow,
@@ -1789,15 +1724,15 @@ class ArchiveChecker:
         def add_callback(chunk):
             id_ = self.key.id_hash(chunk)
             cdata = self.key.encrypt(id_, chunk)
-            add_reference(id_, len(chunk), len(cdata), cdata)
+            add_reference(id_, len(chunk), cdata)
             return id_
 
-        def add_reference(id_, size, csize, cdata=None):
+        def add_reference(id_, size, cdata=None):
             try:
                 self.chunks.incref(id_)
             except KeyError:
                 assert cdata is not None
-                self.chunks[id_] = ChunkIndexEntry(refcount=1, size=size, csize=csize)
+                self.chunks[id_] = ChunkIndexEntry(refcount=1, size=size, csize=0)  # was: csize=csize
                 if self.repair:
                     self.repository.put(id_, cdata)
 
@@ -1811,8 +1746,7 @@ class ArchiveChecker:
                 chunk = Chunk(None, allocation=CH_ALLOC, size=size)
                 chunk_id, data = cached_hash(chunk, self.key.id_hash)
                 cdata = self.key.encrypt(chunk_id, data)
-                csize = len(cdata)
-                return chunk_id, size, csize, cdata
+                return chunk_id, size, cdata
 
             offset = 0
             chunk_list = []
@@ -1835,30 +1769,30 @@ class ArchiveChecker:
                                      'Replacing with all-zero chunk.'.format(
                                      archive_name, item.path, offset, offset + size, bin_to_hex(chunk_id)))
                         self.error_found = chunks_replaced = True
-                        chunk_id, size, csize, cdata = replacement_chunk(size)
-                        add_reference(chunk_id, size, csize, cdata)
+                        chunk_id, size, cdata = replacement_chunk(size)
+                        add_reference(chunk_id, size, cdata)
                     else:
                         logger.info('{}: {}: Previously missing file chunk is still missing (Byte {}-{}, Chunk {}). '
                                     'It has an all-zero replacement chunk already.'.format(
                                     archive_name, item.path, offset, offset + size, bin_to_hex(chunk_id)))
                         chunk_id, size, csize = chunk_current
                         if chunk_id in self.chunks:
-                            add_reference(chunk_id, size, csize)
+                            add_reference(chunk_id, size)
                         else:
                             logger.warning('{}: {}: Missing all-zero replacement chunk detected (Byte {}-{}, Chunk {}). '
                                            'Generating new replacement chunk.'.format(
                                            archive_name, item.path, offset, offset + size, bin_to_hex(chunk_id)))
                             self.error_found = chunks_replaced = True
-                            chunk_id, size, csize, cdata = replacement_chunk(size)
-                            add_reference(chunk_id, size, csize, cdata)
+                            chunk_id, size, cdata = replacement_chunk(size)
+                            add_reference(chunk_id, size, cdata)
                 else:
                     if chunk_current == chunk_healthy:
                         # normal case, all fine.
-                        add_reference(chunk_id, size, csize)
+                        add_reference(chunk_id, size)
                     else:
                         logger.info('{}: {}: Healed previously missing file chunk! (Byte {}-{}, Chunk {}).'.format(
                             archive_name, item.path, offset, offset + size, bin_to_hex(chunk_id)))
-                        add_reference(chunk_id, size, csize)
+                        add_reference(chunk_id, size)
                         mark_as_possibly_superseded(chunk_current[0])  # maybe orphaned the all-zero replacement chunk
                 chunk_list.append([chunk_id, size, csize])  # list-typed element as chunks_healthy is list-of-lists
                 offset += size
@@ -2005,7 +1939,7 @@ class ArchiveChecker:
                 data = msgpack.packb(archive.as_dict())
                 new_archive_id = self.key.id_hash(data)
                 cdata = self.key.encrypt(new_archive_id, data)
-                add_reference(new_archive_id, len(data), len(cdata), cdata)
+                add_reference(new_archive_id, len(data), cdata)
                 self.manifest.archives[info.name] = (new_archive_id, info.ts)
             pi.finish()
 

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1805,7 +1805,7 @@ class ArchiveChecker:
             item.chunks = chunk_list
             if 'size' in item:
                 item_size = item.size
-                item_chunks_size = item.get_size(compressed=False, from_chunks=True)
+                item_chunks_size = item.get_size(from_chunks=True)
                 if item_size != item_chunks_size:
                     # just warn, but keep the inconsistency, so that borg extract can warn about it.
                     logger.warning('{}: {}: size inconsistency detected: size {}, chunks size {}'.format(

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -99,7 +99,7 @@ except BaseException:
 assert EXIT_ERROR == 2, "EXIT_ERROR is not 2, as expected - fix assert AND exception handler right above this line."
 
 
-STATS_HEADER = "                       Original size      Compressed size    Deduplicated size"
+STATS_HEADER = "                       Original size"
 
 PURE_PYTHON_MSGPACK_WARNING = "Using a pure-python msgpack! This will result in lower performance."
 
@@ -1797,8 +1797,8 @@ class Archiver:
                 Command line: {command_line}
                 Utilization of maximum supported archive size: {limits[max_archive_size]:.0%}
                 ------------------------------------------------------------------------------
-                                       Original size      Compressed size    Deduplicated size
-                This archive:   {stats[original_size]:>20s} {stats[compressed_size]:>20s} {stats[deduplicated_size]:>20s}
+                                       Original size
+                This archive:   {stats[original_size]:>20s}
                 {cache}
                 """).strip().format(cache=cache, **info))
             if self.exit_code:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -424,7 +424,7 @@ class Archiver:
                 for item in other_archive.iter_items():
                     if 'chunks' in item:
                         chunks = []
-                        for chunk_id, size, _ in item.chunks:
+                        for chunk_id, size in item.chunks:
                             refcount = cache.seen_chunk(chunk_id, size)
                             if refcount == 0:  # target repo does not yet have this chunk
                                 if not dry_run:
@@ -1331,7 +1331,7 @@ class Archiver:
             """
             Return a file-like object that reads from the chunks of *item*.
             """
-            chunk_iterator = archive.pipeline.fetch_many([chunk_id for chunk_id, _, _ in item.chunks],
+            chunk_iterator = archive.pipeline.fetch_many([chunk_id for chunk_id, _ in item.chunks],
                                                          is_preloaded=True)
             if pi:
                 info = [remove_surrogates(item.path)]

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -361,7 +361,7 @@ class Archiver:
                 chunks, chunks_healthy = hlm.retrieve(id=hlid, default=(None, None))
                 if chunks is not None:
                     item._dict['chunks'] = chunks
-                    for chunk_id, _, _ in chunks:
+                    for chunk_id, _ in chunks:
                         cache.chunk_incref(chunk_id, archive.stats)
                 if chunks_healthy is not None:
                     item._dict['chunks_healthy'] = chunks

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -443,7 +443,7 @@ class Archiver:
                                     chunks.append(chunk_entry)
                                 present_size += size
                         if not dry_run:
-                            item.chunks = chunks  # overwrite! IDs and sizes are same, csizes are likely different
+                            item.chunks = chunks  # TODO: overwrite? IDs and sizes are same.
                             archive.stats.nfiles += 1
                     if not dry_run:
                         archive.add_item(upgrade_item(item))

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -99,7 +99,7 @@ except BaseException:
 assert EXIT_ERROR == 2, "EXIT_ERROR is not 2, as expected - fix assert AND exception handler right above this line."
 
 
-STATS_HEADER = "                       Original size"
+STATS_HEADER = "                       Original size    Deduplicated size"
 
 PURE_PYTHON_MSGPACK_WARNING = "Using a pure-python msgpack! This will result in lower performance."
 
@@ -1797,8 +1797,8 @@ class Archiver:
                 Command line: {command_line}
                 Utilization of maximum supported archive size: {limits[max_archive_size]:.0%}
                 ------------------------------------------------------------------------------
-                                       Original size
-                This archive:   {stats[original_size]:>20s}
+                                       Original size    Deduplicated size
+                This archive:   {stats[original_size]:>20s} {stats[deduplicated_size]:>20s}
                 {cache}
                 """).strip().format(cache=cache, **info))
             if self.exit_code:

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -1015,7 +1015,7 @@ class AdHocCache(CacheStatsMixin):
 
     Compared to the standard LocalCache the AdHocCache does not maintain accurate reference count,
     nor does it provide a files cache (which would require persistence). Chunks that were not added
-    during the current AdHocCache lifetime won't have correct size/csize set (0 bytes) and will
+    during the current AdHocCache lifetime won't have correct size set (0 bytes) and will
     have an infinite reference count (MAX_VALUE).
     """
 

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -907,7 +907,7 @@ class LocalCache(CacheStatsMixin):
         self.repository.put(id, data, wait=wait)
         self.chunks.add(id, 1, size, csize)
         stats.update(size)
-        return ChunkListEntry(id, size, csize)
+        return ChunkListEntry(id, size)
 
     def seen_chunk(self, id, size=None):
         refcount, stored_size, _ = self.chunks.get(id, ChunkIndexEntry(0, None, None))
@@ -921,14 +921,14 @@ class LocalCache(CacheStatsMixin):
     def chunk_incref(self, id, stats, size=None, part=False):
         if not self.txn_active:
             self.begin_txn()
-        count, _size, csize = self.chunks.incref(id)
+        count, _size, _ = self.chunks.incref(id)
         stats.update(_size, part=part)
-        return ChunkListEntry(id, _size, csize)
+        return ChunkListEntry(id, _size)
 
     def chunk_decref(self, id, stats, wait=True, part=False):
         if not self.txn_active:
             self.begin_txn()
-        count, size, csize = self.chunks.decref(id)
+        count, size, _ = self.chunks.decref(id)
         if count == 0:
             del self.chunks[id]
             self.repository.delete(id, wait=wait)
@@ -1075,7 +1075,7 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
         self.repository.put(id, data, wait=wait)
         self.chunks.add(id, 1, size, csize)
         stats.update(size)
-        return ChunkListEntry(id, size, csize)
+        return ChunkListEntry(id, size)
 
     def seen_chunk(self, id, size=None):
         if not self._txn_active:
@@ -1097,7 +1097,7 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
         size = _size or size
         assert size
         stats.update(size, part=part)
-        return ChunkListEntry(id, size, csize)
+        return ChunkListEntry(id, size)
 
     def chunk_decref(self, id, stats, wait=True, part=False):
         if not self._txn_active:

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -423,7 +423,7 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
     def stats(self):
         from .archive import Archive
         # XXX: this should really be moved down to `hashindex.pyx`
-        total_size, _, unique_size, _, total_unique_chunks, total_chunks = self.chunks.summarize()
+        total_size, unique_size, total_unique_chunks, total_chunks = self.chunks.summarize()
         # the above values have the problem that they do not consider part files,
         # thus the total_size might be too high (chunks referenced
         # by the part files AND by the complete file).

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -413,7 +413,6 @@ Chunk index:    {0.total_unique_chunks:20d} {0.total_chunks:20d}"""
 
     def __init__(self, iec=False):
         self.iec = iec
-        self.pre12_meta = {}  # here we cache archive metadata for borg < 1.2
 
     def __str__(self):
         return self.str_format.format(self.format_tuple())
@@ -511,8 +510,6 @@ class LocalCache(CacheStatsMixin):
         os.makedirs(os.path.join(self.path, 'chunks.archive.d'))
         with SaveFile(os.path.join(self.path, files_cache_name()), binary=True):
             pass  # empty file
-        with SaveFile(os.path.join(self.path, 'pre12-meta'), binary=False) as fd:
-            json.dump(self.pre12_meta, fd, indent=4)
 
     def _do_open(self):
         self.cache_config.load()
@@ -523,11 +520,6 @@ class LocalCache(CacheStatsMixin):
             self.files = None
         else:
             self._read_files()
-        try:
-            with open(os.path.join(self.path, 'pre12-meta')) as fd:
-                self.pre12_meta = json.load(fd)
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
 
     def open(self):
         if not os.path.isdir(self.path):
@@ -536,9 +528,6 @@ class LocalCache(CacheStatsMixin):
         self.rollback()
 
     def close(self):
-        # save the pre12_meta cache in any case
-        with open(os.path.join(self.path, 'pre12-meta'), 'w') as fd:
-            json.dump(self.pre12_meta, fd, indent=4)
         if self.cache_config is not None:
             self.cache_config.close()
             self.cache_config = None
@@ -1037,7 +1026,6 @@ Chunk index:    {0.total_unique_chunks:20d}             unknown"""
         self.security_manager = SecurityManager(repository)
         self.security_manager.assert_secure(manifest, key, lock_wait=lock_wait)
 
-        self.pre12_meta = {}
         logger.warning('Note: --no-cache-sync is an experimental feature.')
 
     # Public API

--- a/src/borg/cache_sync/cache_sync.c
+++ b/src/borg/cache_sync/cache_sync.c
@@ -39,10 +39,8 @@ cache_sync_init(HashIndex *chunks)
     /* needs to be set only once */
     ctx->ctx.user.chunks = chunks;
     ctx->ctx.user.parts.size = 0;
-    ctx->ctx.user.parts.csize = 0;
     ctx->ctx.user.parts.num_files = 0;
     ctx->ctx.user.totals.size = 0;
-    ctx->ctx.user.totals.csize = 0;
     ctx->ctx.user.totals.num_files = 0;
     ctx->buf = NULL;
     ctx->head = 0;
@@ -89,18 +87,6 @@ static uint64_t
 cache_sync_size_parts(const CacheSyncCtx *ctx)
 {
     return ctx->ctx.user.parts.size;
-}
-
-static uint64_t
-cache_sync_csize_totals(const CacheSyncCtx *ctx)
-{
-    return ctx->ctx.user.totals.csize;
-}
-
-static uint64_t
-cache_sync_csize_parts(const CacheSyncCtx *ctx)
-{
-    return ctx->ctx.user.parts.csize;
 }
 
 /**

--- a/src/borg/cache_sync/unpack.h
+++ b/src/borg/cache_sync/unpack.h
@@ -279,7 +279,6 @@ static inline int unpack_callback_array_end(unpack_user* u)
             /* refcount, size */
             cache_values[0] = _htole32(1);
             cache_values[1] = _htole32(u->current.size);
-            cache_values[2] = _htole32(0);  /* fake csize for now */
             if(!hashindex_set(u->chunks, u->current.key, cache_values)) {
                 SET_LAST_ERROR("hashindex_set failed");
                 return -1;

--- a/src/borg/cache_sync/unpack.h
+++ b/src/borg/cache_sync/unpack.h
@@ -86,14 +86,12 @@ typedef struct unpack_user {
 
         /*
          * processing ChunkListEntry tuple:
-         * expect_key, expect_size, expect_csize, expect_entry_end
+         * expect_key, expect_size, expect_entry_end
          */
         /* next thing must be the key (raw, l=32) */
         expect_key,
         /* next thing must be the size (int) */
         expect_size,
-        /* next thing must be the csize (int) */
-        expect_csize,
         /* next thing must be the end of the CLE (array_end) */
         expect_entry_end,
 
@@ -103,23 +101,22 @@ typedef struct unpack_user {
     /* collect values here for current chunklist entry */
     struct {
         unsigned char key[32];
-        uint32_t csize;
         uint32_t size;
     } current;
 
     /* summing up chunks sizes here within a single item */
     struct {
-        uint64_t size, csize;
+        uint64_t size;
     } item;
 
     /* total sizes and files count coming from all files */
     struct {
-        uint64_t size, csize, num_files;
+        uint64_t size, num_files;
     } totals;
 
     /* total sizes and files count coming from part files */
     struct {
-        uint64_t size, csize, num_files;
+        uint64_t size, num_files;
     } parts;
 
 } unpack_user;
@@ -147,10 +144,6 @@ static inline int unpack_callback_uint64(unpack_user* u, int64_t d)
     switch(u->expect) {
         case expect_size:
             u->current.size = d;
-            u->expect = expect_csize;
-            break;
-        case expect_csize:
-            u->current.csize = d;
             u->expect = expect_entry_end;
             break;
         default:
@@ -239,7 +232,7 @@ static inline int unpack_callback_array(unpack_user* u, unsigned int n)
     case expect_entry_begin_or_chunks_end:
         /* b'chunks': [ (
          *              ^ */
-        if(n != 3) {
+        if(n != 2) {
             SET_LAST_ERROR("Invalid chunk list entry length");
             return -1;
         }
@@ -283,18 +276,16 @@ static inline int unpack_callback_array_end(unpack_user* u)
             refcount += 1;
             cache_entry[0] = _htole32(MIN(refcount, _MAX_VALUE));
         } else {
-            /* refcount, size, csize */
+            /* refcount, size */
             cache_values[0] = _htole32(1);
             cache_values[1] = _htole32(u->current.size);
-            cache_values[2] = _htole32(u->current.csize);
+            cache_values[2] = _htole32(0);  /* fake csize for now */
             if(!hashindex_set(u->chunks, u->current.key, cache_values)) {
                 SET_LAST_ERROR("hashindex_set failed");
                 return -1;
             }
         }
         u->item.size += u->current.size;
-        u->item.csize += u->current.csize;
-
         u->expect = expect_entry_begin_or_chunks_end;
         break;
     case expect_entry_begin_or_chunks_end:
@@ -330,7 +321,6 @@ static inline int unpack_callback_map(unpack_user* u, unsigned int n)
         u->part = 0;
         u->has_chunks = 0;
         u->item.size = 0;
-        u->item.csize = 0;
     }
 
     if(u->inside_chunks) {
@@ -372,11 +362,9 @@ static inline int unpack_callback_map_end(unpack_user* u)
             if(u->part) {
                 u->parts.num_files += 1;
                 u->parts.size += u->item.size;
-                u->parts.csize += u->item.csize;
             }
             u->totals.num_files += 1;
             u->totals.size += u->item.size;
-            u->totals.csize += u->item.csize;
         }
     }
     return 0;

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -12,7 +12,7 @@ ARCHIVE_KEYS = frozenset(['version', 'name', 'items', 'cmdline', 'hostname', 'us
                           'comment', 'chunker_params',
                           'recreate_cmdline',
                           'recreate_source_id', 'recreate_args', 'recreate_partial_chunks',  # used in 1.1.0b1 .. b2
-                          'size', 'csize', 'nfiles', 'size_parts', 'csize_parts', 'nfiles_parts', ])
+                          'size', 'nfiles', 'size_parts', 'nfiles_parts', ])
 
 # this is the set of keys that are always present in archives:
 REQUIRED_ARCHIVE_KEYS = frozenset(['version', 'name', 'items', 'cmdline', 'time', ])

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -377,7 +377,7 @@ class FuseBackend:
                 file_id = blake2b_128(path)
                 current_version, previous_id = self.versions_index.get(file_id, (0, None))
 
-                contents_id = blake2b_128(b''.join(chunk_id for chunk_id, _, _ in item.chunks))
+                contents_id = blake2b_128(b''.join(chunk_id for chunk_id, _ in item.chunks))
 
                 if contents_id != previous_id:
                     current_version += 1
@@ -658,7 +658,7 @@ class FuseOperations(llfuse.Operations, FuseBackend):
         chunks = item.chunks
         # note: using index iteration to avoid frequently copying big (sub)lists by slicing
         for idx in range(chunk_no, len(chunks)):
-            id, s, csize = chunks[idx]
+            id, s = chunks[idx]
             if s < offset:
                 offset -= s
                 chunk_offset += s

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -387,9 +387,9 @@ cdef class ChunkIndex(IndexBase):
         This index must be a subset of *master_index*.
 
         Return the same statistics tuple as summarize:
-        size, csize, unique_size, unique_csize, unique_chunks, chunks.
+        size, unique_size, unique_chunks, chunks.
         """
-        cdef uint64_t size = 0, csize = 0, unique_size = 0, unique_csize = 0, chunks = 0, unique_chunks = 0
+        cdef uint64_t size = 0, unique_size = 0, chunks = 0, unique_chunks = 0
         cdef uint32_t our_refcount, chunk_size, chunk_csize
         cdef const uint32_t *our_values
         cdef const uint32_t *master_values
@@ -406,18 +406,15 @@ cdef class ChunkIndex(IndexBase):
                 raise ValueError('stats_against: key contained in self but not in master_index.')
             our_refcount = _le32toh(our_values[0])
             chunk_size = _le32toh(master_values[1])
-            chunk_csize = _le32toh(master_values[2])
 
             chunks += our_refcount
             size += <uint64_t> chunk_size * our_refcount
-            csize += <uint64_t> chunk_csize * our_refcount
             if our_values[0] == master_values[0]:
                 # our refcount equals the master's refcount, so this chunk is unique to us
                 unique_chunks += 1
                 unique_size += chunk_size
-                unique_csize += chunk_csize
 
-        return size, csize, unique_size, unique_csize, unique_chunks, chunks
+        return size, unique_size, unique_chunks, chunks
 
     def add(self, key, refs, size, csize):
         assert len(key) == self.key_size

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -49,8 +49,6 @@ cdef extern from "cache_sync/cache_sync.c":
     uint64_t cache_sync_num_files_parts(const CacheSyncCtx *ctx)
     uint64_t cache_sync_size_totals(const CacheSyncCtx *ctx)
     uint64_t cache_sync_size_parts(const CacheSyncCtx *ctx)
-    uint64_t cache_sync_csize_totals(const CacheSyncCtx *ctx)
-    uint64_t cache_sync_csize_parts(const CacheSyncCtx *ctx)
     int cache_sync_feed(CacheSyncCtx *ctx, void *data, uint32_t length)
     void cache_sync_free(CacheSyncCtx *ctx)
 
@@ -544,11 +542,3 @@ cdef class CacheSynchronizer:
     @property
     def size_parts(self):
         return cache_sync_size_parts(self.sync)
-
-    @property
-    def csize_totals(self):
-        return cache_sync_csize_totals(self.sync)
-
-    @property
-    def csize_parts(self):
-        return cache_sync_csize_parts(self.sync)

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -358,7 +358,7 @@ cdef class ChunkIndex(IndexBase):
         return iter
 
     def summarize(self):
-        cdef uint64_t size = 0, csize = 0, unique_size = 0, unique_csize = 0, chunks = 0, unique_chunks = 0
+        cdef uint64_t size = 0, unique_size = 0, chunks = 0, unique_chunks = 0
         cdef uint32_t *values
         cdef uint32_t refcount
         cdef unsigned char *key = NULL
@@ -375,7 +375,7 @@ cdef class ChunkIndex(IndexBase):
             unique_size += _le32toh(values[1])
             size += <uint64_t> _le32toh(values[1]) * _le32toh(values[0])
 
-        return size, csize, unique_size, unique_csize, unique_chunks, chunks
+        return size, unique_size, unique_chunks, chunks
 
     def stats_against(self, ChunkIndex master_index):
         """

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -375,9 +375,7 @@ cdef class ChunkIndex(IndexBase):
             assert refcount <= _MAX_VALUE, "invalid reference count"
             chunks += refcount
             unique_size += _le32toh(values[1])
-            unique_csize += _le32toh(values[2])
             size += <uint64_t> _le32toh(values[1]) * _le32toh(values[0])
-            csize += <uint64_t> _le32toh(values[2]) * _le32toh(values[0])
 
         return size, csize, unique_size, unique_csize, unique_chunks, chunks
 

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -698,6 +698,7 @@ class ItemFormatter(BaseFormatter):
         'source': 'link target for symlinks (identical to linktarget)',
         'hlid': 'hard link identity (same if hardlinking same fs object)',
         'extra': 'prepends {source} with " -> " for soft links and " link to " for hard links',
+        'dsize': 'deduplicated size',
         'num_chunks': 'number of chunks in this file',
         'unique_chunks': 'number of unique chunks in this file',
         'xxh64': 'XXH64 checksum of this file (note: this is NOT a cryptographic hash!)',
@@ -705,7 +706,7 @@ class ItemFormatter(BaseFormatter):
     }
     KEY_GROUPS = (
         ('type', 'mode', 'uid', 'gid', 'user', 'group', 'path', 'bpath', 'source', 'linktarget', 'hlid', 'flags'),
-        ('size', 'num_chunks', 'unique_chunks'),
+        ('size', 'dsize', 'num_chunks', 'unique_chunks'),
         ('mtime', 'ctime', 'atime', 'isomtime', 'isoctime', 'isoatime'),
         tuple(sorted(hash_algorithms)),
         ('archiveid', 'archivename', 'extra'),
@@ -713,7 +714,7 @@ class ItemFormatter(BaseFormatter):
     )
 
     KEYS_REQUIRING_CACHE = (
-        'unique_chunks',
+        'dsize', 'unique_chunks',
     )
 
     @classmethod
@@ -771,6 +772,7 @@ class ItemFormatter(BaseFormatter):
         self.format_keys = {f[1] for f in Formatter().parse(format)}
         self.call_keys = {
             'size': self.calculate_size,
+            'dsize': partial(self.sum_unique_chunks_metadata, lambda chunk: chunk.size),
             'num_chunks': self.calculate_num_chunks,
             'unique_chunks': partial(self.sum_unique_chunks_metadata, lambda chunk: 1),
             'isomtime': partial(self.format_iso_time, 'mtime'),

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -698,9 +698,6 @@ class ItemFormatter(BaseFormatter):
         'source': 'link target for symlinks (identical to linktarget)',
         'hlid': 'hard link identity (same if hardlinking same fs object)',
         'extra': 'prepends {source} with " -> " for soft links and " link to " for hard links',
-        'csize': 'compressed size',
-        'dsize': 'deduplicated size',
-        'dcsize': 'deduplicated compressed size',
         'num_chunks': 'number of chunks in this file',
         'unique_chunks': 'number of unique chunks in this file',
         'xxh64': 'XXH64 checksum of this file (note: this is NOT a cryptographic hash!)',
@@ -708,7 +705,7 @@ class ItemFormatter(BaseFormatter):
     }
     KEY_GROUPS = (
         ('type', 'mode', 'uid', 'gid', 'user', 'group', 'path', 'bpath', 'source', 'linktarget', 'hlid', 'flags'),
-        ('size', 'csize', 'dsize', 'dcsize', 'num_chunks', 'unique_chunks'),
+        ('size', 'num_chunks', 'unique_chunks'),
         ('mtime', 'ctime', 'atime', 'isomtime', 'isoctime', 'isoatime'),
         tuple(sorted(hash_algorithms)),
         ('archiveid', 'archivename', 'extra'),
@@ -716,7 +713,7 @@ class ItemFormatter(BaseFormatter):
     )
 
     KEYS_REQUIRING_CACHE = (
-        'dsize', 'dcsize', 'unique_chunks',
+        'unique_chunks',
     )
 
     @classmethod
@@ -774,9 +771,6 @@ class ItemFormatter(BaseFormatter):
         self.format_keys = {f[1] for f in Formatter().parse(format)}
         self.call_keys = {
             'size': self.calculate_size,
-            'csize': self.calculate_csize,
-            'dsize': partial(self.sum_unique_chunks_metadata, lambda chunk: chunk.size),
-            'dcsize': partial(self.sum_unique_chunks_metadata, lambda chunk: chunk.csize),
             'num_chunks': self.calculate_num_chunks,
             'unique_chunks': partial(self.sum_unique_chunks_metadata, lambda chunk: 1),
             'isomtime': partial(self.format_iso_time, 'mtime'),
@@ -847,10 +841,6 @@ class ItemFormatter(BaseFormatter):
     def calculate_size(self, item):
         # note: does not support hardlink slaves, they will be size 0
         return item.get_size(compressed=False)
-
-    def calculate_csize(self, item):
-        # note: does not support hardlink slaves, they will be csize 0
-        return item.get_size(compressed=True)
 
     def hash_item(self, hash_function, item):
         if 'chunks' not in item:

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -840,7 +840,7 @@ class ItemFormatter(BaseFormatter):
 
     def calculate_size(self, item):
         # note: does not support hardlink slaves, they will be size 0
-        return item.get_size(compressed=False)
+        return item.get_size()
 
     def hash_item(self, hash_function, item):
         if 'chunks' not in item:

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -284,17 +284,14 @@ class Item(PropDict):
 
     part = PropDict._make_property('part', int)
 
-    def get_size(self, memorize=False, compressed=False, from_chunks=False, consider_ids=None):
+    def get_size(self, *, memorize=False, from_chunks=False, consider_ids=None):
         """
-        Determine the (uncompressed or compressed) size of this item.
+        Determine the uncompressed size of this item.
 
         :param memorize: Whether the computed size value will be stored into the item.
-        :param compressed: Whether the compressed or uncompressed size will be returned.
         :param from_chunks: If true, size is computed from chunks even if a precomputed value is available.
         :param consider_ids: Returns the size of the given ids only.
         """
-        if compressed:
-            return 0  # try to live without csize
         attr = 'size'
         assert not (consider_ids is not None and memorize), "Can't store size when considering only certain ids"
         try:
@@ -497,10 +494,8 @@ class ArchiveItem(PropDict):
     recreate_args = PropDict._make_property('recreate_args', list)  # list of s-e-str
     recreate_partial_chunks = PropDict._make_property('recreate_partial_chunks', list)  # list of tuples
     size = PropDict._make_property('size', int)
-    csize = PropDict._make_property('csize', int)
     nfiles = PropDict._make_property('nfiles', int)
     size_parts = PropDict._make_property('size_parts', int)
-    csize_parts = PropDict._make_property('csize_parts', int)
     nfiles_parts = PropDict._make_property('nfiles_parts', int)
 
     def update_internal(self, d):

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -61,10 +61,10 @@ def fix_list_of_chunkentries(v):
     chunks = []
     for ce in v:
         assert isinstance(ce, (tuple, list))
-        assert len(ce) == 3  # id, size, csize
+        assert len(ce) in (2, 3)  # id, size[, csize]
         assert isinstance(ce[1], int)
-        assert isinstance(ce[2], int)
-        ce_fixed = [want_bytes(ce[0]), ce[1], ce[2]]  # list!
+        assert len(ce) == 2 or isinstance(ce[2], int)
+        ce_fixed = [want_bytes(ce[0]), ce[1]]  # list! id, size only, drop csize
         chunks.append(ce_fixed)  # create a list of lists
     return chunks
 
@@ -227,7 +227,7 @@ class PropDict:
         return property(_get, _set, _del, doc=doc)
 
 
-ChunkListEntry = namedtuple('ChunkListEntry', 'id size csize')
+ChunkListEntry = namedtuple('ChunkListEntry', 'id size')
 
 class Item(PropDict):
     """

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -293,8 +293,9 @@ class Item(PropDict):
         :param from_chunks: If true, size is computed from chunks even if a precomputed value is available.
         :param consider_ids: Returns the size of the given ids only.
         """
-        attr = 'csize' if compressed else 'size'
-        assert not (compressed and memorize), 'Item does not have a csize field.'
+        if compressed:
+            return 0  # try to live without csize
+        attr = 'size'
         assert not (consider_ids is not None and memorize), "Can't store size when considering only certain ids"
         try:
             if from_chunks or consider_ids is not None:

--- a/src/borg/testsuite/archive.py
+++ b/src/borg/testsuite/archive.py
@@ -95,7 +95,7 @@ class MockCache:
 
     def add_chunk(self, id, chunk, stats=None, wait=True):
         self.objects[id] = chunk
-        return id, len(chunk), len(chunk)
+        return id, len(chunk)
 
 
 class ArchiveTimestampTestCase(BaseTestCase):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1543,7 +1543,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         cache = info_repo['cache']
         stats = cache['stats']
         assert all(isinstance(o, int) for o in stats.values())
-        assert all(key in stats for key in ('total_chunks', 'total_csize', 'total_size', 'total_unique_chunks', 'unique_csize', 'unique_size'))
+        assert all(key in stats for key in ('total_chunks', 'total_size', 'total_unique_chunks', 'unique_size'))
 
         info_archive = json.loads(self.cmd('info', '--json', self.repository_location + '::test'))
         assert info_repo['repository'] == info_archive['repository']
@@ -2363,12 +2363,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         test_archive = self.repository_location + '::test'
         self.cmd('create', '-C', 'lz4', test_archive, 'input')
-        output = self.cmd('list', '--format', '{size} {csize} {dsize} {dcsize} {path}{NL}', test_archive)
-        size, csize, dsize, dcsize, path = output.split("\n")[1].split(" ")
-        assert int(csize) < int(size)
-        assert int(dcsize) < int(dsize)
-        assert int(dsize) <= int(size)
-        assert int(dcsize) <= int(csize)
+        output = self.cmd('list', '--format', '{size} {path}{NL}', test_archive)
+        size, path = output.split("\n")[1].split(" ")
+        assert int(size) == 10000
 
     def test_list_json(self):
         self.create_regular_file('file1', size=1024 * 80)
@@ -2440,69 +2437,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         log = self.cmd('--debug', 'create', self.repository_location + '::test', 'input')
         assert 'security: read previous location' in log
-
-    def _get_sizes(self, compression, compressible, size=10000):
-        if compressible:
-            contents = b'X' * size
-        else:
-            contents = os.urandom(size)
-        self.create_regular_file('file', contents=contents)
-        self.cmd('init', '--encryption=none', self.repository_location)
-        archive = self.repository_location + '::test'
-        self.cmd('create', '-C', compression, archive, 'input')
-        output = self.cmd('list', '--format', '{size} {csize} {path}{NL}', archive)
-        size, csize, path = output.split("\n")[1].split(" ")
-        return int(size), int(csize)
-
-    def test_compression_none_compressible(self):
-        size, csize = self._get_sizes('none', compressible=True)
-        assert csize == size + 3
-
-    def test_compression_none_uncompressible(self):
-        size, csize = self._get_sizes('none', compressible=False)
-        assert csize == size + 3
-
-    def test_compression_zlib_compressible(self):
-        size, csize = self._get_sizes('zlib', compressible=True)
-        assert csize < size * 0.1
-        assert csize == 37
-
-    def test_compression_zlib_uncompressible(self):
-        size, csize = self._get_sizes('zlib', compressible=False)
-        assert csize >= size
-
-    def test_compression_auto_compressible(self):
-        size, csize = self._get_sizes('auto,zlib', compressible=True)
-        assert csize < size * 0.1
-        assert csize == 37  # same as compression 'zlib'
-
-    def test_compression_auto_uncompressible(self):
-        size, csize = self._get_sizes('auto,zlib', compressible=False)
-        assert csize == size + 3  # same as compression 'none'
-
-    def test_compression_lz4_compressible(self):
-        size, csize = self._get_sizes('lz4', compressible=True)
-        assert csize < size * 0.1
-
-    def test_compression_lz4_uncompressible(self):
-        size, csize = self._get_sizes('lz4', compressible=False)
-        assert csize == size + 3  # same as compression 'none'
-
-    def test_compression_lzma_compressible(self):
-        size, csize = self._get_sizes('lzma', compressible=True)
-        assert csize < size * 0.1
-
-    def test_compression_lzma_uncompressible(self):
-        size, csize = self._get_sizes('lzma', compressible=False)
-        assert csize == size + 3  # same as compression 'none'
-
-    def test_compression_zstd_compressible(self):
-        size, csize = self._get_sizes('zstd', compressible=True)
-        assert csize < size * 0.1
-
-    def test_compression_zstd_uncompressible(self):
-        size, csize = self._get_sizes('zstd', compressible=False)
-        assert csize == size + 3  # same as compression 'none'
 
     def test_change_passphrase(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
@@ -2951,13 +2885,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 correct_chunks = cache.chunks
         assert original_chunks is not correct_chunks
         seen = set()
-        for id, (refcount, size, csize) in correct_chunks.iteritems():
-            o_refcount, o_size, o_csize = original_chunks[id]
+        for id, (refcount, size, _) in correct_chunks.iteritems():
+            o_refcount, o_size, _ = original_chunks[id]
             assert refcount == o_refcount
             assert size == o_size
-            assert csize == o_csize
             seen.add(id)
-        for id, (refcount, size, csize) in original_chunks.iteritems():
+        for id, (refcount, size, _) in original_chunks.iteritems():
             assert id in seen
 
     def test_check_cache(self):
@@ -3051,15 +2984,13 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.cmd('create', self.repository_location + '::test', 'input', '-C', 'none')
         file_list = self.cmd('list', self.repository_location + '::test', 'input/compressible',
-                             '--format', '{size} {csize} {sha256}')
-        size, csize, sha256_before = file_list.split(' ')
-        assert int(csize) >= int(size)  # >= due to metadata overhead
+                             '--format', '{size} {sha256}')
+        size, sha256_before = file_list.split(' ')
         self.cmd('recreate', self.repository_location, '-C', 'lz4', '--recompress')
         self.check_cache()
         file_list = self.cmd('list', self.repository_location + '::test', 'input/compressible',
-                             '--format', '{size} {csize} {sha256}')
-        size, csize, sha256_after = file_list.split(' ')
-        assert int(csize) < int(size)
+                             '--format', '{size} {sha256}')
+        size, sha256_after = file_list.split(' ')
         assert sha256_before == sha256_after
 
     def test_recreate_timestamp(self):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2885,12 +2885,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 correct_chunks = cache.chunks
         assert original_chunks is not correct_chunks
         seen = set()
-        for id, (refcount, size, _) in correct_chunks.iteritems():
-            o_refcount, o_size, _ = original_chunks[id]
+        for id, (refcount, size) in correct_chunks.iteritems():
+            o_refcount, o_size = original_chunks[id]
             assert refcount == o_refcount
             assert size == o_size
             seen.add(id)
-        for id, (refcount, size, _) in original_chunks.iteritems():
+        for id, (refcount, size) in original_chunks.iteritems():
             assert id in seen
 
     def test_check_cache(self):

--- a/src/borg/testsuite/cache.py
+++ b/src/borg/testsuite/cache.py
@@ -49,8 +49,8 @@ class TestCacheSynchronizer:
         })
         sync.feed(data)
         assert len(index) == 2
-        assert index[H(1)] == (1, 1, 0)
-        assert index[H(2)] == (1, 2, 0)
+        assert index[H(1)] == (1, 1)
+        assert index[H(2)] == (1, 2)
 
     def test_multiple(self, index, sync):
         data = packb({
@@ -103,9 +103,9 @@ class TestCacheSynchronizer:
         sync.feed(part2)
         sync.feed(part3)
         assert len(index) == 3
-        assert index[H(1)] == (3, 1, 0)
-        assert index[H(2)] == (2, 2, 0)
-        assert index[H(3)] == (1, 1, 0)
+        assert index[H(1)] == (3, 1)
+        assert index[H(2)] == (2, 2)
+        assert index[H(3)] == (1, 1)
 
     @pytest.mark.parametrize('elem,error', (
         ({1: 2}, 'Unexpected object: map'),
@@ -189,7 +189,7 @@ class TestCacheSynchronizer:
             ]
         })
         sync.feed(data)
-        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
+        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234)
 
     def test_refcount_one_below_max_value(self):
         index = self.make_index_with_refcount(ChunkIndex.MAX_VALUE - 1)
@@ -201,9 +201,9 @@ class TestCacheSynchronizer:
         })
         sync.feed(data)
         # Incremented to maximum
-        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
+        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234)
         sync.feed(data)
-        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234, 5678)
+        assert index[H(0)] == (ChunkIndex.MAX_VALUE, 1234)
 
 
 class TestAdHocCache:

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -147,7 +147,7 @@ class HashIndexTestCase(BaseTestCase):
         idx[H(2)] = 2, 2000, 200
         idx[H(3)] = 3, 3000, 300
 
-        size, _, unique_size, _, unique_chunks, chunks = idx.summarize()
+        size, unique_size, unique_chunks, chunks = idx.summarize()
         assert size == 1000 + 2 * 2000 + 3 * 3000
         assert unique_size == 1000 + 2000 + 3000
         assert chunks == 1 + 2 + 3

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -147,11 +147,9 @@ class HashIndexTestCase(BaseTestCase):
         idx[H(2)] = 2, 2000, 200
         idx[H(3)] = 3, 3000, 300
 
-        size, csize, unique_size, unique_csize, unique_chunks, chunks = idx.summarize()
+        size, _, unique_size, _, unique_chunks, chunks = idx.summarize()
         assert size == 1000 + 2 * 2000 + 3 * 3000
-        assert csize == 100 + 2 * 200 + 3 * 300
         assert unique_size == 1000 + 2000 + 3000
-        assert unique_csize == 100 + 200 + 300
         assert chunks == 1 + 2 + 3
         assert unique_chunks == 3
 

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -91,8 +91,8 @@ class HashIndexTestCase(BaseTestCase):
                            '85f72b036c692c8266e4f51ccf0cff2147204282b5e316ae508d30a448d88fef')
 
     def test_chunkindex(self):
-        self._generic_test(ChunkIndex, lambda x: (x, x, x),
-                           'c83fdf33755fc37879285f2ecfc5d1f63b97577494902126b6fb6f3e4d852488')
+        self._generic_test(ChunkIndex, lambda x: (x, x),
+                           '85f72b036c692c8266e4f51ccf0cff2147204282b5e316ae508d30a448d88fef')
 
     def test_resize(self):
         n = 2000  # Must be >= MIN_BUCKETS
@@ -126,26 +126,26 @@ class HashIndexTestCase(BaseTestCase):
 
     def test_chunkindex_merge(self):
         idx1 = ChunkIndex()
-        idx1[H(1)] = 1, 100, 100
-        idx1[H(2)] = 2, 200, 200
-        idx1[H(3)] = 3, 300, 300
+        idx1[H(1)] = 1, 100
+        idx1[H(2)] = 2, 200
+        idx1[H(3)] = 3, 300
         # no H(4) entry
         idx2 = ChunkIndex()
-        idx2[H(1)] = 4, 100, 100
-        idx2[H(2)] = 5, 200, 200
+        idx2[H(1)] = 4, 100
+        idx2[H(2)] = 5, 200
         # no H(3) entry
-        idx2[H(4)] = 6, 400, 400
+        idx2[H(4)] = 6, 400
         idx1.merge(idx2)
-        assert idx1[H(1)] == (5, 100, 100)
-        assert idx1[H(2)] == (7, 200, 200)
-        assert idx1[H(3)] == (3, 300, 300)
-        assert idx1[H(4)] == (6, 400, 400)
+        assert idx1[H(1)] == (5, 100)
+        assert idx1[H(2)] == (7, 200)
+        assert idx1[H(3)] == (3, 300)
+        assert idx1[H(4)] == (6, 400)
 
     def test_chunkindex_summarize(self):
         idx = ChunkIndex()
-        idx[H(1)] = 1, 1000, 100
-        idx[H(2)] = 2, 2000, 200
-        idx[H(3)] = 3, 3000, 300
+        idx[H(1)] = 1, 1000
+        idx[H(2)] = 2, 2000
+        idx[H(3)] = 3, 3000
 
         size, unique_size, unique_chunks, chunks = idx.summarize()
         assert size == 1000 + 2 * 2000 + 3 * 3000
@@ -167,14 +167,14 @@ class HashIndexExtraTestCase(BaseTestCase):
         keys, to_delete_keys = all_keys[0:(2*key_count//3)], all_keys[(2*key_count//3):]
 
         for i, key in enumerate(keys):
-            index[key] = (i, i, i)
+            index[key] = (i, i)
         for i, key in enumerate(to_delete_keys):
-            index[key] = (i, i, i)
+            index[key] = (i, i)
 
         for key in to_delete_keys:
             del index[key]
         for i, key in enumerate(keys):
-            assert index[key] == (i, i, i)
+            assert index[key] == (i, i)
         for key in to_delete_keys:
             assert index.get(key) is None
 
@@ -188,12 +188,12 @@ class HashIndexExtraTestCase(BaseTestCase):
 class HashIndexSizeTestCase(BaseTestCase):
     def test_size_on_disk(self):
         idx = ChunkIndex()
-        assert idx.size() == 18 + 1031 * (32 + 3 * 4)
+        assert idx.size() == 18 + 1031 * (32 + 2 * 4)
 
     def test_size_on_disk_accurate(self):
         idx = ChunkIndex()
         for i in range(1234):
-            idx[H(i)] = i, i**2, i**3
+            idx[H(i)] = i, i**2
         with tempfile.NamedTemporaryFile() as file:
             idx.write(file.name)
             size = os.path.getsize(file.name)
@@ -203,7 +203,7 @@ class HashIndexSizeTestCase(BaseTestCase):
 class HashIndexRefcountingTestCase(BaseTestCase):
     def test_chunkindex_limit(self):
         idx = ChunkIndex()
-        idx[H(1)] = ChunkIndex.MAX_VALUE - 1, 1, 2
+        idx[H(1)] = ChunkIndex.MAX_VALUE - 1, 1
 
         # 5 is arbitrary, any number of incref/decrefs shouldn't move it once it's limited
         for i in range(5):
@@ -217,9 +217,9 @@ class HashIndexRefcountingTestCase(BaseTestCase):
     def _merge(self, refcounta, refcountb):
         def merge(refcount1, refcount2):
             idx1 = ChunkIndex()
-            idx1[H(1)] = refcount1, 1, 2
+            idx1[H(1)] = refcount1, 1
             idx2 = ChunkIndex()
-            idx2[H(1)] = refcount2, 1, 2
+            idx2[H(1)] = refcount2, 1
             idx1.merge(idx2)
             refcount, *_ = idx1[H(1)]
             return refcount
@@ -251,44 +251,44 @@ class HashIndexRefcountingTestCase(BaseTestCase):
 
     def test_chunkindex_add(self):
         idx1 = ChunkIndex()
-        idx1.add(H(1), 5, 6, 7)
-        assert idx1[H(1)] == (5, 6, 7)
-        idx1.add(H(1), 1, 2, 3)
-        assert idx1[H(1)] == (6, 2, 3)
+        idx1.add(H(1), 5, 6)
+        assert idx1[H(1)] == (5, 6)
+        idx1.add(H(1), 1, 2)
+        assert idx1[H(1)] == (6, 2)
 
     def test_incref_limit(self):
         idx1 = ChunkIndex()
-        idx1[H(1)] = (ChunkIndex.MAX_VALUE, 6, 7)
+        idx1[H(1)] = ChunkIndex.MAX_VALUE, 6
         idx1.incref(H(1))
         refcount, *_ = idx1[H(1)]
         assert refcount == ChunkIndex.MAX_VALUE
 
     def test_decref_limit(self):
         idx1 = ChunkIndex()
-        idx1[H(1)] = ChunkIndex.MAX_VALUE, 6, 7
+        idx1[H(1)] = ChunkIndex.MAX_VALUE, 6
         idx1.decref(H(1))
         refcount, *_ = idx1[H(1)]
         assert refcount == ChunkIndex.MAX_VALUE
 
     def test_decref_zero(self):
         idx1 = ChunkIndex()
-        idx1[H(1)] = 0, 0, 0
+        idx1[H(1)] = 0, 0
         with self.assert_raises(AssertionError):
             idx1.decref(H(1))
 
     def test_incref_decref(self):
         idx1 = ChunkIndex()
-        idx1.add(H(1), 5, 6, 7)
-        assert idx1[H(1)] == (5, 6, 7)
+        idx1.add(H(1), 5, 6)
+        assert idx1[H(1)] == (5, 6)
         idx1.incref(H(1))
-        assert idx1[H(1)] == (6, 6, 7)
+        assert idx1[H(1)] == (6, 6)
         idx1.decref(H(1))
-        assert idx1[H(1)] == (5, 6, 7)
+        assert idx1[H(1)] == (5, 6)
 
     def test_setitem_raises(self):
         idx1 = ChunkIndex()
         with self.assert_raises(AssertionError):
-            idx1[H(1)] = ChunkIndex.MAX_VALUE + 1, 0, 0
+            idx1[H(1)] = ChunkIndex.MAX_VALUE + 1, 0
 
     def test_keyerror(self):
         idx = ChunkIndex()
@@ -299,14 +299,15 @@ class HashIndexRefcountingTestCase(BaseTestCase):
         with self.assert_raises(KeyError):
             idx[H(1)]
         with self.assert_raises(OverflowError):
-            idx.add(H(1), -1, 0, 0)
+            idx.add(H(1), -1, 0)
 
 
 class HashIndexDataTestCase(BaseTestCase):
-    # This bytestring was created with 1.0-maint at c2f9533
-    HASHINDEX = b'eJzt0L0NgmAUhtHLT0LDEI6AuAEhMVYmVnSuYefC7AB3Aj9KNedJbnfyFne6P67P27w0EdG1Eac+Cm1ZybAsy7Isy7Isy7Isy7I' \
-                b'sy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7Isy7LsL9nhc+cqTZ' \
-                b'3XlO2Ys++Du5fX+l1/YFmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVmWZVn2/+0O2rYccw=='
+    # This bytestring was created with borg2-pre 2022-06-10
+    HASHINDEX = b'eJzt0LEJg1AYhdE/JqBjOEJMNhBBrAQrO9ewc+HsoG+CPMsEz1cfbnHbceqXoZvvEVE+IuoqMu2pnOE4' \
+                b'juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4juM4' \
+                b'juM4juM4juM4jruie36vuSVT5N0rzW0n9t7r5z9+4TiO4ziO4ziO4ziO4ziO4ziO4ziO4ziO4ziO4ziO' \
+                b'4ziO4ziO4ziO4ziO4ziO437LHbSVHGw='
 
     def _serialize_hashindex(self, idx):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -330,23 +331,23 @@ class HashIndexDataTestCase(BaseTestCase):
 
     def test_identical_creation(self):
         idx1 = ChunkIndex()
-        idx1[H(1)] = 1, 2, 3
-        idx1[H(2)] = 2**31 - 1, 0, 0
-        idx1[H(3)] = 4294962296, 0, 0  # 4294962296 is -5000 interpreted as an uint32_t
+        idx1[H(1)] = 1, 2
+        idx1[H(2)] = 2**31 - 1, 0
+        idx1[H(3)] = 4294962296, 0  # 4294962296 is -5000 interpreted as an uint32_t
 
         serialized = self._serialize_hashindex(idx1)
         assert self._unpack(serialized) == self._unpack(self.HASHINDEX)
 
     def test_read_known_good(self):
         idx1 = self._deserialize_hashindex(self.HASHINDEX)
-        assert idx1[H(1)] == (1, 2, 3)
-        assert idx1[H(2)] == (2**31 - 1, 0, 0)
-        assert idx1[H(3)] == (4294962296, 0, 0)
+        assert idx1[H(1)] == (1, 2)
+        assert idx1[H(2)] == (2**31 - 1, 0)
+        assert idx1[H(3)] == (4294962296, 0)
 
         idx2 = ChunkIndex()
-        idx2[H(3)] = 2**32 - 123456, 6, 7
+        idx2[H(3)] = 2**32 - 123456, 6
         idx1.merge(idx2)
-        assert idx1[H(3)] == (ChunkIndex.MAX_VALUE, 6, 7)
+        assert idx1[H(3)] == (ChunkIndex.MAX_VALUE, 6)
 
 
 class HashIndexIntegrityTestCase(HashIndexDataTestCase):
@@ -497,16 +498,16 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
     def test_merge(self):
         master = ChunkIndex()
         idx1 = ChunkIndex()
-        idx1[H(1)] = 1, 100, 100
-        idx1[H(2)] = 2, 200, 200
-        idx1[H(3)] = 3, 300, 300
+        idx1[H(1)] = 1, 100
+        idx1[H(2)] = 2, 200
+        idx1[H(3)] = 3, 300
         idx1.compact()
-        assert idx1.size() == 18 + 3 * (32 + 3 * 4)
+        assert idx1.size() == 18 + 3 * (32 + 2 * 4)
 
         master.merge(idx1)
-        assert master[H(1)] == (1, 100, 100)
-        assert master[H(2)] == (2, 200, 200)
-        assert master[H(3)] == (3, 300, 300)
+        assert master[H(1)] == (1, 100)
+        assert master[H(2)] == (2, 200)
+        assert master[H(3)] == (3, 300)
 
 
 class NSIndexTestCase(BaseTestCase):

--- a/src/borg/testsuite/item.py
+++ b/src/borg/testsuite/item.py
@@ -143,11 +143,10 @@ def test_unknown_property():
 
 def test_item_file_size():
     item = Item(mode=0o100666, chunks=[
-        ChunkListEntry(csize=0, size=1000, id=None),
-        ChunkListEntry(csize=0, size=2000, id=None),
+        ChunkListEntry(size=1000, id=None),
+        ChunkListEntry(size=2000, id=None),
     ])
     assert item.get_size() == 3000
-    assert item.get_size(compressed=True) == 0  # no csize any more
     item.get_size(memorize=True)
     assert item.size == 3000
 

--- a/src/borg/testsuite/item.py
+++ b/src/borg/testsuite/item.py
@@ -143,13 +143,11 @@ def test_unknown_property():
 
 def test_item_file_size():
     item = Item(mode=0o100666, chunks=[
-        ChunkListEntry(csize=1, size=1000, id=None),
-        ChunkListEntry(csize=1, size=2000, id=None),
+        ChunkListEntry(csize=0, size=1000, id=None),
+        ChunkListEntry(csize=0, size=2000, id=None),
     ])
     assert item.get_size() == 3000
-    with pytest.raises(AssertionError):
-        item.get_size(compressed=True, memorize=True)
-    assert item.get_size(compressed=True) == 2
+    assert item.get_size(compressed=True) == 0  # no csize any more
     item.get_size(memorize=True)
     assert item.size == 3000
 


### PR DESCRIPTION
"what would we lose/win if we would just not track csize (the compressed size of a chunk)", see #2357.
- do not have csize in the item.chunks list entries
- do not have csize in the ChunkIndex entries
- do not track csize in Statistics
- but: my other PR https://github.com/borgbackup/borg/pull/6705 would make borg track csize in the repo index

What we lose (some stuff could be just done differently):
- archive info: compressed size and deduplicated-compressed size stats (the latter is based on csize and refcount)
- archive list: placeholders for csize / dcsize

What we win:
- get rid of some ugly / complicated code
- repo-scope recompression would be easily doable, because there is no csize to "fix" in the archives (and in the chunks index)
- no super expensive `fetch_missing_csize` and no `zero_csize_ids` any more for the (still experimental) `AdHocCache`
- 10% less memory needs for the chunks index and the item.chunks list (in memory and in the stored archive)

Also:
- I reimplemented the deduplicate size info, but now based on the uncompressed sizes.