### PR TITLE
recreate: --chunker-params must default to None, fixes #7337

### DIFF
--- a/src/borg/archiver/recreate_cmd.py
+++ b/src/borg/archiver/recreate_cmd.py
@@ -219,10 +219,10 @@ class RecreateMixIn:
             dest="chunker_params",
             action=Highlander,
             type=ChunkerParams,
-            default=CHUNKER_PARAMS,
-            help="specify the chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, "
-            "HASH_MASK_BITS, HASH_WINDOW_SIZE) or `default` to use the current defaults. "
-            "default: %s,%d,%d,%d,%d" % CHUNKER_PARAMS,
+            default=None,
+            help="rechunk using given chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, "
+            "HASH_MASK_BITS, HASH_WINDOW_SIZE) or `default` to use the chunker defaults. "
+            "default: do not rechunk",
         )
 
         subparser.add_argument(


### PR DESCRIPTION
also add a test: recreate without --chunker-params shall not rechunk

before the fix, it triggered rechunking if an archive was created with non-default chunker params.

but it only should rechunk if borg recreate is invoked with explicitly giving --chunker-params=....

forward port of #7337.