### PR TITLE
archive.save(): always use metadata from stats, fixes #7072

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -190,7 +190,7 @@ class CreateMixIn:
                     # we already have a checkpoint archive in this case.
                     self.print_error("Got Ctrl-C / SIGINT.")
                 else:
-                    archive.save(comment=args.comment, timestamp=args.timestamp, stats=archive.stats)
+                    archive.save(comment=args.comment, timestamp=args.timestamp)
                     args.stats |= args.json
                     if args.stats:
                         if args.json:

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -100,7 +100,7 @@ class TransferMixIn:
                         archive.add_item(upgrader.upgrade_item(item=item))
                 if not dry_run:
                     additional_metadata = upgrader.upgrade_archive_metadata(metadata=other_archive.metadata)
-                    archive.save(stats=archive.stats, additional_metadata=additional_metadata)
+                    archive.save(additional_metadata=additional_metadata)
                     print(
                         f"{name}: finished. "
                         f"transfer_size: {format_file_size(transfer_size)} "


### PR DESCRIPTION
e.g. nfiles, size, etc.

fixes:
- checkpoint archives did not have this metadata yet
- borg import-tar did not have this metadata yet
