### PR TITLE
Windows: simplify building

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Install dependencies
         run: ./scripts/msys2-install-deps development
       - name: Build
-        run: ./scripts/msys2-build
+        run: |
+          pip install -e .
+          pyinstaller -y scripts/borg.exe.spec
       - uses: actions/upload-artifact@v3
         with:
           name: borg-windows
@@ -30,5 +32,4 @@ jobs:
       - name: Run tests
         run: |
           ./dist/borg.exe -V
-          pip install -e .
           pytest --benchmark-skip -vv -rs -k "not remote"

--- a/scripts/msys2-build
+++ b/scripts/msys2-build
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-python setup.py build_ext --inplace
-python setup.py bdist_wheel
-pyinstaller -y scripts/borg.exe.spec


### PR DESCRIPTION
Use the standard pip build command, and get rid of the build script.