### PR TITLE
check repo version / borg rinfo extended

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1692,12 +1692,16 @@ class Archiver:
             print(textwrap.dedent("""
             Repository ID: {id}
             Location: {location}
+            Repository version: {version}
+            Append only: {append_only}
             {encryption}
             Cache: {cache.path}
             Security dir: {security_dir}
             """).strip().format(
                 id=bin_to_hex(repository.id),
                 location=repository._location.canonical_path(),
+                version=repository.version,
+                append_only=repository.append_only,
                 **info))
             print(str(cache))
         return self.exit_code

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -191,6 +191,9 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
                                         args=args)
 
             with repository:
+                if repository.version not in (2, ):
+                    raise Error("This borg version only accepts version 2 repos for -r/--repo. "
+                                "You can use 'borg transfer' to copy archives from old to new repos.")
                 if manifest or cache:
                     kwargs['manifest'], kwargs['key'] = Manifest.load(repository, compatibility)
                     if 'compression' in args:
@@ -233,6 +236,8 @@ def with_other_repository(manifest=False, key=False, cache=False, compatibility=
                                         args=args)
 
             with repository:
+                if repository.version not in (1, 2, ):
+                    raise Error("This borg version only accepts version 1 or 2 repos for --other-repo.")
                 kwargs['other_repository'] = repository
                 if manifest or key or cache:
                     manifest_, key_ = Manifest.load(repository, compatibility)

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -133,6 +133,7 @@ compatMap = {
     'break_lock': (),
     'negotiate': ('client_data', ),
     'open': ('path', 'create', 'lock_wait', 'lock', 'exclusive', 'append_only', ),
+    'info': (),
     'get_free_nonce': (),
     'commit_nonce_reservation': ('next_unreserved', 'start_nonce', ),
 }
@@ -150,6 +151,7 @@ class RepositoryServer:  # pragma: no cover
         'scan',
         'negotiate',
         'open',
+        'info',
         'put',
         'rollback',
         'save_key',
@@ -580,6 +582,9 @@ class RemoteRepository:
                 self.id = self.open(path=self.location.path, create=create, lock_wait=lock_wait,
                                     lock=lock, exclusive=exclusive, append_only=append_only,
                                     make_parent_dirs=make_parent_dirs)
+                info = self.info()
+                self.version = info['version']
+                self.append_only = info['append_only']
 
             if self.dictFormat:
                 do_open()
@@ -896,6 +901,10 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
          make_parent_dirs={'since': parse_version('1.1.9'), 'previously': False})
     def open(self, path, create=False, lock_wait=None, lock=True, exclusive=False, append_only=False,
              make_parent_dirs=False):
+        """actual remoting is done via self.call in the @api decorator"""
+
+    @api(since=parse_version('2.0.0a3'))
+    def info(self):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(since=parse_version('1.0.0'),

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -491,6 +491,14 @@ class Repository:
                 self.close()
                 raise self.AtticRepository(path)
 
+    def info(self):
+        """return some infos about the repo (must be opened first)"""
+        return dict(
+            id=self.id,
+            version=self.version,
+            append_only=self.append_only,
+        )
+
     def close(self):
         if self.lock:
             if self.io:


### PR DESCRIPTION
old repos only accepted for `--other-repo` (for borg rcreate / borg transfer) so users can transfer their archives into related repos.

other than that, only accept new repos (version 2).

also, borg2 will reject talking to a borg < 2 repo server because that will not have the new `info` rpc call added in this PR. for the archives transfer, borg2 shall be used on the server (including for reading the old repo).