### PR TITLE
[1.2-maint] Fix test_size_on_disk_accurate for large st_blksize, fixes #7250

### DIFF
--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -196,9 +196,9 @@ class HashIndexSizeTestCase(BaseTestCase):
         idx = ChunkIndex()
         for i in range(1234):
             idx[H(i)] = i, i**2, i**3
-        with tempfile.NamedTemporaryFile() as file:
-            idx.write(file)
-            size = os.path.getsize(file.fileno())
+        with unopened_tempfile() as filepath:
+            idx.write(filepath)
+            size = os.path.getsize(filepath)
         assert idx.size() == size
 
 


### PR DESCRIPTION
python's io.BufferedWriter sizes its buffer based on st_blksize

If the write fits in this buffer, then it's possible none (or only some) of the data from idx.write() has been written through to fileno()

Note:1.2-maint counterpart of #7251.

I see that the contribution guidelines ask for PRs only against master (leaving backports up to you maintainers) but in this case I want to publicly post a commit based on 1.2-maint to this repo, so that @mweinelt can have the nixpkgs derivation cherry-pick that commit for testing. I think we understand what's going on, but the failure is being seen on nixos autobuilders that use ZFS for $TEMP, and I don't personally have anything with that configuration, or direct access to those build machines.

Fixes #7250