### PR TITLE
repository.scan: use same end_segment within same scan

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1747,9 +1747,9 @@ class ArchiveChecker:
         pi = ProgressIndicatorPercent(
             total=chunks_count_index, msg="Verifying data %6.2f%%", step=0.01, msgid="check.verify_data"
         )
-        marker = None
+        state = None
         while True:
-            chunk_ids, marker = self.repository.scan(limit=100, marker=marker)
+            chunk_ids, state = self.repository.scan(limit=100, state=state)
             if not chunk_ids:
                 break
             chunks_count_segments += len(chunk_ids)

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -152,12 +152,10 @@ class DebugMixIn:
             cdata = repository.get(ids[0])
             key = key_factory(repository, cdata)
             repo_objs = RepoObj(key)
-            marker = None
+            state = None
             i = 0
             while True:
-                ids, marker = repository.scan(
-                    limit=LIST_SCAN_LIMIT, marker=marker
-                )  # must use on-disk order scanning here
+                ids, state = repository.scan(limit=LIST_SCAN_LIMIT, state=state)  # must use on-disk order scanning here
                 if not ids:
                     break
                 for id in ids:
@@ -203,12 +201,12 @@ class DebugMixIn:
         key = key_factory(repository, cdata)
         repo_objs = RepoObj(key)
 
-        marker = None
+        state = None
         last_data = b""
         last_id = None
         i = 0
         while True:
-            ids, marker = repository.scan(limit=LIST_SCAN_LIMIT, marker=marker)  # must use on-disk order scanning here
+            ids, state = repository.scan(limit=LIST_SCAN_LIMIT, state=state)  # must use on-disk order scanning here
             if not ids:
                 break
             for id in ids:

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -989,8 +989,8 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
     def list(self, limit=None, marker=None, mask=0, value=0):
         """actual remoting is done via self.call in the @api decorator"""
 
-    @api(since=parse_version("1.1.0b3"))
-    def scan(self, limit=None, marker=None):
+    @api(since=parse_version("2.0.0b2"))
+    def scan(self, limit=None, state=None):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(since=parse_version("2.0.0b2"))

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -191,10 +191,10 @@ class RepositoryTestCase(RepositoryTestCaseBase):
         self.repository.commit(compact=False)
         all, _ = self.repository.scan()
         assert len(all) == 100
-        first_half, marker = self.repository.scan(limit=50)
+        first_half, state = self.repository.scan(limit=50)
         assert len(first_half) == 50
         assert first_half == all[:50]
-        second_half, _ = self.repository.scan(marker=marker)
+        second_half, _ = self.repository.scan(state=state)
         assert len(second_half) == 50
         assert second_half == all[50:]
         # check result order == on-disk order (which is hash order)


### PR DESCRIPTION
achieved by putting it into the state that is now used instead of the marker.
