### PR TITLE
Fix test_size_on_disk_accurate on Windows

### DIFF
--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -260,7 +260,7 @@ class HashIndexSizeTestCase(BaseTestCase):
             idx[H(i)] = i, i**2
         with tempfile.NamedTemporaryFile() as file:
             idx.write(file)
-            size = os.path.getsize(file.name)
+            size = os.path.getsize(file.fileno())
         assert idx.size() == size
 
 


### PR DESCRIPTION
Pass the python file object / fd instead of the file path.

On Windows, a tempfile cannot be opened again, unlike on Unix systems. See https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
