### PR TITLE
Update borg-recreate.1: fix `--target TARGET` description

### DIFF
--- a/docs/man/borg-recreate.1
+++ b/docs/man/borg-recreate.1
@@ -160,7 +160,7 @@ consider archives older than (now \- TIMESPAN), e.g. 7d oder 12m.
 consider archives newer than (now \- TIMESPAN), e.g. 7d or 12m.
 .TP
 .BI \-\-target \ TARGET
-create a new archive with the name ARCHIVE, do not replace existing archive (only applies for a single archive)
+create a new archive with the name TARGET, do not replace existing archive (only applies for a single archive)
 .TP
 .BI \-c \ SECONDS\fR,\fB \ \-\-checkpoint\-interval \ SECONDS
 write checkpoint every SECONDS seconds (Default: 1800)


### PR DESCRIPTION
In `--target TARGET` description it says the new archive will have the  name `ARCHIVE` while the correct is the new name `TARGET`.

