### PR TITLE
remove remainders of attic legacy

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1080,7 +1080,7 @@ class MetadataCollector:
 
     def stat_simple_attrs(self, st):
         attrs = dict(mode=st.st_mode, uid=st.st_uid, gid=st.st_gid, mtime=safe_ns(st.st_mtime_ns))
-        # borg can work with archives only having mtime (older attic archives do not have
+        # borg can work with archives only having mtime (very old borg archives do not have
         # atime/ctime). it can be useful to omit atime/ctime, if they change without the
         # file content changing - e.g. to get better metadata deduplication.
         if not self.noatime:

--- a/src/borg/archiver/recreate.py
+++ b/src/borg/archiver/recreate.py
@@ -89,8 +89,7 @@ class RecreateMixIn:
         There is no risk of data loss by this.
 
         ``--chunker-params`` will re-chunk all files in the archive, this can be
-        used to have upgraded Borg 0.xx or Attic archives deduplicate with
-        Borg 1.x archives.
+        used to have upgraded Borg 0.xx archives deduplicate with Borg 1.x archives.
 
         **USE WITH CAUTION.**
         Depending on the PATHs and patterns given, recreate can be used to permanently

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -135,7 +135,7 @@ class KeyType:
     # in borg 2. all of its code and also the "borg key migrate-to-repokey" command was removed.
     # if you still need to, you can use "borg key migrate-to-repokey" with borg 1.0, 1.1 and 1.2.
     # Nowadays, we just dispatch this to RepoKey and assume the passphrase was migrated to a repokey.
-    PASSPHRASE = 0x01  # legacy, attic and borg < 1.0
+    PASSPHRASE = 0x01  # legacy, borg < 1.0
     PLAINTEXT = 0x02
     REPO = 0x03
     BLAKE2KEYFILE = 0x04

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -791,11 +791,6 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
                     raise IntegrityError("(not available)")
                 else:
                     raise IntegrityError(args[0])
-            elif error == "AtticRepository":
-                if old_server:
-                    raise Repository.AtticRepository("(not available)")
-                else:
-                    raise Repository.AtticRepository(args[0])
             elif error == "PathNotAllowed":
                 if old_server:
                     raise PathNotAllowed("(unknown)")

--- a/src/borg/testsuite/crypto.py
+++ b/src/borg/testsuite/crypto.py
@@ -34,7 +34,7 @@ class CryptoTestCase(BaseTestCase):
         self.assert_equal(got_data, data)
 
     def test_AES256_CTR_HMAC_SHA256(self):
-        # this tests the layout as in attic / borg < 1.2 (1 type byte, no aad)
+        # this tests the layout as in borg < 1.2 (1 type byte, no aad)
         mac_key = b"Y" * 32
         enc_key = b"X" * 32
         iv = 0

--- a/src/borg/upgrade.py
+++ b/src/borg/upgrade.py
@@ -102,7 +102,7 @@ class UpgraderFrom12To20:
         def upgrade_zlib_and_level(chunk):
             if ZLIB_legacy.detect(chunk):
                 ctype = ZLIB.ID
-                chunk = ctype + level + bytes(chunk)  # get rid of the attic legacy: prepend separate type/level bytes
+                chunk = ctype + level + bytes(chunk)  # get rid of the legacy: prepend separate type/level bytes
             else:
                 ctype = bytes(chunk[0:1])
                 chunk = ctype + level + bytes(chunk[2:])  # keep type same, but set level


### PR DESCRIPTION
we expect that everybody has upgraded to borg
using borg 1.2.x or older, thus we do not need
to care about attic repos any more in borg2.
