### PR TITLE
PR: `testsuite/platform.py` conversion to pytest + remove `BaseTestCase`

### DIFF
--- a/src/borg/testsuite/platform.py
+++ b/src/borg/testsuite/platform.py
@@ -5,6 +5,8 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+
 from ..platformflags import is_win32
 from ..platform import acl_get, acl_set, swidth
 from ..platform import get_process_id, process_alive
@@ -161,68 +163,59 @@ class PlatformLinuxTestCase(BaseTestCase):
         self.assert_equal(acl_use_local_uid_gid(b"group:root:rw-:0"), b"group:0:rw-")
 
 
-@unittest.skipUnless(sys.platform.startswith("darwin"), "macOS only test")
-@unittest.skipIf(fakeroot_detected(), "not compatible with fakeroot")
-class PlatformDarwinTestCase(BaseTestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-
-    def get_acl(self, path, numeric_ids=False):
+@pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="macOS only test")
+@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+@pytest.mark.skipIf(not are_acls_working(), "ACLs do not work")
+def test_platform_darwin_access_acl(tmp_path):
+    def get_acl(path, numeric_ids=False):
         item = {}
         acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
         return item
 
-    def set_acl(self, path, acl, numeric_ids=False):
+    def set_acl(path, acl, numeric_ids=False):
         item = {"acl_extended": acl}
         acl_set(path, item, numeric_ids=numeric_ids)
 
-    @unittest.skipIf(not are_acls_working(), "ACLs do not work")
-    def test_access_acl(self):
-        file = tempfile.NamedTemporaryFile()
-        file2 = tempfile.NamedTemporaryFile()
-        self.assert_equal(self.get_acl(file.name), {})
-        self.set_acl(
-            file.name,
-            b"!#acl 1\n"
-            b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
-            b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
-            numeric_ids=False,
-        )
-        self.assert_in(
-            b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read", self.get_acl(file.name)["acl_extended"]
-        )
-        self.assert_in(
-            b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read", self.get_acl(file.name)["acl_extended"]
-        )
-        self.set_acl(
-            file2.name,
-            b"!#acl 1\n"
-            b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
-            b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
-            numeric_ids=True,
-        )
-        self.assert_in(
-            b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read", self.get_acl(file2.name)["acl_extended"]
-        )
-        self.assert_in(
-            b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read",
-            self.get_acl(file2.name, numeric_ids=True)["acl_extended"],
-        )
+    file = tempfile.NamedTemporaryFile()
+    file2 = tempfile.NamedTemporaryFile()
+    assert get_acl(file.name) == {}
+    set_acl(
+        file.name,
+        b"!#acl 1\n"
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
+        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
+        numeric_ids=False,
+    )
+    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read" in get_acl(file.name)["acl_extended"]
+    assert b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read" in get_acl(file.name)["acl_extended"]
+
+    set_acl(
+        file2.name,
+        b"!#acl 1\n"
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
+        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
+        numeric_ids=True,
+    )
+    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read" in get_acl(file2.name)["acl_extended"]
+    assert (
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read"
+        in get_acl(file2.name, numeric_ids=True)["acl_extended"]
+    )
 
 
-@unittest.skipUnless(sys.platform.startswith(("linux", "freebsd", "darwin")), "POSIX only tests")
-class PlatformPosixTestCase(BaseTestCase):
-    def test_swidth_ascii(self):
-        self.assert_equal(swidth("borg"), 4)
+@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
+def test_platform_posix_swidth_ascii():
+    assert swidth("borg") == 4
 
-    def test_swidth_cjk(self):
-        self.assert_equal(swidth("バックアップ"), 6 * 2)
 
-    def test_swidth_mixed(self):
-        self.assert_equal(swidth("borgバックアップ"), 4 + 6 * 2)
+@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
+def test_platform_posix_swidth_cjk():
+    assert swidth("バックアップ") == 6 * 2
+
+
+@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
+def test_splatform_posix_width_mixed():
+    assert swidth("borgバックアップ") == 4 + 6 * 2
 
 
 def test_process_alive(free_pid):

--- a/src/borg/testsuite/platform.py
+++ b/src/borg/testsuite/platform.py
@@ -1,16 +1,13 @@
 import functools
 import os
-import sys
-import tempfile
 
 import pytest
 
