### PR TITLE
Add parse-obj and format-obj debug commands

### DIFF
--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -280,11 +280,11 @@ class DebugMixIn:
             print("object id %s is invalid [%s]." % (hex_id, str(err)))
             return EXIT_ERROR
 
-        with open(args.cdata, "rb") as f:
-            cdata = f.read()
+        with open(args.object_path, "rb") as f:
+            object_file = f.read()
 
         repo_objs = manifest.repo_objs
-        meta, data = repo_objs.parse(id=id, cdata=cdata)
+        meta, data = repo_objs.parse(id=id, cdata=object_file)
 
         with open(args.json_path, "w") as f:
             json.dump(meta, f)
@@ -592,7 +592,7 @@ class DebugMixIn:
         subparser.set_defaults(func=self.do_debug_parse_obj)
         subparser.add_argument("id", metavar="ID", type=str, help="hex object ID to get from the repo")
         subparser.add_argument(
-            "cdata", metavar="COMPRESSED_DATA", type=str, help="path of the objectfile to parse data from"
+            "object_path", metavar="OBJECT_PATH", type=str, help="path of the objectfile to parse data from"
         )
         subparser.add_argument(
             "binary_path", metavar="BINARY_PATH", type=str, help="path of the file to write uncompressed data into"

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -268,7 +268,7 @@ class DebugMixIn:
 
     @with_repository(compatibility=Manifest.NO_OPERATION_CHECK)
     def do_debug_parse_obj(self, args, repository, manifest):
-        """parse object file into meta dict and data (decrypting, decompressing)"""
+        """parse borg object file into meta dict and data (decrypting, decompressing)"""
 
         # get the object from id
         hex_id = args.id
@@ -281,10 +281,10 @@ class DebugMixIn:
             return EXIT_ERROR
 
         with open(args.object_path, "rb") as f:
-            object_file = f.read()
+            cdata = f.read()
 
         repo_objs = manifest.repo_objs
-        meta, data = repo_objs.parse(id=id, cdata=object_file)
+        meta, data = repo_objs.parse(id=id, cdata=cdata)
 
         with open(args.json_path, "w") as f:
             json.dump(meta, f)
@@ -587,12 +587,12 @@ class DebugMixIn:
             description=self.do_debug_parse_obj.__doc__,
             epilog=debug_parse_obj_epilog,
             formatter_class=argparse.RawDescriptionHelpFormatter,
-            help="parse objectfile into meta dict and data",
+            help="parse borg object file into meta dict and data",
         )
         subparser.set_defaults(func=self.do_debug_parse_obj)
         subparser.add_argument("id", metavar="ID", type=str, help="hex object ID to get from the repo")
         subparser.add_argument(
-            "object_path", metavar="OBJECT_PATH", type=str, help="path of the objectfile to parse data from"
+            "object_path", metavar="OBJECT_PATH", type=str, help="path of the object file to parse data from"
         )
         subparser.add_argument(
             "binary_path", metavar="BINARY_PATH", type=str, help="path of the file to write uncompressed data into"

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -3,7 +3,6 @@ from binascii import unhexlify, hexlify
 import functools
 import json
 import textwrap
-import traceback
 
 from ..archive import Archive
 from ..compress import CompressionSpec
@@ -285,12 +284,7 @@ class DebugMixIn:
             cdata = f.read()
 
         repo_objs = manifest.repo_objs
-
-        try:
-            meta, data = repo_objs.parse(id=id, cdata=cdata, decompress=True)
-        except Exception:
-            traceback.print_exc()
-            return EXIT_ERROR
+        meta, data = repo_objs.parse(id=id, cdata=cdata, decompress=True)
 
         with open(args.json_path, "w") as f:
             json.dump(meta, f)
@@ -321,19 +315,11 @@ class DebugMixIn:
             meta = json.load(f)
 
         repo_objs = manifest.repo_objs
+        data_encrypted = repo_objs.format(id=id, meta=meta, data=data)
 
-        ctype = repo_objs.compressor.ID
-        clevel = repo_objs.compressor.level
-
-        try:
-            data_encrypted = repo_objs.format(id=id, meta=meta, data=data, ctype=ctype, clevel=clevel)
-        except Exception:
-            traceback.print_exc()
-            return EXIT_ERROR
-        else:
-            with open(args.output_path, "wb") as f:
-                f.write(data_encrypted)
-            return EXIT_SUCCESS
+        with open(args.output_path, "wb") as f:
+            f.write(data_encrypted)
+        return EXIT_SUCCESS
 
     @with_repository(manifest=False, exclusive=True)
     def do_debug_put_obj(self, args, repository):

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -284,12 +284,12 @@ class DebugMixIn:
             cdata = f.read()
 
         repo_objs = manifest.repo_objs
-        meta, data = repo_objs.parse(id=id, cdata=cdata, decompress=True)
+        meta, data = repo_objs.parse(id=id, cdata=cdata)
 
         with open(args.json_path, "w") as f:
             json.dump(meta, f)
 
-        with open(args.data_path, "wb") as f:
+        with open(args.binary_path, "wb") as f:
             f.write(data)
 
         return EXIT_SUCCESS
@@ -308,7 +308,7 @@ class DebugMixIn:
             print("object id %s is invalid [%s]." % (hex_id, str(err)))
             return EXIT_ERROR
 
-        with open(args.data_path, "rb") as f:
+        with open(args.binary_path, "rb") as f:
             data = f.read()
 
         with open(args.json_path, "r") as f:
@@ -317,7 +317,7 @@ class DebugMixIn:
         repo_objs = manifest.repo_objs
         data_encrypted = repo_objs.format(id=id, meta=meta, data=data)
 
-        with open(args.output_path, "wb") as f:
+        with open(args.object_path, "wb") as f:
             f.write(data_encrypted)
         return EXIT_SUCCESS
 
@@ -595,7 +595,7 @@ class DebugMixIn:
             "cdata", metavar="COMPRESSED_DATA", type=str, help="path of the objectfile to parse data from"
         )
         subparser.add_argument(
-            "data_path", metavar="DATA_PATH", type=str, help="path of the file to write uncompressed data into"
+            "binary_path", metavar="BINARY_PATH", type=str, help="path of the file to write uncompressed data into"
         )
         subparser.add_argument(
             "json_path", metavar="JSON_PATH", type=str, help="path of the json file to write metadata into"
@@ -619,7 +619,7 @@ class DebugMixIn:
         subparser.set_defaults(func=self.do_debug_format_obj)
         subparser.add_argument("id", metavar="ID", type=str, help="hex object ID to get from the repo")
         subparser.add_argument(
-            "data_path", metavar="DATA_PATH", type=str, help="path of the file to convert into objectfile"
+            "binary_path", metavar="BINARY_PATH", type=str, help="path of the file to convert into objectfile"
         )
         subparser.add_argument(
             "json_path", metavar="JSON_PATH", type=str, help="path of the json file to read metadata from"
@@ -634,8 +634,8 @@ class DebugMixIn:
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )
         subparser.add_argument(
-            "output_path",
-            metavar="OUTPUT_PATH",
+            "object_path",
+            metavar="OBJECT_PATH",
             type=str,
             help="path of the objectfile to write compressed encrypted data into",
         )

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -287,12 +287,12 @@ class DebugMixIn:
         repo_objs = manifest.repo_objs
 
         try:
-            meta, data = repo_objs.parse(obj_id=id, cdata=cdata, decompress=True)
+            meta, data = repo_objs.parse(id=id, cdata=cdata, decompress=True)
         except Exception:
             traceback.print_exc()
             return EXIT_ERROR
 
-        with open(args.json_path, "wb") as f:
+        with open(args.json_path, "w") as f:
             json.dump(meta, f)
 
         with open(args.data_path, "wb") as f:
@@ -326,7 +326,7 @@ class DebugMixIn:
         clevel = repo_objs.compressor.level
 
         try:
-            data_encrypted = repo_objs.format(id=hex_id, meta=meta, data=data, ctype=ctype, clevel=clevel)
+            data_encrypted = repo_objs.format(id=id, meta=meta, data=data, ctype=ctype, clevel=clevel)
         except Exception:
             traceback.print_exc()
             return EXIT_ERROR

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -1,4 +1,5 @@
 from struct import Struct
+from typing import Optional
 
 from .helpers import msgpack
 from .compress import Compressor, LZ4_COMPRESSOR, get_compressor
@@ -29,9 +30,9 @@ class RepoObj:
         meta: dict,
         data: bytes,
         compress: bool = True,
-        size: int = None,
-        ctype: int = None,
-        clevel: int = None,
+        size: Optional[int] = None,
+        ctype: Optional[int] = None,
+        clevel: Optional[int] = None,
     ) -> bytes:
         assert isinstance(id, bytes)
         assert isinstance(meta, dict)
