### PR TITLE
feat(docs): use virtualenv on Cygwin

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -332,6 +332,7 @@ Use the Cygwin installer to install the dependencies::
     libssl-devel libxxhash-devel liblz4-devel libzstd-devel
     binutils gcc-g++ git make openssh
 
+Make sure to use a virtual environment to avoid confusions with any Python installed on Windows.
 
 .. _windows-binary:
 


### PR DESCRIPTION
Hint for Cygwin users to make sure they use a virtual environment. Not using a virtual environment will be likely troublesome if there is already a Python installed on Windows.


Fell free to change anything in this text :)