### PR TITLE
list: fix {flags:<WIDTH>} formatting, fixes #6081

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -818,7 +818,7 @@ class ItemFormatter(BaseFormatter):
         item_data["source"] = source
         item_data["linktarget"] = source
         item_data["hlid"] = hlid
-        item_data["flags"] = item.get("bsdflags")
+        item_data["flags"] = item.get("bsdflags", 0)
         for key in self.used_call_keys:
             item_data[key] = self.call_keys[key](item)
         return item_data


### PR DESCRIPTION
item.bsdflags is either not present or an int, thus we default to 0 (== no flags) if not present.
