### PR TITLE
fix failing hashing_time test

### DIFF
--- a/src/borg/testsuite/archiver/create_cmd.py
+++ b/src/borg/testsuite/archiver/create_cmd.py
@@ -783,7 +783,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
         # Test case set up: create a repository and a file
         self.cmd(f"--repo={self.repository_location}", "rcreate", "--encryption=none")
-        self.create_regular_file("testfile", contents=randbytes(6000000))
+        self.create_regular_file("testfile", contents=randbytes(15000000))  # more data might be needed for faster CPUs
         # Archive
         result = self.cmd(f"--repo={self.repository_location}", "create", "--stats", "test_archive", self.input_path)
         hashing_time = extract_hashing_time(result)


### PR DESCRIPTION
fast CPUs failed the test due to rounding down to 0.00s.
