### PR TITLE
remove --save-space

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1691,16 +1691,13 @@ class ArchiveChecker:
         self.error_found = False
         self.possibly_superseded = set()
 
-    def check(
-        self, repository, repair=False, first=0, last=0, sort_by="", match=None, verify_data=False, save_space=False
-    ):
+    def check(self, repository, repair=False, first=0, last=0, sort_by="", match=None, verify_data=False):
         """Perform a set of checks on 'repository'
 
         :param repair: enable repair mode, write updated or corrected data into repository
         :param first/last/sort_by: only check this number of first/last archives ordered by sort_by
         :param match: only check archives matching this pattern
         :param verify_data: integrity verification of data referenced by archives
-        :param save_space: Repository.commit(save_space)
         """
         logger.info("Starting archive consistency check...")
         self.check_all = not any((first, last, match))
@@ -1728,7 +1725,7 @@ class ArchiveChecker:
                 self.manifest = self.rebuild_manifest()
         self.rebuild_refcounts(match=match, first=first, last=last, sort_by=sort_by)
         self.orphan_chunks_check()
-        self.finish(save_space=save_space)
+        self.finish()
         if self.error_found:
             logger.error("Archive consistency check complete, problems found.")
         else:
@@ -2192,12 +2189,12 @@ class ArchiveChecker:
         else:
             logger.info("Orphaned objects check skipped (needs all archives checked).")
 
-    def finish(self, save_space=False):
+    def finish(self):
         if self.repair:
             logger.info("Writing Manifest.")
             self.manifest.write()
             logger.info("Committing repo.")
-            self.repository.commit(compact=False, save_space=save_space)
+            self.repository.commit(compact=False)
 
 
 class ArchiveRecreater:

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -47,7 +47,7 @@ class CheckMixIn:
             self.print_error("--repository-only is required for --max-duration support.")
             return EXIT_ERROR
         if not args.archives_only:
-            if not repository.check(repair=args.repair, save_space=args.save_space, max_duration=args.max_duration):
+            if not repository.check(repair=args.repair, max_duration=args.max_duration):
                 return EXIT_WARNING
         if not args.repo_only and not ArchiveChecker().check(
             repository,
@@ -57,7 +57,6 @@ class CheckMixIn:
             sort_by=args.sort_by or "ts",
             match=args.match_archives,
             verify_data=args.verify_data,
-            save_space=args.save_space,
         ):
             return EXIT_WARNING
         return EXIT_SUCCESS
@@ -167,9 +166,6 @@ class CheckMixIn:
         )
         subparser.add_argument(
             "--repair", dest="repair", action="store_true", help="attempt to repair any inconsistencies found"
-        )
-        subparser.add_argument(
-            "--save-space", dest="save_space", action="store_true", help="work slower, but using less space"
         )
         subparser.add_argument(
             "--max-duration",

--- a/src/borg/archiver/delete_cmd.py
+++ b/src/borg/archiver/delete_cmd.py
@@ -60,7 +60,7 @@ class DeleteMixIn:
 
             def checkpoint_func():
                 manifest.write()
-                repository.commit(compact=False, save_space=args.save_space)
+                repository.commit(compact=False)
                 cache.commit()
 
             msg_delete = "Would delete archive: {} ({}/{})" if dry_run else "Deleting archive: {} ({}/{})"
@@ -156,9 +156,6 @@ class DeleteMixIn:
             action="count",
             default=0,
             help="force deletion of corrupted archives, " "use ``--force --force`` in case ``--force`` does not work.",
-        )
-        subparser.add_argument(
-            "--save-space", dest="save_space", action="store_true", help="work slower, but using less space"
         )
         subparser.add_argument(
             "-c",

--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -123,7 +123,7 @@ class PruneMixIn:
 
             def checkpoint_func():
                 manifest.write()
-                repository.commit(compact=False, save_space=args.save_space)
+                repository.commit(compact=False)
                 cache.commit()
 
             list_logger = logging.getLogger("borg.output.list")
@@ -289,9 +289,6 @@ class PruneMixIn:
             "-y", "--keep-yearly", dest="yearly", type=int, default=0, help="number of yearly archives to keep"
         )
         define_archive_filters_group(subparser, sort_by=False, first_last=False)
