### PR TITLE
Prevent CLI argument issues in scripts/glibc_check.py

### DIFF
--- a/scripts/glibc_check.py
+++ b/scripts/glibc_check.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 
 verbose = True
-objdump = "objdump -T %s"
 glibc_re = re.compile(r"GLIBC_([0-9]\.[0-9]+)")
 
 
@@ -32,7 +31,7 @@ def main():
     overall_versions = set()
     for filename in filenames:
         try:
-            output = subprocess.check_output(objdump % filename, shell=True, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(["objdump", "-T", filename], stderr=subprocess.STDOUT)
             output = output.decode()
             versions = {parse_version(match.group(1)) for match in glibc_re.finditer(output)}
             requires_glibc = max(versions)


### PR DESCRIPTION
Hi y'all,

There's a small issue in `scripts/glibc_check.py`: it uses `shell=True` with untrusted input leading to some problems. Given that it's a completely separate script mentioned at the bottom of the FAQ meant for developers it's not in a practical sense a security issue, but still.

Before:
```
$ python3 scripts/glibc_check.py 2.11 '/bin/date; touch /tmp/ohno'
The binaries do not work with the given glibc 2.11. Minimum is: 2.34

$ ls -al /tmp/ohno 
-rw-r--r-- 1 quinox development 0 Oct  6 14:40 /tmp/ohno
```

After:
```
$ python3 scripts/glibc_check.py 2.11 '/bin/date; touch /tmp/ohno'
/bin/date; touch /tmp/ohno errored.
Traceback (most recent call last):
  File "/tmp/borg/scripts/glibc_check.py", line 61, in <module>
    ok = main()
  File "/tmp/borg/scripts/glibc_check.py", line 46, in main
    wanted = max(overall_versions)
ValueError: max() arg is an empty sequence

$ ls -la /tmp/ohno
ls: cannot access '/tmp/ohno': No such file or directory
```

(the crash was already present in the original version when given a non-existing path)