### PR TITLE
fix tox4 issue on macOS CI (1.2-maint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
 
     needs: lint
     strategy:
+      fail-fast: true
       matrix:
         include:
             - os: ubuntu-20.04

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,10 @@ commands = py.test -v -n {env:XDISTN:1} -rs --cov=borg --cov-config=.coveragerc 
 passenv = *
 
 
+[testenv:.pkg]
+passenv = *  # needed by tox4, so env vars are visible for building borg
+
+
 [testenv:flake8]
 skip_sdist=true
 skip_install=true


### PR DESCRIPTION
also: have a setting to disable fail-fast, in case something breaks again.
