### PR TITLE
rlist: size and nfiles format keys

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -672,11 +672,14 @@ class ArchiveFormatter(BaseFormatter):
         "id": "internal ID of the archive",
         "hostname": "hostname of host on which this archive was created",
         "username": "username of user who created this archive",
+        "size": "size of this archive (data plus metadata, not considering compression and deduplication)",
+        "nfiles": "count of files in this archive",
     }
     KEY_GROUPS = (
         ("archive", "name", "comment", "id"),
         ("start", "time", "end", "command_line"),
         ("hostname", "username"),
+        ("size", "nfiles"),
     )
 
     @classmethod
@@ -726,6 +729,8 @@ class ArchiveFormatter(BaseFormatter):
             "username": partial(self.get_meta, "username", ""),
             "comment": partial(self.get_meta, "comment", ""),
             "command_line": partial(self.get_meta, "command_line", ""),
+            "size": partial(self.get_meta, "size", 0),
+            "nfiles": partial(self.get_meta, "nfiles", 0),
             "end": self.get_ts_end,
         }
         self.used_call_keys = set(self.call_keys) & self.format_keys

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -722,10 +722,10 @@ class ArchiveFormatter(BaseFormatter):
         self.format = partial_format(format, static_keys)
         self.format_keys = {f[1] for f in Formatter().parse(format)}
         self.call_keys = {
-            "hostname": partial(self.get_meta, "hostname"),
-            "username": partial(self.get_meta, "username"),
-            "comment": partial(self.get_meta, "comment"),
-            "command_line": partial(self.get_meta, "command_line"),
+            "hostname": partial(self.get_meta, "hostname", ""),
+            "username": partial(self.get_meta, "username", ""),
+            "comment": partial(self.get_meta, "comment", ""),
+            "command_line": partial(self.get_meta, "command_line", ""),
             "end": self.get_ts_end,
         }
         self.used_call_keys = set(self.call_keys) & self.format_keys
@@ -771,8 +771,8 @@ class ArchiveFormatter(BaseFormatter):
             self._archive = Archive(self.manifest, self.name, iec=self.iec)
         return self._archive
 
-    def get_meta(self, key):
-        return self.archive.metadata.get(key, "")
+    def get_meta(self, key, default=None):
+        return self.archive.metadata.get(key, default)
 
     def get_ts_end(self):
         return self.format_time(self.archive.ts_end)

--- a/src/borg/testsuite/archiver/rlist_cmd.py
+++ b/src/borg/testsuite/archiver/rlist_cmd.py
@@ -40,6 +40,19 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.assert_in("test-1 comment 1" + os.linesep, output_3)
         self.assert_in("test-2 comment 2" + os.linesep, output_3)
 
+    def test_size_nfiles(self):
+        self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
+        self.create_regular_file("file1", size=123000)
+        self.create_regular_file("file2", size=456)
+        self.cmd(f"--repo={self.repository_location}", "create", "test", "input/file1", "input/file2")
+        output = self.cmd(f"--repo={self.repository_location}", "list", "test")
+        print(output)
+        output = self.cmd(f"--repo={self.repository_location}", "rlist", "--format", "{name} {nfiles} {size}")
+        o_t = output.split()
+        assert o_t[0] == "test"
+        assert int(o_t[1]) == 2
+        assert 123456 <= int(o_t[2]) < 123999  # there is some metadata overhead
+
     def test_date_matching(self):
         self.cmd(f"--repo={self.repository_location}", "rcreate", RK_ENCRYPTION)
         earliest_ts = "2022-11-20T23:59:59"


### PR DESCRIPTION
```
$ borg rlist --format '{name} {size} {nfiles}{NL}' 
docs 20150956 436
```