### PR TITLE
docs: fix some -a / --match-archives issues

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -369,8 +369,8 @@ different prefixes. For example, you could have a script that does::
 
 Then you would have two different prune calls with different policies::
 
-    borg prune --verbose --list -d 30 -a 'main-*'
-    borg prune --verbose --list -d 7  -a 'logs-*'
+    borg prune --verbose --list -d 30 -a 'sh:main-*'
+    borg prune --verbose --list -d 7  -a 'sh:logs-*'
 
 This will keep 7 days of logs and 30 days of everything else.
 

--- a/docs/quickstart_example.rst.inc
+++ b/docs/quickstart_example.rst.inc
@@ -48,8 +48,8 @@
 
     $ borg -r /path/to/repo delete -a Monday
 
-   Please note the ``-a`` option here (short for ``--glob-archives``) which enables you
-   to give a globbing pattern to delete multiple archives, like ``-a 'oldcrap-*'``.
+   Please note the ``-a`` option here (short for ``--match-archives``) which enables you
+   to give a pattern to delete multiple archives, like ``-a 'sh:oldcrap-*'``.
    You can also combine this with ``--first``, ``--last`` and ``--sort-by``.
    Be careful, always first use with ``--dry-run`` and ``--list``!
 

--- a/docs/usage/delete.rst
+++ b/docs/usage/delete.rst
@@ -10,11 +10,11 @@ Examples
     $ borg compact
 
     # delete all archives whose names begin with the machine's hostname followed by "-"
-    $ borg delete -a '{hostname}-*'
+    $ borg delete -a 'sh:{hostname}-*'
 
     # delete all archives whose names contain "-2012-"
-    $ borg delete -a '*-2012-*'
+    $ borg delete -a 'sh:*-2012-*'
 
     # see what would be deleted if delete was run without --dry-run
-    $ borg delete --list --dry-run -a '*-May-*'
+    $ borg delete --list --dry-run -a 'sh:*-May-*'
 

--- a/docs/usage/mount.rst
+++ b/docs/usage/mount.rst
@@ -27,7 +27,7 @@ Examples
     # Archive filters are supported.
     # These are especially handy for the "versions view",
     # which does not support lazy processing of archives.
-    $ borg mount -o versions --glob-archives '*-my-home' --last 10 /tmp/mymountpoint
+    $ borg mount -o versions --match-archives 'sh:*-my-home' --last 10 /tmp/mymountpoint
 
     # Exclusion options are supported.
     # These can speed up mounting and lower memory needs significantly.

--- a/docs/usage/prune.rst
+++ b/docs/usage/prune.rst
@@ -7,7 +7,7 @@ Be careful, prune is a potentially dangerous command, it will remove backup
 archives.
 
 The default of prune is to apply to **all archives in the repository** unless
-you restrict its operation to a subset of the archives using ``-a`` / ``--glob-archives``.
+you restrict its operation to a subset of the archives using ``-a`` / ``--match-archives``.
 When using ``-a``, be careful to choose a good pattern - e.g. do not use a
 prefix "foo" if you do not also want to match "foobar".
 
@@ -22,7 +22,7 @@ first so you will see what it would do without it actually doing anything.
 
     # Same as above but only apply to archive names starting with the hostname
     # of the machine followed by a "-" character:
-    $ borg prune -v --list --keep-daily=7 --keep-weekly=4 -a '{hostname}-*'
+    $ borg prune -v --list --keep-daily=7 --keep-weekly=4 -a 'sh:{hostname}-*'
     # actually free disk space:
     $ borg compact
 


### PR DESCRIPTION
at some places, the docs were not updated yet.

for borg 1.x, -a (aka --glob-archives) expected
sh: style glob patterns ONLY (but one must not
give sh: explicitly).

for borg 2, -a (aka --match-archives) defaults
to id: style (identical match), so one must give
sh: if one wants shell-style globbing.
