### PR TITLE
clarify platformdirs requirements, fixes #7393

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,8 @@ setup_requires =
 install_requires =
   msgpack >=1.0.3, <=1.0.4
   packaging
-  platformdirs >=3.0.0, <4.0.0
+  platformdirs >=3.0.0, <4.0.0; sys_platform == 'darwin'  # for macOS: breaking changes in 3.0.0,
+  platformdirs >=2.6.0, <4.0.0; sys_platform != 'darwin'  # for others: 2.6+ works consistently.
   argon2-cffi
 tests_require =
   pytest


### PR DESCRIPTION
3.0.0 is only required for macOS due to breaking changes.

2.6.0 was the last breaking change for Linux/UNIX.
