### PR TITLE
implement BORG_<CMD>_FORMAT env vars, fixes #5166

### DIFF
--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -104,6 +104,14 @@ General:
             caused EROFS. You will need this to make archives from volume shadow copies
             in WSL1 (Windows Subsystem for Linux 1).
 
+Output formatting:
+    BORG_LIST_FORMAT
+        Giving the default value for ``borg list --format=X``.
+    BORG_RLIST_FORMAT
+        Giving the default value for ``borg rlist --format=X``.
+    BORG_PRUNE_FORMAT
+        Giving the default value for ``borg prune --format=X``.
+
 Some automatic "answerers" (if set, they automatically answer confirmation questions):
     BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)
         For "Warning: Attempting to access a previously unknown unencrypted repository"

--- a/src/borg/archiver/list_cmd.py
+++ b/src/borg/archiver/list_cmd.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import textwrap
 import sys
 
@@ -24,7 +25,7 @@ class ListMixIn:
         elif args.short:
             format = "{path}{NL}"
         else:
-            format = "{mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}"
+            format = os.environ.get("BORG_LIST_FORMAT", "{mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")
 
         def _list_inner(cache):
             archive = Archive(manifest, args.name, cache=cache)

--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
 import logging
 from operator import attrgetter
+import os
 import re
 
 from ._common import with_repository, Highlander
@@ -87,7 +88,7 @@ class PruneMixIn:
         elif args.short:
             format = "{archive}"
         else:
-            format = "{archive:<36} {time} [{id}]"
+            format = os.environ.get("BORG_PRUNE_FORMAT", "{archive:<36} {time} [{id}]")
         formatter = ArchiveFormatter(format, repository, manifest, manifest.key, json=False, iec=args.iec)
 
         checkpoint_re = r"\.checkpoint(\.\d+)?"

--- a/src/borg/archiver/rlist_cmd.py
+++ b/src/borg/archiver/rlist_cmd.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import textwrap
 import sys
 
@@ -21,7 +22,7 @@ class RListMixIn:
         elif args.short:
             format = "{archive}{NL}"
         else:
-            format = "{archive:<36} {time} [{id}]{NL}"
+            format = os.environ.get("BORG_RLIST_FORMAT", "{archive:<36} {time} [{id}]{NL}")
         formatter = ArchiveFormatter(format, repository, manifest, manifest.key, json=args.json, iec=args.iec)
 
         output_data = []


### PR DESCRIPTION
for now for: prune, list, rlist.
