### PR TITLE
fix args.paths related argparsing, fixes #6994

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -853,4 +853,4 @@ class CreateMixIn:
         )
 
         subparser.add_argument("name", metavar="NAME", type=NameSpec, help="specify the archive name")
-        subparser.add_argument("paths", metavar="PATH", nargs="*", type=str, help="paths to archive")
+        subparser.add_argument("paths", metavar="PATH", nargs="*", type=str, action="extend", help="paths to archive")


### PR DESCRIPTION
argparse: the default action is "store" and that overwrote an already existing list in args.paths (e.g. from --pattern="R someroot") when it started to process the positional PATH args.

with "extend" it now extends the existing args.paths with the list of positional PATH arguments (which can be 0..N elements long, nargs="*").

note: "extend" is new since python 3.8, thus this can only be backported to 1.2-maint, but not to 1.1-maint.
