### PR TITLE
remove twine from requirements

### DIFF
--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -10,5 +10,4 @@ pytest-xdist==3.3.1
 pytest-cov==4.1.0
 pytest-benchmark==4.0.0
 Cython==3.0.2
-twine==4.0.2
 pre-commit==3.4.0

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -10,5 +10,4 @@ pytest-xdist
 pytest-cov
 pytest-benchmark
 Cython
-twine
 pre-commit


### PR DESCRIPTION
twine is only needed at release time, no need
for all developers or all test runs to install
this.

also, some requirement of twine needs a rust
compiler, so if there is no rust compiler,
automated runs will abort due to that.
