### PR TITLE
Python 3.13: include `unistd.h` in `_chunker.c`

### DIFF
--- a/src/borg/_chunker.c
+++ b/src/borg/_chunker.c
@@ -1,5 +1,8 @@
 #include <Python.h>
 #include <fcntl.h>
+#if !defined(_MSC_VER)
+#   include <unistd.h>
+#endif
 
 /* Cyclic polynomial / buzhash
 


### PR DESCRIPTION
With Python 3.13, Python.h no longer includes the `<unistd.h>` standard header file: https://docs.python.org/3.13/whatsnew/3.13.html#id8

Disclaimer: I only tested this with borg 1.2 as I failed to create a Python 3.13 virtualenv with borg 2. However the fix 