### PR TITLE
Fix msgpack runtime on big-endian OpenBSD/sparc64

### DIFF
--- a/src/borg/algorithms/msgpack/_version.py
+++ b/src/borg/algorithms/msgpack/_version.py
@@ -2,5 +2,9 @@
 # Changes:
 # +borg1: drop support for old buffer protocol to be compatible with py310
 #         (backport of commit 9ae43709e42092c7f6a4e990d696d9005fa1623d)
-version = (0, 5, 6, '+borg1')
+# +borg2: Usef __BYTE_ORDER__ instead of __BYTE_ORDER (#513)
+#         (backport of commit 9d45926a596028e39ec59dd909a56eb5e9e8fee7)
+#         Fix build error caused by ntohs, ntohl (#514)
+#         (backport of commit edca770071fc702e0b4c33f87fb0fa3682b486b4)
+version = (0, 5, 6, '+borg2')
 

--- a/src/borg/algorithms/msgpack/sysdep.h
+++ b/src/borg/algorithms/msgpack/sysdep.h
@@ -61,8 +61,6 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 #endif
 
-#else
-#include <arpa/inet.h>  /* __BYTE_ORDER */
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)

--- a/src/borg/algorithms/msgpack/sysdep.h
+++ b/src/borg/algorithms/msgpack/sysdep.h
@@ -61,6 +61,8 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 #endif
 
+#else /* _WIN32 */
+#include <arpa/inet.h> /* ntohs, ntohl */
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
@@ -93,7 +95,7 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #ifdef _WIN32
 #  if defined(ntohl)
 #    define _msgpack_be32(x) ntohl(x)
-#  elif defined(_byteswap_ulong) || (defined(_MSC_VER) && _MSC_VER >= 1400)
+#  elif defined(_byteswap_ulong) || defined(_MSC_VER)
 #    define _msgpack_be32(x) ((uint32_t)_byteswap_ulong((unsigned long)x))
 #  else
 #    define _msgpack_be32(x) \
@@ -106,7 +108,7 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #  define _msgpack_be32(x) ntohl(x)
 #endif
 
-#if defined(_byteswap_uint64) || (defined(_MSC_VER) && _MSC_VER >= 1400)
+#if defined(_byteswap_uint64) || defined(_MSC_VER)
 #  define _msgpack_be64(x) (_byteswap_uint64(x))
 #elif defined(bswap_64)
 #  define _msgpack_be64(x) bswap_64(x)

--- a/src/borg/algorithms/msgpack/sysdep.h
+++ b/src/borg/algorithms/msgpack/sysdep.h
@@ -66,6 +66,15 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+/*
+ * __BYTE_ORDER, __LITTLE_ENDIAN and __BIG_ENDIAN are nonstandard and not
+ * always available. In those cases, fallback to common compiler defines.
+ */
+#if !defined(__BYTE_ORDER)
+#define __BYTE_ORDER __BYTE_ORDER__
+#define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#endif
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __LITTLE_ENDIAN__
 #elif __BYTE_ORDER == __BIG_ENDIAN

--- a/src/borg/algorithms/msgpack/sysdep.h
+++ b/src/borg/algorithms/msgpack/sysdep.h
@@ -66,18 +66,9 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-/*
- * __BYTE_ORDER, __LITTLE_ENDIAN and __BIG_ENDIAN are nonstandard and not
- * always available. In those cases, fallback to common compiler defines.
- */
-#if !defined(__BYTE_ORDER)
-#define __BYTE_ORDER __BYTE_ORDER__
-#define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
-#define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
-#endif
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define __LITTLE_ENDIAN__
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define __BIG_ENDIAN__
 #elif _WIN32
 #define __LITTLE_ENDIAN__


### PR DESCRIPTION
- Fallback to compiler defines when __BYTE_ORDER is not available
- simplify the endianity handling
- additional cleanup
- Fix build error caused by ntohs, ntohl

Backport https://github.com/msgpack/msgpack-python/pull/513 (as discussed in
https://github.com/borgbackup/borg/pull/6149#issuecomment-1335745572) and https://github.com/msgpack/msgpack-python/pull/514.

Applied with
```
$ gh -R msgpack/msgpack-python pr diff --patch 513 |
	git am --directory src/borg/algorithms/ -
$ gh -R msgpack/msgpack-python pr diff --patch 514 |
	git am --directory src/borg/algorithms/ -
```

Tested on OpenBSD/sparc64 (big-endian) and OpenBSD/amd64 (little-endian).
