### PR TITLE
linux: use pkgconfig to find libacl

### DIFF
--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -194,6 +194,9 @@ Directories and files:
 Building:
     BORG_OPENSSL_PREFIX
         Adds given OpenSSL header file directory to the default locations (setup.py).
+    BORG_LIBACL_PREFIX
+        Adds given prefix directory to the default locations. If an 'include/acl/libacl.h' is found
+        Borg will be linked against the system libacl instead of a bundled implementation. (setup.py)
     BORG_LIBLZ4_PREFIX
         Adds given prefix directory to the default locations. If a 'include/lz4.h' is found Borg
         will be linked against the system liblz4 instead of a bundled implementation. (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,17 @@ if not on_rtd:
         dict(extra_compile_args=cflags),
     )
 
+    if sys.platform == "linux":
+        linux_ext_kwargs = members_appended(
+            dict(sources=[platform_linux_source]),
+            lib_ext_kwargs(pc, "BORG_LIBACL_PREFIX", "acl", "libacl", ">=2.3.1"),
+            dict(extra_compile_args=cflags),
+        )
+    else:
+        linux_ext_kwargs = members_appended(
+            dict(sources=[platform_linux_source], libraries=["acl"], extra_compile_args=cflags),
+        )
+
     # note: _chunker.c and _hashindex.c are relatively complex/large pieces of handwritten C code,
     # thus we undef NDEBUG for them, so the compiled code will contain and execute assert().
     ext_modules += [
@@ -198,7 +209,8 @@ if not on_rtd:
     ]
 
     posix_ext = Extension("borg.platform.posix", [platform_posix_source], extra_compile_args=cflags)
-    linux_ext = Extension("borg.platform.linux", [platform_linux_source], libraries=["acl"], extra_compile_args=cflags)
+    linux_ext = Extension("borg.platform.linux", **linux_ext_kwargs)
+
     syncfilerange_ext = Extension(
         "borg.platform.syncfilerange", [platform_syncfilerange_source], extra_compile_args=cflags
     )


### PR DESCRIPTION
Using pkgconfig gives a more meaningful error message in case libacl development files are missing.