### PR TITLE
fix test_obfuscate byte accounting

### DIFF
--- a/src/borg/testsuite/compress.py
+++ b/src/borg/testsuite/compress.py
@@ -188,11 +188,13 @@ def test_obfuscate():
     data = bytes(1000)
     compressed = compressor.compress(data)
     # N blocks + 2 id bytes obfuscator. 4 length bytes
-    assert 1000 + 6 <= len(compressed) <= 1000 + 6 + 1024
+    # The 'none' compressor also adds 2 id bytes
+    assert 6 + 2 + 1000 <= len(compressed) <= 6 + 2 + 1000 + 1024
     data = bytes(1100)
     compressed = compressor.compress(data)
     # N blocks + 2 id bytes obfuscator. 4 length bytes
-    assert 1100 + 6 <= len(compressed) <= 1100 + 6 + 1024
+    # The 'none' compressor also adds 2 id bytes
+    assert 6 + 2 + 1100 <= len(compressed) <= 6 + 2 + 1100 + 1024
 
 
 def test_compression_specs():


### PR DESCRIPTION
This PR fixes the `test_obfuscate` length accounting for the `none` compression algorithm.
Specifically, it wasn't accounting for the 2 ID bytes that the `none` compression also adds.

This caused a test failure, where the "compressed" size was 2031 but the test expected a maximum of 2030, as you can see below:

