### PR TITLE
Fix repository tests on Windows

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1448,13 +1448,12 @@ class LoggedIO:
 
     def cleanup(self, transaction_id):
         """Delete segment files left by aborted transactions"""
+        self.close_segment()
         self.segment = transaction_id + 1
         count = 0
         for segment, filename in self.segment_iterator(reverse=True):
             if segment > transaction_id:
-                if segment in self.fds:
-                    del self.fds[segment]
-                safe_unlink(filename)
+                self.delete_segment(segment)
                 count += 1
             else:
                 break

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -636,7 +636,7 @@ class Repository:
             os.fsync(fd.fileno())
 
         def rename_tmp(file):
-            os.rename(file + ".tmp", file)
+            os.replace(file + ".tmp", file)
 
         hints = {
             "version": 2,

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -844,7 +844,7 @@ class RepositoryCheckTestCase(RepositoryTestCaseBase):
             fd.write(b"BOOM")
 
     def delete_segment(self, segment):
-        os.unlink(os.path.join(self.tmppath, "repository", "data", "0", str(segment)))
+        self.repository.io.delete_segment(segment)
 
     def delete_index(self):
         os.unlink(os.path.join(self.tmppath, "repository", f"index.{self.get_head()}"))

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -1138,6 +1138,14 @@ class RemoteRepositoryCheckTestCase(RepositoryCheckTestCase):
         # skip this test, we can't mock-patch a Repository class in another process!
         pass
 
+    def test_repair_missing_commit_segment(self):
+        # skip this test, files in RemoteRepository cannot be deleted
+        pass
+
+    def test_repair_missing_segment(self):
+        # skip this test, files in RemoteRepository cannot be deleted
+        pass
+
 
 class RemoteLoggerTestCase(BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
`pytest -k "repository.py and not remote"`

Before: `==== 17 failed, 44 passed, 1521 deselected, 3 warnings, 2 errors in 4.27s =====`
With these changes `=============== 61 passed, 1521 deselected, 3 warnings in 2.96s ===============`