### PR TITLE
"auto" compressor tests: do not assume zlib is better than lz4, fixes #7363 (forwardport-master)

### DIFF
--- a/src/borg/testsuite/compress.py
+++ b/src/borg/testsuite/compress.py
@@ -146,7 +146,8 @@ def test_auto():
     ratio = len(compressed_zlib) / len(compressed_lz4)
     assert meta["ctype"] == ZLIB.ID if ratio < 0.99 else LZ4.ID
     assert meta["clevel"] == 9 if ratio < 0.99 else 255
-    assert meta["csize"] == len(compressed_auto_zlib)
+    smallest_csize = min(len(compressed_zlib), len(compressed_lz4))
+    assert meta["csize"] == len(compressed_auto_zlib) == smallest_csize
 
     data = b"\x00\xb8\xa3\xa2-O\xe1i\xb6\x12\x03\xc21\xf3\x8a\xf78\\\x01\xa5b\x07\x95\xbeE\xf8\xa3\x9ahm\xb1~"
     meta, compressed = compressor_auto_zlib.compress(dict(meta), data)


### PR DESCRIPTION
As the test structure got refactored in master and as far as i can see does not explicitly check against the output size of the different compression algorithms anymore,  i only adapted commit a6cd0fd2bfaa6f912a4930a4329166d9bde71e94

See:
#7372
#7364