### PR TITLE
Clarify borg prune -a option description

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3025,10 +3025,7 @@ class Archiver:
             group.add_argument('-a', '--glob-archives', metavar='GLOB', dest='glob_archives',
                                type=GlobSpec, action=Highlander,
                                help='only consider archive names matching the glob. '
-                               'sh: rules apply (without actually using the sh: prefix), see "borg help patterns".\n'
-                               'Warning: In borg v2 the option -a will accept general patterns like sh:, re:, etc.'
-                               'This has the sideffect that patterns with a wildcard (*) will not be expanded but matched exactly.'
-                               'See borg v2 documentation for borg prune.')
+                                    'sh: rules apply (without actually using the sh: prefix), see "borg help patterns".')
 
             if sort_by:
                 sort_by_default = 'timestamp'

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3025,7 +3025,8 @@ class Archiver:
             group.add_argument('-a', '--glob-archives', metavar='GLOB', dest='glob_archives',
                                type=GlobSpec, action=Highlander,
                                help='only consider archive names matching the glob. '
-                                    'sh: rules apply, see "borg help patterns".')
+                               'sh: rules apply (without actually using the sh: prefix), see "borg help patterns".\n'
+                               'Warning: In borg v2 the option -a will acceptgeneral patterns like sh:, re:, etc. This has the sideffect that patterns with a wildcard * will not be expanded but matched exactly. See borg v2 documentation for borg prune. ')
 
             if sort_by:
                 sort_by_default = 'timestamp'

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3026,7 +3026,9 @@ class Archiver:
                                type=GlobSpec, action=Highlander,
                                help='only consider archive names matching the glob. '
                                'sh: rules apply (without actually using the sh: prefix), see "borg help patterns".\n'
-                               'Warning: In borg v2 the option -a will acceptgeneral patterns like sh:, re:, etc. This has the sideffect that patterns with a wildcard * will not be expanded but matched exactly. See borg v2 documentation for borg prune. ')
+                               'Warning: In borg v2 the option -a will accept general patterns like sh:, re:, etc.'
+                               'This has the sideffect that patterns with a wildcard (*) will not be expanded but matched exactly.'
+                               'See borg v2 documentation for borg prune.')
 
             if sort_by:
                 sort_by_default = 'timestamp'


### PR DESCRIPTION
The -a option for borg prune accepts only glob pattern (i.e. sh:) but not the actual prefix sh: which can be confusing especially for people who don't actually know what a glob pattern is. Also added a warning for the change in behaviour in borg v2.

fixes #7868 