### PR TITLE
fix args.paths related argparsing, fixes #6994

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3614,7 +3614,7 @@ class Archiver:
         subparser.add_argument('location', metavar='ARCHIVE',
                                type=location_validator(archive=True),
                                help='name of archive to create (must be also a valid directory name)')
-        subparser.add_argument('paths', metavar='PATH', nargs='*', type=str,
+        subparser.add_argument('paths', metavar='PATH', nargs='*', type=str, action='extend',
                                help='paths to archive')
 
         # borg debug


### PR DESCRIPTION
argparse: the default action is "store" and that overwrote an already existing list in args.paths (e.g. from --pattern="R someroot") when it started to process the positional PATH args.

with "extend" it now extends the existing args.paths with the list of positional PATH arguments (which can be 0..N elements long, nargs="*").

note: "extend" is new since python 3.8, thus this can only be backported to 1.2-maint, but not to 1.1-maint.
