### PR TITLE
undef NDEBUG for chunker and hashindex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,12 +186,14 @@ if not on_rtd:
         dict(extra_compile_args=cflags),
     )
 
+    # note: _chunker.c and _hashindex.c are relatively complex/large pieces of handwritten C code,
+    # thus we undef NDEBUG for them, so the compiled code will contain and execute assert().
     ext_modules += [
         Extension("borg.crypto.low_level", **crypto_ext_kwargs),
         Extension("borg.compress", **compress_ext_kwargs),
-        Extension("borg.hashindex", [hashindex_source], extra_compile_args=cflags),
+        Extension("borg.hashindex", [hashindex_source], extra_compile_args=cflags, undef_macros=["NDEBUG"]),
         Extension("borg.item", [item_source], extra_compile_args=cflags),
-        Extension("borg.chunker", [chunker_source], extra_compile_args=cflags),
+        Extension("borg.chunker", [chunker_source], extra_compile_args=cflags, undef_macros=["NDEBUG"]),
         Extension("borg.checksums", **checksums_ext_kwargs),
     ]
 


### PR DESCRIPTION
note:
intentionally not undef'ing it for all the cython-only generated C code.
