### PR TITLE
gh actions: increase timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   lint:
 
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 180
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
especially the macos workers are sometimes extremely slow.