### PR TITLE
key change-passphrase: fix --encryption value in examples

### DIFF
--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -37,7 +37,7 @@ Fully automated using environment variables:
 
 ::
 
-    $ BORG_NEW_PASSPHRASE=old borg rcreate -e=repokey
+    $ BORG_NEW_PASSPHRASE=old borg rcreate --encryption=repokey-aes-ocb
     # now "old" is the current passphrase.
     $ BORG_PASSPHRASE=old BORG_NEW_PASSPHRASE=new borg key change-passphrase
     # now "new" is the current passphrase.


### PR DESCRIPTION
"repokey" (as in borg < 2.0, referring to the AES-CTR mode) does not exist any more and was superseded by other repokey-* modes.