### PR TITLE
include unistd.h in _chunker.c

### DIFF
--- a/src/borg/_chunker.c
+++ b/src/borg/_chunker.c
@@ -1,5 +1,8 @@
 #include <Python.h>
 #include <fcntl.h>
+#if !defined(_MSC_VER)
+#   include <unistd.h>
+#endif
 
 /* Cyclic polynomial / buzhash
 


### PR DESCRIPTION
With Python 3.13, Python.h no longer includes the <unistd.h> standard header file: https://docs.python.org/3.13/whatsnew/3.13.html#id8

(backport from master)