### PR TITLE
docs: add link to OS dependencies

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,6 +145,17 @@ the old version using the same steps as shown above.
 From Source
 -----------
 
+Operating System
+~~~~~~~~~~~~~~~~
+
+* :ref:`debian-ubuntu`
+* :ref:`fedora`
+* :ref:`opensuse-tumbleweed-leap`
+* :ref:`macos`
+* :ref:`freebsd`
+* :ref:`windows-10-s-linux-subsystem`
+* :ref:`cygwin`
+
 .. note::
 
   Some older Linux systems (like RHEL/CentOS 5) and Python interpreter binaries
@@ -327,6 +338,8 @@ Virtualenv_ can be used to build and install Borg without affecting
 the system Python or requiring root access.  Using a virtual environment is
 optional, but recommended except for the most simple use cases.
 
+Ensure to install the dependencies as described within :ref:`source-install`.
+
 .. note::
     If you install into a virtual environment, you need to **activate** it
     first (``source borg-env/bin/activate``), before running ``borg``.
@@ -375,6 +388,8 @@ Using git
 
 This uses latest, unreleased development code from git.
 While we try not to break master, there are no guarantees on anything.
+
+Ensure to install the dependencies as described within :ref:`source-install`.
 
 ::
 


### PR DESCRIPTION
I've replayed the dev-installation on a fresh ubuntu 22.04 and fell into the same trap as the author of #7356, because my doc entry-point was:

* https://borgbackup.readthedocs.io/en/stable/development.html#
  * https://borgbackup.readthedocs.io/en/stable/development.html#building-a-development-environment

Then..

The "Building a development environment" section links to the "Using git" section. This can result in developers overseeing the os dependencies necessity.

re #7356 (via #7398)

(dev environment setup can be further streamlined, if this is of interest)
