### PR TITLE
clear empty directories at end of compact process, fixes #6823

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -879,6 +879,7 @@ class Repository:
             pi.show()
         pi.finish()
         complete_xfer(intermediate=False)
+        self.io.clear_empty_dirs()
         quota_use_after = self.storage_quota_use
         logger.info('compaction freed about %s repository space.', format_file_size(quota_use_before - quota_use_after))
         logger.debug('compaction completed.')
@@ -1494,6 +1495,22 @@ class LoggedIO:
             safe_unlink(self.segment_filename(segment))
         except FileNotFoundError:
             pass
+
+    def clear_empty_dirs(self):
+        """Delete empty segment dirs, i.e those with no segment files.
+        """
+        data_dir = os.path.join(self.path, 'data')
+        segment_dirs = self.get_segment_dirs(data_dir)
+        for segment_dir in segment_dirs:
+            try:
+                # os.rmdir will only delete the directory if it is empty
+                # so we don't need to explicitly check for emptiness first.
+                os.rmdir(segment_dir)
+            except OSError:
+                # OSError is raised by os.rmdir if directory is not empty. This is expected.
+                # It's subclass FileNotFoundError may be raised if the directory already does not exist. Ignorable.
+                pass
+        sync_dir(data_dir)
 
     def segment_exists(self, segment):
         filename = self.segment_filename(segment)


### PR DESCRIPTION
With this commit, empty directories are cleared after segments compacting.
Fixes https://github.com/borgbackup/borg/issues/6823