### PR TITLE
create: --list --dry-run output for directories, fixes #7209

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -442,8 +442,11 @@ class CreateMixIn:
                                         )
                                 self.print_file_status("x", path)
                             return
-                    if not recurse_excluded_dir and not dry_run:
-                        status = fso.process_dir_with_fd(path=path, fd=child_fd, st=st)
+                    if not recurse_excluded_dir:
+                        if not dry_run:
+                            status = fso.process_dir_with_fd(path=path, fd=child_fd, st=st)
+                        else:
+                            status = "-"
                     if recurse:
                         with backup_io("scandir"):
                             entries = helpers.scandir_inorder(path=path, fd=child_fd)

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -118,7 +118,8 @@ class CreateMixIn:
                     if status == "C":
                         self.print_warning("%s: file changed while we backed it up", path)
                     self.print_file_status(status, path)
-                    fso.stats.files_stats[status] += 1
+                    if not dry_run and status is not None:
+                        fso.stats.files_stats[status] += 1
                 if args.paths_from_command:
                     rc = proc.wait()
                     if rc != 0:
@@ -142,7 +143,8 @@ class CreateMixIn:
                         else:
                             status = "-"
                         self.print_file_status(status, path)
-                        fso.stats.files_stats[status] += 1
+                        if not dry_run and status is not None:
+                            fso.stats.files_stats[status] += 1
                         continue
                     path = os.path.normpath(path)
                     parent_dir = os.path.dirname(path) or "."
@@ -475,7 +477,7 @@ class CreateMixIn:
             self.print_warning("%s: file changed while we backed it up", path)
         if not recurse_excluded_dir:
             self.print_file_status(status, path)
-            if status is not None:
+            if not dry_run and status is not None:
                 fso.stats.files_stats[status] += 1
 
     def build_parser_create(self, subparsers, common_parser, mid_common_parser):


### PR DESCRIPTION
Without the status being set no output was generated in dry-run mode, confusing users about whether borg would back up directories (in non-dry-run mode).

"-" == item not backed up just because of dry-run mode
"x" == item excluded