-from ..platformflags import is_win32
-from ..platform import acl_get, acl_set, swidth
+from ..platformflags import is_darwin, is_freebsd, is_linux, is_win32
+from ..platform import acl_get, acl_set
 from ..platform import get_process_id, process_alive
 from . import unopened_tempfile
 from .locking import free_pid  # NOQA
-
 
 ACCESS_ACL = """
 user::rw-
@@ -37,8 +34,6 @@ other::r--
 """.strip().encode(
     "ascii"
 )
-
-# _acls_working = None
 
 
 def fakeroot_detected():
@@ -75,162 +70,13 @@ def are_acls_working():
         return False
 
 
-def get_linux_acl(path, numeric_ids=False):
-    item = {}
-    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
-    return item
-
-
-def set_linux_acl(path, access=None, default=None, numeric_ids=False):
-    item = {"acl_access": access, "acl_default": default}
-    acl_set(path, item, numeric_ids=numeric_ids)
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
-@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
-def test_linux_access_acl():
-    file = tempfile.NamedTemporaryFile()
-    assert get_linux_acl(file.name) == {}
-
-    set_linux_acl(
-        file.name,
-        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
-        numeric_ids=False,
-    )
-    assert b"user:root:rw-:0" in get_linux_acl(file.name)["acl_access"]
-    assert b"group:root:rw-:0" in get_linux_acl(file.name)["acl_access"]
-    assert b"user:0:rw-:0" in get_linux_acl(file.name, numeric_ids=True)["acl_access"]
-
-    file2 = tempfile.NamedTemporaryFile()
-    set_linux_acl(
-        file2.name,
-        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
-        numeric_ids=True,
-    )
-    assert b"user:9999:rw-:9999" in get_linux_acl(file2.name)["acl_access"]
-    assert b"group:9999:rw-:9999" in get_linux_acl(file2.name)["acl_access"]
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
-@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
-def test_linux_default_acl():
-    tmpdir = tempfile.mkdtemp()
-    assert get_linux_acl(tmpdir) == {}
-    set_linux_acl(tmpdir, access=ACCESS_ACL, default=DEFAULT_ACL)
-    assert get_linux_acl(tmpdir)["acl_access"] == ACCESS_ACL
-    assert get_linux_acl(tmpdir)["acl_default"] == DEFAULT_ACL
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
-@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
-@pytest.mark.skipif(not user_exists("übel"), reason="requires übel user")
-def test_linux_non_ascii_acl():
-    # Testing non-ascii ACL processing to see whether our code is robust.
-    # I have no idea whether non-ascii ACLs are allowed by the standard,
-    # but in practice they seem to be out there and must not make our code explode.
-    file = tempfile.NamedTemporaryFile()
-    assert get_linux_acl(file.name) == {}
-    nothing_special = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\n"
-    # TODO: can this be tested without having an existing system user übel with uid 666 gid 666?
-    user_entry = "user:übel:rw-:666".encode()
-    user_entry_numeric = b"user:666:rw-:666"
-    group_entry = "group:übel:rw-:666".encode()
-    group_entry_numeric = b"group:666:rw-:666"
-    acl = b"\n".join([nothing_special, user_entry, group_entry])
-    set_linux_acl(file.name, access=acl, numeric_ids=False)
-
-    acl_access = get_linux_acl(file.name, numeric_ids=False)["acl_access"]
-    assert user_entry in acl_access
-    assert group_entry in acl_access
-
-    acl_access_numeric = get_linux_acl(file.name, numeric_ids=True)["acl_access"]
-    assert user_entry_numeric in acl_access_numeric
-    assert group_entry_numeric in acl_access_numeric
-
-    file2 = tempfile.NamedTemporaryFile()
-    set_linux_acl(file2.name, access=acl, numeric_ids=True)
-    acl_access = get_linux_acl(file2.name, numeric_ids=False)["acl_access"]
-    assert user_entry in acl_access
-    assert group_entry in acl_access
-
-    acl_access_numeric = get_linux_acl(file.name, numeric_ids=True)["acl_access"]
-    assert user_entry_numeric in acl_access_numeric
-    assert group_entry_numeric in acl_access_numeric
-
-
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
-@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-def test_linux_utils():
-    from ..platform.linux import acl_use_local_uid_gid
-
-    assert acl_use_local_uid_gid(b"user:nonexistent1234:rw-:1234") == b"user:1234:rw-"
-    assert acl_use_local_uid_gid(b"group:nonexistent1234:rw-:1234") == b"group:1234:rw-"
-    assert acl_use_local_uid_gid(b"user:root:rw-:0") == b"user:0:rw-"
-    assert acl_use_local_uid_gid(b"group:root:rw-:0") == b"group:0:rw-"
-
-
-def get_darwin_acl(path, numeric_ids=False):
-    item = {}
-    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
-    return item
-
-
-def set_darwin_acl(path, acl, numeric_ids=False):
-    item = {"acl_extended": acl}
-    acl_set(path, item, numeric_ids=numeric_ids)
-
-
-@pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="macOS only test")
-@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
-def test_darwin_access_acl(tmp_path):
-    file = tempfile.NamedTemporaryFile()
-    assert get_darwin_acl(file.name) == {}
-    set_darwin_acl(
-        file.name,
-        b"!#acl 1\n"
-        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
-        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
-        numeric_ids=False,
-    )
-    assert (
-        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read" in get_darwin_acl(file.name)["acl_extended"]
-    )
-    assert b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read" in get_darwin_acl(file.name)["acl_extended"]
-
-    file2 = tempfile.NamedTemporaryFile()
-    set_darwin_acl(
-        file2.name,
-        b"!#acl 1\n"
-        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
-        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
-        numeric_ids=True,
-    )
-    assert (
-        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read" in get_darwin_acl(file2.name)["acl_extended"]
-    )
-    assert (
-        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read"
-        in get_darwin_acl(file2.name, numeric_ids=True)["acl_extended"]
-    )
-
-
-@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_posix_swidth_ascii():
-    assert swidth("borg") == 4
-
-
-@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_posix_swidth_cjk():
-    assert swidth("バックアップ") == 6 * 2
-
-
-@pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_posix_swidth_mixed():
-    assert swidth("borgバックアップ") == 4 + 6 * 2
+# define skips available to platform tests
+skipif_not_linux = pytest.mark.skipif(not is_linux, reason="linux only test")
+skipif_not_darwin = pytest.mark.skipif(not is_darwin, reason="darwin only test")
+skipif_not_posix = pytest.mark.skipif(not (is_linux or is_freebsd or is_darwin), reason="POSIX only tests")
+skipif_fakeroot_detected = pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+skipif_acls_not_working = pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
+skipif_no_ubel_user = pytest.mark.skipif(not user_exists("übel"), reason="requires übel user")
 
 
 def test_process_alive(free_pid):

