### PR TITLE
better included/excluded status chars, docs, fixes #7321

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2341,10 +2341,10 @@ class ArchiveRecreater:
 
         for item in archive.iter_items():
             if not matcher.match(item.path):
-                self.print_file_status("x", item.path)
+                self.print_file_status("-", item.path)  # excluded (either by "-" or by "!")
                 continue
             if self.dry_run:
-                self.print_file_status("-", item.path)
+                self.print_file_status("+", item.path)  # included
             else:
                 self.process_item(archive, target, item)
         if self.progress:

--- a/src/borg/testsuite/archiver/create_cmd.py
+++ b/src/borg/testsuite/archiver/create_cmd.py
@@ -332,8 +332,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "input",
         )
         self.assert_in("A input/file_important", output)
-        self.assert_in("x input/file1", output)
-        self.assert_in("x input/file2", output)
+        self.assert_in("- input/file1", output)
+        self.assert_in("- input/file2", output)
 
     def test_create_pattern_file(self):
         """test file patterns during create"""
@@ -353,9 +353,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "input",
         )
         self.assert_in("A input/file_important", output)
-        self.assert_in("x input/file1", output)
-        self.assert_in("x input/file2", output)
-        self.assert_in("x input/otherfile", output)
+        self.assert_in("- input/file1", output)
+        self.assert_in("- input/file2", output)
+        self.assert_in("- input/otherfile", output)
 
     def test_create_pattern_exclude_folder_but_recurse(self):
         """test when patterns exclude a parent folder, but include a child"""
@@ -376,7 +376,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "test",
             "input",
         )
-        self.assert_in("x input/x/a/foo_a", output)
+        self.assert_in("- input/x/a/foo_a", output)
         self.assert_in("A input/x/b/foo_b", output)
         self.assert_in("A input/y/foo_y", output)
 
@@ -645,7 +645,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in("A input/file1", output)
         self.assert_in("A input/file2", output)
         if has_lchflags:
-            self.assert_in("x input/file3", output)
+            self.assert_in("- input/file3", output)
         # should find second file as excluded
         output = self.cmd(
             f"--repo={self.repository_location}",
@@ -658,9 +658,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "*/file2",
         )
         self.assert_in("U input/file1", output)
-        self.assert_in("x input/file2", output)
+        self.assert_in("- input/file2", output)
         if has_lchflags:
-            self.assert_in("x input/file3", output)
+            self.assert_in("- input/file3", output)
 
     def test_file_status_counters(self):
         """Test file status counters in the stats of `borg create --stats`"""

--- a/src/borg/testsuite/archiver/recreate_cmd.py
+++ b/src/borg/testsuite/archiver/recreate_cmd.py
@@ -241,22 +241,22 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         )
         self.check_cache()
         self.assert_in("input/file1", output)
-        self.assert_in("x input/file2", output)
+        self.assert_in("- input/file2", output)
 
         output = self.cmd(f"--repo={self.repository_location}", "recreate", "-a", "test", "--list", "-e", "input/file3")
         self.check_cache()
         self.assert_in("input/file1", output)
-        self.assert_in("x input/file3", output)
+        self.assert_in("- input/file3", output)
 
         output = self.cmd(f"--repo={self.repository_location}", "recreate", "-a", "test", "-e", "input/file4")
         self.check_cache()
         self.assert_not_in("input/file1", output)
-        self.assert_not_in("x input/file4", output)
+        self.assert_not_in("- input/file4", output)
 
         output = self.cmd(f"--repo={self.repository_location}", "recreate", "-a", "test", "--info", "-e", "input/file5")
         self.check_cache()
         self.assert_not_in("input/file1", output)
-        self.assert_not_in("x input/file5", output)
+        self.assert_not_in("- input/file5", output)
 
     def test_comment(self):
         self.create_regular_file("file1", size=1024 * 80)


### PR DESCRIPTION
more consistent now between dry-run and non-dry-run mode.

--filter=... users might need to update the status chars they filter for.