-        subparser.add_argument(
-            "--save-space", dest="save_space", action="store_true", help="work slower, but using less space"
-        )
         subparser.add_argument(
             "-c",
             "--checkpoint-interval",

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -119,8 +119,8 @@ class UnexpectedRPCDataFormatFromServer(Error):
 
 
 compatMap = {
-    "check": ("repair", "save_space"),
-    "commit": ("save_space",),
+    "check": ("repair",),
+    "commit": (),
     "rollback": (),
     "destroy": (),
     "__len__": (),
@@ -958,7 +958,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(since=parse_version("1.0.0"), max_duration={"since": parse_version("1.2.0a4"), "previously": 0})
-    def check(self, repair=False, save_space=False, max_duration=0):
+    def check(self, repair=False, max_duration=0):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(
@@ -966,7 +966,7 @@ This problem will go away as soon as the server has been upgraded to 1.0.7+.
         compact={"since": parse_version("1.2.0a0"), "previously": True, "dontcare": True},
         threshold={"since": parse_version("1.2.0a8"), "previously": 0.1, "dontcare": True},
     )
-    def commit(self, save_space=False, compact=True, threshold=0.1):
+    def commit(self, compact=True, threshold=0.1):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(since=parse_version("1.0.0"))

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -505,9 +505,8 @@ class Repository:
             self.lock.release()
             self.lock = None
 
-    def commit(self, save_space=False, compact=True, threshold=0.1):
+    def commit(self, compact=True, threshold=0.1):
         """Commit transaction"""
-        # save_space is not used anymore, but stays for RPC/API compatibility.
         if self.transaction_doomed:
             exception = self.transaction_doomed
             self.rollback()
@@ -1022,7 +1021,7 @@ class Repository:
                 # The outcome of the DELETE has been recorded in the PUT branch already.
                 self.compact[segment] += header_size(tag) + size
 
-    def check(self, repair=False, save_space=False, max_duration=0):
+    def check(self, repair=False, max_duration=0):
         """Check repository consistency
 
         This method verifies all segment checksums and makes sure

--- a/src/borg/testsuite/archiver/prune_cmd.py
+++ b/src/borg/testsuite/archiver/prune_cmd.py
@@ -161,21 +161,6 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         assert re.search(r"Keeping archive \(rule: monthly #1\):\s+september30", output)
         self.assert_not_in("original_archive", output)
 
-    def test_prune_repository_save_space(self):
-        self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
-        self.cmd(f"--repo={self.repository_location}", "create", "test1", src_dir)
-        self.cmd(f"--repo={self.repository_location}", "create", "test2", src_dir)
-        output = self.cmd(f"--repo={self.repository_location}", "prune", "--list", "--dry-run", "--keep-daily=1")
-        assert re.search(r"Keeping archive \(rule: daily #1\):\s+test2", output)
-        assert re.search(r"Would prune:\s+test1", output)
-        output = self.cmd(f"--repo={self.repository_location}", "rlist")
-        self.assert_in("test1", output)
-        self.assert_in("test2", output)
-        self.cmd(f"--repo={self.repository_location}", "prune", "--save-space", "--keep-daily=1")
-        output = self.cmd(f"--repo={self.repository_location}", "rlist")
-        self.assert_not_in("test1", output)
-        self.assert_in("test2", output)
-
     def test_prune_repository_prefix(self):
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         self.cmd(f"--repo={self.repository_location}", "create", "foo-2015-08-12-10:00", src_dir)


### PR DESCRIPTION
this option did not change behaviour since longer, we only had kept it for API compatibility.

as a borg2 repo server won't have old clients talking to it, we can safely remove this everywhere now.
