### PR TITLE
PR: Remove BaseTestCase from `testsuite/`

### DIFF
--- a/src/borg/testsuite/chunker_slow.py
+++ b/src/borg/testsuite/chunker_slow.py
@@ -5,35 +5,33 @@ from .chunker import cf
 from ..chunker import Chunker
 from ..crypto.low_level import blake2b_256
 from ..constants import *  # NOQA
-from . import BaseTestCase
 
 
-class ChunkerRegressionTestCase(BaseTestCase):
-    def test_chunkpoints_unchanged(self):
-        def twist(size):
-            x = 1
-            a = bytearray(size)
-            for i in range(size):
-                x = (x * 1103515245 + 12345) & 0x7FFFFFFF
-                a[i] = x & 0xFF
-            return a
+def test_chunkpoints_unchanged():
+    def twist(size):
+        x = 1
+        a = bytearray(size)
+        for i in range(size):
+            x = (x * 1103515245 + 12345) & 0x7FFFFFFF
+            a[i] = x & 0xFF
+        return a
 
-        data = twist(100000)
+    data = twist(100000)
 
-        runs = []
-        for winsize in (65, 129, HASH_WINDOW_SIZE, 7351):
-            for minexp in (4, 6, 7, 11, 12):
-                for maxexp in (15, 17):
-                    if minexp >= maxexp:
-                        continue
-                    for maskbits in (4, 7, 10, 12):
-                        for seed in (1849058162, 1234567653):
-                            fh = BytesIO(data)
-                            chunker = Chunker(seed, minexp, maxexp, maskbits, winsize)
-                            chunks = [blake2b_256(b"", c) for c in cf(chunker.chunkify(fh, -1))]
-                            runs.append(blake2b_256(b"", b"".join(chunks)))
+    runs = []
+    for winsize in (65, 129, HASH_WINDOW_SIZE, 7351):
+        for minexp in (4, 6, 7, 11, 12):
+            for maxexp in (15, 17):
+                if minexp >= maxexp:
+                    continue
+                for maskbits in (4, 7, 10, 12):
+                    for seed in (1849058162, 1234567653):
+                        fh = BytesIO(data)
+                        chunker = Chunker(seed, minexp, maxexp, maskbits, winsize)
+                        chunks = [blake2b_256(b"", c) for c in cf(chunker.chunkify(fh, -1))]
+                        runs.append(blake2b_256(b"", b"".join(chunks)))
 
-        # The "correct" hash below matches the existing chunker behavior.
-        # Future chunker optimisations must not change this, or existing repos will bloat.
-        overall_hash = blake2b_256(b"", b"".join(runs))
-        self.assert_equal(overall_hash, unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3"))
+    # The "correct" hash below matches the existing chunker behavior.
+    # Future chunker optimisations must not change this, or existing repos will bloat.
+    overall_hash = blake2b_256(b"", b"".join(runs))
+    assert overall_hash == unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3")

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -14,52 +14,36 @@ import pytest
 from ..archiver.prune_cmd import prune_within, prune_split
 from .. import platform
 from ..constants import MAX_DATA_SIZE
-from ..helpers import DEFAULTISH, FALSISH, SUPPORT_32BIT_PLATFORMS, TRUISH
+from ..helpers import Location
+from ..helpers import Buffer
 from ..helpers import (
-    Buffer,
-    ChunkerParams,
-    ChunkIteratorFileWrapper,
-    Location,
-    PlaceholderError,
-    ProgressIndicatorPercent,
-    StableDict,
-)
-from ..helpers import (
-    archivename_validator,
-    bin_to_hex,
-    binary_to_json,
-    chunkit,
-    clean_lines,
-    dash_open,
-    eval_escapes,
-    format_file_size,
-    format_line,
-    format_timedelta,
-    get_base_dir,
-    get_cache_dir,
-    get_config_dir,
-    get_keys_dir,
-    get_runtime_dir,
-    get_security_dir,
-    interval,
-    is_slow_msgpack,
-    iter_separated,
-    make_path_safe,
-    msgpack,
-    parse_file_size,
-    parse_timestamp,
     partial_format,
-    popen_with_error_handling,
-    remove_dotdot_prefixes,
+    format_file_size,
+    parse_file_size,
+    format_timedelta,
+    format_line,
+    PlaceholderError,
     replace_placeholders,
-    safe_ns,
-    safe_s,
-    safe_unlink,
-    swidth_slice,
-    text_to_json,
-    text_validator,
-    yes,
 )
+from ..helpers import remove_dotdot_prefixes, make_path_safe, clean_lines
+from ..helpers import interval
+from ..helpers import get_base_dir, get_cache_dir, get_keys_dir, get_security_dir, get_config_dir, get_runtime_dir
+from ..helpers import is_slow_msgpack
+from ..helpers import msgpack
+from ..helpers import yes, TRUISH, FALSISH, DEFAULTISH
+from ..helpers import StableDict, bin_to_hex
+from ..helpers import parse_timestamp, ChunkIteratorFileWrapper, ChunkerParams
+from ..helpers import archivename_validator, text_validator
+from ..helpers import ProgressIndicatorPercent
+from ..helpers import swidth_slice
+from ..helpers import chunkit
+from ..helpers import safe_ns, safe_s, SUPPORT_32BIT_PLATFORMS
+from ..helpers import popen_with_error_handling
+from ..helpers import dash_open
+from ..helpers import iter_separated
+from ..helpers import eval_escapes
+from ..helpers import safe_unlink
+from ..helpers import text_to_json, binary_to_json
 from ..helpers.passphrase import Passphrase, PasswordRetriesExceeded
 from ..platform import is_cygwin, is_win32, is_darwin
 from . import FakeInputs, are_hardlinks_supported


### PR DESCRIPTION
Now that the `ArchiverBaseTestCase` has been removed from `testsuite/archiver/__init__.py`, I would now like to remove `BaseTestCase` from the `testsuite/__init__.py`. After @ThomasWaldmann's recent update to the `BaseTestCase`[here](https://github.com/borgbackup/borg/pull/7736), all that remains are a few assert methods that seem superfluous and could be replaced with the built-in python asserts.