### PR TITLE
create: --list --dry-run output for directories, fixes #7209

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -810,8 +810,11 @@ class Archiver:
                                                 restrict_dev=restrict_dev, read_special=read_special, dry_run=dry_run)
                                 self.print_file_status('x', path)
                             return
-                    if not recurse_excluded_dir and not dry_run:
-                        status = fso.process_dir_with_fd(path=path, fd=child_fd, st=st)
+                    if not recurse_excluded_dir:
+                        if not dry_run:
+                            status = fso.process_dir_with_fd(path=path, fd=child_fd, st=st)
+                        else:
+                            status = '-'
                     if recurse:
                         with backup_io('scandir'):
                             entries = helpers.scandir_inorder(path=path, fd=child_fd)


### PR DESCRIPTION
Without the status being set no output was generated in dry-run mode, confusing users about whether borg would back up directories (in non-dry-run mode).

"-" == item not backed up just because of dry-run mode
"x" == item excluded
