### PR TITLE
Make timestamps in manual pages reproducible

### DIFF
--- a/setup_docs.py
+++ b/setup_docs.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 from collections import OrderedDict
 from datetime import datetime
+import time
 
 from setuptools import Command
 
@@ -470,7 +471,10 @@ class build_man(Command):
         self.write_heading(write, description, double_sided=True)
         # man page metadata
         write(":Author: The Borg Collective")
-        write(":Date:", datetime.utcnow().date().isoformat())
+        write(
+            ":Date:",
+            datetime.utcfromtimestamp(int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))).date().isoformat(),
+        )
         write(":Manual section: 1")
         write(":Manual group: borg backup tool")
         write()


### PR DESCRIPTION
Refer to https://reproducible-builds.org/docs/source-date-epoch/ for documentation on SOURCE_DATE_EPOCH.
