### PR TITLE
list: fix --pattern examples, fixes #7611

### DIFF
--- a/docs/usage/list.rst
+++ b/docs/usage/list.rst
@@ -34,11 +34,11 @@ Examples
     -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.text
     ...
 
-    $ borg list /path/to/repo/::archiveA --pattern 're:\.ext$'
+    $ borg list /path/to/repo/::archiveA --pattern '+ re:\.ext$' --pattern '- re:^.*$'
     -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.ext
     ...
 
-    $ borg list /path/to/repo/::archiveA --pattern 're:.ext$'
+    $ borg list /path/to/repo/::archiveA --pattern '+ re:.ext$' --pattern '- re:^.*$'
     -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.ext
     -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.text
     ...


### PR DESCRIPTION
- pattern needs to start with + - !
- first match wins
- the default is to list everything, thus a 2nd pattern is needed to exclude everything not matched by 1st pattern.
