### PR TITLE
Support for date-based matching during archive listing

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1692,7 +1692,8 @@ class ArchiveChecker:
         self.error_found = False
         self.possibly_superseded = set()
 
-    def check(self, repository, repair=False, first=0, last=0, sort_by="", match=None, verify_data=False):
+    def check(self, repository, repair=False, first=0, last=0, sort_by="", match=None, older=None, oldest=None,
+              newer=None, newest=None, verify_data=False):
         """Perform a set of checks on 'repository'
 
         :param repair: enable repair mode, write updated or corrected data into repository
@@ -1724,7 +1725,8 @@ class ArchiveChecker:
                 self.error_found = True
                 del self.chunks[Manifest.MANIFEST_ID]
                 self.manifest = self.rebuild_manifest()
-        self.rebuild_refcounts(match=match, first=first, last=last, sort_by=sort_by)
+        self.rebuild_refcounts(match=match, first=first, last=last, sort_by=sort_by, older=older, oldest=oldest,
+                               newer=newer, newest=newest)
         self.orphan_chunks_check()
         self.finish()
         if self.error_found:
@@ -1919,7 +1921,8 @@ class ArchiveChecker:
         logger.info("Manifest rebuild complete.")
         return manifest
 
-    def rebuild_refcounts(self, first=0, last=0, sort_by="", match=None):
+    def rebuild_refcounts(self, first=0, last=0, sort_by="", match=None, older=None, oldest=None, newer=None,
+                          newest=None):
         """Rebuild object reference counts by walking the metadata
 
         Missing and/or incorrect data is repaired when detected
@@ -2113,8 +2116,9 @@ class ArchiveChecker:
                     i += 1
 
         sort_by = sort_by.split(",")
-        if any((first, last, match)):
-            archive_infos = self.manifest.archives.list(sort_by=sort_by, match=match, first=first, last=last)
+        if any((first, last, match, older, newer, newest, oldest)):
+            archive_infos = self.manifest.archives.list(sort_by=sort_by, match=match, first=first, last=last,
+                                                        oldest=oldest, newest=newest, older=older, newer=newer)
             if match and not archive_infos:
                 logger.warning("--match-archives %s does not match any archives", match)
             if first and len(archive_infos) < first:

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1701,8 +1701,8 @@ class ArchiveChecker:
         sort_by="",
         match=None,
         older=None,
-        oldest=None,
         newer=None,
+        oldest=None,
         newest=None,
         verify_data=False,
     ):
@@ -1711,10 +1711,12 @@ class ArchiveChecker:
         :param repair: enable repair mode, write updated or corrected data into repository
         :param first/last/sort_by: only check this number of first/last archives ordered by sort_by
         :param match: only check archives matching this pattern
+        :param older/newer: only check archives older/newer than timedelta from now
+        :param oldest/newest: only check archives older/newer than timedelta from oldest/newest archive timestamp
         :param verify_data: integrity verification of data referenced by archives
         """
         logger.info("Starting archive consistency check...")
-        self.check_all = not any((first, last, match))
+        self.check_all = not any((first, last, match, older, newer, oldest, newest))
         self.repair = repair
         self.repository = repository
         self.init_chunks()
@@ -1935,7 +1937,7 @@ class ArchiveChecker:
         return manifest
 
     def rebuild_refcounts(
-        self, first=0, last=0, sort_by="", match=None, older=None, oldest=None, newer=None, newest=None
+        self, first=0, last=0, sort_by="", match=None, older=None, newer=None, oldest=None, newest=None
     ):
         """Rebuild object reference counts by walking the metadata
 

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1692,8 +1692,20 @@ class ArchiveChecker:
         self.error_found = False
         self.possibly_superseded = set()
 
