### PR TITLE
OpenBSD only: switch to OpenSSL-3.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,7 @@ def packages_openbsd
     pkg_add lz4
     pkg_add zstd
     pkg_add git  # no fakeroot
-    pkg_add openssl%1.1
+    pkg_add openssl%3.0
     pkg_add py3-pip
     pkg_add py3-virtualenv
   EOF

--- a/setup.py
+++ b/setup.py
@@ -161,8 +161,8 @@ if not on_rtd:
         # Use openssl (not libressl) because we need AES-OCB via EVP api. Link
         # it statically to avoid conflicting with shared libcrypto from the base
         # OS pulled in via dependencies.
-        crypto_ext_lib = {"include_dirs": ["/usr/local/include/eopenssl11"]}
-        crypto_extra_objects += ["/usr/local/lib/eopenssl11/libcrypto.a"]
+        crypto_ext_lib = {"include_dirs": ["/usr/local/include/eopenssl30"]}
+        crypto_extra_objects += ["/usr/local/lib/eopenssl30/libcrypto.a"]
     else:
         crypto_ext_lib = lib_ext_kwargs(pc, "BORG_OPENSSL_PREFIX", "crypto", "libcrypto", ">=1.1.1")
 


### PR DESCRIPTION
OpenSSL-1.1.1 reached EOL status. Switch building on OpenBSD to OpenSSL-3.0 (LTS version).