### PR TITLE
debug id-hash: implement file content id-hash computation, see #7406 (forwardport-master)

### DIFF
--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -255,6 +255,16 @@ class DebugMixIn:
         print("object %s fetched." % hex_id)
         return EXIT_SUCCESS
 
+    @with_repository(compatibility=Manifest.NO_OPERATION_CHECK)
+    def do_debug_id_hash(self, args, repository, manifest):
+        """compute id-hash for file contents"""
+        with open(args.path, "rb") as f:
+            data = f.read()
+        key = manifest.key
+        id = key.id_hash(data)
+        print(id.hex())
+        return EXIT_SUCCESS
+
     @with_repository(manifest=False, exclusive=True)
     def do_debug_put_obj(self, args, repository):
         """put file contents into the repository"""
@@ -488,6 +498,24 @@ class DebugMixIn:
             metavar="WANTED",
             type=str,
             help="term to search the repo for, either 0x1234abcd hex term or a string",
+        )
+        debug_id_hash_epilog = process_epilog(
+            """
+                This command computes the id-hash for some file content.
+                """
+        )
+        subparser = debug_parsers.add_parser(
+            "id-hash",
+            parents=[common_parser],
+            add_help=False,
+            description=self.do_debug_id_hash.__doc__,
+            epilog=debug_id_hash_epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            help="compute id-hash for some file content (debug)",
+        )
+        subparser.set_defaults(func=self.do_debug_id_hash)
+        subparser.add_argument(
+            "path", metavar="PATH", type=str, help="content for which the id-hash shall get computed"
         )
 
         debug_get_obj_epilog = process_epilog(

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -47,8 +47,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         data = b"some data"
         self.create_regular_file("file", contents=data)
-        # TODO: to compute the correct hexkey, we need: borg debug id-hash file
-        id_hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"  # 256bit = 64 hex digits
+        output = self.cmd(f"--repo={self.repository_location}", "debug", "id-hash", "input/file")
+        id_hash = output.strip()
         output = self.cmd(f"--repo={self.repository_location}", "debug", "put-obj", id_hash, "input/file")
         assert id_hash in output
         output = self.cmd(f"--repo={self.repository_location}", "debug", "get-obj", id_hash, "output/file")


### PR DESCRIPTION
Forward-port of eb8ccd22d46f60896a66e1d6ce03b204489dba30 #7411