--- a/src/borg/testsuite/platform.py
+++ b/src/borg/testsuite/platform.py
@@ -1,16 +1,14 @@
 import functools
 import os
-import shutil
 import sys
 import tempfile
-import unittest
 
 import pytest
 
 from ..platformflags import is_win32
 from ..platform import acl_get, acl_set, swidth
 from ..platform import get_process_id, process_alive
-from . import BaseTestCase, unopened_tempfile
+from . import unopened_tempfile
 from .locking import free_pid  # NOQA
 
 
@@ -77,144 +75,161 @@ def are_acls_working():
         return False
 
 
-@unittest.skipUnless(sys.platform.startswith("linux"), "linux only test")
-@unittest.skipIf(fakeroot_detected(), "not compatible with fakeroot")
-class PlatformLinuxTestCase(BaseTestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
+def get_linux_acl(path, numeric_ids=False):
+    item = {}
+    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
+    return item
 
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
 
-    def get_acl(self, path, numeric_ids=False):
-        item = {}
-        acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
-        return item
+def set_linux_acl(path, access=None, default=None, numeric_ids=False):
+    item = {"acl_access": access, "acl_default": default}
+    acl_set(path, item, numeric_ids=numeric_ids)
 
-    def set_acl(self, path, access=None, default=None, numeric_ids=False):
-        item = {"acl_access": access, "acl_default": default}
-        acl_set(path, item, numeric_ids=numeric_ids)
 
-    @unittest.skipIf(not are_acls_working(), "ACLs do not work")
-    def test_access_acl(self):
-        file = tempfile.NamedTemporaryFile()
-        self.assert_equal(self.get_acl(file.name), {})
-        self.set_acl(
-            file.name,
-            access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
-            numeric_ids=False,
-        )
-        self.assert_in(b"user:root:rw-:0", self.get_acl(file.name)["acl_access"])
-        self.assert_in(b"group:root:rw-:0", self.get_acl(file.name)["acl_access"])
-        self.assert_in(b"user:0:rw-:0", self.get_acl(file.name, numeric_ids=True)["acl_access"])
-        file2 = tempfile.NamedTemporaryFile()
-        self.set_acl(
-            file2.name,
-            access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
-            numeric_ids=True,
-        )
-        self.assert_in(b"user:9999:rw-:9999", self.get_acl(file2.name)["acl_access"])
-        self.assert_in(b"group:9999:rw-:9999", self.get_acl(file2.name)["acl_access"])
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
+@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
+def test_linux_access_acl():
+    file = tempfile.NamedTemporaryFile()
+    assert get_linux_acl(file.name) == {}
 
-    @unittest.skipIf(not are_acls_working(), "ACLs do not work")
-    def test_default_acl(self):
-        self.assert_equal(self.get_acl(self.tmpdir), {})
-        self.set_acl(self.tmpdir, access=ACCESS_ACL, default=DEFAULT_ACL)
-        self.assert_equal(self.get_acl(self.tmpdir)["acl_access"], ACCESS_ACL)
-        self.assert_equal(self.get_acl(self.tmpdir)["acl_default"], DEFAULT_ACL)
+    set_linux_acl(
+        file.name,
+        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
+        numeric_ids=False,
+    )
+    assert b"user:root:rw-:0" in get_linux_acl(file.name)["acl_access"]
+    assert b"group:root:rw-:0" in get_linux_acl(file.name)["acl_access"]
+    assert b"user:0:rw-:0" in get_linux_acl(file.name, numeric_ids=True)["acl_access"]
 
-    @unittest.skipIf(not user_exists("übel"), "requires übel user")
-    @unittest.skipIf(not are_acls_working(), "ACLs do not work")
-    def test_non_ascii_acl(self):
-        # Testing non-ascii ACL processing to see whether our code is robust.
-        # I have no idea whether non-ascii ACLs are allowed by the standard,
-        # but in practice they seem to be out there and must not make our code explode.
-        file = tempfile.NamedTemporaryFile()
-        self.assert_equal(self.get_acl(file.name), {})
-        nothing_special = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\n"
-        # TODO: can this be tested without having an existing system user übel with uid 666 gid 666?
-        user_entry = "user:übel:rw-:666".encode()
-        user_entry_numeric = b"user:666:rw-:666"
-        group_entry = "group:übel:rw-:666".encode()
-        group_entry_numeric = b"group:666:rw-:666"
-        acl = b"\n".join([nothing_special, user_entry, group_entry])
-        self.set_acl(file.name, access=acl, numeric_ids=False)
-        acl_access = self.get_acl(file.name, numeric_ids=False)["acl_access"]
-        self.assert_in(user_entry, acl_access)
-        self.assert_in(group_entry, acl_access)
-        acl_access_numeric = self.get_acl(file.name, numeric_ids=True)["acl_access"]
-        self.assert_in(user_entry_numeric, acl_access_numeric)
-        self.assert_in(group_entry_numeric, acl_access_numeric)
-        file2 = tempfile.NamedTemporaryFile()
-        self.set_acl(file2.name, access=acl, numeric_ids=True)
-        acl_access = self.get_acl(file2.name, numeric_ids=False)["acl_access"]
-        self.assert_in(user_entry, acl_access)
-        self.assert_in(group_entry, acl_access)
-        acl_access_numeric = self.get_acl(file.name, numeric_ids=True)["acl_access"]
-        self.assert_in(user_entry_numeric, acl_access_numeric)
-        self.assert_in(group_entry_numeric, acl_access_numeric)
+    file2 = tempfile.NamedTemporaryFile()
+    set_linux_acl(
+        file2.name,
+        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
+        numeric_ids=True,
+    )
+    assert b"user:9999:rw-:9999" in get_linux_acl(file2.name)["acl_access"]
+    assert b"group:9999:rw-:9999" in get_linux_acl(file2.name)["acl_access"]
 
-    def test_utils(self):
-        from ..platform.linux import acl_use_local_uid_gid
 
-        self.assert_equal(acl_use_local_uid_gid(b"user:nonexistent1234:rw-:1234"), b"user:1234:rw-")
-        self.assert_equal(acl_use_local_uid_gid(b"group:nonexistent1234:rw-:1234"), b"group:1234:rw-")
-        self.assert_equal(acl_use_local_uid_gid(b"user:root:rw-:0"), b"user:0:rw-")
-        self.assert_equal(acl_use_local_uid_gid(b"group:root:rw-:0"), b"group:0:rw-")
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
+@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
+def test_linux_default_acl():
+    tmpdir = tempfile.mkdtemp()
+    assert get_linux_acl(tmpdir) == {}
+    set_linux_acl(tmpdir, access=ACCESS_ACL, default=DEFAULT_ACL)
+    assert get_linux_acl(tmpdir)["acl_access"] == ACCESS_ACL
+    assert get_linux_acl(tmpdir)["acl_default"] == DEFAULT_ACL
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
+@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
+@pytest.mark.skipif(not user_exists("übel"), reason="requires übel user")
+def test_linux_non_ascii_acl():
+    # Testing non-ascii ACL processing to see whether our code is robust.
+    # I have no idea whether non-ascii ACLs are allowed by the standard,
+    # but in practice they seem to be out there and must not make our code explode.
+    file = tempfile.NamedTemporaryFile()
+    assert get_linux_acl(file.name) == {}
+    nothing_special = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\n"
+    # TODO: can this be tested without having an existing system user übel with uid 666 gid 666?
+    user_entry = "user:übel:rw-:666".encode()
+    user_entry_numeric = b"user:666:rw-:666"
+    group_entry = "group:übel:rw-:666".encode()
+    group_entry_numeric = b"group:666:rw-:666"
+    acl = b"\n".join([nothing_special, user_entry, group_entry])
+    set_linux_acl(file.name, access=acl, numeric_ids=False)
+
+    acl_access = get_linux_acl(file.name, numeric_ids=False)["acl_access"]
+    assert user_entry in acl_access
+    assert group_entry in acl_access
+
+    acl_access_numeric = get_linux_acl(file.name, numeric_ids=True)["acl_access"]
+    assert user_entry_numeric in acl_access_numeric
+    assert group_entry_numeric in acl_access_numeric
+
+    file2 = tempfile.NamedTemporaryFile()
+    set_linux_acl(file2.name, access=acl, numeric_ids=True)
+    acl_access = get_linux_acl(file2.name, numeric_ids=False)["acl_access"]
+    assert user_entry in acl_access
+    assert group_entry in acl_access
+
+    acl_access_numeric = get_linux_acl(file.name, numeric_ids=True)["acl_access"]
+    assert user_entry_numeric in acl_access_numeric
+    assert group_entry_numeric in acl_access_numeric
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="linux only test")
+@pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
+def test_linux_utils():
+    from ..platform.linux import acl_use_local_uid_gid
+
+    assert acl_use_local_uid_gid(b"user:nonexistent1234:rw-:1234") == b"user:1234:rw-"
+    assert acl_use_local_uid_gid(b"group:nonexistent1234:rw-:1234") == b"group:1234:rw-"
+    assert acl_use_local_uid_gid(b"user:root:rw-:0") == b"user:0:rw-"
+    assert acl_use_local_uid_gid(b"group:root:rw-:0") == b"group:0:rw-"
+
+
+def get_darwin_acl(path, numeric_ids=False):
+    item = {}
+    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
+    return item
+
+
+def set_darwin_acl(path, acl, numeric_ids=False):
+    item = {"acl_extended": acl}
+    acl_set(path, item, numeric_ids=numeric_ids)
 
 
 @pytest.mark.skipif(not sys.platform.startswith("darwin"), reason="macOS only test")
 @pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
