### PR TITLE
docs: remove OS directory from install docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,17 +145,6 @@ the old version using the same steps as shown above.
 From Source
 -----------
 
-Operating System
-~~~~~~~~~~~~~~~~
-
-* :ref:`debian-ubuntu`
-* :ref:`fedora`
-* :ref:`opensuse-tumbleweed-leap`
-* :ref:`macos`
-* :ref:`freebsd`
-* :ref:`windows-10-s-linux-subsystem`
-* :ref:`cygwin`
-
 .. note::
 
   Some older Linux systems (like RHEL/CentOS 5) and Python interpreter binaries


### PR DESCRIPTION
- links did not work that way
- each OS has its own headline and can be discovered easily without that directory
