### PR TITLE
CI: increase timeout to 90min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
esp. the macOS CI jobs are sometimes rather slow,
so 40min were not enough.
