### PR TITLE
implement "borg version", fixes #7829

### DIFF
--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -90,6 +90,7 @@ from .rlist_cmd import RListMixIn
 from .serve_cmd import ServeMixIn
 from .tar_cmds import TarMixIn
 from .transfer_cmd import TransferMixIn
+from .version_cmd import VersionMixIn
 
 
 class Archiver(
@@ -119,6 +120,7 @@ class Archiver(
     ServeMixIn,
     TarMixIn,
     TransferMixIn,
+    VersionMixIn,
 ):
     def __init__(self, lock_wait=None, prog=None):
         self.exit_code = EXIT_SUCCESS
@@ -347,6 +349,7 @@ class Archiver(
         self.build_parser_serve(subparsers, common_parser, mid_common_parser)
         self.build_parser_tar(subparsers, common_parser, mid_common_parser)
         self.build_parser_transfer(subparsers, common_parser, mid_common_parser)
+        self.build_parser_version(subparsers, common_parser, mid_common_parser)
         return parser
 
     def get_args(self, argv, cmd):

--- a/src/borg/archiver/version_cmd.py
+++ b/src/borg/archiver/version_cmd.py
@@ -1,0 +1,65 @@
+import argparse
+
+from .. import __version__
+from ..constants import *  # NOQA
+from ..helpers import EXIT_SUCCESS
+from ..remote import RemoteRepository
+
+from ..logger import create_logger
+
+logger = create_logger()
+
+
+class VersionMixIn:
+    def do_version(self, args):
+        """Display the borg client / borg server version"""
+        from borg.version import parse_version, format_version
+
+        client_version = parse_version(__version__)
+        if args.location.proto in ("ssh", "socket"):
+            with RemoteRepository(args.location, lock=False, args=args) as repository:
+                server_version = repository.server_version
+        else:
+            server_version = client_version
+        print(f"{format_version(client_version)} / {format_version(server_version)}")
+        return EXIT_SUCCESS
+
+    def build_parser_version(self, subparsers, common_parser, mid_common_parser):
+        from ._common import process_epilog
+
+        version_epilog = process_epilog(
+            """
+        This command displays the borg client version / borg server version.
+
+        If a local repo is given, the client code directly accesses the repository,
+        thus we show the client version also as the server version.
+
+        If a remote repo is given (e.g. ssh:), the remote borg is queried and
+        its version is displayed as the server version.
+
+        Examples::
+
+            # local repo (client uses 1.4.0 alpha version)
+            $ borg version /mnt/backup
+            1.4.0a / 1.4.0a
+
+            # remote repo (client uses 1.4.0 alpha, server uses 1.2.7 release)
+            $ borg version ssh://borg@borgbackup:repo
+            1.4.0a / 1.2.7
+
+        Due to the version tuple format used in borg client/server negotiation, only
+        a simplified version is displayed (as provided by borg.version.format_version).
+
+        There is also borg --version to display a potentially more precise client version.
+        """
+        )
+        subparser = subparsers.add_parser(
+            "version",
+            parents=[common_parser],
+            add_help=False,
+            description=self.do_version.__doc__,
+            epilog=version_epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            help="display borg client version / borg server version",
+        )
+        subparser.set_defaults(func=self.do_version)


### PR DESCRIPTION
Additional new command "borg -r <REPO> version" which shows client and server version.
