### PR TITLE
new crypto does not need to call ._assert_id()

### DIFF
--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -180,8 +180,6 @@ Decryption::
 
     decompressed = decompress(decrypted)
 
-    ASSERT( CONSTANT-TIME-COMPARISON( chunk-id, MAC(id_key, decompressed) ) )
-
 Notable:
 
 - More modern and often faster AEAD ciphers instead of self-assembled stuff.

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -21,7 +21,7 @@ logger = create_logger()
 from . import xattr
 from .chunker import get_chunker, Chunk
 from .cache import ChunkListEntry
-from .crypto.key import key_factory
+from .crypto.key import key_factory, AEADKeyBase
 from .compress import Compressor, CompressionSpec
 from .constants import *  # NOQA
 from .crypto.low_level import IntegrityError as IntegrityErrorBase
@@ -1684,6 +1684,12 @@ class ArchiveChecker:
         chunks_count_index = len(self.chunks)
         chunks_count_segments = 0
         errors = 0
+        # for the new crypto, derived from AEADKeyBase, we know that it checks authenticity on
+        # the crypto.low_level level - invalid chunks will fail to AEAD authenticate.
+        # for these key types, we know that there is no need to decompress the data afterwards.
+        # for all other modes, we assume that we must decompress, so we can verify authenticity
+        # based on the plaintext MAC (via calling ._assert_id(id, plaintext)).
+        decompress = not isinstance(self.key, AEADKeyBase)
         defect_chunks = []
         pi = ProgressIndicatorPercent(
             total=chunks_count_index, msg="Verifying data %6.2f%%", step=0.01, msgid="check.verify_data"
@@ -1714,7 +1720,7 @@ class ArchiveChecker:
                         chunk_data_iter = self.repository.get_many(chunk_ids)
                 else:
                     try:
-                        self.key.decrypt(chunk_id, encrypted_data)
+                        self.key.decrypt(chunk_id, encrypted_data, decompress=decompress)
                     except IntegrityErrorBase as integrity_error:
                         self.error_found = True
                         errors += 1
@@ -1745,7 +1751,7 @@ class ArchiveChecker:
                     # from the underlying media.
                     try:
                         encrypted_data = self.repository.get(defect_chunk)
-                        self.key.decrypt(defect_chunk, encrypted_data)
+                        self.key.decrypt(defect_chunk, encrypted_data, decompress=decompress)
                     except IntegrityErrorBase:
                         # failed twice -> get rid of this chunk
                         del self.chunks[defect_chunk]

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -871,7 +871,10 @@ class AEADKeyBase(KeyBase):
         if not decompress:
             return payload
         data = self.decompress(memoryview(payload))
-        self.assert_id(id, data)
+        # note: calling self.assert_id(id, data) is not needed any more for the new AEAD crypto.
+        # we put the id into AAD when storing the chunk, so it gets into the authentication tag computation.
+        # when decrypting, we provide the id we **want** as AAD for the auth tag verification, so
+        # decrypting only succeeds if we got the ciphertext we wrote **for that chunk id**.
         return data
 
     def init_from_given_data(self, *, enc_key, enc_hmac_key, id_key, chunk_seed):


### PR DESCRIPTION
See: https://github.com/borgbackup/borg/pull/6463#discussion_r925436156
