### PR TITLE
"auto" compressor tests: don't assume a specific size, fixes #7363

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.d/development.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
         restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
@@ -120,7 +120,7 @@ jobs:
     - name: Install Python requirements
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.d/development.txt
+        pip install -r requirements.d/development.lock.txt
     - name: Install borgbackup
       run: |
         # pip install -e .

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py{35,36,37,38,39,310}
 
 [testenv]
 deps =
-     -rrequirements.d/development.txt
+     -rrequirements.d/development.lock.txt
      -rrequirements.d/fuse.txt
 commands = py.test -n {env:XDISTN:4} -rs --cov=borg --cov-config=.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:


### PR DESCRIPTION
The tests assumed a specific compressed results size, which is bad, because it might vary depending on the zlib implementation.

Now the "auto" compressor tests just check if it is the same size as when unconditionally using the zlib compressor.