-    def check(self, repository, repair=False, first=0, last=0, sort_by="", match=None, older=None, oldest=None,
-              newer=None, newest=None, verify_data=False):
+    def check(
+        self,
+        repository,
+        repair=False,
+        first=0,
+        last=0,
+        sort_by="",
+        match=None,
+        older=None,
+        oldest=None,
+        newer=None,
+        newest=None,
+        verify_data=False,
+    ):
         """Perform a set of checks on 'repository'
 
         :param repair: enable repair mode, write updated or corrected data into repository
@@ -1725,8 +1737,9 @@ class ArchiveChecker:
                 self.error_found = True
                 del self.chunks[Manifest.MANIFEST_ID]
                 self.manifest = self.rebuild_manifest()
-        self.rebuild_refcounts(match=match, first=first, last=last, sort_by=sort_by, older=older, oldest=oldest,
-                               newer=newer, newest=newest)
+        self.rebuild_refcounts(
+            match=match, first=first, last=last, sort_by=sort_by, older=older, oldest=oldest, newer=newer, newest=newest
+        )
         self.orphan_chunks_check()
         self.finish()
         if self.error_found:
@@ -1921,8 +1934,9 @@ class ArchiveChecker:
         logger.info("Manifest rebuild complete.")
         return manifest
 
-    def rebuild_refcounts(self, first=0, last=0, sort_by="", match=None, older=None, oldest=None, newer=None,
-                          newest=None):
+    def rebuild_refcounts(
+        self, first=0, last=0, sort_by="", match=None, older=None, oldest=None, newer=None, newest=None
+    ):
         """Rebuild object reference counts by walking the metadata
 
         Missing and/or incorrect data is repaired when detected
@@ -2117,8 +2131,16 @@ class ArchiveChecker:
 
         sort_by = sort_by.split(",")
         if any((first, last, match, older, newer, newest, oldest)):
-            archive_infos = self.manifest.archives.list(sort_by=sort_by, match=match, first=first, last=last,
-                                                        oldest=oldest, newest=newest, older=older, newer=newer)
+            archive_infos = self.manifest.archives.list(
+                sort_by=sort_by,
+                match=match,
+                first=first,
+                last=last,
+                oldest=oldest,
+                newest=newest,
+                older=older,
+                newer=newer,
+            )
             if match and not archive_infos:
                 logger.warning("--match-archives %s does not match any archives", match)
             if first and len(archive_infos) < first:

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -353,7 +353,7 @@ def define_exclusion_group(subparser, **kwargs):
     return exclude_group
 
 
-def define_archive_filters_group(subparser, *, sort_by=True, first_last=True):
+def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, oldest_newest=True, older_newer=True):
     filters_group = subparser.add_argument_group(
         "Archive filters", "Archive filters can be applied to repository targets."
     )
@@ -397,6 +397,36 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True):
             default=0,
             type=positive_int_validator,
             help="consider last N archives after other filters were applied",
+        )
+
+    if oldest_newest:
+        group = filters_group.add_mutually_exclusive_group()
+        group.add_argument(
+            "--oldest",
+            metavar="Nd",
+            dest="oldest",
+            help="consider archives N-days after the oldest archive's timestamp",
+        )
+        group.add_argument(
+            "--newest",
+            metavar="Nd",
+            dest="newest",
+            help="consider archives N-days before the newest archive's timestamp",
+        )
+
+    if older_newer:
+        group = filters_group.add_mutually_exclusive_group()
+        group.add_argument(
+            "--older",
+            metavar="Nd",
+            dest="older",
+            help="consider archives older than N-days ago",
+        )
+        group.add_argument(
+            "--newer",
+            metavar="Nd",
+            dest="newer",
+            help="consider archives between now and N-days ago",
         )
 
     return filters_group

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -406,14 +406,14 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, ol
             metavar="Nd",
             type=relative_time_marker_validator,
             dest="oldest",
-            help="consider archives N-days after the oldest archive's timestamp",
+            help="consider archives N [days/months] after the oldest archive's timestamp",
         )
         group.add_argument(
             "--newest",
             metavar="Nd",
             type=relative_time_marker_validator,
             dest="newest",
-            help="consider archives N-days before the newest archive's timestamp",
+            help="consider archives N [days/months] before the newest archive's timestamp",
         )
 
     if older_newer:
@@ -423,14 +423,14 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, ol
             metavar="Nd",
             type=relative_time_marker_validator,
             dest="older",
