### PR TITLE
repository api: flags support, fixes #6982

### DIFF
--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -146,6 +146,8 @@ class RepositoryServer:  # pragma: no cover
         "commit",
         "delete",
         "destroy",
+        "flags",
+        "flags_many",
         "get",
         "list",
         "scan",
@@ -979,12 +981,24 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
     def __len__(self):
         """actual remoting is done via self.call in the @api decorator"""
 
-    @api(since=parse_version("1.0.0"))
-    def list(self, limit=None, marker=None):
+    @api(
+        since=parse_version("1.0.0"),
+        mask={"since": parse_version("2.0.0b2"), "previously": 0},
+        value={"since": parse_version("2.0.0b2"), "previously": 0},
+    )
+    def list(self, limit=None, marker=None, mask=0, value=0):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(since=parse_version("1.1.0b3"))
     def scan(self, limit=None, marker=None):
+        """actual remoting is done via self.call in the @api decorator"""
+
+    @api(since=parse_version("2.0.0b2"))
+    def flags(self, id, mask=0xFFFFFFFF, value=None):
+        """actual remoting is done via self.call in the @api decorator"""
+
+    @api(since=parse_version("2.0.0b2"))
+    def flags_many(self, ids, mask=0xFFFFFFFF, value=None):
         """actual remoting is done via self.call in the @api decorator"""
 
     def get(self, id):


### PR DESCRIPTION
- .list: only return IDs for objects where flags & mask == value.
- .flags(_many) (new) to set/query flags
