### PR TITLE
packaging: Explicit add data files to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ prune .github
 include src/borg/platform/darwin.c src/borg/platform/freebsd.c src/borg/platform/linux.c src/borg/platform/posix.c
 include src/borg/platform/syncfilerange.c
 include src/borg/platform/windows.c
+include src/borg/paperkey.html
+include src/borg/testsuite/archiver/repo12.tar.gz


### PR DESCRIPTION
We've started seeing some failures to build in Debian and Ubuntu that can be traced to those files missing from the manifest when we're calling setup.py install.

Now, this started failing fairly recently, so I'm guessing it's actually a change of behaviour in the SCM plugin and/or setuptools. It makes sense though, since we're packaging from the tarball, which isn't in the Git context needed to actually include those data files.