-            help="consider archives older than N-days ago",
+            help="consider archives older than N [days/months] ago",
         )
         group.add_argument(
             "--newer",
             metavar="Nd",
             type=relative_time_marker_validator,
             dest="newer",
-            help="consider archives between now and N-days ago",
+            help="consider archives between now and N [days/months] ago",
         )
 
     return filters_group

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -8,7 +8,7 @@ from ..archive import Archive
 from ..constants import *  # NOQA
 from ..cache import Cache, assert_secure
 from ..helpers import Error
-from ..helpers import SortBySpec, positive_int_validator, location_validator, Location
+from ..helpers import SortBySpec, positive_int_validator, location_validator, Location, relative_time_marker_validator
 from ..helpers.nanorst import rst_to_terminal
 from ..manifest import Manifest, AI_HUMAN_SORT_KEYS
 from ..patterns import PatternMatcher
@@ -404,12 +404,14 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, ol
         group.add_argument(
             "--oldest",
             metavar="Nd",
+            type=relative_time_marker_validator,
             dest="oldest",
             help="consider archives N-days after the oldest archive's timestamp",
         )
         group.add_argument(
             "--newest",
             metavar="Nd",
+            type=relative_time_marker_validator,
             dest="newest",
             help="consider archives N-days before the newest archive's timestamp",
         )
@@ -419,12 +421,14 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, ol
         group.add_argument(
             "--older",
             metavar="Nd",
+            type=relative_time_marker_validator,
             dest="older",
             help="consider archives older than N-days ago",
         )
         group.add_argument(
             "--newer",
             metavar="Nd",
+            type=relative_time_marker_validator,
             dest="newer",
             help="consider archives between now and N-days ago",
         )

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -403,34 +403,34 @@ def define_archive_filters_group(subparser, *, sort_by=True, first_last=True, ol
         group = filters_group.add_mutually_exclusive_group()
         group.add_argument(
             "--oldest",
-            metavar="Nd",
+            metavar="TIMESTAMP",
             type=relative_time_marker_validator,
             dest="oldest",
-            help="consider archives N [days/months] after the oldest archive's timestamp",
+            help="consider archives between the oldest archive's timestamp and the TIMESTAMP offset. e.g. 3d 7m",
         )
         group.add_argument(
             "--newest",
-            metavar="Nd",
+            metavar="TIMESTAMP",
             type=relative_time_marker_validator,
             dest="newest",
-            help="consider archives N [days/months] before the newest archive's timestamp",
+            help="consider archives between the newest archive's timestamp and the TIMESTAMP offset. e.g. 3d 7m",
         )
 
     if older_newer:
         group = filters_group.add_mutually_exclusive_group()
         group.add_argument(
             "--older",
-            metavar="Nd",
+            metavar="TIMESTAMP",
             type=relative_time_marker_validator,
             dest="older",
-            help="consider archives older than N [days/months] ago",
+            help="consider archives older than (now - TIMESTAMP). e.g. 3d 7m",
         )
         group.add_argument(
             "--newer",
-            metavar="Nd",
+            metavar="TIMESTAMP",
             type=relative_time_marker_validator,
             dest="newer",
-            help="consider archives between now and N [days/months] ago",
+            help="consider archives after (now - TIMESTAMP). e.g. 3d 7m",
         )
 
     return filters_group

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -57,6 +57,10 @@ class CheckMixIn:
             sort_by=args.sort_by or "ts",
             match=args.match_archives,
             verify_data=args.verify_data,
+            oldest=args.oldest,
+            newest=args.newest,
+            older=args.older,
+            newer=args.newer
         ):
             return EXIT_WARNING
         return EXIT_SUCCESS

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -60,7 +60,7 @@ class CheckMixIn:
             oldest=args.oldest,
             newest=args.newest,
             older=args.older,
