### PR TITLE
feat: add cache dir to --debug

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -262,6 +262,7 @@ class CacheConfig:
     def __init__(self, repository, path=None, lock_wait=None):
         self.repository = repository
         self.path = cache_dir(repository, path)
+        logger.debug("Using %s as cache", self.path)
         self.config_path = os.path.join(self.path, "config")
         self.lock = None
         self.lock_wait = lock_wait


### PR DESCRIPTION
fixes #5963 
--debug output now:
```bash
➜  borg git:(master) ✗ ./borg-env/bin/borg -r /home/divyansh/Desktop/borg2 rlist --debug 
using builtin fallback logging configuration
38 self tests completed in 0.06 seconds
Verified integrity of /home/divyansh/Desktop/borg2/index.9
Enter passphrase for key /home/divyansh/Desktop/borg2: 
TAM-verified manifest
Using /home/divyansh/.cache/borg/496f0ecf408beb37acb21eac471aecaeae36e549fc70d1a49778e64413242cb9 as cache
security: read previous location '/home/divyansh/Desktop/borg2'
security: read manifest timestamp '2023-02-25T21:03:06.588359+00:00'
security: determined newest manifest timestamp as 2023-02-25T21:03:06.588359+00:00
security: repository checks ok, allowing access
Monday                               Sun, 2023-02-26 02:31:47 +0530 [0aec6822f0dc8c7e76ab2f26277beba306a54884764db4cd505931442da01045]
Tuesday                              Sun, 2023-02-26 02:33:06 +0530 [c9848cadcdecd1961d976d8474199e18d6296224e988f894245b9c5de2fba33e]
```