### PR TITLE
ProgressIndicatorPercent: fix space computation for wide chars, fixes #3027

### DIFF
--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -144,10 +144,12 @@ class ProgressIndicatorPercent(ProgressIndicatorBase):
             # truncate the last argument, if no space is available
             if info is not None:
                 if not self.json:
+                    from ..platform import swidth  # avoid circular import
+
                     # no need to truncate if we're not outputting to a terminal
                     terminal_space = get_terminal_size(fallback=(-1, -1))[0]
                     if terminal_space != -1:
-                        space = terminal_space - len(self.msg % tuple([pct] + info[:-1] + [""]))
+                        space = terminal_space - swidth(self.msg % tuple([pct] + info[:-1] + [""]))
                         info[-1] = ellipsis_truncate(info[-1], space)
                 return self.output(self.msg % tuple([pct] + info), justify=False, info=info)
 


### PR DESCRIPTION
needs to use swidth() in case there are wide chars (like CJK) in the left part of the msg (e.g. an archive name).
