### PR TITLE
docs: json progress_percent: some values are optional, fixes #4074

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -90,12 +90,14 @@ progress_percent
         can have this property set to *true*.
     message
         A formatted progress message, this will include the percentage and perhaps other information
+        (absent for finished == true)
     current
-        Current value (always less-or-equal to *total*)
+        Current value (always less-or-equal to *total*, absent for finished == true)
     info
         Array that describes the current item, may be *null*, contents depend on *msgid*
+        (absent for finished == true)
     total
-        Total value
+        Total value (absent for finished == true)
     time
         Unix timestamp (float)
 


### PR DESCRIPTION
in the finished == true message, these are missing:
- message
- current / total
- info

This is to be somewhat consistent with #6683 by only providing a minimal set of values for the finished case.

The finished messages is primarily intended for cleanup purposes, e.g. clearing the progress display.
