### PR TITLE
CI: test on macOS 11 without fuse / fuse tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,7 @@ jobs:
             - os: ubuntu-20.04
               python-version: '3.10'
               toxenv: py310
-            - os: macos-10.15  # macos-latest is macos 11.6.2 and hanging at test_fuse, #6099
-              # note: it seems that 3.8 and 3.9 are currently broken,
-              # neverending RuntimeError crashes...
+            - os: macos-11
               python-version: '3.7'
               toxenv: py37
 
@@ -117,7 +115,7 @@ jobs:
         brew install zstd || brew upgrade zstd
         brew install lz4 || brew upgrade lz4
         brew install openssl@1.1 || brew upgrade openssl@1.1
-        brew install --cask macfuse || brew upgrade --cask macfuse  # Required for Python llfuse module
+        echo "# no FUSE support wanted on macOS github CI due to #6099, see also #6196!" > requirements.d/fuse.txt
 
     - name: Install Python requirements
       run: |


### PR DESCRIPTION
too troublesome on github CI due to kernel extensions needed by macFUSE.