@@ -65,7 +66,7 @@ class RepoObj:
         hdr = obj[:offs]
         len_meta_encrypted = self.meta_len_hdr.unpack(hdr)[0]
         assert offs + len_meta_encrypted <= len(obj)
-        meta_encrypted = obj[offs : offs + len_meta_encrypted]
+        meta_encrypted = obj[offs: offs + len_meta_encrypted]
         meta_packed = self.key.decrypt(id, meta_encrypted)
         meta = msgpack.unpackb(meta_packed)
         return meta
@@ -78,7 +79,7 @@ class RepoObj:
         hdr = obj[:offs]
         len_meta_encrypted = self.meta_len_hdr.unpack(hdr)[0]
         assert offs + len_meta_encrypted <= len(obj)
-        meta_encrypted = obj[offs : offs + len_meta_encrypted]
+        meta_encrypted = obj[offs: offs + len_meta_encrypted]
         offs += len_meta_encrypted
         meta_packed = self.key.decrypt(id, meta_encrypted)
         meta = msgpack.unpackb(meta_packed)

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -30,9 +30,9 @@ class RepoObj:
         meta: dict,
         data: bytes,
         compress: bool = True,
-        size: Optional[int] = None,
-        ctype: Optional[int] = None,
-        clevel: Optional[int] = None,
+        size: int = None,
+        ctype: int = None,
+        clevel: int = None,
     ) -> bytes:
         assert isinstance(id, bytes)
         assert isinstance(meta, dict)

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -1,5 +1,4 @@
 from struct import Struct
