### PR TITLE
Revert "re-add stretch64 vm, fixes #7010"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -314,22 +314,6 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("buster64", ".*none.*")
   end
 
-  config.vm.define "stretch64" do |b|
-    b.vm.box = "debian/stretch64"
-    b.vm.provider :virtualbox do |v|
-      v.memory = 1024 + $wmem
-    end
-    b.vm.provision "fs init", :type => :shell, :inline => fs_init("vagrant")
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid("vagrant")
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("stretch64")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("stretch64")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("stretch64")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("llfuse")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller()
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("stretch64")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("stretch64", ".*(fuse3|none).*")
-  end
-
   config.vm.define "freebsd64" do |b|
     b.vm.box = "generic/freebsd13"
     b.vm.provider :virtualbox do |v|


### PR DESCRIPTION
This reverts commit 7fec5ff0516be6950611c1df77ab5ee006994a01.

Does not work, we need libxxhash-dev and it is not available on debian stretch.