### PR TITLE
Add support to build dependencies from source to the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -418,6 +418,23 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("buster64", ".*none.*")
   end
 
+  config.vm.define "stretch64" do |b|
+    b.vm.box = "debian/stretch64"
+    b.vm.provider :virtualbox do |v|
+      v.memory = 1024 + $wmem
+    end
+    b.vm.provision "fs init", :type => :shell, :inline => fs_init("vagrant")
+    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid("vagrant")
+    b.vm.provision "install source dependencies", :type => :shell, :privileged => true, :inline => install_source_dependencies("vagrant")
+    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("stretch64")
+    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("stretch64")
+    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("stretch64")
+    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("llfuse")
+    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller()
+    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("stretch64")
+    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("stretch64", ".*none.*")
+  end
+
   config.vm.define "freebsd64" do |b|
     b.vm.box = "generic/freebsd13"
     b.vm.provider :virtualbox do |v|


### PR DESCRIPTION
Fix #7010 #7459

This adds support to build the borg dependencies from source and re-adds the stretch64 VM.

* Libraries: LIBATTR=2.5.1, LIBACL=2.3.1, LIBFUSE=3.14.0, LIBLZ4=1.9.4, LIBZSTD=1.5.4, LIBXXHASH=0.8.1, OPENSSL=1.1.1t
* `pyenv` will detect the custom openssl version and use it. This is needed to build python >= 3.10 with openssl >= 1.1.1.
* The stretch64 VM is re-added.

The stretch64 `llfuse` tests seem okay, except 3 issues caused by fakeroot. This is likely unrelated.

The stretch64 `pyfuse3` tests show a few errors for the borg.exe, which is not built with pyfuse3. This seems due to how the FUSE_IMPL is detected.
```
borg mount not available: no FUSE support, BORG_FUSE_IMPL=pyfuse3. 
```
* A borg.exe built with llfuse, will fail the tests when called with `BORG_FUSE_IMPL=pyfuse3` and fall through to `None`.
* A borg.exe built with pyfuse3 will not work with the current `borg.exe.spec`. It excludes the bundled `trio/_ssl.py` import from pyfuse3 causing a silent fall-through to `None`.
  * Replace `fuse_impl.py` line 15 `pass`, with a RuntimeError to show:
 ```
Traceback (most recent call last):
File "borg/fuse_impl.py", line 13, in <module>
File "src/pyfuse3.pyx", line 68, in init pyfuse3
File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
File "trio/__init__.py", line 74, in <module>
File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
File "trio/_ssl.py", line 153, in <module>
ModuleNotFoundError: No module named 'ssl'
```
* A workaround like `mv /vagrant/borg/borg.exe /vagrant/borg/borg.exe~` will skip the binary tests and work.