### PR TITLE
Fix test_size_on_disk_accurate for large st_blksize, fixes #7250

### DIFF
--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -258,9 +258,9 @@ class HashIndexSizeTestCase(BaseTestCase):
         idx = ChunkIndex()
         for i in range(1234):
             idx[H(i)] = i, i**2
-        with tempfile.NamedTemporaryFile() as file:
-            idx.write(file)
-            size = os.path.getsize(file.fileno())
+        with unopened_tempfile() as filepath:
+            idx.write(filepath)
+            size = os.path.getsize(filepath)
         assert idx.size() == size
 
 


### PR DESCRIPTION
python's io.BufferedWriter sizes its buffer based on st_blksize

If the write fits in this buffer, then it's possible none (or only some) of the data from idx.write() has been written through to fileno()

Fixes #7250