### PR TITLE
`cmd` function now creates repo_location argument

### DIFF
--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -147,7 +147,9 @@ def cmd(archiver, *args, **kw):
     binary_output = kw.get("binary_output", False)
     if fork is None:
         fork = archiver.FORK_DEFAULT
-    ret, output = exec_cmd(*args, archiver=archiver.archiver, fork=fork, exe=archiver.EXE, **kw)
+    ret, output = exec_cmd(
+        f"--repo={archiver.repository_location}", *args, archiver=archiver.archiver, fork=fork, exe=archiver.EXE, **kw
+    )
     if ret != exit_code:
         print(output)
     assert ret == exit_code
@@ -160,11 +162,10 @@ def cmd(archiver, *args, **kw):
 
 
 def create_src_archive(archiver, name, ts=None):
-    repo_location, source_dir = archiver.repository_location, src_dir
     if ts:
-        cmd(archiver, f"--repo={repo_location}", "create", "--compression=lz4", f"--timestamp={ts}", name, source_dir)
+        cmd(archiver, "create", "--compression=lz4", f"--timestamp={ts}", name, src_dir)
     else:
-        cmd(archiver, f"--repo={repo_location}", "create", "--compression=lz4", name, source_dir)
+        cmd(archiver, "create", "--compression=lz4", name, src_dir)
 
 
 def open_archive(repo_path, name):
@@ -270,29 +271,28 @@ def _set_repository_id(repo_path, id):
 
 
 def _extract_hardlinks_setup(archiver):
-    repo_location, input_path = archiver.repository_location, archiver.input_path
+    os.mkdir(os.path.join(archiver.input_path, "dir1"))
+    os.mkdir(os.path.join(archiver.input_path, "dir1/subdir"))
 
-    os.mkdir(os.path.join(input_path, "dir1"))
-    os.mkdir(os.path.join(input_path, "dir1/subdir"))
+    create_regular_file(archiver.input_path, "source", contents=b"123456")
+    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "abba"))
+    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "dir1/hardlink"))
+    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "dir1/subdir/hardlink"))
 
-    create_regular_file(input_path, "source", contents=b"123456")
-    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "abba"))
-    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "dir1/hardlink"))
-    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "dir1/subdir/hardlink"))
+    create_regular_file(archiver.input_path, "dir1/source2")
+    os.link(os.path.join(archiver.input_path, "dir1/source2"), os.path.join(archiver.input_path, "dir1/aaaa"))
 
-    create_regular_file(input_path, "dir1/source2")
-    os.link(os.path.join(input_path, "dir1/source2"), os.path.join(input_path, "dir1/aaaa"))
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
 
 
 def _create_test_caches(archiver):
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    create_regular_file(input_path, "cache1/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff")
-    create_regular_file(input_path, "cache2/%s" % CACHE_TAG_NAME, contents=b"invalid signature")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    create_regular_file(
+        archiver.input_path, "cache1/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff"
+    )
+    create_regular_file(archiver.input_path, "cache2/%s" % CACHE_TAG_NAME, contents=b"invalid signature")
     os.mkdir("input/cache3")
     if are_hardlinks_supported():
         os.link("input/cache1/%s" % CACHE_TAG_NAME, "input/cache3/%s" % CACHE_TAG_NAME)
@@ -304,13 +304,13 @@ def _create_test_caches(archiver):
 
 def _assert_test_caches(archiver):
     with changedir("output"):
-        cmd(archiver, f"--repo={archiver.repository_location}", "extract", "test")
+        cmd(archiver, "extract", "test")
     assert sorted(os.listdir("output/input")) == ["cache2", "file1"]
     assert sorted(os.listdir("output/input/cache2")) == [CACHE_TAG_NAME]
 
 
 def _create_test_tagged(archiver):
-    cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_regular_file(archiver.input_path, "file1", size=1024 * 80)
     create_regular_file(archiver.input_path, "tagged1/.NOBACKUP")
     create_regular_file(archiver.input_path, "tagged2/00-NOBACKUP")
@@ -319,13 +319,13 @@ def _create_test_tagged(archiver):
 
 def _assert_test_tagged(archiver):
     with changedir("output"):
-        cmd(archiver, f"--repo={archiver.repository_location}", "extract", "test")
+        cmd(archiver, "extract", "test")
     assert sorted(os.listdir("output/input")) == ["file1"]
 
 
 def _create_test_keep_tagged(archiver):
     input_path = archiver.input_path
-    cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_regular_file(input_path, "file0", size=1024)
     create_regular_file(input_path, "tagged1/.NOBACKUP1")
     create_regular_file(input_path, "tagged1/file1", size=1024)
@@ -341,7 +341,7 @@ def _create_test_keep_tagged(archiver):
 
 def _assert_test_keep_tagged(archiver):
     with changedir("output"):
-        cmd(archiver, f"--repo={archiver.repository_location}", "extract", "test")
+        cmd(archiver, "extract", "test")
     assert sorted(os.listdir("output/input")), ["file0", "tagged1", "tagged2", "tagged3", "taggedall"]
     assert os.listdir("output/input/tagged1"), [".NOBACKUP1"]
     assert os.listdir("output/input/tagged2"), [".NOBACKUP2"]
@@ -351,7 +351,7 @@ def _assert_test_keep_tagged(archiver):
 
 def check_cache(archiver):
     # First run a regular borg check
-    cmd(archiver, f"--repo={archiver.repository_location}", "check")
+    cmd(archiver, "check")
     # Then check that the cache on disk matches exactly what's in the repo.
     with open_repository(archiver) as repository:
         manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -483,7 +483,7 @@ def wait_for_mountstate(mountpoint, *, mounted, timeout=5):
 
 
 @contextmanager
-def fuse_mount(archiver, location, mountpoint=None, *options, fork=True, os_fork=False, **kwargs):
+def fuse_mount(archiver, mountpoint=None, *options, fork=True, os_fork=False, **kwargs):
     # For a successful mount, `fork = True` is required for
     # the borg mount daemon to work properly or the tests
     # will just freeze. Therefore, if argument `fork` is not
@@ -502,7 +502,7 @@ def fuse_mount(archiver, location, mountpoint=None, *options, fork=True, os_fork
         mountpoint = tempfile.mkdtemp()
     else:
         os.mkdir(mountpoint)
-    args = [f"--repo={location}", "mount", mountpoint] + list(options)
+    args = ["mount", mountpoint] + list(options)
     if os_fork:
         # Do not spawn, but actually (OS) fork.
         if os.fork() == 0:

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -271,35 +271,33 @@ def _set_repository_id(repo_path, id):
 
 
 def _extract_hardlinks_setup(archiver):
-    os.mkdir(os.path.join(archiver.input_path, "dir1"))
-    os.mkdir(os.path.join(archiver.input_path, "dir1/subdir"))
+    input_path = archiver.input_path
+    os.mkdir(os.path.join(input_path, "dir1"))
+    os.mkdir(os.path.join(input_path, "dir1/subdir"))
 
-    create_regular_file(archiver.input_path, "source", contents=b"123456")
-    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "abba"))
-    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "dir1/hardlink"))
-    os.link(os.path.join(archiver.input_path, "source"), os.path.join(archiver.input_path, "dir1/subdir/hardlink"))
+    create_regular_file(input_path, "source", contents=b"123456")
+    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "abba"))
+    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "dir1/hardlink"))
+    os.link(os.path.join(input_path, "source"), os.path.join(input_path, "dir1/subdir/hardlink"))
 
-    create_regular_file(archiver.input_path, "dir1/source2")
-    os.link(os.path.join(archiver.input_path, "dir1/source2"), os.path.join(archiver.input_path, "dir1/aaaa"))
+    create_regular_file(input_path, "dir1/source2")
+    os.link(os.path.join(input_path, "dir1/source2"), os.path.join(input_path, "dir1/aaaa"))
 
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     cmd(archiver, "create", "test", "input")
 
 
 def _create_test_caches(archiver):
+    input_path = archiver.input_path
     cmd(archiver, "rcreate", RK_ENCRYPTION)
-    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
-    create_regular_file(
-        archiver.input_path, "cache1/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff"
-    )
-    create_regular_file(archiver.input_path, "cache2/%s" % CACHE_TAG_NAME, contents=b"invalid signature")
+    create_regular_file(input_path, "file1", size=1024 * 80)
+    create_regular_file(input_path, "cache1/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff")
+    create_regular_file(input_path, "cache2/%s" % CACHE_TAG_NAME, contents=b"invalid signature")
     os.mkdir("input/cache3")
     if are_hardlinks_supported():
         os.link("input/cache1/%s" % CACHE_TAG_NAME, "input/cache3/%s" % CACHE_TAG_NAME)
     else:
-        create_regular_file(
-            archiver.input_path, "cache3/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff"
-        )
+        create_regular_file(input_path, "cache3/%s" % CACHE_TAG_NAME, contents=CACHE_TAG_CONTENTS + b" extra stuff")
 
 
 def _assert_test_caches(archiver):
@@ -310,11 +308,12 @@ def _assert_test_caches(archiver):
 
 
 def _create_test_tagged(archiver):
+    input_path = archiver.input_path
     cmd(archiver, "rcreate", RK_ENCRYPTION)
-    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
-    create_regular_file(archiver.input_path, "tagged1/.NOBACKUP")
-    create_regular_file(archiver.input_path, "tagged2/00-NOBACKUP")
-    create_regular_file(archiver.input_path, "tagged3/.NOBACKUP/file2", size=1024)
+    create_regular_file(input_path, "file1", size=1024 * 80)
+    create_regular_file(input_path, "tagged1/.NOBACKUP")
+    create_regular_file(input_path, "tagged2/00-NOBACKUP")
+    create_regular_file(input_path, "tagged3/.NOBACKUP/file2", size=1024)
 
 
 def _assert_test_tagged(archiver):

--- a/src/borg/testsuite/archiver/argparsing.py
+++ b/src/borg/testsuite/archiver/argparsing.py
@@ -6,28 +6,24 @@ from . import Archiver, RK_ENCRYPTION, cmd
 
 
 def test_bad_filters(archiver):
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    cmd(archiver, f"--repo={repo_location}", "delete", "--first", "1", "--last", "1", fork=True, exit_code=2)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    cmd(archiver, "delete", "--first", "1", "--last", "1", fork=True, exit_code=2)
 
 
 def test_highlander(archiver):
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "--comment", "comment 1", "test-1", __file__)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "--comment", "comment 1", "test-1", __file__)
     error_msg = "There can be only one"
     # Default umask value is 0077
     # Test that it works with a one time specified default or custom value
-    output_default = cmd(archiver, f"--repo={repo_location}", "--umask", "0077", "rlist")
+    output_default = cmd(archiver, "--umask", "0077", "rlist")
     assert error_msg not in output_default
-    output_custom = cmd(archiver, f"--repo={repo_location}", "--umask", "0007", "rlist")
+    output_custom = cmd(archiver, "--umask", "0007", "rlist")
     assert error_msg not in output_custom
     # Test that all combinations of custom and default values fail
     for first, second in [("0007", "0007"), ("0007", "0077"), ("0077", "0007"), ("0077", "0077")]:
-        output_custom = cmd(
-            archiver, f"--repo={repo_location}", "--umask", first, "--umask", second, "rlist", exit_code=2
-        )
+        output_custom = cmd(archiver, "--umask", first, "--umask", second, "rlist", exit_code=2)
         assert error_msg in output_custom
 
 

--- a/src/borg/testsuite/archiver/benchmark_cmd.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd.py
@@ -4,6 +4,6 @@ from . import cmd, RK_ENCRYPTION
 
 
 def test_benchmark_crud(archiver):
-    cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     with environment_variable(_BORG_BENCHMARK_CRUD_TEST="YES"):
-        cmd(archiver, f"--repo={archiver.repository_location}", "benchmark", "crud", archiver.input_path)
+        cmd(archiver, "benchmark", "crud", archiver.input_path)

--- a/src/borg/testsuite/archiver/bypass_lock_option.py
+++ b/src/borg/testsuite/archiver/bypass_lock_option.py
@@ -80,7 +80,6 @@ def test_readonly_extract(archiver):
 def test_readonly_info(archiver):
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
-
     with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
@@ -97,7 +96,6 @@ def test_readonly_info(archiver):
 def test_readonly_list(archiver):
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
-
     with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
@@ -115,19 +113,18 @@ def test_readonly_list(archiver):
 def test_readonly_mount(archiver):
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
-
     with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            with fuse_mount(archiver, archiver.repository_location, exit_code=EXIT_ERROR):
+            with fuse_mount(archiver, exit_code=EXIT_ERROR):
                 pass
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
                 # self.fuse_mount always assumes fork=True, so for this test we have to set fork=False manually
-                with fuse_mount(archiver, archiver.repository_location, fork=False):
+                with fuse_mount(archiver, fork=False):
                     pass
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        with fuse_mount(archiver, archiver.repository_location, None, "--bypass-lock"):
+        with fuse_mount(archiver, None, "--bypass-lock"):
             pass

--- a/src/borg/testsuite/archiver/bypass_lock_option.py
+++ b/src/borg/testsuite/archiver/bypass_lock_option.py
@@ -9,132 +9,125 @@ from . import cmd, create_src_archive, RK_ENCRYPTION, read_only, fuse_mount
 
 
 def test_readonly_check(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "check", "--verify-data", exit_code=EXIT_ERROR)
