### PR TITLE
ssh:// URLs: remove support for /~otheruser/, see #6855

### DIFF
--- a/docs/usage/general/repository-urls.rst.inc
+++ b/docs/usage/general/repository-urls.rst.inc
@@ -20,8 +20,6 @@ Note: you may also prepend a ``file://`` to a filesystem path to get URL style.
 
 ``ssh://user@host:port/~/path/to/repo`` - path relative to user's home directory
 
-``ssh://user@host:port/~other/path/to/repo`` - path relative to other's home directory
-
 
 If you frequently need the same repo URL, it is a good idea to set the
 ``BORG_REPO`` environment variable to set a default for the repo URL:

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -332,10 +332,8 @@ class RepositoryServer:  # pragma: no cover
     def _resolve_path(self, path):
         if isinstance(path, bytes):
             path = os.fsdecode(path)
-        if path.startswith("/~/"):  # /~/x = path x relative to home dir
+        if path.startswith("/~/"):  # /~/x = path x relative to own home dir
             path = os.path.join(get_base_dir(), path[3:])
-        elif path.startswith("/~"):  # /~username/x = relative to "user" home dir
-            path = os.path.expanduser(path[1:])
         elif path.startswith("/./"):  # /./x = path x relative to cwd
             path = path[3:]
         return os.path.realpath(path)

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -206,11 +206,6 @@ class TestLocationWithoutEnv:
             == "Location(proto='ssh', user='user', host='host', port=None, path='/~/some/path')"
         )
         assert Location("ssh://user@host/~/some/path").to_key_filename() == keys_dir + "host__some_path"
-        assert (
-            repr(Location("ssh://user@host/~user/some/path"))
-            == "Location(proto='ssh', user='user', host='host', port=None, path='/~user/some/path')"
-        )
-        assert Location("ssh://user@host/~user/some/path").to_key_filename() == keys_dir + "host__user_some_path"
 
     def test_with_colons(self, monkeypatch, keys_dir):
         monkeypatch.delenv("BORG_REPO", raising=False)


### PR DESCRIPTION
If you used this, just replace it by:

ssh://user@host:port/home/otheruser/