-from typing import Optional
 
 from .helpers import msgpack
 from .compress import Compressor, LZ4_COMPRESSOR, get_compressor

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -66,7 +66,7 @@ class RepoObj:
         hdr = obj[:offs]
         len_meta_encrypted = self.meta_len_hdr.unpack(hdr)[0]
         assert offs + len_meta_encrypted <= len(obj)
-        meta_encrypted = obj[offs: offs + len_meta_encrypted]
+        meta_encrypted = obj[offs : offs + len_meta_encrypted]
         meta_packed = self.key.decrypt(id, meta_encrypted)
         meta = msgpack.unpackb(meta_packed)
         return meta
@@ -79,7 +79,7 @@ class RepoObj:
         hdr = obj[:offs]
         len_meta_encrypted = self.meta_len_hdr.unpack(hdr)[0]
         assert offs + len_meta_encrypted <= len(obj)
-        meta_encrypted = obj[offs: offs + len_meta_encrypted]
+        meta_encrypted = obj[offs : offs + len_meta_encrypted]
         offs += len_meta_encrypted
         meta_packed = self.key.decrypt(id, meta_encrypted)
         meta = msgpack.unpackb(meta_packed)

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -68,7 +68,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         """Test format-obj and parse-obj commands"""
 
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
-        data = b"some data"
+        data = b"some data" * 100
         meta_dict = {"some": "property"}
         meta = json.dumps(meta_dict, ensure_ascii=False).encode()
 
