### PR TITLE
Make hashindex_compact simpler and probably faster

### DIFF
--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -570,11 +570,11 @@ hashindex_read(PyObject *file_py, int permit_compact, int legacy)
     }
     index->buckets = index->buckets_buffer.buf;
 
-    if(!permit_compact) {
-        index->min_empty = get_min_empty(index->num_buckets);
-        if (index->num_empty == -1)  // we read a legacy index without num_empty value
-            index->num_empty = count_empty(index);
+    index->min_empty = get_min_empty(index->num_buckets);
+    if (index->num_empty == -1)  // we read a legacy index without num_empty value
+        index->num_empty = count_empty(index);
 
+    if(!permit_compact) {
         if(index->num_empty < index->min_empty) {
             /* too many tombstones here / not enough empty buckets, do a same-size rebuild */
             if(!hashindex_resize(index, index->num_buckets)) {

--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -837,7 +837,7 @@ hashindex_compact(HashIndex *index)
     int tail = 0;
     uint64_t saved_size = (index->num_buckets - index->num_entries) * (uint64_t)index->bucket_size;
 
-    /* idx will point to the last filled spot and tail will point to the first empty spot. */
+    /* idx will point to the last filled spot and tail will point to the first empty or deleted spot. */
     for(;;) {
         /* Find the last filled spot >= index->num_entries. */
         while((idx >= index->num_entries) && BUCKET_IS_EMPTY_OR_DELETED(index, idx)) {

--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -113,6 +113,7 @@ static int hash_sizes[] = {
 
 #define BUCKET_IS_DELETED(index, idx) (*((uint32_t *)(BUCKET_ADDR(index, idx) + index->key_size)) == DELETED)
 #define BUCKET_IS_EMPTY(index, idx) (*((uint32_t *)(BUCKET_ADDR(index, idx) + index->key_size)) == EMPTY)
+#define BUCKET_IS_EMPTY_OR_DELETED(index, idx) (BUCKET_IS_EMPTY(index, idx) || BUCKET_IS_DELETED(index, idx))
 
 #define BUCKET_MARK_DELETED(index, idx) (*((uint32_t *)(BUCKET_ADDR(index, idx) + index->key_size)) = DELETED)
 #define BUCKET_MARK_EMPTY(index, idx) (*((uint32_t *)(BUCKET_ADDR(index, idx) + index->key_size)) = EMPTY)
@@ -819,7 +820,7 @@ hashindex_next_key(HashIndex *index, const unsigned char *key)
     if (idx == index->num_buckets) {
         return NULL;
     }
-    while(BUCKET_IS_EMPTY(index, idx) || BUCKET_IS_DELETED(index, idx)) {
+    while(BUCKET_IS_EMPTY_OR_DELETED(index, idx)) {
         idx ++;
         if (idx == index->num_buckets) {
             return NULL;
@@ -828,56 +829,32 @@ hashindex_next_key(HashIndex *index, const unsigned char *key)
     return BUCKET_ADDR(index, idx);
 }
 
+/* Move all non-empty/non-deleted entries in the hash table to the beginning. This does not preserve the order, and it does not mark the previously used entries as empty or deleted. But it reduces num_buckets so that those entries will never be accessed. */
 static uint64_t
 hashindex_compact(HashIndex *index)
 {
-    int idx = 0;
-    int start_idx;
-    int begin_used_idx;
-    int empty_slot_count, count, buckets_to_copy;
-    int compact_tail_idx = 0;
+    int idx = index->num_buckets - 1;
+    int tail = 0;
     uint64_t saved_size = (index->num_buckets - index->num_entries) * (uint64_t)index->bucket_size;
 
-    if(index->num_buckets - index->num_entries == 0) {
-        /* already compact */
-        return 0;
-    }
-
-    while(idx < index->num_buckets) {
-        /* Phase 1: Find some empty slots */
-        start_idx = idx;
-        while((idx < index->num_buckets) && (BUCKET_IS_EMPTY(index, idx) || BUCKET_IS_DELETED(index, idx))) {
-            idx++;
+    /* idx will point to the last filled spot and tail will point to the first empty spot. */
+    for(;;) {
+        /* Find the last filled spot >= index->num_entries. */
+        while((idx >= index->num_entries) && BUCKET_IS_EMPTY_OR_DELETED(index, idx)) {
+            idx--;
         }
-
-        /* everything from start_idx to idx-1 (inclusive) is empty or deleted */
-        count = empty_slot_count = idx - start_idx;
-        begin_used_idx = idx;
-
-        if(!empty_slot_count) {
-            /* In case idx==compact_tail_idx, the areas overlap */
-            memmove(BUCKET_ADDR(index, compact_tail_idx), BUCKET_ADDR(index, idx), index->bucket_size);
-            idx++;
-            compact_tail_idx++;
-            continue;
-        }
-
-        /* Phase 2: Find some non-empty/non-deleted slots we can move to the compact tail */
-
-        while(empty_slot_count && (idx < index->num_buckets) && !(BUCKET_IS_EMPTY(index, idx) || BUCKET_IS_DELETED(index, idx))) {
-            idx++;
-            empty_slot_count--;
-        }
-
-        buckets_to_copy = count - empty_slot_count;
-
-        if(!buckets_to_copy) {
-            /* Nothing to move, reached end of the buckets array with no used buckets. */
+        /* If all spots >= index->num_entries are empty, then we must be in a compact state. */
+        if(idx < index->num_entries) {
             break;
         }
-
-        memcpy(BUCKET_ADDR(index, compact_tail_idx), BUCKET_ADDR(index, begin_used_idx), buckets_to_copy * index->bucket_size);
-        compact_tail_idx += buckets_to_copy;
+        /* Find the first empty or deleted spot < index->num_entries. */
+        while((tail < index->num_entries) && !BUCKET_IS_EMPTY_OR_DELETED(index, tail)) {
+            tail++;
+        }
+        assert(tail < index->num_entries);
+        memcpy(BUCKET_ADDR(index, tail), BUCKET_ADDR(index, idx), index->bucket_size);
+        idx--;
+        tail++;
     }
 
     index->num_buckets = index->num_entries;

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -523,11 +523,25 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
     def test_empty(self):
         self.compare_compact("DEDEED")
 
+    def test_num_buckets_zero(self):
+        self.compare_compact("")
+
     def test_already_compact(self):
         self.compare_compact("***")
 
     def test_all_at_front(self):
+        self.compare_compact("*DEEED")
+        self.compare_compact("**DEED")
         self.compare_compact("***EED")
+        self.compare_compact("****ED")
+        self.compare_compact("*****D")
+
+    def test_all_at_back(self):
+        self.compare_compact("EDEEE*")
+        self.compare_compact("DEDE**")
+        self.compare_compact("DED***")
+        self.compare_compact("ED****")
+        self.compare_compact("D*****")
 
     def test_merge(self):
         master = ChunkIndex()

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -488,18 +488,18 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
         and 'E' (empty).
         """
         num_buckets = len(layout)
-        num_empty = layout.count('E')
-        num_entries = layout.count('*')
+        num_empty = layout.count("E")
+        num_entries = layout.count("*")
         self.index(num_entries=num_entries, num_buckets=num_buckets, num_empty=num_empty)
         k = 0
         for c in layout:
-            if c == 'D':
+            if c == "D":
                 self.write_deleted(H2(k))
-            elif c == 'E':
+            elif c == "E":
                 self.write_empty(H2(k))
             else:
-                assert c == '*'
-                self.write_entry(H2(k), 3*k+1, 3*k+2, 3*k+3)
+                assert c == "*"
+                self.write_entry(H2(k), 3 * k + 1, 3 * k + 2, 3 * k + 3)
             k += 1
         idx = self.index_from_data()
         cpt = self.index_from_data()
@@ -509,25 +509,25 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
         self.compare_indexes(idx, cpt)
 
     def test_simple(self):
-        self.compare_compact('*DE**E')
+        self.compare_compact("*DE**E")
 
     def test_first_empty(self):
-        self.compare_compact('D*E**E')
+        self.compare_compact("D*E**E")
 
     def test_last_used(self):
-        self.compare_compact('D*E*E*')
+        self.compare_compact("D*E*E*")
 
     def test_too_few_empty_slots(self):
-        self.compare_compact('D**EE*')
+        self.compare_compact("D**EE*")
 
     def test_empty(self):
-        self.compare_compact('DEDEED')
+        self.compare_compact("DEDEED")
 
     def test_already_compact(self):
-        self.compare_compact('***')
+        self.compare_compact("***")
 
     def test_all_at_front(self):
-        self.compare_compact('***EED')
+        self.compare_compact("***EED")
 
     def test_merge(self):
         master = ChunkIndex()

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -478,6 +478,9 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
         self.write_entry(key, 0xFFFFFFFE, 0, 0)
 
     def compare_indexes(self, idx1, idx2):
+        """Check that the two hash tables contain the same data.  idx1
+        is allowed to have "mis-filed" entries, because we only need to
+        iterate over it.  But idx2 needs to support lookup."""
         for k, v in idx1.iteritems():
             assert v == idx2[k]
         assert len(idx1) == len(idx2)
@@ -504,6 +507,9 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
         idx = self.index_from_data()
         cpt = self.index_from_data()
         cpt.compact()
+        # Note that idx is not a valid hash table, since the entries are not
+        # stored where they should be.  So lookups of the form idx[k] can fail.
+        # But cpt is a valid hash table, since there are no empty buckets.
         assert idx.size() == 1024 + num_buckets * (32 + 3 * 4)
         assert cpt.size() == 1024 + num_entries * (32 + 3 * 4)
         self.compare_indexes(idx, cpt)

--- a/src/borg/testsuite/hashindex.py
+++ b/src/borg/testsuite/hashindex.py
@@ -601,9 +601,7 @@ class HashIndexCompactTestCase(HashIndexDataTestCase):
         assert idx1.size() == 1024 + 3 * (32 + 2 * 4)
 
         master.merge(idx1)
-        assert master[H(1)] == (1, 100)
-        assert master[H(2)] == (2, 200)
-        assert master[H(3)] == (3, 300)
+        self.compare_indexes(idx1, master)
 
 
 class NSIndexTestCase(BaseTestCase):

--- a/src/borg/testsuite/hashindex_pytest.py
+++ b/src/borg/testsuite/hashindex_pytest.py
@@ -8,6 +8,15 @@ import pytest
 from ..hashindex import NSIndex
 
 
+def verify_hash_table(kv, idx):
+    """kv should be a python dictionary and idx an NSIndex.  Check that idx
+    has the expected entries and the right number of entries.
+    """
+    for k, v in kv.items():
+        assert k in idx and idx[k] == (v, v, v)
+    assert len(idx) == len(kv)
+
+
 def make_hashtables(*, entries, loops):
     idx = NSIndex()
     kv = {}
@@ -23,11 +32,7 @@ def make_hashtables(*, entries, loops):
         for k in delete_keys:
             v = kv.pop(k)
             assert idx.pop(k) == (v, v, v)
-        # check if remaining entries are as expected
-        for k, v in kv.items():
-            assert idx[k] == (v, v, v)
-        # check entry count
-        assert len(kv) == len(idx)
+        verify_hash_table(kv, idx)
     return idx, kv
 
 
@@ -53,9 +58,7 @@ def test_hashindex_compact():
     assert saved_space > 0
     assert size_noncompact - size_compact == saved_space
     # did we lose anything?
-    for k, v in kv.items():
-        assert k in idx and idx[k] == (v, v, v)
-    assert len(idx) == len(kv)
+    verify_hash_table(kv, idx)
     # now expand the hashtable again. trigger a resize/rebuild by adding an entry.
     k = b"x" * 32
     idx[k] = (0, 0, 0)
@@ -63,6 +66,4 @@ def test_hashindex_compact():
     size_rebuilt = idx.size()
     assert size_rebuilt > size_compact + 1
     # did we lose anything?
-    for k, v in kv.items():
-        assert k in idx and idx[k] == (v, v, v)
-    assert len(idx) == len(kv)
+    verify_hash_table(kv, idx)

--- a/src/borg/testsuite/hashindex_pytest.py
+++ b/src/borg/testsuite/hashindex_pytest.py
@@ -67,3 +67,9 @@ def test_hashindex_compact():
     assert size_rebuilt > size_compact + 1
     # did we lose anything?
     verify_hash_table(kv, idx)
+
+
+@pytest.mark.skipif("BORG_TESTS_SLOW" not in os.environ, reason="slow tests not enabled, use BORG_TESTS_SLOW=1")
+def test_hashindex_compact_stress():
+    for _ in range(100):
+        test_hashindex_compact()


### PR DESCRIPTION
The second commit adjusts the tests so that they no longer assume that `hashindex_compact` preserves the order of the entries.  Other early commits clean up some tests and add additional tests.  The change to hashindex_compact is in the second-last commit.  All tests pass after each commit including the two relevant tests run when `BORG_TESTS_SLOW=1`.  I also ran tests with extreme values of `HASH_MAX_LOAD` and `HASH_MAX_EFF_LOAD`.

Please check the new code carefully before merging.  Check for off-by-one errors.

I didn't test the speed.  I'm not sure if compacting takes enough time for it to be worth checking this.

I have a couple of other questions that I will ask at the relevant spot in the code.
