### PR TITLE
Security support docs (master)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ These borg releases are currently supported with security updates.
 | Version | Supported          |
 |---------|--------------------|
 | 1.2.x   | :white_check_mark: |
-| 1.1.x   | :white_check_mark: |
+| 1.1.x   | :x:                |
 | < 1.1   | :x:                |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ These borg releases are currently supported with security updates.
 
 | Version | Supported          |
 |---------|--------------------|
+| 2.0.x   | :x: (not released) |
 | 1.2.x   | :white_check_mark: |
 | 1.1.x   | :x:                |
 | < 1.1   | :x:                |


### PR DESCRIPTION
At 1.2.4 release, this update was added to 1.2-maint branch, but not to master branch.

Also tell that 2.0.x is not released yet and thus there is also no security support for it yet.