### PR TITLE
prune/delete --checkpoint-interval=1800 and ctrl-c/SIGINT support, fixes #6284

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ ignore = E226, W503
 per_file_ignores =
     docs/conf.py:E121,E126,E265,E305,E401,E402
     src/borg/archive.py:E122,E125,E127,E402,E501,F401,F405,W504
-    src/borg/archiver.py:E126,E127,E128,E501,E722,E731,E741,F401,F405,W504
+    src/borg/archiver.py:E125,E126,E127,E128,E501,E722,E731,E741,F401,F405,W504
     src/borg/cache.py:E127,E128,E402,E501,E722,W504
     src/borg/fuse.py:E402,E501,E722,W504
     src/borg/fuse_impl.py:F811


### PR DESCRIPTION
manifest, repo and cache are committed every checkpoint interval.

also, when ctrl-c is pressed, finish deleting the current archive, commit and then terminate.
