### PR TITLE
repository: add debug logging for issue #6687

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -817,9 +817,10 @@ class Repository:
                 elif tag == TAG_DELETE and not in_index:
                     # If the shadow index doesn't contain this key, then we can't say if there's a shadowed older tag,
                     # therefore we do not drop the delete, but write it to a current segment.
-                    shadowed_put_exists = key not in self.shadow_index or any(
-                        # If the key is in the shadow index and there is any segment with an older PUT of this
-                        # key, we have a shadowed put.
+                    key_not_in_shadow_index = key not in self.shadow_index
+                    # If the key is in the shadow index and there is any segment with an older PUT of this
+                    # key, we have a shadowed put.
+                    shadowed_put_exists = key_not_in_shadow_index or any(
                         shadowed < segment for shadowed in self.shadow_index[key])
                     delete_is_not_stable = index_transaction_id is None or segment > index_transaction_id
 
@@ -865,6 +866,10 @@ class Repository:
                         self.compact[new_segment] += size
                         segments.setdefault(new_segment, 0)
                     else:
+                        logger.debug('dropping DEL for id %s - seg %d, iti %r, knisi %r, spe %r, dins %r, si %r',
+                                     bin_to_hex(key), segment, index_transaction_id,
+                                     key_not_in_shadow_index, shadowed_put_exists, delete_is_not_stable,
+                                     self.shadow_index.get(key))
                         # we did not keep the delete tag for key (see if-branch)
                         if not self.shadow_index[key]:
                             # shadowed segments list is empty -> remove it


### PR DESCRIPTION
i suspect that compact_segments wrongly drops some DEL tags.

this could make already deleted chunks re-appear, leading to:
- suddenly more repo index entries than previously (check, repo part)
- suddenly orphaned chunks appearing (check, archives part)

if this is the case, the issue is harmless, but annoying/confusing.

to fix the issue, i need the complete log line "dropping DEL for id X".
the id X it mentions is one of the chunk ids borg check complains about.
