### PR TITLE
sync with 1.2-maint

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -390,8 +390,12 @@ Fixes:
 - check/compact: fix spurious reappearance of orphan chunks since borg 1.2, #6687 -
   this consists of 2 fixes:
 
-  - for existing chunks: check --repair: recreate shadow index, #6687
-  - for newly created chunks: update shadow index when doing a double-put, #5661
+  - for existing chunks: check --repair: recreate shadow index, #7897 #6687
+  - for newly created chunks: update shadow index when doing a double-put, #7896 #5661
+
+  If you have experienced issue #6687, you may want to run borg check --repair
+  after upgrading to borg 1.2.7 to recreate the shadow index and get rid of the
+  issue for existing chunks.
 - LockRoster.modify: no KeyError if element was already gone, #7937
 - create --X-from-command: run subcommands with a clean environment, #7916
 - list --sort-by: support "archive" as alias of "name", #7873

--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -14,7 +14,7 @@ resource usage (RAM and disk space) as the amount of resources needed is
 (also) determined by the total amount of chunks in the repository (see
 :ref:`cache-memory-usage` for details).
 
-``--chunker-params=buzhash,10,23,16,4095`` results in a fine-grained deduplication|
+``--chunker-params=buzhash,10,23,16,4095`` results in a fine-grained deduplication
 and creates a big amount of chunks and thus uses a lot of resources to manage
 them. This is good for relatively small data volumes and if the machine has a
 good amount of free RAM and disk space.


### PR DESCRIPTION
I forked a new maintenance branch `1.4-maint` at borg 1.2.7.

This brings it in sync with updates that were done in 1.2-maint after 1.2.7.