### PR TITLE
create --*-from-command: run subcommands with a clean environment, fixes #7916

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -25,6 +25,7 @@ from ..helpers import dir_is_tagged
 from ..helpers import log_multi
 from ..helpers import basic_json_data, json_print
 from ..helpers import flags_dir, flags_special_follow, flags_special
+from ..helpers import prepare_subprocess_env
 from ..helpers import sig_int, ignore_sigint
 from ..helpers import iter_separated
 from ..helpers import MakePathSafeAction
@@ -70,8 +71,12 @@ class CreateMixIn:
                 if not dry_run:
                     try:
                         try:
+                            env = prepare_subprocess_env(system=True)
                             proc = subprocess.Popen(
-                                args.paths, stdout=subprocess.PIPE, preexec_fn=None if is_win32 else ignore_sigint
+                                args.paths,
+                                stdout=subprocess.PIPE,
+                                env=env,
+                                preexec_fn=None if is_win32 else ignore_sigint,
                             )
                         except (FileNotFoundError, PermissionError) as e:
                             self.print_error("Failed to execute command: %s", e)
@@ -93,8 +98,9 @@ class CreateMixIn:
                 paths_sep = eval_escapes(args.paths_delimiter) if args.paths_delimiter is not None else "\n"
                 if args.paths_from_command:
                     try:
+                        env = prepare_subprocess_env(system=True)
                         proc = subprocess.Popen(
-                            args.paths, stdout=subprocess.PIPE, preexec_fn=None if is_win32 else ignore_sigint
+                            args.paths, stdout=subprocess.PIPE, env=env, preexec_fn=None if is_win32 else ignore_sigint
                         )
                     except (FileNotFoundError, PermissionError) as e:
                         self.print_error("Failed to execute command: %s", e)


### PR DESCRIPTION
When borg invokes a system command, it needs to prepare the environment for that. This is especially important when using a pyinstaller-made borg fat binary that works with a modified env var LD_LIBRARY_PATH - system commands may crash with that.

borg already had calls to prepare_subprocess_env at some places (e.g. when invoking ssh for the remote repo connection), but they were missing for:

borg create --content-from-command ...
borg create --paths-from-command ...