-            newer=args.newer
+            newer=args.newer,
         ):
             return EXIT_WARNING
         return EXIT_SUCCESS

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -22,17 +22,10 @@ from .parseformat import bin_to_hex, safe_encode, safe_decode
 from .parseformat import remove_surrogates, eval_escapes, decode_dict, positive_int_validator, interval
 from .parseformat import SortBySpec, ChunkerParams, FilesCacheMode, partial_format, DatetimeWrapper
 from .parseformat import format_file_size, parse_file_size, FileSize, parse_storage_quota
-from .parseformat import sizeof_fmt, sizeof_fmt_iec, sizeof_fmt_decimal
-from .parseformat import format_line, replace_placeholders, PlaceholderError
+from .parseformat import sizeof_fmt, sizeof_fmt_iec, sizeof_fmt_decimal, Location, text_validator
+from .parseformat import format_line, replace_placeholders, PlaceholderError, relative_time_marker_validator
 from .parseformat import format_archive, parse_stringified_list, clean_lines
-from .parseformat import (
-    Location,
-    location_validator,
-    archivename_validator,
-    comment_validator,
-    text_validator,
-    relative_time_marker_validator,
-)
+from .parseformat import location_validator, archivename_validator, comment_validator
 from .parseformat import BaseFormatter, ArchiveFormatter, ItemFormatter, file_status
 from .parseformat import swidth_slice, ellipsis_truncate
 from .parseformat import BorgJsonEncoder, basic_json_data, json_print, json_dump, prepare_dump_dict

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -25,7 +25,14 @@ from .parseformat import format_file_size, parse_file_size, FileSize, parse_stor
 from .parseformat import sizeof_fmt, sizeof_fmt_iec, sizeof_fmt_decimal
 from .parseformat import format_line, replace_placeholders, PlaceholderError
 from .parseformat import format_archive, parse_stringified_list, clean_lines
-from .parseformat import Location, location_validator, archivename_validator, comment_validator, text_validator
+from .parseformat import (
+    Location,
+    location_validator,
+    archivename_validator,
+    comment_validator,
+    text_validator,
+    relative_time_marker_validator,
+)
 from .parseformat import BaseFormatter, ArchiveFormatter, ItemFormatter, file_status
 from .parseformat import swidth_slice, ellipsis_truncate
 from .parseformat import BorgJsonEncoder, basic_json_data, json_print, json_dump, prepare_dump_dict

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -537,11 +537,9 @@ def location_validator(proto=None, other=False):
 
 
 def relative_time_marker_validator(text: str):
-    day_offset_regex = r"^\d+d$"
-    month_offset_regex = r"^\d+m$"
-    day_match = re.compile(day_offset_regex).search(text)
-    month_match = re.compile(month_offset_regex).search(text)
-    if not day_match and not month_match:
+    time_marker_regex = r"^\d+[md]$"
+    match = re.compile(time_marker_regex).search(text)
+    if not match:
         raise argparse.ArgumentTypeError(f"Invalid relative time marker used: {text}")
     else:
         return text

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -536,6 +536,17 @@ def location_validator(proto=None, other=False):
     return validator
 
 
+def relative_time_marker_validator(text: str):
+    day_offset_regex = r"^\d+d$"
+    month_offset_regex = r"^\d+m$"
+    day_match = re.compile(day_offset_regex).search(text)
+    month_match = re.compile(month_offset_regex).search(text)
+    if not day_match and not month_match:
+        raise argparse.ArgumentTypeError(f"Invalid relative time marker used: {text}")
+    else:
+        return text
+
+
 def text_validator(*, name, max_length, min_length=0, invalid_ctrl_chars="\0", invalid_chars="", no_blanks=False):
     def validator(text):
         assert isinstance(text, str)

--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -1,6 +1,6 @@
 import os
