### PR TITLE
do not use version_tuple placeholder in setuptools_scm template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ setup(
     name='borgbackup',
     use_scm_version={
         'write_to': 'src/borg/_version.py',
-        'write_to_template': '__version__ = version = {version!r}\n__version_tuple__ = version_tuple = {version_tuple!r}\n',
+        'write_to_template': '__version__ = version = {version!r}\n',
     },
     author='The Borg Collective (see AUTHORS file)',
     author_email='borgbackup@python.org',


### PR DESCRIPTION
that would require setuptools_scm>=5.0.0 but some dists do not have that yet.

also, we do not use the version_tuple from _version.py, so it is not required anyway.
