### PR TITLE
transfer/upgrade: do not access Item._dict, fixes #7077

### DIFF
--- a/src/borg/upgrade.py
+++ b/src/borg/upgrade.py
@@ -77,18 +77,18 @@ class UpgraderFrom12To20:
         }
 
         if self.hlm.borg1_hardlink_master(item):
-            item._dict["hlid"] = hlid = self.hlm.hardlink_id_from_path(item._dict["path"])
-            self.hlm.remember(id=hlid, info=(item._dict.get("chunks"), item._dict.get("chunks_healthy")))
+            item.hlid = hlid = self.hlm.hardlink_id_from_path(item.path)
+            self.hlm.remember(id=hlid, info=(item.get("chunks"), item.get("chunks_healthy")))
         elif self.hlm.borg1_hardlink_slave(item):
-            item._dict["hlid"] = hlid = self.hlm.hardlink_id_from_path(item._dict["source"])
+            item.hlid = hlid = self.hlm.hardlink_id_from_path(item.source)
             chunks, chunks_healthy = self.hlm.retrieve(id=hlid, default=(None, None))
             if chunks is not None:
-                item._dict["chunks"] = chunks
+                item.chunks = chunks
                 for chunk_id, _ in chunks:
                     self.cache.chunk_incref(chunk_id, self.archive.stats)
             if chunks_healthy is not None:
-                item._dict["chunks_healthy"] = chunks
-            item._dict.pop("source")  # not used for hardlinks any more, replaced by hlid
+                item.chunks_healthy = chunks
+            del item.source  # not used for hardlinks any more, replaced by hlid
         # make sure we only have desired stuff in the new item. specifically, make sure to get rid of:
         # - 'acl' remnants of bug in attic <= 0.13
         # - 'hardlink_master' (superseded by hlid)


### PR DESCRIPTION
after the cython code refactor in #7063, accessing the internal _dict is not possible any more.

but looks like we do not even need that.