+            cmd(archiver, "check", "--verify-data", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "check", "--verify-data")
+                cmd(archiver, "check", "--verify-data")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "check", "--verify-data", "--bypass-lock")
+        cmd(archiver, "check", "--verify-data", "--bypass-lock")
 
 
 def test_readonly_diff(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "a")
     create_src_archive(archiver, "b")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "diff", "a", "b", exit_code=EXIT_ERROR)
+            cmd(archiver, "diff", "a", "b", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "diff", "a", "b")
+                cmd(archiver, "diff", "a", "b")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "diff", "a", "b", "--bypass-lock")
+        cmd(archiver, "diff", "a", "b", "--bypass-lock")
 
 
 def test_readonly_export_tar(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "export-tar", "test", "test.tar", exit_code=EXIT_ERROR)
+            cmd(archiver, "export-tar", "test", "test.tar", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "export-tar", "test", "test.tar")
+                cmd(archiver, "export-tar", "test", "test.tar")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "export-tar", "test", "test.tar", "--bypass-lock")
+        cmd(archiver, "export-tar", "test", "test.tar", "--bypass-lock")
 
 
 def test_readonly_extract(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "extract", "test", exit_code=EXIT_ERROR)
+            cmd(archiver, "extract", "test", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "extract", "test")
+                cmd(archiver, "extract", "test")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "extract", "test", "--bypass-lock")
+        cmd(archiver, "extract", "test", "--bypass-lock")
 
 
 def test_readonly_info(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "rinfo", exit_code=EXIT_ERROR)
+            cmd(archiver, "rinfo", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "rinfo")
+                cmd(archiver, "rinfo")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "rinfo", "--bypass-lock")
+        cmd(archiver, "rinfo", "--bypass-lock")
 
 
 def test_readonly_list(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            cmd(archiver, f"--repo={repo_location}", "rlist", exit_code=EXIT_ERROR)
+            cmd(archiver, "rlist", exit_code=EXIT_ERROR)
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
-                cmd(archiver, f"--repo={repo_location}", "rlist")
+                cmd(archiver, "rlist")
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        cmd(archiver, f"--repo={repo_location}", "rlist", "--bypass-lock")
+        cmd(archiver, "rlist", "--bypass-lock")
 
 
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_readonly_mount(archiver):
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
 
-    with read_only(repo_path):
+    with read_only(archiver.repository_path):
         # verify that command normally doesn't work with read-only repo
         if archiver.FORK_DEFAULT:
-            with fuse_mount(archiver, repo_location, exit_code=EXIT_ERROR):
+            with fuse_mount(archiver, archiver.repository_location, exit_code=EXIT_ERROR):
                 pass
         else:
             with pytest.raises((LockFailed, RemoteRepository.RPCError)) as excinfo:
                 # self.fuse_mount always assumes fork=True, so for this test we have to set fork=False manually
-                with fuse_mount(archiver, repo_location, fork=False):
+                with fuse_mount(archiver, archiver.repository_location, fork=False):
                     pass
             if isinstance(excinfo.value, RemoteRepository.RPCError):
                 assert excinfo.value.exception_class == "LockFailed"
         # verify that command works with read-only repo when using --bypass-lock
-        with fuse_mount(archiver, repo_location, None, "--bypass-lock"):
+        with fuse_mount(archiver, archiver.repository_location, None, "--bypass-lock"):
             pass

--- a/src/borg/testsuite/archiver/check_cmd.py
+++ b/src/borg/testsuite/archiver/check_cmd.py
@@ -16,7 +16,7 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def check_cmd_setup(archiver):
     with patch.object(ChunkBuffer, "BUFFER_SIZE", 10):
-        cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", RK_ENCRYPTION)
+        cmd(archiver, "rcreate", RK_ENCRYPTION)
         create_src_archive(archiver, "archive1")
         create_src_archive(archiver, "archive2")
 
@@ -24,32 +24,29 @@ def check_cmd_setup(archiver):
 def test_check_usage(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)
-    repo_location = archiver.repository_location
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--progress", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--progress", exit_code=0)
     assert "Starting repository check" in output
     assert "Starting archive consistency check" in output
     assert "Checking segments" in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--repository-only", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--repository-only", exit_code=0)
     assert "Starting repository check" in output
     assert "Starting archive consistency check" not in output
     assert "Checking segments" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", exit_code=0)
     assert "Starting repository check" not in output
     assert "Starting archive consistency check" in output
 
-    output = cmd(
-        archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--match-archives=archive2", exit_code=0
-    )
+    output = cmd(archiver, "check", "-v", "--archives-only", "--match-archives=archive2", exit_code=0)
     assert "archive1" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--first=1", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--first=1", exit_code=0)
     assert "archive1" in output
     assert "archive2" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--last=1", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--last=1", exit_code=0)
     assert "archive1" not in output
     assert "archive2" in output
 