-from datetime import datetime, timezone
-
+import re
+from datetime import datetime, timezone, timedelta
 
 def parse_timestamp(timestamp, tzinfo=timezone.utc):
     """Parse a ISO 8601 timestamp string.
@@ -107,6 +107,48 @@ def format_timedelta(td):
     if td.days:
         txt = "%d days %s" % (td.days, txt)
     return txt
+
+
+def calculate_relative_offset(format_string, from_date, earlier=False):
+    """ Calculates offset based on a relative marker. 7d (7 days), 8m (8 months)
+        earlier: whether offset should be calculated to an earlier time.
+    """
+    if from_date is None:
+        from_date = archive_ts_now().date()
+
+    if format_string is None:
+        return from_date
+
+    day_offset_regex = re.compile(r'\d+d')
+    month_offset_regex = re.compile(r'\d+m')
+
+    day_offset_str = day_offset_regex.search(format_string)
+    if day_offset_str is not None:
+        day_offset = int(day_offset_str.group()[:-1])
+        day_offset *= -1 if earlier else 1
+        return from_date + timedelta(days=day_offset)
+
+    month_offset_str = month_offset_regex.search(format_string)
+    if month_offset_str is not None:
+        month_offset = int(month_offset_str.group()[:-1])
+        month_offset *= -1 if earlier else 1
+        return offset_n_months(from_date, month_offset)
+
+    return from_date
+
+
+def offset_n_months(from_date, n_months):
+    # Calculate target month and year by getting completed total_months until target_month
+    total_months = (from_date.year * 12) + from_date.month + n_months
+    target_year = (total_months - 1) // 12
+    target_month = (total_months % 12) or 12
+
+    # calculate the max days of the target month by subtracting a day from the next month
+    next_month_month = ((total_months + 1) % 12) or 12
+    next_month_year = (total_months + 1) // 12
+    max_days_in_month = (datetime(next_month_year, next_month_month, 1) - timedelta(1)).day
+
+    return datetime(day=min(from_date.day, max_days_in_month), month=target_month, year=target_year).replace(tzinfo=timezone.utc)
 
 
 class OutputTimestamp:

--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -111,7 +111,8 @@ def format_timedelta(td):
 
 
 def calculate_relative_offset(format_string, from_ts, earlier=False):
-    """Calculates offset based on a relative marker. 7d (7 days), 8m (8 months)
+    """
+    Calculates offset based on a relative marker. 7d (7 days), 8m (8 months)
     earlier: whether offset should be calculated to an earlier time.
     """
     if from_ts is None:

--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -119,7 +119,7 @@ def calculate_relative_offset(format_string, from_date, earlier=False):
 
     if format_string is not None:
         day_offset_regex = re.compile(r"(?P<offset>\d+)d")
-        month_offset_regex = re.compile(r"(?P<offset>\d+)+m")
+        month_offset_regex = re.compile(r"(?P<offset>\d+)m")
 
         day_offset_match = day_offset_regex.search(format_string)
         if day_offset_match:

--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -126,11 +126,11 @@ def calculate_relative_offset(format_string, from_ts, earlier=False):
             offset = int(match.group("offset"))
             offset *= -1 if earlier else 1
 
-            if unit == 'd':
+            if unit == "d":
                 return from_ts + timedelta(days=offset)
-            elif unit == 'm':
+            elif unit == "m":
                 return offset_n_months(from_ts, offset)
-    
+
     raise ValueError(f"Invalid relative ts offset format: {format_string}")
 
 
@@ -148,7 +148,9 @@ def offset_n_months(from_ts, n_months):
     following_month, year_of_following_month = get_month_and_year_from_total(total_months + 1)
     max_days_in_month = (datetime(year_of_following_month, following_month, 1) - timedelta(1)).day
 
-    return datetime(day=min(from_ts.day, max_days_in_month), month=target_month, year=target_year).replace(tzinfo=from_ts.tzinfo)
+    return datetime(day=min(from_ts.day, max_days_in_month), month=target_month, year=target_year).replace(
+        tzinfo=from_ts.tzinfo
+    )
 
 
 class OutputTimestamp:

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -34,7 +34,7 @@ AI_HUMAN_SORT_KEYS = ["timestamp"] + list(ArchiveInfo._fields)
 AI_HUMAN_SORT_KEYS.remove("ts")
 
 
-def filter_archives_by_date(archives, oldest=None, newest=None, older=None, newer=None):
+def filter_archives_by_date(archives, older=None, newer=None, oldest=None, newest=None):
     def get_first_and_last_archive_ts(archives_list):
         timestamps = [x.ts for x in archives_list]
         return min(timestamps), max(timestamps)
