### PR TITLE
replace `LRUCache` internals with `OrderedDict`

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1236,7 +1236,7 @@ class MetadataCollector:
 # (hash_func, chunk_length) -> chunk_hash
 # we play safe and have the hash_func in the mapping key, in case we
 # have different hash_funcs within the same borg run.
-zero_chunk_ids = LRUCache(10, dispose=lambda _: None)
+zero_chunk_ids = LRUCache(10)  # type: ignore[var-annotated]
 
 
 def cached_hash(chunk, id_hash):

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -115,7 +115,7 @@ class ItemCache:
         # tend to re-read the same chunks over and over.
         # The capacity is kept low because increasing it does not provide any significant advantage,
         # but makes LRUCache's square behaviour noticeable and consumes more memory.
-        self.chunks = LRUCache(capacity=10, dispose=lambda _: None)
+        self.chunks = LRUCache(capacity=10)
 
         # Instrumentation
         # Count of indirect items, i.e. data is cached in the object cache, not directly in this cache
@@ -252,7 +252,7 @@ class FuseBackend:
         # not contained in archives.
         self._items = {}
         # cache up to <FILES> Items
-        self._inode_cache = LRUCache(capacity=FILES, dispose=lambda _: None)
+        self._inode_cache = LRUCache(capacity=FILES)
         # _inode_count is the current count of synthetic inodes, i.e. those in self._items
         self.inode_count = 0
         # Maps inode numbers to the inode number of the parent
@@ -445,8 +445,8 @@ class FuseOperations(llfuse.Operations, FuseBackend):
         self.decrypted_repository = decrypted_repository
         data_cache_capacity = int(os.environ.get("BORG_MOUNT_DATA_CACHE_ENTRIES", os.cpu_count() or 1))
         logger.debug("mount data cache capacity: %d chunks", data_cache_capacity)
-        self.data_cache = LRUCache(capacity=data_cache_capacity, dispose=lambda _: None)
-        self._last_pos = LRUCache(capacity=FILES, dispose=lambda _: None)
+        self.data_cache = LRUCache(capacity=data_cache_capacity)
+        self._last_pos = LRUCache(capacity=FILES)
 
     def sig_info_handler(self, sig_no, stack):
         logger.debug(
@@ -689,7 +689,7 @@ class FuseOperations(llfuse.Operations, FuseBackend):
             size -= n
             if not size:
                 if fh in self._last_pos:
-                    self._last_pos.upd(fh, (chunk_no, chunk_offset))
+                    self._last_pos.replace(fh, (chunk_no, chunk_offset))
                 else:
                     self._last_pos[fh] = (chunk_no, chunk_offset)
                 break

--- a/src/borg/helpers/lrucache.py
+++ b/src/borg/helpers/lrucache.py
@@ -2,16 +2,15 @@ from collections import OrderedDict
 from collections.abc import Callable, ItemsView, Iterator, KeysView, MutableMapping, ValuesView
 from typing import TypeVar
 
-sentinel = object()
 K = TypeVar("K")
 V = TypeVar("V")
 
 
 class LRUCache(MutableMapping[K, V]):
     """
-    Mapping which maintains a maximum size by dropping the least recently used value.
-    Items are passed to dispose before being removed and replacing an item without
-    removing it first is forbidden.
+    Mapping which maintains a maximum size by removing the least recently used value.
+    Items are passed to dispose before being removed and setting an item which is
+    already in the cache has to be done using the replace method.
     """
 
     _cache: OrderedDict[K, V]

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1536,7 +1536,7 @@ class LoggedIO:
         else:
             # we only have fresh enough stuff here.
             # update the timestamp of the lru cache entry.
-            self.fds.upd(segment, (now, fd))
+            self.fds.replace(segment, (now, fd))
         return fd
 
     def close_segment(self):

--- a/src/borg/testsuite/lrucache.py
+++ b/src/borg/testsuite/lrucache.py
@@ -7,7 +7,7 @@ from ..helpers.lrucache import LRUCache
 
 class TestLRUCache:
     def test_lrucache(self):
-        c = LRUCache(2, dispose=lambda _: None)
+        c = LRUCache(2)
         assert len(c) == 0
         assert c.items() == set()
         for i, x in enumerate("abc"):


### PR DESCRIPTION
Hello,
while looking trough the code I noticed that `LRUCache` is using custom logic to keep track of ordering which handles the `list` operations not very efficiently.
Since `OrderedDict` is implemented in C it should provide a speedup and allow for a simpler implementation.

I tried to run the tests on my machine but `conftest.py` fails to parse the version made up by setuptools-scm.