### PR TITLE
set .hardlink_master for hardlinkable items, fixes #7175

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1350,6 +1350,8 @@ class FilesystemObjectProcessors:
             with OsOpen(path=path, parent_fd=parent_fd, name=name, flags=flags_normal, noatime=True) as fd:
                 with backup_io('fstat'):
                     st = stat_update_check(st, os.fstat(fd))
+                if not hardlinked or hardlink_master:
+                    item.hardlink_master = hardlinked
                 item.update(self.metadata_collector.stat_attrs(st, path, fd=fd))
                 return status
 
@@ -1359,6 +1361,8 @@ class FilesystemObjectProcessors:
             with backup_io('stat'):
                 st = stat_update_check(st, os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False))
             item.rdev = st.st_rdev
+            if not hardlinked or hardlink_master:
+                item.hardlink_master = hardlinked
             item.update(self.metadata_collector.stat_attrs(st, path))
             return status
 
@@ -1395,6 +1399,7 @@ class FilesystemObjectProcessors:
         self.process_file_chunks(item, cache, self.stats, self.show_progress, backup_io_iter(self.chunker.chunkify(fd)))
         item.get_size(memorize=True)
         self.stats.nfiles += 1
+        item.hardlink_master = False
         self.add_item(item, stats=self.stats)
         return status
 


### PR DESCRIPTION
before, we only set this for regular files, but we better set this for block/char devices and fifos also, so we have it for all item types borg 1.x considers "hardlinkable".

this is important for sequential processing of items in an archive: if we encounter a hardlinkable item and .source is not set (that would make it a hardlink slave), it could be a hardlink master or not:

- hardlink_master == False  # this item is not part of a hl group
- hardlink_master == True  # this item is a hardlink master

This will also be important when items are converted to borg2.