### PR TITLE
`platform_freebsd.py` dummy test file

### DIFF
--- a/src/borg/testsuite/platform.py
+++ b/src/borg/testsuite/platform.py
@@ -73,6 +73,7 @@ def are_acls_working():
 # define skips available to platform tests
 skipif_not_linux = pytest.mark.skipif(not is_linux, reason="linux only test")
 skipif_not_darwin = pytest.mark.skipif(not is_darwin, reason="darwin only test")
+skipif_not_freebsd = pytest.mark.skipif(not is_freebsd, reason="freebsd only test")
 skipif_not_posix = pytest.mark.skipif(not (is_linux or is_freebsd or is_darwin), reason="POSIX only tests")
 skipif_fakeroot_detected = pytest.mark.skipif(fakeroot_detected(), reason="not compatible with fakeroot")
 skipif_acls_not_working = pytest.mark.skipif(not are_acls_working(), reason="ACLs do not work")

--- a/src/borg/testsuite/platform_freebsd.py
+++ b/src/borg/testsuite/platform_freebsd.py
@@ -1,4 +1,4 @@
-""" Dummy file for now, will eventually contain FreeBSD ACL tests """
+"""Dummy file for now, will eventually contain FreeBSD ACL tests."""
 import pytest
 
 from .platform import skipif_not_freebsd

--- a/src/borg/testsuite/platform_freebsd.py
+++ b/src/borg/testsuite/platform_freebsd.py
@@ -1,0 +1,25 @@
+""" Dummy file for now, will eventually contain freebsd ACL tests """
+import pytest
+
+from .platform import skipif_not_freebsd
+
+# set module-level skips
+pytestmark = [skipif_not_freebsd]
+
+
+def get_acl():
+    return
+
+
+def get_set_acl():
+    return
+
+
+@pytest.mark.skip(reason="not yet implemented")
+def test_access_acl():
+    pass
+
+
+@pytest.mark.skip(reason="not yet implemented")
+def test_default_acl():
+    pass

--- a/src/borg/testsuite/platform_freebsd.py
+++ b/src/borg/testsuite/platform_freebsd.py
@@ -1,4 +1,4 @@
-""" Dummy file for now, will eventually contain freebsd ACL tests """
+""" Dummy file for now, will eventually contain FreeBSD ACL tests """
 import pytest
 
 from .platform import skipif_not_freebsd
@@ -22,4 +22,9 @@ def test_access_acl():
 
 @pytest.mark.skip(reason="not yet implemented")
 def test_default_acl():
+    pass
+
+
+@pytest.mark.skip(reason="not yet implemented")
+def test_nfs4_acl():
     pass


### PR DESCRIPTION
Creates a dummy file for ACL testing FreeBSD. Relates to issue #7745.