### PR TITLE
remove twine from requirements

### DIFF
--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -9,5 +9,4 @@ pytest-xdist==3.1.0
 pytest-cov==4.0.0
 pytest-benchmark==4.0.0
 Cython==0.29.36
-twine==4.0.2
 python-dateutil==2.8.2

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -9,6 +9,5 @@ pytest-xdist
 pytest-cov
 pytest-benchmark
 Cython
-twine
 python-dateutil
 pre-commit


### PR DESCRIPTION
twine is only needed at release time, no need
for all developers or all test runs to install
this.

also, some requirement of twine needs a rust
compiler, so if there is no rust compiler,
automated runs will abort due to that.
