### PR TITLE
Fix failing test on OpenBSD

### DIFF
--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -800,7 +800,8 @@ def test_get_runtime_dir(monkeypatch):
     else:
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
         monkeypatch.delenv("BORG_RUNTIME_DIR", raising=False)
-        assert get_runtime_dir() == os.path.join("/run/user", str(os.getuid()), "borg")
+        if not sys.platform.startswith("openbsd"):
+            assert get_runtime_dir() == os.path.join("/run/user", str(os.getuid()), "borg")
         monkeypatch.setenv("XDG_RUNTIME_DIR", "/var/tmp/.cache")
         assert get_runtime_dir() == os.path.join("/var/tmp/.cache", "borg")
         monkeypatch.setenv("BORG_RUNTIME_DIR", "/var/tmp")


### PR DESCRIPTION
A borgbackup-2.0.0b6 test fails on OpenBSD with the message below.

```
=================================== FAILURES ===================================
_____________________________ test_get_runtime_dir _____________________________

path = '/run/user/55/borg', mode = 511, pretty_deadly = True

    def ensure_dir(path, mode=stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO, pretty_deadly=True):
        """
        Ensures that the dir exists with the right permissions.
        1) Make sure the directory exists in a race-free operation
        2) If mode is not None and the directory has been created, give the right
        permissions to the leaf directory. The current umask value is masked out first.
        3) If pretty_deadly is True, catch exceptions, reraise them with a pretty
        message.
        Returns if the directory has been created and has the right permissions,
        An exception otherwise. If a deadly exception happened it is reraised.
        """
        try:
>           os.makedirs(path, mode=mode, exist_ok=True)

build/lib.openbsd-7.3-amd64-cpython-310/borg/helpers/fs.py:37:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
...
...
```

I think `/run/user` is something that is created by systemd, which is not used on OpenBSD. Despite of
https://github.com/borgbackup/borg/blob/master/src/borg/platformflags.py#L4, proposal is to test if we are on OpenBSD, and act accordingly. Reason for this shortcut is that adding `is_openbsd` to `platformflags.py` results in more code, and I'm not sure this makes sense for a unit test.