### PR TITLE
check --repair fixes shadow_index (1.2-maint)

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -917,6 +917,7 @@ class Repository:
                     s, _ = self.index[key]
                     self.compact[s] += size
                     self.segments[s] -= 1
+                    self.shadow_index.setdefault(key, []).append(s)
                 except KeyError:
                     pass
                 self.index[key] = segment, offset
@@ -935,6 +936,7 @@ class Repository:
                         self.segments[s] -= 1
                         size = self.io.read(s, offset, key, read_data=False)
                         self.compact[s] += size
+                        self.shadow_index.setdefault(key, []).append(s)
             elif tag == TAG_COMMIT:
                 continue
             else:

--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -826,6 +826,15 @@ class RepositoryHintsTestCase(RepositoryTestCaseBase):
         self.assert_equal(compact_expected, self.repository.compact)
         del self.repository.segments[2]  # ignore the segment created by put(H(42), ...)
         self.assert_equal(segments_expected, self.repository.segments)
+        self.reopen()
+        self.assert_equal(self.repository.check(repair=True), True)
+        self.reopen()
+        self.repository.put(H(42), b'foobar')  # this will call prepare_txn() and load the hints data
+        self.assert_equal(shadow_index_expected, self.repository.shadow_index)
+        # sizes do not match, with vs. without header?
+        # self.assert_equal(compact_expected, self.repository.compact)
+        del self.repository.segments[2]  # ignore the segment created by put(H(42), ...)
+        self.assert_equal(segments_expected, self.repository.segments)
 
     def test_hints_behaviour(self):
         self.repository.put(H(0), b'data')


### PR DESCRIPTION
This is a fix to `borg check --repair` so it will recreate a complete shadow_index inside the hints file.

Doing that should fix **past** issues caused by the double-put bug (see #7896) and by the persistence of the shadow index, which is new since borg 1.2.

When running borg in client/server mode (with a remote repo), the fix needs to get applied repo/server-side.