### PR TITLE
cache.py: be less verbose during cache sync

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -837,7 +837,7 @@ class LocalCache(CacheStatsMixin):
             return archive_names
 
         def create_master_idx(chunk_idx):
-            logger.debug("Synchronizing chunks cache...")
+            logger.debug("Synchronizing chunks index...")
             cached_ids = cached_archives()
             archive_ids = repo_archives()
             logger.info(
@@ -857,7 +857,7 @@ class LocalCache(CacheStatsMixin):
                 pi = ProgressIndicatorPercent(
                     total=len(archive_ids),
                     step=0.1,
-                    msg="%3.0f%% Syncing chunks cache. Processing archive %s",
+                    msg="%3.0f%% Syncing chunks index. Processing archive %s.",
                     msgid="cache.sync",
                 )
                 archive_ids_to_names = get_archive_ids_to_names(archive_ids)
@@ -871,26 +871,26 @@ class LocalCache(CacheStatsMixin):
                         if archive_id not in cached_ids:
                             # Do not make this an else branch; the FileIntegrityError exception handler
                             # above can remove *archive_id* from *cached_ids*.
-                            logger.info("Fetching and building archive index for %s", archive_name)
+                            logger.info("Fetching and building archive index for %s.", archive_name)
                             archive_chunk_idx = ChunkIndex()
                             fetch_and_build_idx(archive_id, decrypted_repository, archive_chunk_idx)
-                        logger.debug("Merging into master chunks index")
+                        logger.debug("Merging into master chunks index.")
                         chunk_idx.merge(archive_chunk_idx)
                     else:
                         chunk_idx = chunk_idx or ChunkIndex(usable=master_index_capacity)
-                        logger.info("Fetching archive index for %s", archive_name)
+                        logger.info("Fetching archive index for %s.", archive_name)
                         fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx)
                 pi.finish()
                 logger.debug(
-                    "Cache sync: processed %s (%d chunks) of metadata",
+                    "Cache index sync: processed %s (%d chunks) of metadata.",
                     format_file_size(processed_item_metadata_bytes),
                     processed_item_metadata_chunks,
                 )
                 logger.debug(
-                    "Cache sync: compact chunks.archive.d storage saved %s bytes",
+                    "Cache index sync: compact chunks.archive.d storage saved %s bytes.",
                     format_file_size(compact_chunks_archive_saved_space),
                 )
-            logger.debug("Cache sync done.")
+            logger.debug("Cache index sync done.")
             return chunk_idx
 
         # The cache can be used by a command that e.g. only checks against Manifest.Operation.WRITE,

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -882,15 +882,15 @@ class LocalCache(CacheStatsMixin):
                         fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx)
                 pi.finish()
                 logger.debug(
-                    "Cache index sync: processed %s (%d chunks) of metadata.",
+                    "Chunks index sync: processed %s (%d chunks) of metadata.",
                     format_file_size(processed_item_metadata_bytes),
                     processed_item_metadata_chunks,
                 )
                 logger.debug(
-                    "Cache index sync: compact chunks.archive.d storage saved %s bytes.",
+                    "Chunks index sync: compact chunks.archive.d storage saved %s bytes.",
                     format_file_size(compact_chunks_archive_saved_space),
                 )
-            logger.debug("Cache index sync done.")
+            logger.debug("Chunks index sync done.")
             return chunk_idx
 
         # The cache can be used by a command that e.g. only checks against Manifest.Operation.WRITE,

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -797,7 +797,7 @@ class LocalCache(CacheStatsMixin):
 
         def read_archive_index(archive_id, archive_name):
             archive_chunk_idx_path = mkpath(archive_id)
-            logger.info("Reading cached archive chunk index for %s ...", archive_name)
+            logger.info("Reading cached archive chunk index for %s", archive_name)
             try:
                 try:
                     # Attempt to load compact index first
@@ -837,13 +837,12 @@ class LocalCache(CacheStatsMixin):
             return archive_names
 
         def create_master_idx(chunk_idx):