-@pytest.mark.skipIf(not are_acls_working(), "ACLs do not work")
-def test_platform_darwin_access_acl(tmp_path):
-    def get_acl(path, numeric_ids=False):
-        item = {}
-        acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
-        return item
-
-    def set_acl(path, acl, numeric_ids=False):
-        item = {"acl_extended": acl}
-        acl_set(path, item, numeric_ids=numeric_ids)
-
+@pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")
+def test_darwin_access_acl(tmp_path):
     file = tempfile.NamedTemporaryFile()
-    file2 = tempfile.NamedTemporaryFile()
-    assert get_acl(file.name) == {}
-    set_acl(
+    assert get_darwin_acl(file.name) == {}
+    set_darwin_acl(
         file.name,
         b"!#acl 1\n"
         b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
         b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
         numeric_ids=False,
     )
-    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read" in get_acl(file.name)["acl_extended"]
-    assert b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read" in get_acl(file.name)["acl_extended"]
+    assert (
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read" in get_darwin_acl(file.name)["acl_extended"]
+    )
+    assert b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read" in get_darwin_acl(file.name)["acl_extended"]
 
-    set_acl(
+    file2 = tempfile.NamedTemporaryFile()
+    set_darwin_acl(
         file2.name,
         b"!#acl 1\n"
         b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
         b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
         numeric_ids=True,
     )
-    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read" in get_acl(file2.name)["acl_extended"]
+    assert (
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read" in get_darwin_acl(file2.name)["acl_extended"]
+    )
     assert (
         b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read"
-        in get_acl(file2.name, numeric_ids=True)["acl_extended"]
+        in get_darwin_acl(file2.name, numeric_ids=True)["acl_extended"]
     )
 
 
 @pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_platform_posix_swidth_ascii():
+def test_posix_swidth_ascii():
     assert swidth("borg") == 4
 
 
 @pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_platform_posix_swidth_cjk():
+def test_posix_swidth_cjk():
     assert swidth("バックアップ") == 6 * 2
 
 
 @pytest.mark.skipif(not sys.platform.startswith(("linux", "freebsd", "darwin")), reason="POSIX only tests")
-def test_splatform_posix_width_mixed():
+def test_posix_swidth_mixed():
     assert swidth("borgバックアップ") == 4 + 6 * 2
 
 

--- a/src/borg/testsuite/platform_darwin.py
+++ b/src/borg/testsuite/platform_darwin.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+
+from ..platform import acl_get, acl_set
+from .platform import skipif_not_darwin, skipif_fakeroot_detected, skipif_acls_not_working
+
+# set module-level skips
+pytestmark = [skipif_not_darwin, skipif_fakeroot_detected]
+
+
+def get_acl(path, numeric_ids=False):
+    item = {}
+    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
+    return item
+
+
+def set_acl(path, acl, numeric_ids=False):
+    item = {"acl_extended": acl}
+    acl_set(path, item, numeric_ids=numeric_ids)
+
+
+@skipif_acls_not_working
+def test_access_acl():
+    file = tempfile.NamedTemporaryFile()
+    assert get_acl(file.name) == {}
+    set_acl(
+        file.name,
+        b"!#acl 1\n"
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
+        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
+        numeric_ids=False,
+    )
+    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000014:staff:20:allow:read" in get_acl(file.name)["acl_extended"]
+    assert b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read" in get_acl(file.name)["acl_extended"]
+
+    file2 = tempfile.NamedTemporaryFile()
+    set_acl(
+        file2.name,
+        b"!#acl 1\n"
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\n"
+        b"user:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n",
+        numeric_ids=True,
+    )
+    assert b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read" in get_acl(file2.name)["acl_extended"]
+    assert (
+        b"group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read"
+        in get_acl(file2.name, numeric_ids=True)["acl_extended"]
+    )

--- a/src/borg/testsuite/platform_linux.py
+++ b/src/borg/testsuite/platform_linux.py
@@ -1,0 +1,104 @@
+import os
+import tempfile
+
+from ..platform import acl_get, acl_set
+from .platform import (
+    DEFAULT_ACL,
+    ACCESS_ACL,
+    skipif_not_linux,
+    skipif_fakeroot_detected,
+    skipif_acls_not_working,
+    skipif_no_ubel_user,
+)
+
+# set module-level skips
+pytestmark = [skipif_not_linux, skipif_fakeroot_detected]
+
+
+def get_acl(path, numeric_ids=False):
+    item = {}
+    acl_get(path, item, os.stat(path), numeric_ids=numeric_ids)
+    return item
+
+
+def set_acl(path, access=None, default=None, numeric_ids=False):
+    item = {"acl_access": access, "acl_default": default}
+    acl_set(path, item, numeric_ids=numeric_ids)
+
+
+@skipif_acls_not_working
+def test_access_acl():
+    file = tempfile.NamedTemporaryFile()
+    assert get_acl(file.name) == {}
+
+    set_acl(
+        file.name,
+        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
+        numeric_ids=False,
+    )
+    assert b"user:root:rw-:0" in get_acl(file.name)["acl_access"]
+    assert b"group:root:rw-:0" in get_acl(file.name)["acl_access"]
+    assert b"user:0:rw-:0" in get_acl(file.name, numeric_ids=True)["acl_access"]
+
+    file2 = tempfile.NamedTemporaryFile()
+    set_acl(
+        file2.name,
+        access=b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n",
+        numeric_ids=True,
+    )
+    assert b"user:9999:rw-:9999" in get_acl(file2.name)["acl_access"]
+    assert b"group:9999:rw-:9999" in get_acl(file2.name)["acl_access"]
+
+
+@skipif_acls_not_working
+def test_default_acl():
+    tmpdir = tempfile.mkdtemp()
+    assert get_acl(tmpdir) == {}
+    set_acl(tmpdir, access=ACCESS_ACL, default=DEFAULT_ACL)
+    assert get_acl(tmpdir)["acl_access"] == ACCESS_ACL
+    assert get_acl(tmpdir)["acl_default"] == DEFAULT_ACL
+
+
+@skipif_acls_not_working
+@skipif_no_ubel_user
+def test_non_ascii_acl():
+    # Testing non-ascii ACL processing to see whether our code is robust.
+    # I have no idea whether non-ascii ACLs are allowed by the standard,
+    # but in practice they seem to be out there and must not make our code explode.
+    file = tempfile.NamedTemporaryFile()
+    assert get_acl(file.name) == {}
+    nothing_special = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\n"
+    # TODO: can this be tested without having an existing system user übel with uid 666 gid 666?
+    user_entry = "user:übel:rw-:666".encode()
+    user_entry_numeric = b"user:666:rw-:666"
+    group_entry = "group:übel:rw-:666".encode()
+    group_entry_numeric = b"group:666:rw-:666"
+    acl = b"\n".join([nothing_special, user_entry, group_entry])
+    set_acl(file.name, access=acl, numeric_ids=False)
+
+    acl_access = get_acl(file.name, numeric_ids=False)["acl_access"]
+    assert user_entry in acl_access
+    assert group_entry in acl_access
+
+    acl_access_numeric = get_acl(file.name, numeric_ids=True)["acl_access"]
+    assert user_entry_numeric in acl_access_numeric
+    assert group_entry_numeric in acl_access_numeric
+
+    file2 = tempfile.NamedTemporaryFile()
+    set_acl(file2.name, access=acl, numeric_ids=True)
+    acl_access = get_acl(file2.name, numeric_ids=False)["acl_access"]
+    assert user_entry in acl_access
+    assert group_entry in acl_access
+
+    acl_access_numeric = get_acl(file.name, numeric_ids=True)["acl_access"]
+    assert user_entry_numeric in acl_access_numeric
+    assert group_entry_numeric in acl_access_numeric
+
+
+def test_utils():
+    from ..platform.linux import acl_use_local_uid_gid
+
+    assert acl_use_local_uid_gid(b"user:nonexistent1234:rw-:1234") == b"user:1234:rw-"
+    assert acl_use_local_uid_gid(b"group:nonexistent1234:rw-:1234") == b"group:1234:rw-"
+    assert acl_use_local_uid_gid(b"user:root:rw-:0") == b"user:0:rw-"
+    assert acl_use_local_uid_gid(b"group:root:rw-:0") == b"group:0:rw-"

--- a/src/borg/testsuite/platform_posix.py
+++ b/src/borg/testsuite/platform_posix.py
@@ -1,0 +1,18 @@
+from ..platform import swidth
+from .platform import skipif_not_posix
+
+
+# set module-level skips
+pytestmark = skipif_not_posix
+
+
+def test_posix_swidth_ascii():
+    assert swidth("borg") == 4
+
+
+def test_posix_swidth_cjk():
+    assert swidth("バックアップ") == 6 * 2
+
+
+def test_posix_swidth_mixed():
+    assert swidth("borgバックアップ") == 4 + 6 * 2


### PR DESCRIPTION
This is one of the last remaining files in the test suite to have quite a bit of unittest and `BaseTestCase` usages, so I split it into its own PR. Will convert all unittest to pytest, remove `BaseTestCase` entirely, and rename some tests to follow the naming conventions of the classes they are being pull from. 