@@ -57,49 +54,47 @@ def test_check_usage(archivers, request):
 def test_date_matching(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
 
-    shutil.rmtree(repo_path)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    shutil.rmtree(archiver.repository_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     earliest_ts = "2022-11-20T23:59:59"
     ts_in_between = "2022-12-18T23:59:59"
     create_src_archive(archiver, "archive1", ts=earliest_ts)
     create_src_archive(archiver, "archive2", ts=ts_in_between)
     create_src_archive(archiver, "archive3")
-    cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--oldest=23e", exit_code=2)
+    cmd(archiver, "check", "-v", "--archives-only", "--oldest=23e", exit_code=2)
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--oldest=1m", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--oldest=1m", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
     assert "archive3" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--newest=1m", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--newest=1m", exit_code=0)
     assert "archive3" in output
     assert "archive2" not in output
     assert "archive1" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--newer=1d", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--newer=1d", exit_code=0)
     assert "archive3" in output
     assert "archive1" not in output
     assert "archive2" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--older=1d", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--older=1d", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
     assert "archive3" not in output
 
     # check for output when timespan older than the earliest archive is given. Issue #1711
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--archives-only", "--older=9999m", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--archives-only", "--older=9999m", exit_code=0)
     for archive in ("archive1", "archive2", "archive3"):
         assert archive not in output
 
 
 def test_missing_file_chunk(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
 
-    archive, repository = open_archive(repo_path, "archive1")
+    archive, repository = open_archive(archiver.repository_path, "archive1")
 
     with repository:
         for item in archive.iter_items():
@@ -112,17 +107,17 @@ def test_missing_file_chunk(archivers, request):
             pytest.fail("should not happen")  # convert 'fail'
         repository.commit(compact=False)
 
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    output = cmd(archiver, "check", "--repair", exit_code=0)
     assert "New missing file chunk detected" in output
 
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
-    output = cmd(archiver, f"--repo={repo_location}", "list", "archive1", "--format={health}#{path}{NL}", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
+    output = cmd(archiver, "list", "archive1", "--format={health}#{path}{NL}", exit_code=0)
     assert "broken#" in output
 
     # check that the file in the old archives has now a different chunk list without the killed chunk
     for archive_name in ("archive1", "archive2"):
-        archive, repository = open_archive(repo_path, archive_name)
+        archive, repository = open_archive(archiver.repository_path, archive_name)
         with repository:
             for item in archive.iter_items():
                 if item.path.endswith(src_file):
@@ -137,13 +132,13 @@ def test_missing_file_chunk(archivers, request):
         create_src_archive(archiver, "archive3")
 
     # check should be able to heal the file now:
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--repair", exit_code=0)
+    output = cmd(archiver, "check", "-v", "--repair", exit_code=0)
     assert "Healed previously missing file chunk" in output
     assert f"{src_file}: Completely healed previously damaged file!" in output
 
     # check that the file in the old archives has the correct chunks again
     for archive_name in ("archive1", "archive2"):
-        archive, repository = open_archive(repo_path, archive_name)
+        archive, repository = open_archive(archiver.repository_path, archive_name)
         with repository:
             for item in archive.iter_items():
                 if item.path.endswith(src_file):
@@ -153,82 +148,68 @@ def test_missing_file_chunk(archivers, request):
                 pytest.fail("should not happen")
 
     # list is also all-healthy again
-    output = cmd(archiver, f"--repo={repo_location}", "list", "archive1", "--format={health}#{path}{NL}", exit_code=0)
+    output = cmd(archiver, "list", "archive1", "--format={health}#{path}{NL}", exit_code=0)
     assert "broken#" not in output
 
 
 def test_missing_archive_item_chunk(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         repository.delete(archive.metadata.items[0])
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair", exit_code=0)
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    cmd(archiver, "check", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
 
 
 def test_missing_archive_metadata(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         repository.delete(archive.id)
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair", exit_code=0)
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    cmd(archiver, "check", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
 
 
 def test_missing_manifest(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         repository.delete(Manifest.MANIFEST_ID)
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    output = cmd(archiver, "check", "-v", "--repair", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
 
 
 def test_corrupted_manifest(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         manifest = repository.get(Manifest.MANIFEST_ID)
         corrupted_manifest = manifest + b"corrupted!"
         repository.put(Manifest.MANIFEST_ID, corrupted_manifest)
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    output = cmd(archiver, "check", "-v", "--repair", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
 
 
 def test_manifest_rebuild_corrupted_chunk(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         manifest = repository.get(Manifest.MANIFEST_ID)
         corrupted_manifest = manifest + b"corrupted!"
@@ -237,20 +218,17 @@ def test_manifest_rebuild_corrupted_chunk(archivers, request):
         corrupted_chunk = chunk + b"corrupted!"
         repository.put(archive.id, corrupted_chunk)
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "-v", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    output = cmd(archiver, "check", "-v", "--repair", exit_code=0)
     assert "archive2" in output
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
 
 
 def test_manifest_rebuild_duplicate_archive(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    archive, repository = open_archive(repo_path, "archive1")
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     repo_objs = archive.repo_objs
-
     with repository:
         manifest = repository.get(Manifest.MANIFEST_ID)
         corrupted_manifest = manifest + b"corrupted!"
@@ -269,10 +247,9 @@ def test_manifest_rebuild_duplicate_archive(archivers, request):
         archive_id = repo_objs.id_hash(archive)
         repository.put(archive_id, repo_objs.format(archive_id, {}, archive))
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair", exit_code=0)
-    output = cmd(archiver, f"--repo={repo_location}", "rlist")
+    cmd(archiver, "check", exit_code=1)
+    cmd(archiver, "check", "--repair", exit_code=0)
+    output = cmd(archiver, "rlist")
     assert "archive1" in output
     assert "archive1.1" in output
     assert "archive2" in output
@@ -282,31 +259,26 @@ def test_extra_chunks(archivers, request):
     archiver = request.getfixturevalue(archivers)
     if archiver.get_kind() == "remote":
         pytest.skip("only works locally")
-    repo_location = archiver.repository_location
     check_cmd_setup(archiver)
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
-
-    with Repository(repo_location, exclusive=True) as repository:
+    cmd(archiver, "check", exit_code=0)
+    with Repository(archiver.repository_location, exclusive=True) as repository:
         repository.put(b"01234567890123456789012345678901", b"xxxx")
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair", exit_code=0)
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
-    cmd(archiver, f"--repo={repo_location}", "extract", "archive1", "--dry-run", exit_code=0)
+    cmd(archiver, "check", exit_code=1)
+    cmd(archiver, "check", exit_code=1)
+    cmd(archiver, "check", "--repair", exit_code=0)
+    cmd(archiver, "check", exit_code=0)
+    cmd(archiver, "extract", "archive1", "--dry-run", exit_code=0)
 
 
 @pytest.mark.parametrize("init_args", [["--encryption=repokey-aes-ocb"], ["--encryption", "none"]])
 def test_verify_data(archivers, request, init_args):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     check_cmd_setup(archiver)
-    shutil.rmtree(repo_path)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", *init_args)
+    shutil.rmtree(archiver.repository_path)
+    cmd(archiver, "rcreate", *init_args)
     create_src_archive(archiver, "archive1")
-    archive, repository = open_archive(repo_path, "archive1")
-
+    archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         for item in archive.iter_items():
             if item.path.endswith(src_file):
@@ -316,13 +288,12 @@ def test_verify_data(archivers, request, init_args):
                 repository.put(chunk.id, data)
                 break
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=0)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "--verify-data", exit_code=1)
+    cmd(archiver, "check", exit_code=0)
+    output = cmd(archiver, "check", "--verify-data", exit_code=1)
     assert bin_to_hex(chunk.id) + ", integrity error" in output
 
     # repair (heal is tested in another test)
-    output = cmd(archiver, f"--repo={repo_location}", "check", "--repair", "--verify-data", exit_code=0)
+    output = cmd(archiver, "check", "--repair", "--verify-data", exit_code=0)
     assert bin_to_hex(chunk.id) + ", integrity error" in output
     assert f"{src_file}: New missing file chunk detected" in output
 
@@ -331,12 +302,9 @@ def test_empty_repository(archivers, request):
     archiver = request.getfixturevalue(archivers)
     if archiver.get_kind() == "remote":
         pytest.skip("only works locally")
-    repo_location = archiver.repository_location
     check_cmd_setup(archiver)
-
-    with Repository(repo_location, exclusive=True) as repository:
+    with Repository(archiver.repository_location, exclusive=True) as repository:
         for id_ in repository.list():
             repository.delete(id_)
         repository.commit(compact=False)
-
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
+    cmd(archiver, "check", exit_code=1)

--- a/src/borg/testsuite/archiver/config_cmd.py
+++ b/src/borg/testsuite/archiver/config_cmd.py
@@ -3,17 +3,15 @@ import os
 from ...constants import *  # NOQA
 from . import RK_ENCRYPTION, create_test_files, cmd, generate_archiver_tests
 
-# Tests that include the 'archivers' argument will generate a tests for each kind of archivers specified.
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_config(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     create_test_files(archiver.input_path)
     os.unlink("input/flagfile")
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    output = cmd(archiver, f"--repo={repo_location}", "config", "--list")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    output = cmd(archiver, "config", "--list")
     assert "[repository]" in output
     assert "version" in output
     assert "segments_per_dir" in output
@@ -23,24 +21,24 @@ def test_config(archivers, request):
     assert "id" in output
     assert "last_segment_checked" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "config", "last_segment_checked", exit_code=1)
+    output = cmd(archiver, "config", "last_segment_checked", exit_code=1)
     assert "No option " in output
-    cmd(archiver, f"--repo={repo_location}", "config", "last_segment_checked", "123")
-    output = cmd(archiver, f"--repo={repo_location}", "config", "last_segment_checked")
+    cmd(archiver, "config", "last_segment_checked", "123")
+    output = cmd(archiver, "config", "last_segment_checked")
     assert output == "123" + os.linesep
-    output = cmd(archiver, f"--repo={repo_location}", "config", "--list")
+    output = cmd(archiver, "config", "--list")
     assert "last_segment_checked" in output
-    cmd(archiver, f"--repo={repo_location}", "config", "--delete", "last_segment_checked")
+    cmd(archiver, "config", "--delete", "last_segment_checked")
 
     for cfg_key, cfg_value in [("additional_free_space", "2G"), ("repository.append_only", "1")]:
-        output = cmd(archiver, f"--repo={repo_location}", "config", cfg_key)
+        output = cmd(archiver, "config", cfg_key)
         assert output == "0" + os.linesep
-        cmd(archiver, f"--repo={repo_location}", "config", cfg_key, cfg_value)
-        output = cmd(archiver, f"--repo={repo_location}", "config", cfg_key)
+        cmd(archiver, "config", cfg_key, cfg_value)
+        output = cmd(archiver, "config", cfg_key)
         assert output == cfg_value + os.linesep
-        cmd(archiver, f"--repo={repo_location}", "config", "--delete", cfg_key)
-        cmd(archiver, f"--repo={repo_location}", "config", cfg_key, exit_code=1)
+        cmd(archiver, "config", "--delete", cfg_key)
+        cmd(archiver, "config", cfg_key, exit_code=1)
 
-    cmd(archiver, f"--repo={repo_location}", "config", "--list", "--delete", exit_code=2)
-    cmd(archiver, f"--repo={repo_location}", "config", exit_code=2)
-    cmd(archiver, f"--repo={repo_location}", "config", "invalid-option", exit_code=1)
+    cmd(archiver, "config", "--list", "--delete", exit_code=2)
+    cmd(archiver, "config", exit_code=2)
+    cmd(archiver, "config", "invalid-option", exit_code=1)

--- a/src/borg/testsuite/archiver/corruption.py
+++ b/src/borg/testsuite/archiver/corruption.py
@@ -12,26 +12,23 @@ from . import cmd, create_src_archive, create_test_files, RK_ENCRYPTION
 
 
 def test_check_corrupted_repository(archiver):
-    repo_location, tmpdir = archiver.repository_location, archiver.tmpdir
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "test")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "check")
+    cmd(archiver, "extract", "test", "--dry-run")
+    cmd(archiver, "check")
 
-    name = sorted(os.listdir(os.path.join(tmpdir, "repository", "data", "0")), reverse=True)[1]
-    with open(os.path.join(tmpdir, "repository", "data", "0", name), "r+b") as fd:
+    name = sorted(os.listdir(os.path.join(archiver.tmpdir, "repository", "data", "0")), reverse=True)[1]
+    with open(os.path.join(archiver.tmpdir, "repository", "data", "0", name), "r+b") as fd:
         fd.seek(100)
         fd.write(b"XXXX")
 
-    cmd(archiver, f"--repo={repo_location}", "check", exit_code=1)
+    cmd(archiver, "check", exit_code=1)
 
 
 def corrupt_archiver(archiver):
     create_test_files(archiver.input_path)
-    cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", RK_ENCRYPTION)
-    archiver.cache_path = json.loads(cmd(archiver, f"--repo={archiver.repository_location}", "rinfo", "--json"))[
-        "cache"
-    ]["path"]
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    archiver.cache_path = json.loads(cmd(archiver, "rinfo", "--json"))["cache"]["path"]
 
 
 def corrupt(file, amount=1):
@@ -44,45 +41,42 @@ def corrupt(file, amount=1):
 
 def test_cache_chunks(archiver):
     corrupt_archiver(archiver)
-    repo_location, cache_path = archiver.repository_location, archiver.cache_path
-    corrupt(os.path.join(cache_path, "chunks"))
+    corrupt(os.path.join(archiver.cache_path, "chunks"))
     if archiver.FORK_DEFAULT:
-        out = cmd(archiver, f"--repo={repo_location}", "rinfo", exit_code=2)
+        out = cmd(archiver, "rinfo", exit_code=2)
         assert "failed integrity check" in out
     else:
         with pytest.raises(FileIntegrityError):
-            cmd(archiver, f"--repo={repo_location}", "rinfo")
+            cmd(archiver, "rinfo")
 
 
 def test_cache_files(archiver):
     corrupt_archiver(archiver)
-    repo_location, cache_path = archiver.repository_location, archiver.cache_path
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    corrupt(os.path.join(cache_path, "files"))
-    out = cmd(archiver, f"--repo={repo_location}", "create", "test1", "input")
+    cmd(archiver, "create", "test", "input")
+    corrupt(os.path.join(archiver.cache_path, "files"))
+    out = cmd(archiver, "create", "test1", "input")
     # borg warns about the corrupt files cache, but then continues without files cache.
     assert "files cache is corrupted" in out
 
 
 def test_chunks_archive(archiver):
     corrupt_archiver(archiver)
-    repo_location, cache_path = archiver.repository_location, archiver.cache_path
-    cmd(archiver, f"--repo={repo_location}", "create", "test1", "input")
+    cmd(archiver, "create", "test1", "input")
     # Find ID of test1, so we can corrupt it later :)
-    target_id = cmd(archiver, f"--repo={repo_location}", "rlist", "--format={id}{NL}").strip()
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input")
+    target_id = cmd(archiver, "rlist", "--format={id}{NL}").strip()
+    cmd(archiver, "create", "test2", "input")
 
     # Force cache sync, creating archive chunks of test1 and test2 in chunks.archive.d
-    cmd(archiver, f"--repo={repo_location}", "rdelete", "--cache-only")
-    cmd(archiver, f"--repo={repo_location}", "rinfo", "--json")
+    cmd(archiver, "rdelete", "--cache-only")
+    cmd(archiver, "rinfo", "--json")
 
-    chunks_archive = os.path.join(cache_path, "chunks.archive.d")
+    chunks_archive = os.path.join(archiver.cache_path, "chunks.archive.d")
     assert len(os.listdir(chunks_archive)) == 4  # two archives, one chunks cache and one .integrity file each
 
     corrupt(os.path.join(chunks_archive, target_id + ".compact"))
 
     # Trigger cache sync by changing the manifest ID in the cache config
-    config_path = os.path.join(cache_path, "config")
+    config_path = os.path.join(archiver.cache_path, "config")
     config = ConfigParser(interpolation=None)
     config.read(config_path)
     config.set("cache", "manifest", bin_to_hex(bytes(32)))
@@ -90,7 +84,7 @@ def test_chunks_archive(archiver):
         config.write(fd)
 
     # Cache sync notices corrupted archive chunks, but automatically recovers.
-    out = cmd(archiver, f"--repo={repo_location}", "create", "-v", "test3", "input", exit_code=1)
+    out = cmd(archiver, "create", "-v", "test3", "input", exit_code=1)
     assert "Reading cached archive chunk index for test1" in out
     assert "Cached archive chunk index of test1 is corrupted" in out
     assert "Fetching and building archive index for test1" in out
@@ -100,12 +94,11 @@ def test_old_version_interfered(archiver):
     corrupt_archiver(archiver)
     # Modify the main manifest ID without touching the manifest ID in the integrity section.
     # This happens if a version without integrity checking modifies the cache.
-    repo_location, cache_path = archiver.repository_location, archiver.cache_path
-    config_path = os.path.join(cache_path, "config")
+    config_path = os.path.join(archiver.cache_path, "config")
     config = ConfigParser(interpolation=None)
     config.read(config_path)
     config.set("cache", "manifest", bin_to_hex(bytes(32)))
     with open(config_path, "w") as fd:
         config.write(fd)
-    out = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    out = cmd(archiver, "rinfo")
     assert "Cache integrity data not available: old Borg version modified the cache." in out

--- a/src/borg/testsuite/archiver/debug_cmds.py
+++ b/src/borg/testsuite/archiver/debug_cmds.py
@@ -12,16 +12,14 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_debug_profile(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_test_files(input_path)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input", "--debug-profile=create.prof")
+    create_test_files(archiver.input_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input", "--debug-profile=create.prof")
     cmd(archiver, "debug", "convert-profile", "create.prof", "create.pyprof")
     stats = pstats.Stats("create.pyprof")
     stats.strip_dirs()
     stats.sort_stats("cumtime")
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input", "--debug-profile=create.pyprof")
+    cmd(archiver, "create", "test2", "input", "--debug-profile=create.pyprof")
     stats = pstats.Stats("create.pyprof")  # Only do this on trusted data!
     stats.strip_dirs()
     stats.sort_stats("cumtime")
@@ -29,13 +27,11 @@ def test_debug_profile(archivers, request):
 
 def test_debug_dump_archive_items(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_test_files(input_path)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_test_files(archiver.input_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
     with changedir("output"):
-        output = cmd(archiver, f"--repo={repo_location}", "debug", "dump-archive-items", "test")
+        output = cmd(archiver, "debug", "dump-archive-items", "test")
     output_dir = sorted(os.listdir("output"))
     assert len(output_dir) > 0 and output_dir[0].startswith("000000_")
     assert "Done." in output
@@ -43,13 +39,11 @@ def test_debug_dump_archive_items(archivers, request):
 
 def test_debug_dump_repo_objs(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_test_files(input_path)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_test_files(archiver.input_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
     with changedir("output"):
-        output = cmd(archiver, f"--repo={repo_location}", "debug", "dump-repo-objs")
+        output = cmd(archiver, "debug", "dump-repo-objs")
     output_dir = sorted(os.listdir("output"))
     assert len(output_dir) > 0 and output_dir[0].startswith("00000000_")
     assert "Done." in output
@@ -57,51 +51,46 @@ def test_debug_dump_repo_objs(archivers, request):
 
 def test_debug_put_get_delete_obj(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     data = b"some data"
-    create_regular_file(input_path, "file", contents=data)
+    create_regular_file(archiver.input_path, "file", contents=data)
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "id-hash", "input/file")
+    output = cmd(archiver, "debug", "id-hash", "input/file")
     id_hash = output.strip()
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "put-obj", id_hash, "input/file")
+    output = cmd(archiver, "debug", "put-obj", id_hash, "input/file")
     assert id_hash in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "get-obj", id_hash, "output/file")
+    output = cmd(archiver, "debug", "get-obj", id_hash, "output/file")
     assert id_hash in output
 
     with open("output/file", "rb") as f:
         data_read = f.read()
     assert data == data_read
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "delete-obj", id_hash)
+    output = cmd(archiver, "debug", "delete-obj", id_hash)
     assert "deleted" in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "delete-obj", id_hash)
+    output = cmd(archiver, "debug", "delete-obj", id_hash)
     assert "not found" in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "delete-obj", "invalid")
+    output = cmd(archiver, "debug", "delete-obj", "invalid")
     assert "is invalid" in output
 
 
 def test_debug_id_hash_format_put_get_parse_obj(archivers, request):
     """Test format-obj and parse-obj commands"""
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     data = b"some data" * 100
     meta_dict = {"some": "property"}
     meta = json.dumps(meta_dict).encode()
-    create_regular_file(input_path, "plain.bin", contents=data)
-    create_regular_file(input_path, "meta.json", contents=meta)
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "id-hash", "input/plain.bin")
+    create_regular_file(archiver.input_path, "plain.bin", contents=data)
+    create_regular_file(archiver.input_path, "meta.json", contents=meta)
+    output = cmd(archiver, "debug", "id-hash", "input/plain.bin")
     id_hash = output.strip()
     cmd(
         archiver,
-        f"--repo={repo_location}",
         "debug",
         "format-obj",
         id_hash,
@@ -110,22 +99,13 @@ def test_debug_id_hash_format_put_get_parse_obj(archivers, request):
         "output/data.bin",
         "--compression=zstd,2",
     )
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "put-obj", id_hash, "output/data.bin")
+    output = cmd(archiver, "debug", "put-obj", id_hash, "output/data.bin")
     assert id_hash in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "get-obj", id_hash, "output/object.bin")
+    output = cmd(archiver, "debug", "get-obj", id_hash, "output/object.bin")
     assert id_hash in output
 
-    cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "debug",
-        "parse-obj",
-        id_hash,
-        "output/object.bin",
-        "output/plain.bin",
-        "output/meta.json",
-    )
+    cmd(archiver, "debug", "parse-obj", id_hash, "output/object.bin", "output/plain.bin", "output/meta.json")
     with open("output/plain.bin", "rb") as f:
         data_read = f.read()
     assert data == data_read
@@ -145,15 +125,12 @@ def test_debug_id_hash_format_put_get_parse_obj(archivers, request):
 
 def test_debug_dump_manifest(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
     dump_file = archiver.output_path + "/dump"
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "dump-manifest", dump_file)
+    output = cmd(archiver, "debug", "dump-manifest", dump_file)
     assert output == ""
-
     with open(dump_file) as f:
         result = json.load(f)
     assert "archives" in result
@@ -166,13 +143,11 @@ def test_debug_dump_manifest(archivers, request):
 
 def test_debug_dump_archive(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
     dump_file = archiver.output_path + "/dump"
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "dump-archive", "test", dump_file)
+    output = cmd(archiver, "debug", "dump-archive", "test", dump_file)
     assert output == ""
 
     with open(dump_file) as f:
@@ -185,20 +160,18 @@ def test_debug_dump_archive(archivers, request):
 
 def test_debug_refcount_obj(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "refcount-obj", "0" * 64).strip()
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    output = cmd(archiver, "debug", "refcount-obj", "0" * 64).strip()
     info = "object 0000000000000000000000000000000000000000000000000000000000000000 not found [info from chunks cache]."
     assert output == info
 
-    create_json = json.loads(cmd(archiver, f"--repo={repo_location}", "create", "--json", "test", "input"))
+    create_json = json.loads(cmd(archiver, "create", "--json", "test", "input"))
     archive_id = create_json["archive"]["id"]
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "refcount-obj", archive_id).strip()
+    output = cmd(archiver, "debug", "refcount-obj", archive_id).strip()
     assert output == f"object {archive_id} has 1 referrers [info from chunks cache]."
 
     # Invalid IDs do not abort or return an error
-    output = cmd(archiver, f"--repo={repo_location}", "debug", "refcount-obj", "124", "xyza").strip()
+    output = cmd(archiver, "debug", "refcount-obj", "124", "xyza").strip()
     assert output == f"object id 124 is invalid.{os.linesep}object id xyza is invalid."
 
 

--- a/src/borg/testsuite/archiver/delete_cmd.py
+++ b/src/borg/testsuite/archiver/delete_cmd.py
@@ -9,52 +9,46 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_delete(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, input_path = archiver.repository_location, archiver.repository_path, archiver.input_path
-
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    create_regular_file(input_path, "dir2/file2", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test.2", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test.3", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "another_test.1", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "another_test.2", "input")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.2", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "delete", "--match-archives", "sh:another_*")
-    cmd(archiver, f"--repo={repo_location}", "delete", "--last", "1")
-    cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.2", "--dry-run")
-    output = cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test.2", "--stats")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    create_regular_file(archiver.input_path, "dir2/file2", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    cmd(archiver, "create", "test.2", "input")
+    cmd(archiver, "create", "test.3", "input")
+    cmd(archiver, "create", "another_test.1", "input")
+    cmd(archiver, "create", "another_test.2", "input")
+    cmd(archiver, "extract", "test", "--dry-run")
+    cmd(archiver, "extract", "test.2", "--dry-run")
+    cmd(archiver, "delete", "--match-archives", "sh:another_*")
+    cmd(archiver, "delete", "--last", "1")
+    cmd(archiver, "delete", "-a", "test")
+    cmd(archiver, "extract", "test.2", "--dry-run")
+    output = cmd(archiver, "delete", "-a", "test.2", "--stats")
     assert "Original size: -" in output  # negative size == deleted data
     # Make sure all data except the manifest has been deleted
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         assert len(repository) == 1
 
 
 def test_delete_multiple(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test1", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test3", "input")
-    cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test1")
-    cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test2")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test3", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test3")
-    assert not cmd(archiver, f"--repo={repo_location}", "rlist")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input")
+    cmd(archiver, "create", "test3", "input")
+    cmd(archiver, "delete", "-a", "test1")
+    cmd(archiver, "delete", "-a", "test2")
+    cmd(archiver, "extract", "test3", "--dry-run")
+    cmd(archiver, "delete", "-a", "test3")
+    assert not cmd(archiver, "rlist")
 
 
 def test_delete_force(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", "--encryption=none")
+    cmd(archiver, "rcreate", "--encryption=none")
     create_src_archive(archiver, "test")
-    with Repository(repo_path, exclusive=True) as repository:
+    with Repository(archiver.repository_path, exclusive=True) as repository:
         manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
         archive = Archive(manifest, "test")
         for item in archive.iter_items():
@@ -64,27 +58,25 @@ def test_delete_force(archivers, request):
         else:
             assert False  # missed the file
         repository.commit(compact=False)
-    output = cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test", "--force")
+    output = cmd(archiver, "delete", "-a", "test", "--force")
     assert "deleted archive was corrupted" in output
 
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair")
-    output = cmd(archiver, f"--repo={repo_location}", "rlist")
+    cmd(archiver, "check", "--repair")
+    output = cmd(archiver, "rlist")
     assert "test" not in output
 
 
 def test_delete_double_force(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", "--encryption=none")
+    cmd(archiver, "rcreate", "--encryption=none")
     create_src_archive(archiver, "test")
-    with Repository(repo_path, exclusive=True) as repository:
+    with Repository(archiver.repository_path, exclusive=True) as repository:
         manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
         archive = Archive(manifest, "test")
         id = archive.metadata.items[0]
         repository.put(id, b"corrupted items metadata stream chunk")
         repository.commit(compact=False)
-    cmd(archiver, f"--repo={repo_location}", "delete", "-a", "test", "--force", "--force")
-    cmd(archiver, f"--repo={repo_location}", "check", "--repair")
-    output = cmd(archiver, f"--repo={repo_location}", "rlist")
+    cmd(archiver, "delete", "-a", "test", "--force", "--force")
+    cmd(archiver, "check", "--repair")
+    output = cmd(archiver, "rlist")
     assert "test" not in output

--- a/src/borg/testsuite/archiver/info_cmd.py
+++ b/src/borg/testsuite/archiver/info_cmd.py
@@ -9,24 +9,22 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_info(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_archive = cmd(archiver, f"--repo={repo_location}", "info", "-a", "test")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    info_archive = cmd(archiver, "info", "-a", "test")
     assert "Archive name: test" + os.linesep in info_archive
-    info_archive = cmd(archiver, f"--repo={repo_location}", "info", "--first", "1")
+    info_archive = cmd(archiver, "info", "--first", "1")
     assert "Archive name: test" + os.linesep in info_archive
 
 
 def test_info_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
 
-    info_archive = json.loads(cmd(archiver, f"--repo={repo_location}", "info", "-a", "test", "--json"))
+    info_archive = json.loads(cmd(archiver, "info", "-a", "test", "--json"))
     archives = info_archive["archives"]
     assert len(archives) == 1
     archive = archives[0]
@@ -42,9 +40,8 @@ def test_info_json(archivers, request):
 def test_info_json_of_empty_archive(archivers, request):
     """See https://github.com/borgbackup/borg/issues/6120"""
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    info_repo = json.loads(cmd(archiver, f"--repo={repo_location}", "info", "--json", "--first=1"))
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    info_repo = json.loads(cmd(archiver, "info", "--json", "--first=1"))
     assert info_repo["archives"] == []
-    info_repo = json.loads(cmd(archiver, f"--repo={repo_location}", "info", "--json", "--last=1"))
+    info_repo = json.loads(cmd(archiver, "info", "--json", "--last=1"))
     assert info_repo["archives"] == []

--- a/src/borg/testsuite/archiver/key_cmds.py
+++ b/src/borg/testsuite/archiver/key_cmds.py
@@ -19,73 +19,67 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_change_passphrase(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     os.environ["BORG_NEW_PASSPHRASE"] = "newpassphrase"
     # here we have both BORG_PASSPHRASE and BORG_NEW_PASSPHRASE set:
-    cmd(archiver, f"--repo={repo_location}", "key", "change-passphrase")
+    cmd(archiver, "key", "change-passphrase")
     os.environ["BORG_PASSPHRASE"] = "newpassphrase"
-    cmd(archiver, f"--repo={repo_location}", "rlist")
+    cmd(archiver, "rlist")
 
 
 def test_change_location_to_keyfile(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    log = cmd(archiver, "rinfo")
     assert "(repokey" in log
-    cmd(archiver, f"--repo={repo_location}", "key", "change-location", "keyfile")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "key", "change-location", "keyfile")
+    log = cmd(archiver, "rinfo")
     assert "(key file" in log
 
 
 def test_change_location_to_b2keyfile(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", "--encryption=repokey-blake2-aes-ocb")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "rcreate", "--encryption=repokey-blake2-aes-ocb")
+    log = cmd(archiver, "rinfo")
     assert "(repokey BLAKE2b" in log
-    cmd(archiver, f"--repo={repo_location}", "key", "change-location", "keyfile")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "key", "change-location", "keyfile")
+    log = cmd(archiver, "rinfo")
     assert "(key file BLAKE2b" in log
 
 
 def test_change_location_to_repokey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    log = cmd(archiver, "rinfo")
     assert "(key file" in log
-    cmd(archiver, f"--repo={repo_location}", "key", "change-location", "repokey")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "key", "change-location", "repokey")
+    log = cmd(archiver, "rinfo")
     assert "(repokey" in log
 
 
 def test_change_location_to_b2repokey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", "--encryption=keyfile-blake2-aes-ocb")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "rcreate", "--encryption=keyfile-blake2-aes-ocb")
+    log = cmd(archiver, "rinfo")
     assert "(key file BLAKE2b" in log
-    cmd(archiver, f"--repo={repo_location}", "key", "change-location", "repokey")
-    log = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    cmd(archiver, "key", "change-location", "repokey")
+    log = cmd(archiver, "rinfo")
     assert "(repokey BLAKE2b" in log
 
 
 def test_key_export_keyfile(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, keys_path = archiver.repository_location, archiver.repository_path, archiver.keys_path
     export_file = archiver.output_path + "/exported"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-    repo_id = _extract_repository_id(repo_path)
-    cmd(archiver, f"--repo={repo_location}", "key", "export", export_file)
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    repo_id = _extract_repository_id(archiver.repository_path)
+    cmd(archiver, "key", "export", export_file)
 
     with open(export_file) as fd:
         export_contents = fd.read()
 
     assert export_contents.startswith("BORG_KEY " + bin_to_hex(repo_id) + "\n")
 
-    key_file = keys_path + "/" + os.listdir(keys_path)[0]
+    key_file = archiver.keys_path + "/" + os.listdir(archiver.keys_path)[0]
 
     with open(key_file) as fd:
         key_contents = fd.read()
@@ -94,7 +88,7 @@ def test_key_export_keyfile(archivers, request):
 
     os.unlink(key_file)
 
-    cmd(archiver, f"--repo={repo_location}", "key", "import", export_file)
+    cmd(archiver, "key", "import", export_file)
 
     with open(key_file) as fd:
         key_contents2 = fd.read()
@@ -104,20 +98,19 @@ def test_key_export_keyfile(archivers, request):
 
 def test_key_import_keyfile_with_borg_key_file(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, keys_path, output_path = archiver.repository_location, archiver.keys_path, archiver.output_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
 
-    exported_key_file = os.path.join(output_path, "exported")
-    cmd(archiver, f"--repo={repo_location}", "key", "export", exported_key_file)
+    exported_key_file = os.path.join(archiver.output_path, "exported")
+    cmd(archiver, "key", "export", exported_key_file)
 
-    key_file = os.path.join(keys_path, os.listdir(keys_path)[0])
+    key_file = os.path.join(archiver.keys_path, os.listdir(archiver.keys_path)[0])
     with open(key_file) as fd:
         key_contents = fd.read()
     os.unlink(key_file)
 
-    imported_key_file = os.path.join(output_path, "imported")
+    imported_key_file = os.path.join(archiver.output_path, "imported")
     with environment_variable(BORG_KEY_FILE=imported_key_file):
-        cmd(archiver, f"--repo={repo_location}", "key", "import", exported_key_file)
+        cmd(archiver, "key", "import", exported_key_file)
     assert not os.path.isfile(key_file), '"borg key import" should respect BORG_KEY_FILE'
 
     with open(imported_key_file) as fd:
@@ -127,18 +120,17 @@ def test_key_import_keyfile_with_borg_key_file(archivers, request):
 
 def test_key_export_repokey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, output_path = archiver.repository_location, archiver.repository_path, archiver.output_path
-    export_file = output_path + "/exported"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    repo_id = _extract_repository_id(repo_path)
-    cmd(archiver, f"--repo={repo_location}", "key", "export", export_file)
+    export_file = archiver.output_path + "/exported"
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    repo_id = _extract_repository_id(archiver.repository_path)
+    cmd(archiver, "key", "export", export_file)
 
     with open(export_file) as fd:
         export_contents = fd.read()
 
     assert export_contents.startswith("BORG_KEY " + bin_to_hex(repo_id) + "\n")
 
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         repo_key = AESOCBRepoKey(repository)
         repo_key.load(None, Passphrase.env_passphrase())
 
@@ -147,12 +139,12 @@ def test_key_export_repokey(archivers, request):
 
     assert repo_key.crypt_key == backup_key.crypt_key
 
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         repository.save_key(b"")
 
-    cmd(archiver, f"--repo={repo_location}", "key", "import", export_file)
+    cmd(archiver, "key", "import", export_file)
 
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         repo_key2 = AESOCBRepoKey(repository)
         repo_key2.load(None, Passphrase.env_passphrase())
 
@@ -161,11 +153,10 @@ def test_key_export_repokey(archivers, request):
 
 def test_key_export_qr(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, output_path = archiver.repository_location, archiver.repository_path, archiver.output_path
-    export_file = output_path + "/exported.html"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    repo_id = _extract_repository_id(repo_path)
-    cmd(archiver, f"--repo={repo_location}", "key", "export", "--qr-html", export_file)
+    export_file = archiver.output_path + "/exported.html"
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    repo_id = _extract_repository_id(archiver.repository_path)
+    cmd(archiver, "key", "export", "--qr-html", export_file)
 
     with open(export_file, encoding="utf-8") as fd:
         export_contents = fd.read()
@@ -177,65 +168,58 @@ def test_key_export_qr(archivers, request):
 
 def test_key_export_directory(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, output_path = archiver.repository_location, archiver.output_path
-    export_directory = output_path + "/exported"
+    export_directory = archiver.output_path + "/exported"
     os.mkdir(export_directory)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "key", "export", export_directory, exit_code=EXIT_ERROR)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "key", "export", export_directory, exit_code=EXIT_ERROR)
 
 
 def test_key_export_qr_directory(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, output_path = archiver.repository_location, archiver.output_path
-    export_directory = output_path + "/exported"
+    export_directory = archiver.output_path + "/exported"
     os.mkdir(export_directory)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "key", "export", "--qr-html", export_directory, exit_code=EXIT_ERROR)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "key", "export", "--qr-html", export_directory, exit_code=EXIT_ERROR)
 
 
 def test_key_import_errors(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, output_path = archiver.repository_location, archiver.output_path
-    export_file = output_path + "/exported"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-
-    cmd(archiver, f"--repo={repo_location}", "key", "import", export_file, exit_code=EXIT_ERROR)
+    export_file = archiver.output_path + "/exported"
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    cmd(archiver, "key", "import", export_file, exit_code=EXIT_ERROR)
 
     with open(export_file, "w") as fd:
         fd.write("something not a key\n")
 
     if archiver.FORK_DEFAULT:
-        cmd(archiver, f"--repo={repo_location}", "key", "import", export_file, exit_code=2)
+        cmd(archiver, "key", "import", export_file, exit_code=2)
     else:
         with pytest.raises(NotABorgKeyFile):
-            cmd(archiver, f"--repo={repo_location}", "key", "import", export_file)
+            cmd(archiver, "key", "import", export_file)
 
     with open(export_file, "w") as fd:
         fd.write("BORG_KEY a0a0a0\n")
 
     if archiver.FORK_DEFAULT:
-        cmd(archiver, f"--repo={repo_location}", "key", "import", export_file, exit_code=2)
+        cmd(archiver, "key", "import", export_file, exit_code=2)
     else:
         with pytest.raises(RepoIdMismatch):
-            cmd(archiver, f"--repo={repo_location}", "key", "import", export_file)
+            cmd(archiver, "key", "import", export_file)
 
 
 def test_key_export_paperkey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, output_path = archiver.repository_location, archiver.repository_path, archiver.output_path
     repo_id = "e294423506da4e1ea76e8dcdf1a3919624ae3ae496fddf905610c351d3f09239"
-
-    export_file = output_path + "/exported"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-    _set_repository_id(repo_path, unhexlify(repo_id))
-
+    export_file = archiver.output_path + "/exported"
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    _set_repository_id(archiver.repository_path, unhexlify(repo_id))
     key_file = archiver.keys_path + "/" + os.listdir(archiver.keys_path)[0]
 
     with open(key_file, "w") as fd:
         fd.write(CHPOKeyfileKey.FILE_ID + " " + repo_id + "\n")
         fd.write(b2a_base64(b"abcdefghijklmnopqrstu").decode())
 
-    cmd(archiver, f"--repo={repo_location}", "key", "export", "--paper", export_file)
+    cmd(archiver, "key", "export", "--paper", export_file)
 
     with open(export_file) as fd:
         export_contents = fd.read()
@@ -254,12 +238,11 @@ id: 2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02
 
 def test_key_import_paperkey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, keys_path = archiver.repository_location, archiver.repository_path, archiver.keys_path
     repo_id = "e294423506da4e1ea76e8dcdf1a3919624ae3ae496fddf905610c351d3f09239"
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-    _set_repository_id(repo_path, unhexlify(repo_id))
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    _set_repository_id(archiver.repository_path, unhexlify(repo_id))
 
-    key_file = keys_path + "/" + os.listdir(keys_path)[0]
+    key_file = archiver.keys_path + "/" + os.listdir(archiver.keys_path)[0]
     with open(key_file, "w") as fd:
         fd.write(AESOCBKeyfileKey.FILE_ID + " " + repo_id + "\n")
         fd.write(b2a_base64(b"abcdefghijklmnopqrstu").decode())
@@ -290,45 +273,40 @@ def test_key_import_paperkey(archivers, request):
     #         print(i.to_bytes(2, 'big'))
     #         break
 
-    cmd(archiver, f"--repo={repo_location}", "key", "import", "--paper", input=typed_input)
+    cmd(archiver, "key", "import", "--paper", input=typed_input)
 
     # Test abort paths
     typed_input = b"\ny\n"
-    cmd(archiver, f"--repo={repo_location}", "key", "import", "--paper", input=typed_input)
+    cmd(archiver, "key", "import", "--paper", input=typed_input)
     typed_input = b"2 / e29442 3506da 4e1ea7 / 25f62a 5a3d41 - 02\n\ny\n"
-    cmd(archiver, f"--repo={repo_location}", "key", "import", "--paper", input=typed_input)
+    cmd(archiver, "key", "import", "--paper", input=typed_input)
 
 
 def test_init_defaults_to_argon2(archivers, request):
     """https://github.com/borgbackup/borg/issues/747#issuecomment-1076160401"""
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    with Repository(repo_path) as repository:
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    with Repository(archiver.repository_path) as repository:
         key = msgpack.unpackb(a2b_base64(repository.load_key()))
         assert key["algorithm"] == "argon2 chacha20-poly1305"
 
 
 def test_change_passphrase_does_not_change_algorithm_argon2(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     os.environ["BORG_NEW_PASSPHRASE"] = "newpassphrase"
-    cmd(archiver, f"--repo={repo_location}", "key", "change-passphrase")
+    cmd(archiver, "key", "change-passphrase")
 
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         key = msgpack.unpackb(a2b_base64(repository.load_key()))
         assert key["algorithm"] == "argon2 chacha20-poly1305"
 
 
 def test_change_location_does_not_change_algorithm_argon2(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
+    cmd(archiver, "rcreate", KF_ENCRYPTION)
+    cmd(archiver, "key", "change-location", "repokey")
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", KF_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "key", "change-location", "repokey")
-
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         key = msgpack.unpackb(a2b_base64(repository.load_key()))
         assert key["algorithm"] == "argon2 chacha20-poly1305"

--- a/src/borg/testsuite/archiver/list_cmd.py
+++ b/src/borg/testsuite/archiver/list_cmd.py
@@ -9,78 +9,66 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_list_format(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", src_dir)
-    output_1 = cmd(archiver, f"--repo={repo_location}", "list", "test")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", src_dir)
+    output_1 = cmd(archiver, "list", "test")
     output_2 = cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "list",
-        "test",
-        "--format",
-        "{mode} {user:6} {group:6} {size:8d} {mtime} {path}{extra}{NEWLINE}",
+        archiver, "list", "test", "--format", "{mode} {user:6} {group:6} {size:8d} {mtime} {path}{extra}{NEWLINE}"
     )
-    output_3 = cmd(archiver, f"--repo={repo_location}", "list", "test", "--format", "{mtime:%s} {path}{NL}")
+    output_3 = cmd(archiver, "list", "test", "--format", "{mtime:%s} {path}{NL}")
     assert output_1 == output_2
     assert output_1 != output_3
 
 
 def test_list_hash(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "empty_file", size=0)
-    create_regular_file(input_path, "amb", contents=b"a" * 1000000)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "--format", "{sha256} {path}{NL}")
+    create_regular_file(archiver.input_path, "empty_file", size=0)
+    create_regular_file(archiver.input_path, "amb", contents=b"a" * 1000000)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    output = cmd(archiver, "list", "test", "--format", "{sha256} {path}{NL}")
     assert "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0 input/amb" in output
     assert "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 input/empty_file" in output
 
 
 def test_list_chunk_counts(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "empty_file", size=0)
-    create_regular_file(input_path, "two_chunks")
-    with open(os.path.join(input_path, "two_chunks"), "wb") as fd:
+    create_regular_file(archiver.input_path, "empty_file", size=0)
+    create_regular_file(archiver.input_path, "two_chunks")
+    with open(os.path.join(archiver.input_path, "two_chunks"), "wb") as fd:
         fd.write(b"abba" * 2000000)
         fd.write(b"baab" * 2000000)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    output = cmd(
-        archiver, f"--repo={repo_location}", "list", "test", "--format", "{num_chunks} {unique_chunks} {path}{NL}"
-    )
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    output = cmd(archiver, "list", "test", "--format", "{num_chunks} {unique_chunks} {path}{NL}")
     assert "0 0 input/empty_file" in output
     assert "2 2 input/two_chunks" in output
 
 
 def test_list_size(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "compressible_file", size=10000)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "-C", "lz4", "test", "input")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "--format", "{size} {path}{NL}")
+    create_regular_file(archiver.input_path, "compressible_file", size=10000)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "-C", "lz4", "test", "input")
+    output = cmd(archiver, "list", "test", "--format", "{size} {path}{NL}")
     size, path = output.split("\n")[1].split(" ")
     assert int(size) == 10000
 
 
 def test_list_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
 
-    list_archive = cmd(archiver, f"--repo={repo_location}", "list", "test", "--json-lines")
+    list_archive = cmd(archiver, "list", "test", "--json-lines")
     items = [json.loads(s) for s in list_archive.splitlines()]
     assert len(items) == 2
     file1 = items[1]
     assert file1["path"] == "input/file1"
     assert file1["size"] == 81920
 
-    list_archive = cmd(archiver, f"--repo={repo_location}", "list", "test", "--json-lines", "--format={sha256}")
+    list_archive = cmd(archiver, "list", "test", "--json-lines", "--format={sha256}")
     items = [json.loads(s) for s in list_archive.splitlines()]
     assert len(items) == 2
     file1 = items[1]

--- a/src/borg/testsuite/archiver/lock_cmds.py
+++ b/src/borg/testsuite/archiver/lock_cmds.py
@@ -8,15 +8,13 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_break_lock(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "break-lock")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "break-lock")
 
 
 def test_with_lock(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    lock_path = os.path.join(repo_path, "lock.exclusive")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    lock_path = os.path.join(archiver.repository_path, "lock.exclusive")
     command = "python3", "-c", 'import os, sys; sys.exit(42 if os.path.exists("%s") else 23)' % lock_path
-    cmd(archiver, f"--repo={repo_location}", "with-lock", *command, fork=True, exit_code=42)
+    cmd(archiver, "with-lock", *command, fork=True, exit_code=42)

--- a/src/borg/testsuite/archiver/mount_cmds.py
+++ b/src/borg/testsuite/archiver/mount_cmds.py
@@ -23,7 +23,6 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_fuse_mount_hardlinks(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     _extract_hardlinks_setup(archiver)
     mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
     # we need to get rid of permissions checking because fakeroot causes issues with it.
@@ -33,15 +32,15 @@ def test_fuse_mount_hardlinks(archivers, request):
         ignore_perms = ["-o", "ignore_permissions,defer_permissions"]
     else:
         ignore_perms = ["-o", "ignore_permissions"]
-    with fuse_mount(
-        archiver, repo_location, mountpoint, "-a", "test", "--strip-components=2", *ignore_perms
-    ), changedir(os.path.join(mountpoint, "test")):
+    with fuse_mount(archiver, mountpoint, "-a", "test", "--strip-components=2", *ignore_perms), changedir(
+        os.path.join(mountpoint, "test")
+    ):
         assert os.stat("hardlink").st_nlink == 2
         assert os.stat("subdir/hardlink").st_nlink == 2
         assert open("subdir/hardlink", "rb").read() == b"123456"
         assert os.stat("aaaa").st_nlink == 2
         assert os.stat("source2").st_nlink == 2
-    with fuse_mount(archiver, repo_location, mountpoint, "input/dir1", "-a", "test", *ignore_perms), changedir(
+    with fuse_mount(archiver, mountpoint, "input/dir1", "-a", "test", *ignore_perms), changedir(
         os.path.join(mountpoint, "test")
     ):
         assert os.stat("input/dir1/hardlink").st_nlink == 2
@@ -49,9 +48,7 @@ def test_fuse_mount_hardlinks(archivers, request):
         assert open("input/dir1/subdir/hardlink", "rb").read() == b"123456"
         assert os.stat("input/dir1/aaaa").st_nlink == 2
         assert os.stat("input/dir1/source2").st_nlink == 2
-    with fuse_mount(archiver, repo_location, mountpoint, "-a", "test", *ignore_perms), changedir(
-        os.path.join(mountpoint, "test")
-    ):
+    with fuse_mount(archiver, mountpoint, "-a", "test", *ignore_perms), changedir(os.path.join(mountpoint, "test")):
         assert os.stat("input/source").st_nlink == 4
         assert os.stat("input/abba").st_nlink == 4
         assert os.stat("input/dir1/hardlink").st_nlink == 4
@@ -64,7 +61,6 @@ def test_fuse(archivers, request):
     archiver = request.getfixturevalue(archivers)
     if archiver.EXE and fakeroot_detected():
         pytest.skip("test_fuse with the binary is not compatible with fakeroot")
-    repo_location, input_path = archiver.repository_location, archiver.input_path
 
     def has_noatime(some_file):
         atime_before = os.stat(some_file).st_atime_ns
@@ -78,7 +74,7 @@ def test_fuse(archivers, request):
             return noatime_used and atime_before == atime_after
 
     cmd(archiver, "rcreate", RK_ENCRYPTION)
-    create_test_files(input_path)
+    create_test_files(archiver.input_path)
     have_noatime = has_noatime("input/file1")
     cmd(archiver, "create", "--exclude-nodump", "--atime", "archive", "input")
     cmd(archiver, "create", "--exclude-nodump", "--atime", "archive2", "input")
@@ -87,18 +83,18 @@ def test_fuse(archivers, request):
         os.remove(os.path.join("input", "flagfile"))
     mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
     # mount the whole repository, archive contents shall show up in archivename subdirectories of mountpoint:
-    with fuse_mount(archiver, repo_location, mountpoint):
+    with fuse_mount(archiver, mountpoint):
         # flags are not supported by the FUSE mount
         # we also ignore xattrs here, they are tested separately
         assert_dirs_equal(
-            input_path, os.path.join(mountpoint, "archive", "input"), ignore_flags=True, ignore_xattrs=True
+            archiver.input_path, os.path.join(mountpoint, "archive", "input"), ignore_flags=True, ignore_xattrs=True
         )
         assert_dirs_equal(
-            input_path, os.path.join(mountpoint, "archive2", "input"), ignore_flags=True, ignore_xattrs=True
+            archiver.input_path, os.path.join(mountpoint, "archive2", "input"), ignore_flags=True, ignore_xattrs=True
         )
-    with fuse_mount(archiver, repo_location, mountpoint, "-a", "archive"):
+    with fuse_mount(archiver, mountpoint, "-a", "archive"):
         assert_dirs_equal(
-            input_path, os.path.join(mountpoint, "archive", "input"), ignore_flags=True, ignore_xattrs=True
+            archiver.input_path, os.path.join(mountpoint, "archive", "input"), ignore_flags=True, ignore_xattrs=True
         )
         # regular file
         in_fn = "input/file1"
@@ -148,7 +144,7 @@ def test_fuse(archivers, request):
         try:
             in_fn = "input/fusexattr"
             out_fn = os.fsencode(os.path.join(mountpoint, "archive", "input", "fusexattr"))
-            if not xattr.XATTR_FAKEROOT and xattr.is_enabled(input_path):
+            if not xattr.XATTR_FAKEROOT and xattr.is_enabled(archiver.input_path):
                 assert sorted(no_selinux(xattr.listxattr(out_fn))) == [b"user.empty", b"user.foo"]
                 assert xattr.getxattr(out_fn, b"user.foo") == b"bar"
                 assert xattr.getxattr(out_fn, b"user.empty") == b""
@@ -171,19 +167,18 @@ def test_fuse(archivers, request):
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_fuse_versions_view(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
     cmd(archiver, "rcreate", RK_ENCRYPTION)
-    create_regular_file(input_path, "test", contents=b"first")
+    create_regular_file(archiver.input_path, "test", contents=b"first")
     if are_hardlinks_supported():
-        create_regular_file(input_path, "hardlink1", contents=b"123456")
+        create_regular_file(archiver.input_path, "hardlink1", contents=b"123456")
         os.link("input/hardlink1", "input/hardlink2")
         os.link("input/hardlink1", "input/hardlink3")
     cmd(archiver, "create", "archive1", "input")
-    create_regular_file(input_path, "test", contents=b"second")
+    create_regular_file(archiver.input_path, "test", contents=b"second")
     cmd(archiver, "create", "archive2", "input")
     mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
     # mount the whole repository, archive contents shall show up in versioned view:
-    with fuse_mount(archiver, repo_location, mountpoint, "-o", "versions"):
+    with fuse_mount(archiver, mountpoint, "-o", "versions"):
         path = os.path.join(mountpoint, "input", "test")  # filename shows up as directory ...
         files = os.listdir(path)
         assert all(f.startswith("test.") for f in files)  # ... with files test.xxxxx in there
@@ -195,7 +190,7 @@ def test_fuse_versions_view(archivers, request):
             assert os.stat(hl1).st_ino == os.stat(hl2).st_ino == os.stat(hl3).st_ino
             assert open(hl3, "rb").read() == b"123456"
     # similar again, but exclude the 1st hardlink:
-    with fuse_mount(archiver, repo_location, mountpoint, "-o", "versions", "-e", "input/hardlink1"):
+    with fuse_mount(archiver, mountpoint, "-o", "versions", "-e", "input/hardlink1"):
         if are_hardlinks_supported():
             hl2 = os.path.join(mountpoint, "input", "hardlink2", "hardlink2.00001")
             hl3 = os.path.join(mountpoint, "input", "hardlink3", "hardlink3.00001")
@@ -206,11 +201,10 @@ def test_fuse_versions_view(archivers, request):
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_fuse_allow_damaged_files(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path = archiver.repository_location, archiver.repository_path
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "archive")
     # Get rid of a chunk and repair it
-    archive, repository = open_archive(repo_path, "archive")
+    archive, repository = open_archive(archiver.repository_path, "archive")
     with repository:
         for item in archive.iter_items():
             if item.path.endswith(src_file):
@@ -223,45 +217,43 @@ def test_fuse_allow_damaged_files(archivers, request):
     cmd(archiver, "check", "--repair", exit_code=0)
 
     mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
-    with fuse_mount(archiver, repo_location, mountpoint, "-a", "archive"):
+    with fuse_mount(archiver, mountpoint, "-a", "archive"):
         with pytest.raises(OSError) as excinfo:
             open(os.path.join(mountpoint, "archive", path))
         assert excinfo.value.errno == errno.EIO
-    with fuse_mount(archiver, repo_location, mountpoint, "-a", "archive", "-o", "allow_damaged_files"):
+    with fuse_mount(archiver, mountpoint, "-a", "archive", "-o", "allow_damaged_files"):
         open(os.path.join(mountpoint, "archive", path)).close()
 
 
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_fuse_mount_options(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     cmd(archiver, "rcreate", RK_ENCRYPTION)
     create_src_archive(archiver, "arch11")
     create_src_archive(archiver, "arch12")
     create_src_archive(archiver, "arch21")
     create_src_archive(archiver, "arch22")
-
     mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
-    with fuse_mount(archiver, repo_location, mountpoint, "--first=2", "--sort=name"):
+    with fuse_mount(archiver, mountpoint, "--first=2", "--sort=name"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == ["arch11", "arch12"]
-    with fuse_mount(archiver, repo_location, mountpoint, "--last=2", "--sort=name"):
+    with fuse_mount(archiver, mountpoint, "--last=2", "--sort=name"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == ["arch21", "arch22"]
-    with fuse_mount(archiver, repo_location, mountpoint, "--match-archives=sh:arch1*"):
+    with fuse_mount(archiver, mountpoint, "--match-archives=sh:arch1*"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == ["arch11", "arch12"]
-    with fuse_mount(archiver, repo_location, mountpoint, "--match-archives=sh:arch2*"):
+    with fuse_mount(archiver, mountpoint, "--match-archives=sh:arch2*"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == ["arch21", "arch22"]
-    with fuse_mount(archiver, repo_location, mountpoint, "--match-archives=sh:arch*"):
+    with fuse_mount(archiver, mountpoint, "--match-archives=sh:arch*"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == ["arch11", "arch12", "arch21", "arch22"]
-    with fuse_mount(archiver, repo_location, mountpoint, "--match-archives=nope"):
+    with fuse_mount(archiver, mountpoint, "--match-archives=nope"):
         assert sorted(os.listdir(os.path.join(mountpoint))) == []
 
 
 @pytest.mark.skipif(not llfuse, reason="llfuse not installed")
 def test_migrate_lock_alive(archivers, request):
+    """Both old_id and new_id must not be stale during lock migration / daemonization."""
     archiver = request.getfixturevalue(archivers)
     if archiver.get_kind() == "remote":
         pytest.skip("only works locally")
-    """Both old_id and new_id must not be stale during lock migration / daemonization."""
     from functools import wraps
     import pickle
     import traceback
@@ -319,7 +311,7 @@ def test_migrate_lock_alive(archivers, request):
         mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
         # In order that the decoration is kept for the borg mount process, we must not spawn, but actually fork;
         # not to be confused with the forking in borg.helpers.daemonize() which is done as well.
-        with fuse_mount(archiver, archiver.repository_location, mountpoint, os_fork=True):
+        with fuse_mount(archiver, mountpoint, os_fork=True):
             pass
         with open(assert_data_file, "rb") as _in:
             assert_data = pickle.load(_in)

--- a/src/borg/testsuite/archiver/rcompress_cmd.py
+++ b/src/borg/testsuite/archiver/rcompress_cmd.py
@@ -10,8 +10,6 @@ from . import create_regular_file, cmd, RK_ENCRYPTION
 
 
 def test_rcompress(archiver):
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
     def check_compression(ctype, clevel, olevel):
         """check if all the chunks in the repo are compressed/obfuscated like expected"""
         repository = Repository(archiver.repository_path, exclusive=True)
@@ -47,38 +45,38 @@ def test_rcompress(archiver):
                         assert "psize" not in meta
                         assert "olevel" not in meta
 
-    create_regular_file(input_path, "file1", size=1024 * 10)
-    create_regular_file(input_path, "file2", contents=os.urandom(1024 * 10))
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 10)
+    create_regular_file(archiver.input_path, "file2", contents=os.urandom(1024 * 10))
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
 
     cname, ctype, clevel, olevel = ZLIB.name, ZLIB.ID, 3, -1
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input", "-C", f"{cname},{clevel}")
+    cmd(archiver, "create", "test", "input", "-C", f"{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZSTD.name, ZSTD.ID, 1, -1  # change compressor (and level)
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZSTD.name, ZSTD.ID, 3, -1  # only change level
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZSTD.name, ZSTD.ID, 3, 110  # only change to obfuscated
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"obfuscate,{olevel},{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"obfuscate,{olevel},{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZSTD.name, ZSTD.ID, 3, 112  # only change obfuscation level
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"obfuscate,{olevel},{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"obfuscate,{olevel},{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZSTD.name, ZSTD.ID, 3, -1  # change to not obfuscated
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZLIB.name, ZLIB.ID, 1, -1
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"auto,{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"auto,{cname},{clevel}")
     check_compression(ctype, clevel, olevel)
 
     cname, ctype, clevel, olevel = ZLIB.name, ZLIB.ID, 2, 111
-    cmd(archiver, f"--repo={repo_location}", "rcompress", "-C", f"obfuscate,{olevel},auto,{cname},{clevel}")
+    cmd(archiver, "rcompress", "-C", f"obfuscate,{olevel},auto,{cname},{clevel}")
     check_compression(ctype, clevel, olevel)

--- a/src/borg/testsuite/archiver/rcreate_cmd.py
+++ b/src/borg/testsuite/archiver/rcreate_cmd.py
@@ -20,18 +20,17 @@ def test_rcreate_parent_dirs(archivers, request):
     remote_repo = archiver.get_kind() == "remote"
     parent_path = os.path.join(archiver.tmpdir, "parent1", "parent2")
     repository_path = os.path.join(parent_path, "repository")
-    repository_location = ("ssh://__testsuite__" + repository_path) if remote_repo else repository_path
+    archiver.repository_location = ("ssh://__testsuite__" + repository_path) if remote_repo else repository_path
     with pytest.raises(Repository.ParentPathDoesNotExist):
         # normal borg rcreate does NOT create missing parent dirs
-        cmd(archiver, f"--repo={repository_location}", "rcreate", "--encryption=none")
+        cmd(archiver, "rcreate", "--encryption=none")
     # but if told so, it does:
-    cmd(archiver, f"--repo={repository_location}", "rcreate", "--encryption=none", "--make-parent-dirs")
+    cmd(archiver, "rcreate", "--encryption=none", "--make-parent-dirs")
     assert os.path.exists(parent_path)
 
 
 def test_rcreate_interrupt(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     if archiver.EXE:
         pytest.skip("patches object")
 
@@ -39,39 +38,39 @@ def test_rcreate_interrupt(archivers, request):
         raise EOFError
 
     with patch.object(FlexiKey, "create", raise_eof):
-        cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION, exit_code=1)
-    assert not os.path.exists(repo_location)
+        cmd(archiver, "rcreate", RK_ENCRYPTION, exit_code=1)
+    assert not os.path.exists(archiver.repository_location)
 
 
 def test_rcreate_requires_encryption_option(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, f"--repo={archiver.repository_location}", "rcreate", exit_code=2)
+    cmd(archiver, "rcreate", exit_code=2)
 
 
 def test_rcreate_nested_repositories(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    archiver.repository_location += "/nested"
     if archiver.FORK_DEFAULT:
-        cmd(archiver, f"--repo={repo_location}/nested", "rcreate", RK_ENCRYPTION, exit_code=2)
+        cmd(archiver, "rcreate", RK_ENCRYPTION, exit_code=2)
     else:
         with pytest.raises(Repository.AlreadyExists):
-            cmd(archiver, f"--repo={repo_location}/nested", "rcreate", RK_ENCRYPTION)
+            cmd(archiver, "rcreate", RK_ENCRYPTION)
 
 
 def test_rcreate_refuse_to_overwrite_keyfile(archivers, request):
     #  BORG_KEY_FILE=something borg rcreate should quit if "something" already exists.
     #  See: https://github.com/borgbackup/borg/pull/6046
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
     keyfile = os.path.join(archiver.tmpdir, "keyfile")
+    original_location = archiver.repository_location
     with environment_variable(BORG_KEY_FILE=keyfile):
-        cmd(archiver, f"--repo={repo_location}0", "rcreate", KF_ENCRYPTION)
+        archiver.repository_location = original_location + "0"
+        cmd(archiver, "rcreate", KF_ENCRYPTION)
         with open(keyfile) as file:
             before = file.read()
-        arg = (f"--repo={repo_location}1", "rcreate", KF_ENCRYPTION)
+        archiver.repository_location = original_location + "1"
+        arg = ("rcreate", KF_ENCRYPTION)
         if archiver.FORK_DEFAULT:
             cmd(archiver, *arg, exit_code=2)
         else:

--- a/src/borg/testsuite/archiver/recreate_cmd.py
+++ b/src/borg/testsuite/archiver/recreate_cmd.py
@@ -27,43 +27,26 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_recreate_exclude_caches(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     _create_test_caches(archiver)
-
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "--exclude-caches")
+    cmd(archiver, "create", "test", "input")
+    cmd(archiver, "recreate", "-a", "test", "--exclude-caches")
     _assert_test_caches(archiver)
 
 
 def test_recreate_exclude_tagged(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     _create_test_tagged(archiver)
-
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "recreate",
-        "-a",
-        "test",
-        "--exclude-if-present",
-        ".NOBACKUP",
-        "--exclude-if-present",
-        "00-NOBACKUP",
-    )
+    cmd(archiver, "create", "test", "input")
+    cmd(archiver, "recreate", "-a", "test", "--exclude-if-present", ".NOBACKUP", "--exclude-if-present", "00-NOBACKUP")
     _assert_test_tagged(archiver)
 
 
 def test_recreate_exclude_keep_tagged(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
     _create_test_keep_tagged(archiver)
-
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    cmd(archiver, "create", "test", "input")
     cmd(
         archiver,
-        f"--repo={repo_location}",
         "recreate",
         "-a",
         "test",
@@ -80,57 +63,45 @@ def test_recreate_exclude_keep_tagged(archivers, request):
 @pytest.mark.skipif(not are_hardlinks_supported(), reason="hardlinks not supported")
 def test_recreate_hardlinked_tags(archivers, request):  # test for issue #4911
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", "--encryption=none")
-    create_regular_file(input_path, "file1", contents=CACHE_TAG_CONTENTS)  # "wrong" filename, but correct tag contents
-    os.mkdir(os.path.join(input_path, "subdir"))  # to make sure the tag is encountered *after* file1
+    cmd(archiver, "rcreate", "--encryption=none")
+    create_regular_file(
+        archiver.input_path, "file1", contents=CACHE_TAG_CONTENTS
+    )  # "wrong" filename, but correct tag contents
+    os.mkdir(os.path.join(archiver.input_path, "subdir"))  # to make sure the tag is encountered *after* file1
     os.link(
-        os.path.join(input_path, "file1"), os.path.join(input_path, "subdir", CACHE_TAG_NAME)
+        os.path.join(archiver.input_path, "file1"), os.path.join(archiver.input_path, "subdir", CACHE_TAG_NAME)
     )  # correct tag name, hardlink to file1
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
+    cmd(archiver, "create", "test", "input")
     # in the "test" archive, we now have, in this order:
     # - a regular file item for "file1"
     # - a hardlink item for "CACHEDIR.TAG" referring back to file1 for its contents
-    cmd(archiver, f"--repo={repo_location}", "recreate", "test", "--exclude-caches", "--keep-exclude-tags")
+    cmd(archiver, "recreate", "test", "--exclude-caches", "--keep-exclude-tags")
     # if issue #4911 is present, the recreate will crash with a KeyError for "input/file1"
 
 
 def test_recreate_target_rc(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    output = cmd(archiver, f"--repo={repo_location}", "recreate", "--target=asdf", exit_code=2)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    output = cmd(archiver, "recreate", "--target=asdf", exit_code=2)
     assert "Need to specify single archive" in output
 
 
 def test_recreate_target(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_test_files(input_path)
+    create_test_files(archiver.input_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    check_cache(archiver)
+    cmd(archiver, "create", "test0", "input")
+    check_cache(archiver)
+    original_archive = cmd(archiver, "rlist")
+    cmd(archiver, "recreate", "test0", "input/dir2", "-e", "input/dir2/file3", "--target=new-archive")
+    check_cache(archiver)
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    check_cache(archiver)
-    cmd(archiver, f"--repo={repo_location}", "create", "test0", "input")
-    check_cache(archiver)
-    original_archive = cmd(archiver, f"--repo={repo_location}", "rlist")
-    cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "recreate",
-        "test0",
-        "input/dir2",
-        "-e",
-        "input/dir2/file3",
-        "--target=new-archive",
-    )
-    check_cache(archiver)
-    archives = cmd(archiver, f"--repo={repo_location}", "rlist")
+    archives = cmd(archiver, "rlist")
     assert original_archive in archives
     assert "new-archive" in archives
 
-    listing = cmd(archiver, f"--repo={repo_location}", "list", "new-archive", "--short")
+    listing = cmd(archiver, "list", "new-archive", "--short")
     assert "file1" not in listing
     assert "dir2/file2" in listing
     assert "dir2/file3" not in listing
@@ -138,15 +109,13 @@ def test_recreate_target(archivers, request):
 
 def test_recreate_basic(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_test_files(input_path)
-    create_regular_file(input_path, "dir2/file3", size=1024 * 80)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test0", "input")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "test0", "input/dir2", "-e", "input/dir2/file3")
+    create_test_files(archiver.input_path)
+    create_regular_file(archiver.input_path, "dir2/file3", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test0", "input")
+    cmd(archiver, "recreate", "test0", "input/dir2", "-e", "input/dir2/file3")
     check_cache(archiver)
-    listing = cmd(archiver, f"--repo={repo_location}", "list", "test0", "--short")
+    listing = cmd(archiver, "list", "test0", "--short")
     assert "file1" not in listing
     assert "dir2/file2" in listing
     assert "dir2/file3" not in listing
@@ -155,131 +124,94 @@ def test_recreate_basic(archivers, request):
 @pytest.mark.skipif(not are_hardlinks_supported(), reason="hardlinks not supported")
 def test_recreate_subtree_hardlinks(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
     # This is essentially the same problem set as in test_extract_hardlinks
     _extract_hardlinks_setup(archiver)
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "input/dir1")
+    cmd(archiver, "create", "test2", "input")
+    cmd(archiver, "recreate", "-a", "test", "input/dir1")
     check_cache(archiver)
     with changedir("output"):
-        cmd(archiver, f"--repo={repo_location}", "extract", "test")
+        cmd(archiver, "extract", "test")
         assert os.stat("input/dir1/hardlink").st_nlink == 2
         assert os.stat("input/dir1/subdir/hardlink").st_nlink == 2
         assert os.stat("input/dir1/aaaa").st_nlink == 2
         assert os.stat("input/dir1/source2").st_nlink == 2
     with changedir("output"):
-        cmd(archiver, f"--repo={repo_location}", "extract", "test2")
+        cmd(archiver, "extract", "test2")
         assert os.stat("input/dir1/hardlink").st_nlink == 4
 
 
 def test_recreate_rechunkify(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    with open(os.path.join(input_path, "large_file"), "wb") as fd:
+    with open(os.path.join(archiver.input_path, "large_file"), "wb") as fd:
         fd.write(b"a" * 280)
         fd.write(b"b" * 280)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test1", "input", "--chunker-params", "7,9,8,128")
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input", "--files-cache=disabled")
-    chunks_list = cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "list",
-        "test1",
-        "input/large_file",
-        "--format",
-        "{num_chunks} {unique_chunks}",
-    )
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input", "--chunker-params", "7,9,8,128")
+    cmd(archiver, "create", "test2", "input", "--files-cache=disabled")
+    chunks_list = cmd(archiver, "list", "test1", "input/large_file", "--format", "{num_chunks} {unique_chunks}")
     num_chunks, unique_chunks = map(int, chunks_list.split(" "))
     # test1 and test2 do not deduplicate
     assert num_chunks == unique_chunks
-    cmd(archiver, f"--repo={repo_location}", "recreate", "--chunker-params", "default")
+    cmd(archiver, "recreate", "--chunker-params", "default")
     check_cache(archiver)
     # test1 and test2 do deduplicate after recreate
-    assert int(cmd(archiver, f"--repo={repo_location}", "list", "test1", "input/large_file", "--format={size}"))
-    assert not int(
-        cmd(archiver, f"--repo={repo_location}", "list", "test1", "input/large_file", "--format", "{unique_chunks}")
-    )
+    assert int(cmd(archiver, "list", "test1", "input/large_file", "--format={size}"))
+    assert not int(cmd(archiver, "list", "test1", "input/large_file", "--format", "{unique_chunks}"))
 
 
 def test_recreate_fixed_rechunkify(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    with open(os.path.join(input_path, "file"), "wb") as fd:
+    with open(os.path.join(archiver.input_path, "file"), "wb") as fd:
         fd.write(b"a" * 8192)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input", "--chunker-params", "7,9,8,128")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "input/file", "--format", "{num_chunks}")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input", "--chunker-params", "7,9,8,128")
+    output = cmd(archiver, "list", "test", "input/file", "--format", "{num_chunks}")
     num_chunks = int(output)
     assert num_chunks > 2
-    cmd(archiver, f"--repo={repo_location}", "recreate", "--chunker-params", "fixed,4096")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "input/file", "--format", "{num_chunks}")
+    cmd(archiver, "recreate", "--chunker-params", "fixed,4096")
+    output = cmd(archiver, "list", "test", "input/file", "--format", "{num_chunks}")
     num_chunks = int(output)
     assert num_chunks == 2
 
 
 def test_recreate_no_rechunkify(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    with open(os.path.join(input_path, "file"), "wb") as fd:
+    with open(os.path.join(archiver.input_path, "file"), "wb") as fd:
         fd.write(b"a" * 8192)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     # first create an archive with non-default chunker params:
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input", "--chunker-params", "7,9,8,128")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "input/file", "--format", "{num_chunks}")
+    cmd(archiver, "create", "test", "input", "--chunker-params", "7,9,8,128")
+    output = cmd(archiver, "list", "test", "input/file", "--format", "{num_chunks}")
     num_chunks = int(output)
     # now recreate the archive and do NOT specify chunker params:
-    output = cmd(
-        archiver, f"--repo={repo_location}", "recreate", "--debug", "--exclude", "filename_never_matches", "-a", "test"
-    )
+    output = cmd(archiver, "recreate", "--debug", "--exclude", "filename_never_matches", "-a", "test")
     assert "Rechunking" not in output  # we did not give --chunker-params, so it must not rechunk!
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test", "input/file", "--format", "{num_chunks}")
+    output = cmd(archiver, "list", "test", "input/file", "--format", "{num_chunks}")
     num_chunks_after_recreate = int(output)
     assert num_chunks == num_chunks_after_recreate
 
 
 def test_recreate_recompress(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "compressible", size=10000)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input", "-C", "none")
-    file_list = cmd(
-        archiver, f"--repo={repo_location}", "list", "test", "input/compressible", "--format", "{size} {sha256}"
-    )
+    create_regular_file(archiver.input_path, "compressible", size=10000)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input", "-C", "none")
+    file_list = cmd(archiver, "list", "test", "input/compressible", "--format", "{size} {sha256}")
     size, sha256_before = file_list.split(" ")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-C", "lz4", "--recompress")
+    cmd(archiver, "recreate", "-C", "lz4", "--recompress")
     check_cache(archiver)
-    file_list = cmd(
-        archiver, f"--repo={repo_location}", "list", "test", "input/compressible", "--format", "{size} {sha256}"
-    )
+    file_list = cmd(archiver, "list", "test", "input/compressible", "--format", "{size} {sha256}")
     size, sha256_after = file_list.split(" ")
     assert sha256_before == sha256_after
 
 
 def test_recreate_timestamp(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    create_test_files(input_path)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test0", "input")
-    cmd(
-        archiver,
-        f"--repo={repo_location}",
-        "recreate",
-        "test0",
-        "--timestamp",
-        "1970-01-02T00:00:00",
-        "--comment",
-        "test",
-    )
-    info = cmd(archiver, f"--repo={repo_location}", "info", "-a", "test0").splitlines()
+    create_test_files(archiver.input_path)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test0", "input")
+    cmd(archiver, "recreate", "test0", "--timestamp", "1970-01-02T00:00:00", "--comment", "test")
+    info = cmd(archiver, "info", "-a", "test0").splitlines()
     dtime = datetime(1970, 1, 2, 0, 0, 0).astimezone()  # local time in local timezone
     s_time = dtime.strftime("%Y-%m-%d %H:%M:.. %z").replace("+", r"\+")
     assert any([re.search(r"Time \(start\).+ %s" % s_time, item) for item in info])
@@ -288,61 +220,54 @@ def test_recreate_timestamp(archivers, request):
 
 def test_recreate_dry_run(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "compressible", size=10000)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    archives_before = cmd(archiver, f"--repo={repo_location}", "list", "test")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-n", "-e", "input/compressible")
+    create_regular_file(archiver.input_path, "compressible", size=10000)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    archives_before = cmd(archiver, "list", "test")
+    cmd(archiver, "recreate", "-n", "-e", "input/compressible")
     check_cache(archiver)
-    archives_after = cmd(archiver, f"--repo={repo_location}", "list", "test")
+    archives_after = cmd(archiver, "list", "test")
     assert archives_after == archives_before
 
 
 def test_recreate_skips_nothing_to_do(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_before = cmd(archiver, f"--repo={repo_location}", "info", "-a", "test")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "--chunker-params", "default")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    info_before = cmd(archiver, "info", "-a", "test")
+    cmd(archiver, "recreate", "--chunker-params", "default")
     check_cache(archiver)
-    info_after = cmd(archiver, f"--repo={repo_location}", "info", "-a", "test")
+    info_after = cmd(archiver, "info", "-a", "test")
     assert info_before == info_after  # includes archive ID
 
 
 def test_recreate_list_output(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=0)
+    create_regular_file(archiver.input_path, "file2", size=0)
+    create_regular_file(archiver.input_path, "file3", size=0)
+    create_regular_file(archiver.input_path, "file4", size=0)
+    create_regular_file(archiver.input_path, "file5", size=0)
+    cmd(archiver, "create", "test", "input")
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    create_regular_file(input_path, "file1", size=0)
-    create_regular_file(input_path, "file2", size=0)
-    create_regular_file(input_path, "file3", size=0)
-    create_regular_file(input_path, "file4", size=0)
-    create_regular_file(input_path, "file5", size=0)
-
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-
-    output = cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "--list", "--info", "-e", "input/file2")
+    output = cmd(archiver, "recreate", "-a", "test", "--list", "--info", "-e", "input/file2")
     check_cache(archiver)
     assert "input/file1" in output
     assert "- input/file2" in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "--list", "-e", "input/file3")
+    output = cmd(archiver, "recreate", "-a", "test", "--list", "-e", "input/file3")
     check_cache(archiver)
     assert "input/file1" in output
     assert "- input/file3" in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "-e", "input/file4")
+    output = cmd(archiver, "recreate", "-a", "test", "-e", "input/file4")
     check_cache(archiver)
     assert "input/file1" not in output
     assert "- input/file4" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test", "--info", "-e", "input/file5")
+    output = cmd(archiver, "recreate", "-a", "test", "--info", "-e", "input/file5")
     check_cache(archiver)
     assert "input/file1" not in output
     assert "- input/file5" not in output
@@ -350,22 +275,21 @@ def test_recreate_list_output(archivers, request):
 
 def test_comment(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test1", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test2", "input", "--comment", "this is the comment")
-    cmd(archiver, f"--repo={repo_location}", "create", "test3", "input", "--comment", '"deleted" comment')
-    cmd(archiver, f"--repo={repo_location}", "create", "test4", "input", "--comment", "preserved comment")
-    assert "Comment: " + os.linesep in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test1")
-    assert "Comment: this is the comment" in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test2")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input", "--comment", "this is the comment")
+    cmd(archiver, "create", "test3", "input", "--comment", '"deleted" comment')
+    cmd(archiver, "create", "test4", "input", "--comment", "preserved comment")
+    assert "Comment: " + os.linesep in cmd(archiver, "info", "-a", "test1")
+    assert "Comment: this is the comment" in cmd(archiver, "info", "-a", "test2")
 
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test1", "--comment", "added comment")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test2", "--comment", "modified comment")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test3", "--comment", "")
-    cmd(archiver, f"--repo={repo_location}", "recreate", "-a", "test4", "12345")
-    assert "Comment: added comment" in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test1")
-    assert "Comment: modified comment" in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test2")
-    assert "Comment: " + os.linesep in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test3")
-    assert "Comment: preserved comment" in cmd(archiver, f"--repo={repo_location}", "info", "-a", "test4")
+    cmd(archiver, "recreate", "-a", "test1", "--comment", "added comment")
+    cmd(archiver, "recreate", "-a", "test2", "--comment", "modified comment")
+    cmd(archiver, "recreate", "-a", "test3", "--comment", "")
+    cmd(archiver, "recreate", "-a", "test4", "12345")
+    assert "Comment: added comment" in cmd(archiver, "info", "-a", "test1")
+    assert "Comment: modified comment" in cmd(archiver, "info", "-a", "test2")
+    assert "Comment: " + os.linesep in cmd(archiver, "info", "-a", "test3")
+    assert "Comment: preserved comment" in cmd(archiver, "info", "-a", "test4")

--- a/src/borg/testsuite/archiver/rename_cmd.py
+++ b/src/borg/testsuite/archiver/rename_cmd.py
@@ -1,29 +1,27 @@
-import pytest
-
 from ...constants import *  # NOQA
 from ...manifest import Manifest
 from ...repository import Repository
-from . import cmd, create_regular_file, RK_ENCRYPTION
+from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
+
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
 
 
-@pytest.mark.parametrize("archivers", ["archiver", "remote_archiver", "binary_archiver"])
 def test_rename(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, repo_path, input_path = archiver.repository_location, archiver.repository_path, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-    create_regular_file(input_path, "dir2/file2", size=1024 * 80)
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    cmd(archiver, f"--repo={repo_location}", "create", "test.2", "input")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.2", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "rename", "test", "test.3")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.2", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "rename", "test.2", "test.4")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.3", "--dry-run")
-    cmd(archiver, f"--repo={repo_location}", "extract", "test.4", "--dry-run")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    create_regular_file(archiver.input_path, "dir2/file2", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    cmd(archiver, "create", "test.2", "input")
+    cmd(archiver, "extract", "test", "--dry-run")
+    cmd(archiver, "extract", "test.2", "--dry-run")
+    cmd(archiver, "rename", "test", "test.3")
+    cmd(archiver, "extract", "test.2", "--dry-run")
+    cmd(archiver, "rename", "test.2", "test.4")
+    cmd(archiver, "extract", "test.3", "--dry-run")
+    cmd(archiver, "extract", "test.4", "--dry-run")
     # Make sure both archives have been renamed
-    with Repository(repo_path) as repository:
+    with Repository(archiver.repository_path) as repository:
         manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
     assert len(manifest.archives) == 2
     assert "test.3" in manifest.archives

--- a/src/borg/testsuite/archiver/rinfo_cmd.py
+++ b/src/borg/testsuite/archiver/rinfo_cmd.py
@@ -9,23 +9,20 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_info(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_repo = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    info_repo = cmd(archiver, "rinfo")
     assert "Original size:" in info_repo
 
 
 def test_info_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_repo = json.loads(cmd(archiver, f"--repo={repo_location}", "rinfo", "--json"))
+    info_repo = json.loads(cmd(archiver, "rinfo", "--json"))
     repository = info_repo["repository"]
     assert len(repository["id"]) == 64
     assert "last_modified" in repository
@@ -42,21 +39,17 @@ def test_info_json(archivers, request):
 
 def test_info_on_repository_with_storage_quota(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", contents=randbytes(1000 * 1000))
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION, "--storage-quota=1G")
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_repo = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    create_regular_file(archiver.input_path, "file1", contents=randbytes(1000 * 1000))
+    cmd(archiver, "rcreate", RK_ENCRYPTION, "--storage-quota=1G")
+    cmd(archiver, "create", "test", "input")
+    info_repo = cmd(archiver, "rinfo")
     assert "Storage quota: 1.00 MB used out of 1.00 GB" in info_repo
 
 
 def test_info_on_repository_without_storage_quota(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", contents=randbytes(1000 * 1000))
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    info_repo = cmd(archiver, f"--repo={repo_location}", "rinfo")
+    create_regular_file(archiver.input_path, "file1", contents=randbytes(1000 * 1000))
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    info_repo = cmd(archiver, "rinfo")
     assert "Storage quota: 1.00 MB used" in info_repo

--- a/src/borg/testsuite/archiver/rlist_cmd.py
+++ b/src/borg/testsuite/archiver/rlist_cmd.py
@@ -9,14 +9,11 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_rlist_glob(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test-1", src_dir)
-    cmd(archiver, f"--repo={repo_location}", "create", "something-else-than-test-1", src_dir)
-    cmd(archiver, f"--repo={repo_location}", "create", "test-2", src_dir)
-
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "--match-archives=sh:test-*")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test-1", src_dir)
+    cmd(archiver, "create", "something-else-than-test-1", src_dir)
+    cmd(archiver, "create", "test-2", src_dir)
+    output = cmd(archiver, "rlist", "--match-archives=sh:test-*")
     assert "test-1" in output
     assert "test-2" in output
     assert "something-else" not in output
@@ -24,32 +21,28 @@ def test_rlist_glob(archivers, request):
 
 def test_archives_format(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "--comment", "comment 1", "test-1", src_dir)
-    cmd(archiver, f"--repo={repo_location}", "create", "--comment", "comment 2", "test-2", src_dir)
-    output_1 = cmd(archiver, f"--repo={repo_location}", "rlist")
-    output_2 = cmd(archiver, f"--repo={repo_location}", "rlist", "--format", "{archive:<36} {time} [{id}]{NL}")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "--comment", "comment 1", "test-1", src_dir)
+    cmd(archiver, "create", "--comment", "comment 2", "test-2", src_dir)
+    output_1 = cmd(archiver, "rlist")
+    output_2 = cmd(archiver, "rlist", "--format", "{archive:<36} {time} [{id}]{NL}")
     assert output_1 == output_2
-    output_1 = cmd(archiver, f"--repo={repo_location}", "rlist", "--short")
+    output_1 = cmd(archiver, "rlist", "--short")
     assert output_1 == "test-1" + os.linesep + "test-2" + os.linesep
-    output_3 = cmd(archiver, f"--repo={repo_location}", "rlist", "--format", "{name} {comment}{NL}")
+    output_3 = cmd(archiver, "rlist", "--format", "{name} {comment}{NL}")
     assert "test-1 comment 1" + os.linesep in output_3
     assert "test-2 comment 2" + os.linesep in output_3
 
 
 def test_size_nfiles(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    create_regular_file(input_path, "file1", size=123000)
-    create_regular_file(input_path, "file2", size=456)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input/file1", "input/file2")
-    output = cmd(archiver, f"--repo={repo_location}", "list", "test")
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=123000)
+    create_regular_file(archiver.input_path, "file2", size=456)
+    cmd(archiver, "create", "test", "input/file1", "input/file2")
+    output = cmd(archiver, "list", "test")
     print(output)
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "--format", "{name} {nfiles} {size}")
+    output = cmd(archiver, "rlist", "--format", "{name} {nfiles} {size}")
     o_t = output.split()
     assert o_t[0] == "test"
     assert int(o_t[1]) == 2
@@ -58,32 +51,30 @@ def test_size_nfiles(archivers, request):
 
 def test_date_matching(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
     earliest_ts = "2022-11-20T23:59:59"
     ts_in_between = "2022-12-18T23:59:59"
     create_src_archive(archiver, "archive1", ts=earliest_ts)
     create_src_archive(archiver, "archive2", ts=ts_in_between)
     create_src_archive(archiver, "archive3")
-    cmd(archiver, f"--repo={repo_location}", "rlist", "-v", "--oldest=23e", exit_code=2)
+    cmd(archiver, "rlist", "-v", "--oldest=23e", exit_code=2)
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "-v", "--oldest=1m", exit_code=0)
+    output = cmd(archiver, "rlist", "-v", "--oldest=1m", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
     assert "archive3" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "-v", "--newest=1m", exit_code=0)
+    output = cmd(archiver, "rlist", "-v", "--newest=1m", exit_code=0)
     assert "archive3" in output
     assert "archive2" not in output
     assert "archive1" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "-v", "--newer=1d", exit_code=0)
+    output = cmd(archiver, "rlist", "-v", "--newer=1d", exit_code=0)
     assert "archive3" in output
     assert "archive1" not in output
     assert "archive2" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "-v", "--older=1d", exit_code=0)
+    output = cmd(archiver, "rlist", "-v", "--older=1d", exit_code=0)
     assert "archive1" in output
     assert "archive2" in output
     assert "archive3" not in output
@@ -91,20 +82,19 @@ def test_date_matching(archivers, request):
 
 def test_rlist_consider_checkpoints(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location = archiver.repository_location
 
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test1", src_dir)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", src_dir)
     # these are not really a checkpoints, but they look like some:
-    cmd(archiver, f"--repo={repo_location}", "create", "test2.checkpoint", src_dir)
-    cmd(archiver, f"--repo={repo_location}", "create", "test3.checkpoint.1", src_dir)
+    cmd(archiver, "create", "test2.checkpoint", src_dir)
+    cmd(archiver, "create", "test3.checkpoint.1", src_dir)
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist")
+    output = cmd(archiver, "rlist")
     assert "test1" in output
     assert "test2.checkpoint" not in output
     assert "test3.checkpoint.1" not in output
 
-    output = cmd(archiver, f"--repo={repo_location}", "rlist", "--consider-checkpoints")
+    output = cmd(archiver, "rlist", "--consider-checkpoints")
     assert "test1" in output
     assert "test2.checkpoint" in output
     assert "test3.checkpoint.1" in output
@@ -112,12 +102,10 @@ def test_rlist_consider_checkpoints(archivers, request):
 
 def test_rlist_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    repo_location, input_path = archiver.repository_location, archiver.input_path
-    create_regular_file(input_path, "file1", size=1024 * 80)
-
-    cmd(archiver, f"--repo={repo_location}", "rcreate", RK_ENCRYPTION)
-    cmd(archiver, f"--repo={repo_location}", "create", "test", "input")
-    list_repo = json.loads(cmd(archiver, f"--repo={repo_location}", "rlist", "--json"))
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "rcreate", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    list_repo = json.loads(cmd(archiver, "rlist", "--json"))
     repository = list_repo["repository"]
     assert len(repository["id"]) == 64
     checkts(repository["last_modified"])


### PR DESCRIPTION
Solves [this comment](https://github.com/borgbackup/borg/pull/7722#issuecomment-1646961750).

Currently, every cmd in `testsuite/archiver/` tests are passing `f"repo={archiver.repository_location}"` as an argument, in addition to the `archiver` itself. @ThomasWaldmann suggested just creating this argument in the function itself, thus removing a lot of redundant and messy code. That is what I have done here.