### PR TITLE
create: implement retries for individual fs files

### DIFF
--- a/src/borg/testsuite/archiver/create_cmd.py
+++ b/src/borg/testsuite/archiver/create_cmd.py
@@ -201,20 +201,20 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         out = self.cmd(
             f"--repo={self.repository_location}",
             "create",
-            f"--chunker-params=fail,{chunk_size},RRRERRR",
+            f"--chunker-params=fail,{chunk_size},rrrEEErrrr",
             "--paths-from-stdin",
             "--list",
             "test",
             input=flist.encode(),
-            exit_code=1,
+            exit_code=0,
         )
-        assert "E input/file2" in out
+        assert "E input/file2" not in out  # we managed to read it in the 3rd retry (after 3 failed reads)
         # repo looking good overall? checks for rc == 0.
         self.cmd(f"--repo={self.repository_location}", "check", "--debug")
         # check files in created archive
         out = self.cmd(f"--repo={self.repository_location}", "list", "test")
         assert "input/file1" in out
-        assert "input/file2" not in out
+        assert "input/file2" in out
         assert "input/file3" in out
 
     def test_create_content_from_command(self):


### PR DESCRIPTION
Errors handled for backup src files:
- BackupOSError (converted from OSError), e.g. I/O Error
- BackupError (stats race, file changed while we backed it up)

Error Handling:
- retry the same file after some sleep time
- sleep time starts from 1ms, increases exponentially up to 10s
- 10 tries

If retrying does not help:
- BackupOSError: skip the file, log it with "E" status
- BackupError: last try will back it up, log it with "C" status

Works for:
- borg create's normal (builtin) fs recursion
- borg create --paths-from-command
- borg create --paths-from-stdin

Notes:
- update stats.files_stats late (so we don't get wrong
  stats in case of e.g. IOErrors while reading the file).
- _process_any: no changes to the big block, just indented
  for adding the retry loop and the try/except.
- test_create_erroneous_file succeeds because we retry the file.