@@ -106,18 +106,25 @@ class Archives(abc.MutableMapping):
         first=None,
         last=None,
         reverse=False,
-        oldest=None,
-        newest=None,
         older=None,
-        newer=None
+        newer=None,
+        oldest=None,
+        newest=None
     ):
         """
         Return list of ArchiveInfo instances according to the parameters.
 
-        First match *match* (considering *match_end*), then *sort_by*.
+        First match *match* (considering *match_end*)
+        then filter by timestamp considering *older* and *newer* followed by a second pass to
+        filter the result considering *oldest* and *newest*
+        then *sort_by*.
+
         Apply *first* and *last* filters, and then possibly *reverse* the list.
 
         *sort_by* is a list of sort keys applied in reverse order.
+        *newer* and *older* are relative time markers that indicate offset from now
+        *newest* and *oldest* are relative time markers that indicate offset from newest/oldest archive's timestamp
+
 
         Note: for better robustness, all filtering / limiting parameters must default to
               "not limit / not filter", so a FULL archive list is produced by a simple .list().

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -42,16 +42,16 @@ def filter_archives_by_date(archives, older=None, newer=None, oldest=None, newes
     now = archive_ts_now()
     earliest_ts, latest_ts = get_first_and_last_archive_ts(archives)
 
-    until_ts = calculate_relative_offset(older, from_date=now, earlier=True) if older is not None else latest_ts
-    from_ts = calculate_relative_offset(newer, from_date=now, earlier=True) if newer is not None else earliest_ts
+    until_ts = calculate_relative_offset(older, now, earlier=True) if older is not None else latest_ts
+    from_ts = calculate_relative_offset(newer, now, earlier=True) if newer is not None else earliest_ts
     archives = [x for x in archives if from_ts <= x.ts <= until_ts]
 
     earliest_ts, latest_ts = get_first_and_last_archive_ts(archives)
     if oldest:
-        until_ts = calculate_relative_offset(oldest, from_date=earliest_ts, earlier=False)
+        until_ts = calculate_relative_offset(oldest, earliest_ts, earlier=False)
         archives = [x for x in archives if x.ts <= until_ts]
     if newest:
-        from_ts = calculate_relative_offset(newest, from_date=latest_ts, earlier=True)
+        from_ts = calculate_relative_offset(newest, latest_ts, earlier=True)
         archives = [x for x in archives if x.ts >= from_ts]
 
     return archives
@@ -114,16 +114,14 @@ class Archives(abc.MutableMapping):
         """
         Return list of ArchiveInfo instances according to the parameters.
 
-        First match *match* (considering *match_end*)
-        then filter by timestamp considering *older* and *newer* followed by a second pass to
-        filter the result considering *oldest* and *newest*
-        then *sort_by*.
+        First match *match* (considering *match_end*), then filter by timestamp considering *older* and *newer*.
+        Second, follow with a filter considering *oldest* and *newest*, then sort by the given *sort_by* argument.
 
         Apply *first* and *last* filters, and then possibly *reverse* the list.
 
         *sort_by* is a list of sort keys applied in reverse order.
-        *newer* and *older* are relative time markers that indicate offset from now
-        *newest* and *oldest* are relative time markers that indicate offset from newest/oldest archive's timestamp
+        *newer* and *older* are relative time markers that indicate offset from now.
+        *newest* and *oldest* are relative time markers that indicate offset from newest/oldest archive's timestamp.
 
 
         Note: for better robustness, all filtering / limiting parameters must default to

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -35,28 +35,24 @@ AI_HUMAN_SORT_KEYS.remove("ts")
 
 
 def filter_archives_by_date(archives, oldest=None, newest=None, older=None, newer=None):
-    def get_first_and_last_archive_dates(archives_list):
-        dates = [x.ts for x in archives_list]
-        return min(dates), max(dates)
+    def get_first_and_last_archive_ts(archives_list):
+        timestamps = [x.ts for x in archives_list]
+        return min(timestamps), max(timestamps)
 