-            logger.info("Synchronizing chunks cache...")
+            logger.debug("Synchronizing chunks cache...")
             cached_ids = cached_archives()
             archive_ids = repo_archives()
             logger.info(
-                "Archives: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.",
-                len(archive_ids),
-                len(cached_ids),
+                "Cached archive chunk indexes: %d fresh, %d stale, %d need fetching.",
+                len(archive_ids & cached_ids),
                 len(cached_ids - archive_ids),
                 len(archive_ids - cached_ids),
             )
@@ -872,14 +871,14 @@ class LocalCache(CacheStatsMixin):
                         if archive_id not in cached_ids:
                             # Do not make this an else branch; the FileIntegrityError exception handler
                             # above can remove *archive_id* from *cached_ids*.
-                            logger.info("Fetching and building archive index for %s ...", archive_name)
+                            logger.info("Fetching and building archive index for %s", archive_name)
                             archive_chunk_idx = ChunkIndex()
                             fetch_and_build_idx(archive_id, decrypted_repository, archive_chunk_idx)
-                        logger.info("Merging into master chunks index ...")
+                        logger.debug("Merging into master chunks index")
                         chunk_idx.merge(archive_chunk_idx)
                     else:
                         chunk_idx = chunk_idx or ChunkIndex(usable=master_index_capacity)
-                        logger.info("Fetching archive index for %s ...", archive_name)
+                        logger.info("Fetching archive index for %s", archive_name)
                         fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx)
                 pi.finish()
                 logger.debug(
@@ -891,7 +890,7 @@ class LocalCache(CacheStatsMixin):
                     "Cache sync: compact chunks.archive.d storage saved %s bytes",
                     format_file_size(compact_chunks_archive_saved_space),
                 )
-            logger.info("Done.")
+            logger.debug("Cache sync done.")
             return chunk_idx
 
         # The cache can be used by a command that e.g. only checks against Manifest.Operation.WRITE,


### PR DESCRIPTION
As discussed in #7271, this makes borg2 less verbose when it is syncing the cache.  (This only happens if you access a repository from multiple hosts.)  Below is how the new output looks with `-v` and with `--debug`.  (With neither, there is no relevant output.)
```
(borg2-env) borg2-test$ export BORG_BASE_DIR=./borg2-base-dir
(borg2-env) borg2-test$ borg create -v host1test20 ./test-data/
Creating archive at "/t/borg2-test/test.repo"
Cached archive chunk indexes: 7 fresh, 0 stale, 2 need fetching.
Reading cached archive chunk index for host1test17
Reading cached archive chunk index for host1test18
Fetching and building archive index for host1test19
Reading cached archive chunk index for host1test2
Reading cached archive chunk index for host2test17
Fetching and building archive index for host2test19
Reading cached archive chunk index for host2test2
Reading cached archive chunk index for host2test3
Reading cached archive chunk index for host2test4

(borg2-env) borg2-test$ export BORG_BASE_DIR=./borg2-base-dir2
(borg2-env) borg2-test$ borg create --debug host2test20 ./test-data/
[Only cache-related output shown.]
Synchronizing chunks cache...
Cached archive chunk indexes: 8 fresh, 0 stale, 2 need fetching.
Reading cached archive chunk index for host1test17
Verified integrity of ./borg2-base-dir2/.cache/borg/c538429994580bb5ad6b23ac1cf1f611c6495c61f27630e5b4b3ab595688353d/chunks.archive.d/f7d238fd1895ab43dbfdce2efd5a46a721f47a13b3c29971347945f76aad991a.compact
Merging into master chunks index
...
Fetching and building archive index for host1test20
Merging into master chunks index
Reading cached archive chunk index for host2test17
Verified integrity of ./borg2-base-dir2/.cache/borg/c538429994580bb5ad6b23ac1cf1f611c6495c61f27630e5b4b3ab595688353d/chunks.archive.d/0e92529973dc6902dcef61c2ac3ed6746bffae6fa96421f904472b52946f2a35.compact
Merging into master chunks index
...
Cache sync: processed 576.92 kB (6 chunks) of metadata
Cache sync: compact chunks.archive.d storage saved 76.72 kB bytes
Cache sync done.
...
(borg2-env) borg2-test$ 
```
I'd also be ok with showing less with `-v` if people prefer.  Note that I removed a few places with `...` in the output to make it look tidier, but I can reverse those.