### PR TITLE
implement "borg version", fixes #7829

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -288,6 +288,17 @@ class Archiver:
             storage_quota=args.storage_quota,
         ).serve()
 
+    def do_version(self, args):
+        """Display the borg client / borg server version"""
+        from borg.version import parse_version, format_version
+        client_version = parse_version(__version__)
+        if args.location.proto == 'ssh':
+            with RemoteRepository(args.location.omit_archive(), lock=False, args=args) as repository:
+                server_version = repository.server_version
+        else:
+            server_version = client_version
+        print(f"{format_version(client_version)} / {format_version(server_version)}")
+
     @with_repository(create=True, exclusive=True, manifest=False)
     def do_init(self, args, repository):
         """Initialize an empty repository"""
@@ -4133,6 +4144,40 @@ class Archiver:
         subparser.add_argument('--json', action='store_true',
                                help='format output as JSON')
         define_archive_filters_group(subparser)
+
+        # borg version
+        version_epilog = process_epilog("""
+        This command displays the borg client version / borg server version.
+
+        If a local repo is given, the client code directly accesses the repository,
+        thus we show the client version also as the server version.
+
+        If a remote repo is given (e.g. ssh:), the remote borg is queried and
+        its version is displayed as the server version.
+
+        Examples::
+
+            # local repo (client uses 1.4.0 alpha version)
+            $ borg version /mnt/backup
+            1.4.0a / 1.4.0a
+
+            # remote repo (client uses 1.4.0 alpha, server uses 1.2.7 release)
+            $ borg version ssh://borg@borgbackup:repo
+            1.4.0a / 1.2.7
+
+        Due to the version tuple format used in borg client/server negotiation, only
+        a simplified version is displayed (as provided by borg.version.format_version).
+
+        There is also borg --version to display a potentially more precise client version.
+        """)
+        subparser = subparsers.add_parser('version', parents=[common_parser], add_help=False,
+                                          description=self.do_version.__doc__, epilog=version_epilog,
+                                          formatter_class=argparse.RawDescriptionHelpFormatter,
+                                          help='display borg client version / borg server version')
+        subparser.set_defaults(func=self.do_version)
+        subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
+                               type=location_validator(archive=False),
+                               help='repository (used to determine client/server situation)')
 
         # borg init
         init_epilog = process_epilog("""


### PR DESCRIPTION
Since long, we have borg --version to display the borg (client) version string in its very detailed form provided by setuptools_scm, e.g.:

borg 1.4.0.dev119+gc7cef548.d20240119

Now there is an additional new command "borg version <REPO>", which shows the client / server version, e.g.:

1.4.0a / 1.2.7

If a local repo is given, the client code directly accesses the repository, thus we show the client version also as the server version.

If a remote repo is given (e.g. ssh:), the remote borg is queried and its version is displayed as the server version.

Due to the version tuple format used in borg client/server negotiation, only a simplified version is displayed (as provided by borg.version.format_version).