@@ -119,8 +119,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         c = Compressor(name="zstd", level=2)
         _, data_compressed = c.compress(meta_dict, data=data)
         assert meta_read.get("csize") == len(data_compressed)
-        assert "ctype" in meta_read
-        assert "clevel" in meta_read
+        assert meta_read.get("ctype") == c.compressor.ID
+        assert meta_read.get("clevel") == c.compressor.level
 
     def test_debug_dump_manifest(self):
         self.create_regular_file("file1", size=1024 * 80)

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -63,7 +63,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd(f"--repo={self.repository_location}", "debug", "delete-obj", "invalid")
         assert "is invalid" in output
 
-    def test_debug_id_hash_format_put_parse_obj(self):
+    def test_debug_id_hash_format_put_get_parse_obj(self):
+        """Test format-obj and parse-obj commands"""
+
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         data = b"some data"
         meta = b'{"some" : "property"}'
@@ -83,6 +85,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "input/file",
             "input/meta.json",
             "output/formatted_file",
+            "--compression=lz4",
         )
 
         output = self.cmd(f"--repo={self.repository_location}", "debug", "put-obj", id_hash, "output/formatted_file")
@@ -103,12 +106,10 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
         with open("output/parsed_file", "rb") as f:
             data_read = f.read()
-
         assert data == data_read
 
         with open("output/meta.json") as f:
             meta_read = json.load(f)
-
         for key, value in meta_dict.items():
             assert meta_read.get(key) == value
 

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -70,7 +70,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         data = b"some data" * 100
         meta_dict = {"some": "property"}
-        meta = json.dumps(meta_dict, ensure_ascii=False).encode()
+        meta = json.dumps(meta_dict).encode()
 
         self.create_regular_file("plain.bin", contents=data)
         self.create_regular_file("meta.json", contents=meta)
@@ -92,7 +92,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         output = self.cmd(f"--repo={self.repository_location}", "debug", "put-obj", id_hash, "output/data.bin")
         assert id_hash in output
 
-        output = self.cmd(f"--repo={self.repository_location}", "debug", "get-obj", id_hash, "output/compressed.bin")
+        output = self.cmd(f"--repo={self.repository_location}", "debug", "get-obj", id_hash, "output/object.bin")
         assert id_hash in output
 
         output = self.cmd(
@@ -100,7 +100,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             "debug",
             "parse-obj",
             id_hash,
-            "output/compressed.bin",
+            "output/object.bin",
             "output/plain.bin",
             "output/meta.json",
         )

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -6,6 +6,7 @@ import unittest
 from ...constants import *  # NOQA
 from .. import changedir
 from . import ArchiverTestCaseBase, RemoteArchiverTestCaseBase, ArchiverTestCaseBinaryBase, RK_ENCRYPTION, BORG_EXES
+from ..compress import Compressor
 
 
 class ArchiverTestCase(ArchiverTestCaseBase):
@@ -114,6 +115,12 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             assert meta_read.get(key) == value
 
         assert meta_read.get("size") == len(data_read)
+
+        c = Compressor(name="zstd", level=2)
+        _, data_compressed = c.compress(meta_dict, data=data)
+        assert meta_read.get("csize") == len(data_compressed)
+        assert "ctype" in meta_read
+        assert "clevel" in meta_read
 
     def test_debug_dump_manifest(self):
         self.create_regular_file("file1", size=1024 * 80)


### PR DESCRIPTION
Implements #7406 

Format of `parse-obj` and `format-obj` commands are:
```python
borg debug parse-obj --repo REPO_PATH INPUT_ID COMPRESSED_FILE OUTPUT_FILE OUTPUT_JSON 
borg debug format-obj --repo REPO_PATH INPUT_ID INPUT_FILE INPUT_JSON OUTPUT_FILE --compression="xyz,4"
```

The user is expected to use `borg debug get-obj` to get `COMPRESSED_FILE` for `parse-obj`.
Similarly, the user is expected to use `borg debug id-hash` to get `INPUT_ID` for `format-obj`.