-    today = archive_ts_now()
-    first_archive_date, last_archive_date = get_first_and_last_archive_dates(archives)
+    now = archive_ts_now()
+    earliest_ts, latest_ts = get_first_and_last_archive_ts(archives)
 
-    until_date = (
-        calculate_relative_offset(older, from_date=today, earlier=True) if older is not None else last_archive_date
-    )
-    from_date = (
-        calculate_relative_offset(newer, from_date=today, earlier=True) if newer is not None else first_archive_date
-    )
-    archives = [x for x in archives if from_date <= x.ts <= until_date]
+    until_ts = calculate_relative_offset(older, from_date=now, earlier=True) if older is not None else latest_ts
+    from_ts = calculate_relative_offset(newer, from_date=now, earlier=True) if newer is not None else earliest_ts
+    archives = [x for x in archives if from_ts <= x.ts <= until_ts]
 
-    first_archive_date, last_archive_date = get_first_and_last_archive_dates(archives)
+    earliest_ts, latest_ts = get_first_and_last_archive_ts(archives)
     if oldest:
-        oldest_date = calculate_relative_offset(oldest, from_date=first_archive_date, earlier=False)
-        archives = [x for x in archives if x.ts <= oldest_date]
+        until_ts = calculate_relative_offset(oldest, from_date=earliest_ts, earlier=False)
+        archives = [x for x in archives if x.ts <= until_ts]
     if newest:
-        newest_date = calculate_relative_offset(newest, from_date=last_archive_date, earlier=True)
-        archives = [x for x in archives if x.ts >= newest_date]
+        from_ts = calculate_relative_offset(newest, from_date=latest_ts, earlier=True)
+        archives = [x for x in archives if x.ts >= from_ts]
 
     return archives
 

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -173,8 +173,10 @@ class ArchiverTestCaseBase(BaseTestCase):
         return output
 
     def create_src_archive(self, name, ts=None):
-        timestamp_arg = f"--timestamp={ts}" if ts else ""
-        self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", timestamp_arg, name, src_dir)
+        if ts:
+            self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir)
+        else:
+            self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", name, src_dir)
 
     def open_archive(self, name):
         repository = Repository(self.repository_path, exclusive=True)

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -174,7 +174,9 @@ class ArchiverTestCaseBase(BaseTestCase):
 
     def create_src_archive(self, name, ts=None):
         if ts:
-            self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir)
+            self.cmd(
+                f"--repo={self.repository_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir
+            )
         else:
             self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", name, src_dir)
 

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -21,7 +21,6 @@ from ...constants import *  # NOQA
 from ...helpers import Location
 from ...helpers import EXIT_SUCCESS
 from ...helpers import bin_to_hex
-from ...helpers import archive_ts_now 
 from ...manifest import Manifest
 from ...logger import setup_logging
 from ...remote import RemoteRepository
@@ -173,8 +172,9 @@ class ArchiverTestCaseBase(BaseTestCase):
         output = empty.join(line for line in output.splitlines(keepends=True) if pp_msg not in line)
         return output
 
-    def create_src_archive(self, name, ts=archive_ts_now().isoformat()):
-        self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir)
+    def create_src_archive(self, name, ts=None):
+        timestamp_arg = f"--timestamp={ts}" if ts else ""
+        self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", timestamp_arg, name, src_dir)
 
     def open_archive(self, name):
         repository = Repository(self.repository_path, exclusive=True)

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -21,6 +21,7 @@ from ...constants import *  # NOQA
 from ...helpers import Location
 from ...helpers import EXIT_SUCCESS
 from ...helpers import bin_to_hex
+from ...helpers import archive_ts_now 
 from ...manifest import Manifest
 from ...logger import setup_logging
 from ...remote import RemoteRepository
@@ -172,8 +173,8 @@ class ArchiverTestCaseBase(BaseTestCase):
         output = empty.join(line for line in output.splitlines(keepends=True) if pp_msg not in line)
         return output
 
