### PR TITLE
catch FileNotFoundError in `borg with-lock`, fixes #8022

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1853,7 +1853,7 @@ class Archiver:
             ret = subprocess.call([args.command] + args.args, env=env)
         except (ValueError, FileNotFoundError, OSError) as e:
             self.print_error(f"Could not execute '{args.command}': {e}")
-            ret = -1
+            ret = -2
         finally:
             # we need to commit the "no change" operation we did to the manifest
             # because it created a new segment file in the repository. if we would

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1852,8 +1852,8 @@ class Archiver:
             # we exit with the return code we get from the subprocess
             ret = subprocess.call([args.command] + args.args, env=env)
         except (ValueError, FileNotFoundError, OSError) as e:
-            self.print_error(f"Could not execute '{args.command}': {e}")
-            ret = -2
+            self.print_error(f"Error while trying to run '{args.command}': {e}")
+            ret = EXIT_ERROR
         finally:
             # we need to commit the "no change" operation we did to the manifest
             # because it created a new segment file in the repository. if we would

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1851,7 +1851,7 @@ class Archiver:
         try:
             # we exit with the return code we get from the subprocess
             ret = subprocess.call([args.command] + args.args, env=env)
-        except (ValueError, FileNotFoundError, OSError) as e:
+        except (FileNotFoundError, OSError, ValueError) as e:
             self.print_error(f"Error while trying to run '{args.command}': {e}")
             ret = EXIT_ERROR
         finally:

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1850,7 +1850,13 @@ class Archiver:
         env = prepare_subprocess_env(system=True)
         try:
             # we exit with the return code we get from the subprocess
-            return subprocess.call([args.command] + args.args, env=env)
+            try:
+                ret = subprocess.call([args.command] + args.args, env=env)
+            except FileNotFoundError as e:
+                self.print_error(f"Could not execute '{args.command}': {e}")
+                ret = 1
+            finally:
+                return ret
         finally:
             # we need to commit the "no change" operation we did to the manifest
             # because it created a new segment file in the repository. if we would

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3188,7 +3188,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     def test_with_lock_non_existent_command(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
-        cmd = 'non_existent_command',
+        cmd = ['non_existent_command', ]
         self.cmd('with-lock', self.repository_location, *cmd, fork=True, exit_code=EXIT_ERROR)
 
     def test_recreate_list_output(self):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3188,7 +3188,7 @@ class ArchiverTestCase(ArchiverTestCaseBase):
 
     def test_with_lock_non_existent_command(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
-        cmd = 'non_existant_command'
+        cmd = 'non_existent_command',
         self.cmd('with-lock', self.repository_location, *cmd, fork=True, exit_code=EXIT_ERROR)
 
     def test_recreate_list_output(self):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3186,6 +3186,11 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         cmd = 'python3', '-c', 'import os, sys; sys.exit(42 if os.path.exists("%s") else 23)' % lock_path
         self.cmd('with-lock', self.repository_location, *cmd, fork=True, exit_code=42)
 
+    def test_with_lock_non_existent_command(self):
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        cmd = 'non_existant_command'
+        self.cmd('with-lock', self.repository_location, *cmd, fork=True, exit_code=EXIT_ERROR)
+
     def test_recreate_list_output(self):
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.create_regular_file('file1', size=0)


### PR DESCRIPTION
Add exception handling. Prints error message instead of exception if binary run with `with-lock` does not exist:

```bash
(venv) kmille@linbox:borg venv/bin/borg with-lock ~/tmp/borgrepo noo
Could not execute 'noo': [Errno 2] No such file or directory: 'noo'
```

I only handle `FileNotFoundException`. Here are the [subprocess docs about exceptions](https://docs.python.org/3/library/subprocess.html#exceptions). We could also catch [SubprocessError](https://docs.python.org/3/library/subprocess.html#subprocess.SubprocessError), [OSError](https://docs.python.org/3/library/exceptions.html#OSError) and [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError) but then I'm still not sure if that's all. I really like python but to find out which exceptions can be raised is... pain..

Let me hear what you think.