<details>
<summary>Test output</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-7.1.1, pluggy-1.0.0
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
Tests enabled: BSD flags, fuse3, root, symlinks, hardlinks, atime/mtime, modes
Tests disabled: fuse2
rootdir: /build/borgbackup-1.2.0, configfile: setup.cfg
plugins: benchmark-3.4.1, xdist-2.5.0, forked-1.4.0
gw0 [1494] / gw1 [1494] / gw2 [1494] / gw3 [1494] / gw4 [1494] / gw5 [1494] / gw6 [1494] / gw7 [1494] / gw8 [1494] / gw9 [1494] / gw10 [1494] / gw11 [1494] / gw12 [1494] / gw13 [1494] / gw14 [1494] / gw15 [1494] / gw16 [1494] / gw17 [1494] / gw18 [1494] / gw19 [1494] / gw20 [1494] / gw21 [1494] / gw22 [1494] / gw23 [1494] / gw24 [1494] / gw25 [1494] / gw26 [1494] / gw27 [1494] / gw28 [1494] / gw29 [1494] / gw30 [1494] / gw31 [1494]
.......................ss.............................s................. [  4%]
....s....................................s.............................. [  9%]
ssssss.s.ss.ss....sss.s.ssss.ss.....ss.ss.ss.ssss.s.ss.s.ssssssss.s.ssss [ 14%]
s...sss..sssss..sss..ssssssssss.sssssss.sss.sssss..ss.sss...sss.ssssss.s [ 19%]
ss.sss..s..sss.ss.ss.s..........s........s..............s..s.ssssss..ss. [ 24%]
s.ss.ss....sss..s..ssss..ss.s.ssssss..ssss.ssss.sssssss..s.ssssssssss.ss [ 28%]
.s.sssss.ss.ss..ss.sss.sss..s...s..s.s..s............................... [ 33%]
..s.s.....s..s.ss..s..ss.s..ss...s.s.s...s.ss...s.ss.sss...s..s..ss..F.s [ 38%]
..............................s.......s...s.....s.........s...s......... [ 43%]
........................................................................ [ 48%]
........................................................................ [ 53%]
........................................................................ [ 57%]
........................................................................ [ 62%]
........................................................................ [ 67%]
....................................s......sss.......................... [ 72%]
........................................................................ [ 77%]
........................................................................ [ 81%]
........................................................................ [ 86%]
..........s..s..s....sssss...........s....sssss........s.ss.ss.......... [ 91%]
...s.................................................................... [ 96%]
s.........s....s.........s......ss....................                   [100%]
=================================== FAILURES ===================================
________________________________ test_obfuscate ________________________________
[gw6] linux -- Python 3.9.13 /nix/store/i64wb3khfb8b9n1dwhj3vbf043jyynvs-python3-3.9.13/bin/python3.9
def test_obfuscate():
        compressor = CompressionSpec('obfuscate,1,none').compressor
        data = bytes(10000)
        compressed = compressor.compress(data)
        # 2 id bytes compression, 2 id bytes obfuscator. 4 length bytes
        assert len(data) + 8 <= len(compressed) <= len(data) * 101 + 8
        # compressing 100 times the same data should give at least 50 different result sizes
        assert len(set(len(compressor.compress(data)) for i in range(100))) > 50
    
        cs = CompressionSpec('obfuscate,2,lz4')
        assert isinstance(cs.inner.compressor, LZ4)
        compressor = cs.compressor
        data = bytes(10000)
        compressed = compressor.compress(data)
        # 2 id bytes compression, 2 id bytes obfuscator. 4 length bytes
        min_compress, max_compress = 0.2, 0.001  # estimate compression factor outer boundaries
        assert max_compress * len(data) + 8 <= len(compressed) <= min_compress * len(data) * 1001 + 8
        # compressing 100 times the same data should give multiple different result sizes
        assert len(set(len(compressor.compress(data)) for i in range(100))) > 10
    
        cs = CompressionSpec('obfuscate,6,zstd,3')
        assert isinstance(cs.inner.compressor, ZSTD)
        compressor = cs.compressor
        data = bytes(10000)
        compressed = compressor.compress(data)
        # 2 id bytes compression, 2 id bytes obfuscator. 4 length bytes
        min_compress, max_compress = 0.2, 0.001  # estimate compression factor outer boundaries
        assert max_compress * len(data) + 8 <= len(compressed) <= min_compress * len(data) * 10000001 + 8
        # compressing 100 times the same data should give multiple different result sizes
        assert len(set(len(compressor.compress(data)) for i in range(100))) > 90
    
        cs = CompressionSpec('obfuscate,2,auto,zstd,10')
        assert isinstance(cs.inner.compressor, Auto)
        compressor = cs.compressor
        data = bytes(10000)
        compressed = compressor.compress(data)
        # 2 id bytes compression, 2 id bytes obfuscator. 4 length bytes
        min_compress, max_compress = 0.2, 0.001  # estimate compression factor outer boundaries
        assert max_compress * len(data) + 8 <= len(compressed) <= min_compress * len(data) * 1001 + 8
        # compressing 100 times the same data should give multiple different result sizes
        assert len(set(len(compressor.compress(data)) for i in range(100))) > 10
    
        cs = CompressionSpec('obfuscate,110,none')
        assert isinstance(cs.inner.compressor, CNONE)
        compressor = cs.compressor
        data = bytes(1000)
        compressed = compressor.compress(data)
        # N blocks + 2 id bytes obfuscator. 4 length bytes
>       assert 1000 + 6 <= len(compressed) <= 1000 + 6 + 1024
E       AssertionError: assert 2031 <= ((1000 + 6) + 1024)
E        +  where 2031 = len(b'\x04\x00\x00\x00\x03\xea\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00...00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')

/nix/store/ysqxnyc57hk2dsbwrskhkcwxlxric28d-borgbackup-1.2.0/lib/python3.9/site-packages/borg/testsuite/compress.py:191: AssertionError
=========================== short test summary info ============================
FAILED compress.py::test_obfuscate
=========== 1 failed, 1224 passed, 269 skipped in 169.31s (0:02:49) ============
```
</details>

Note how at offset 2, the byte sequence `\x00\x00\x03\xea` representing the compressed size of the `none` algorithm (in big endian byte order) is `1002` (the 1000 bytes plus the 2 ID bytes, which weren't being accounted for).

Note: I haven't actually tested whether the accounting is correct in all cases, my patch is only based on code inspection.