### PR TITLE
tests: avoid long ids in pytest output

### DIFF
--- a/src/borg/testsuite/archive.py
+++ b/src/borg/testsuite/archive.py
@@ -259,6 +259,7 @@ IK = sorted(list(ITEM_KEYS))
             OrderedDict((k, b"x" * 1000) for k in IK),  # as big (key count and volume) as it gets
         ]
     ],
+    ids=["minimal", "empty-values", "long-values"],
 )
 def test_valid_msgpacked_items(packed, item_keys_serialized):
     assert valid_msgpacked_dict(packed, item_keys_serialized)

--- a/src/borg/testsuite/archiver/help_cmd.py
+++ b/src/borg/testsuite/archiver/help_cmd.py
@@ -51,6 +51,7 @@ def test_help_formatting(command, parser):
         assert parser.epilog.rst
 
 
-@pytest.mark.parametrize("topic, helptext", list(Archiver.helptext.items()))
-def test_help_formatting_helptexts(topic, helptext):
+@pytest.mark.parametrize("topic", list(Archiver.helptext.keys()))
+def test_help_formatting_helptexts(topic):
+    helptext = Archiver.helptext[topic]
     assert str(rst_to_terminal(helptext))

--- a/src/borg/testsuite/cache.py
+++ b/src/borg/testsuite/cache.py
@@ -74,6 +74,7 @@ class TestCacheSynchronizer:
             (False, "Unexpected object: false"),
             (None, "Unexpected object: nil"),
         ),
+        ids=["map", "bytes", "int", "double", "true", "false", "none"],
     )
     @pytest.mark.parametrize(
         "structure",

--- a/src/borg/testsuite/key.py
+++ b/src/borg/testsuite/key.py
@@ -315,7 +315,11 @@ class TestTAM:
         with pytest.raises(exc):
             key.unpack_and_verify_manifest(blob)
 
-    @pytest.mark.parametrize("hmac, salt", (({}, bytes(64)), (bytes(64), {}), (None, bytes(64)), (bytes(64), None)))
+    @pytest.mark.parametrize(
+        "hmac, salt",
+        (({}, bytes(64)), (bytes(64), {}), (None, bytes(64)), (bytes(64), None)),
+        ids=["ed-b64", "b64-ed", "n-b64", "b64-n"],
+    )
     def test_wrong_types(self, key, hmac, salt):
         data = {"tam": {"type": "HKDF_HMAC_SHA512", "hmac": hmac, "salt": salt}}
         tam = data["tam"]


### PR DESCRIPTION
sometimes the automatically computed IDs are just too long, so rather give IDs directly or avoid them otherwise.