-    def create_src_archive(self, name):
-        self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", name, src_dir)
+    def create_src_archive(self, name, ts=archive_ts_now().isoformat()):
+        self.cmd(f"--repo={self.repository_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir)
 
     def open_archive(self, name):
         repository = Repository(self.repository_path, exclusive=True)

--- a/src/borg/testsuite/archiver/check_cmd.py
+++ b/src/borg/testsuite/archiver/check_cmd.py
@@ -54,6 +54,41 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         self.assert_not_in("archive1", output)
         self.assert_in("archive2", output)
 
+    def test_date_matching(self):
+        shutil.rmtree(self.repository_path)
+        self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
+        earliest_ts = "2022-11-20T23:59:59"
+        ts_in_between = "2022-12-18T23:59:59"
+        latest_between = "2023-01-17T23:59:59"
+        self.create_src_archive("archive1", ts=earliest_ts)
+        self.create_src_archive("archive2", ts=ts_in_between)
+        self.create_src_archive("archive3", ts=latest_between)
+        output = self.cmd(
+            f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--oldest=1m", exit_code=0
+        )
+        self.assert_in("archive1", output)
+        self.assert_in("archive2", output)
+        self.assert_not_in("archive3", output)
+
+        output = self.cmd(
+            f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--newest=1m", exit_code=0
+        )
+        self.assert_in("archive2", output)
+        self.assert_in("archive3", output)
+        self.assert_not_in("archive1", output)
+        output = self.cmd(
+            f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--newer=1d", exit_code=0
+        )
+        self.assert_in("archive3", output)
+        self.assert_not_in("archive1", output)
+        self.assert_not_in("archive2", output)
+        output = self.cmd(
+            f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--older=1d", exit_code=0
+        )
+        self.assert_in("archive1", output)
+        self.assert_in("archive2", output)
+        self.assert_not_in("archive3", output)
+
     def test_missing_file_chunk(self):
         archive, repository = self.open_archive("archive1")
         with repository:

--- a/src/borg/testsuite/archiver/check_cmd.py
+++ b/src/borg/testsuite/archiver/check_cmd.py
@@ -64,6 +64,9 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         self.create_src_archive("archive2", ts=ts_in_between)
         self.create_src_archive("archive3", ts=latest_between)
         output = self.cmd(
+            f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--oldest=23e", exit_code=2
+        )
+        output = self.cmd(
             f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--oldest=1m", exit_code=0
         )
         self.assert_in("archive1", output)

--- a/src/borg/testsuite/archiver/check_cmd.py
+++ b/src/borg/testsuite/archiver/check_cmd.py
@@ -59,10 +59,9 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         earliest_ts = "2022-11-20T23:59:59"
         ts_in_between = "2022-12-18T23:59:59"
-        latest_between = "2023-01-17T23:59:59"
         self.create_src_archive("archive1", ts=earliest_ts)
         self.create_src_archive("archive2", ts=ts_in_between)
-        self.create_src_archive("archive3", ts=latest_between)
+        self.create_src_archive("archive3")
         output = self.cmd(
             f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--oldest=23e", exit_code=2
         )

--- a/src/borg/testsuite/archiver/check_cmd.py
+++ b/src/borg/testsuite/archiver/check_cmd.py
@@ -75,8 +75,8 @@ class ArchiverCheckTestCase(ArchiverTestCaseBase):
         output = self.cmd(
             f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--newest=1m", exit_code=0
         )
-        self.assert_in("archive2", output)
         self.assert_in("archive3", output)
+        self.assert_not_in("archive2", output)
         self.assert_not_in("archive1", output)
         output = self.cmd(
             f"--repo={self.repository_location}", "check", "-v", "--archives-only", "--newer=1d", exit_code=0


### PR DESCRIPTION
Support for date-matching during archive listing (fix for #7062)
---
- Added arguments --older --newer --newest --oldest to argparser
- Added parser to detect relative time markers i.e. 1d/1m
- Added an in-house month-offseter
- Edited manifest to initially filter by date if markers are present
- Added test cases to test date matching arguments