### PR TITLE
Fixed exclusion of cache and temp folders in quickstart example.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,8 +181,8 @@ backed up and that the ``prune`` command keeps and deletes the correct backups.
         --show-rc                       \
         --compression lz4               \
         --exclude-caches                \
-        --exclude 'home/*/.cache/*'     \
-        --exclude 'var/tmp/*'           \
+        --exclude '/home/*/.cache/*'    \
+        --exclude '/var/tmp/*'          \
                                         \
         '{hostname}-{now}'              \
         /etc                            \


### PR DESCRIPTION
The example in the quickstart documentation was missing a leading slash in the excluded folders, resulting in the .cache and temp folders not being excluded.
I am using version 1.1.16, but I found nothing leading me to believe that the path handeling of excluded folders has changed since that version.
