### PR TITLE
Fix test_size_on_disk_accurate on Windows

### DIFF
--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -197,8 +197,8 @@ class HashIndexSizeTestCase(BaseTestCase):
         for i in range(1234):
             idx[H(i)] = i, i**2, i**3
         with tempfile.NamedTemporaryFile() as file:
-            idx.write(file.name)
-            size = os.path.getsize(file.name)
+            idx.write(file)
+            size = os.path.getsize(file.fileno())
         assert idx.size() == size
 
 


### PR DESCRIPTION
Pass the python file object / fd instead of the file path.

On Windows, a tempfile cannot be opened again, unlike on Unix systems. See https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
