### PR TITLE
docs: minor fix to CVE-2023-36811 related upgrade instructions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,7 +29,7 @@ places. Borg now considers archives without TAM as garbage or an attack.
 
 We are not aware of others having discovered, disclosed or exploited this vulnerability.
 
-Below, if we speak of borg 1.2.5, we mean a borg version >= 1.2.5 **or** a
+Below, if we speak of borg 1.2.6, we mean a borg version >= 1.2.6 **or** a
 borg version that has the relevant security patches for this vulnerability applied
 (could be also an older version in that case).
 


### PR DESCRIPTION
while the main issue in the code has been fixed since 1.2.5, let's better refer to 1.2.6, which has fixes in upgrade docs and code.
