### PR TITLE
Docs: Rewrite `borg check` docs

### DIFF
--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -177,49 +177,6 @@ class CheckMixIn:
         lost data. However, this "healing process" can only happen in repair mode.
         Thus it is advised to run ``--repair`` a second time after creating some new
         backups.
-
-        Technical description
-        +++++++++++++++++++++
-
-        First, the underlying repository data files are checked:
-
-        - For all segments, the segment magic header is checked.
-        - For all objects stored in the segments, all metadata (e.g. CRC and size) and
-          all data is read. The read data is checked by size and CRC. Bit rot and other
-          types of accidental damage can be detected this way.
-        - In repair mode, if an integrity error is detected in a segment, try to recover
-          as many objects from the segment as possible.
-        - In repair mode, make sure that the index is consistent with the data stored in
-          the segments.
-        - If checking a remote repo via ``ssh:``, the repo check is executed on the server
-          without causing significant network traffic.
-        - The repository check can be skipped using the ``--archives-only`` option.
-        - A repository check can be time consuming. Partial checks are possible with the
-          ``--max-duration`` option.
-
-        Second, the consistency and correctness of the archive metadata is verified:
-
-        - Is the repo manifest present? If not, it is rebuilt from archive metadata
-          chunks (this requires reading and decrypting of all metadata and data).
-        - Check if archive metadata chunk is present; if not, remove archive from manifest.
-        - For all files (items) in the archive, for all chunks referenced by these
-          files, check if chunk is present. In repair mode, if a chunk is not present,
-          replace it with a same-size replacement chunk of zeroes. If a previously lost
-          chunk reappears (e.g. via a later backup), in repair mode the all-zero replacement
-          chunk will be replaced by the correct chunk. This requires reading of archive and
-          file metadata, but not data.
-        - In repair mode, when all the archives were checked, orphaned chunks are deleted
-          from the repo. One cause of orphaned chunks are input file related errors (like
-          read errors) in the archive creation process.
-        - In verify-data mode, a complete cryptographic verification of the archive data
-          integrity is performed. This conflicts with ``--repository-only`` as this mode
-          only makes sense if the archive checks are enabled. The full details of this mode
-          are documented above.
-        - If checking a remote repo via ``ssh:``, the archive check is executed on the
-          client machine because it requires decryption, and this is always done client-side
-          as key access is needed.
-        - The archive checks can be time consuming; they can be skipped using the
-          ``--repository-only`` option.
         """
         )
         subparser = subparsers.add_parser(

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -103,15 +103,17 @@ class CheckMixIn:
         would take 7 hours, then running a daily check with ``--max-duration=3600``
         (1 hour) would result in one full repository check per week. Doing a full
         repository check aborts any previous partial check; the next partial check will
-        restart from the beginning. You can use ``--max-duration`` with neither
-        ``--repair``, nor ``--archives-only``.
+        restart from the beginning. With partial repository checks you can run neither
+        archive checks, nor enable repair mode. Consequently, if you want to use
+        ``--max-duration`` you must also pass ``--repository-only``, and must pass
+        neither ``--archives-only``, nor ``--repair``.
 
         **Warning:** Please note that partial repository checks (i.e. running it with
         ``--max-duration``) can only perform non-cryptographic checksum checks on the
         segment files. A full repository check (i.e. without ``--max-duration``) can
-        also do a repository index check. Even though this is often no issue, partial
-        checks may therefore be useful only with very large repositories where a full
-        check would take too long.
+        also do a repository index check. Enabling partial repository checks excepts
+        archive checks for the same reason. Therefore partial checks may be useful with
+        very large repositories only where a full check would take too long.
 
         The ``--verify-data`` option will perform a full integrity verification (as
         opposed to checking the CRC32 of the segment) of data, which means reading the


### PR DESCRIPTION
The current `borg check` docs have a very tech-centered focus. Some rather important bits for users are just small notes in subordinate clauses and the docs didn't really focus on what the user needs to know and what he's supposed to do (see e.g. #7578). Therefore I rewrote the docs. It appears like a rewrite from scratch, but in reality heavily relies on what was there before.

**Important!** I rewrote the docs based on what I understood from the old docs. Since the old docs were a bit ambiguous sometimes, I might got some things wrong. Thus it's very important that someone with actual code insight checks this.

Some open questions:

- ~~I was a bit confused about what `--max-duration` is lacking compared to a full repo check. Does only a full repo check include the repo index check, or does this check even require `--repair`? The old docs didn't explain this well...~~ **edit**: Fixed
- ~~I'm claiming in the new docs that the check that `--max-duration` is lacking is no big issue. Is this true? If it is a big deal, how big of a deal is it? Is `--max-duration` discouraged or not?~~ **edit**: Fixed
- ~~Does `--max-duration` require `--repository-only`? The old docs switched to "partial `--repository-only` check" in the second paragraph, but the repo checks don't actually require `--repository-only`!? :confused:~~ **edit**: Fixed
- Should we keep the technical description? IMHO they are redundant because everything a user needs to know is already included, just differently. I have thus removed it in the second commit, but it can be restored easily.
- I guess this should be backported to all older Borg branches, right?
- Is this PR mergeable as-is or am I supposed to run some commands? When reading https://borgbackup.readthedocs.io/en/master/development.html#documentation I just don't know whether I'm supposed to run the commands myself or not...

Fixes #7578