### PR TITLE
Fix test_size_on_disk_accurate on Windows

### DIFF
--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -259,7 +259,7 @@ class HashIndexSizeTestCase(BaseTestCase):
         for i in range(1234):
             idx[H(i)] = i, i**2
         with tempfile.NamedTemporaryFile() as file:
-            idx.write(file.name)
+            idx.write(file)
             size = os.path.getsize(file.name)
         assert idx.size() == size
 


### PR DESCRIPTION
Pass the file descriptor instead of the file path
