### PR TITLE
gh actions: increase timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   lint:
 
     runs-on: ubuntu-22.04
-    timeout-minutes: 2
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v3
@@ -139,7 +139,7 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
     - uses: actions/checkout@v3
@@ -195,7 +195,7 @@ jobs:
   windows:
 
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs: linux
 
     env:


### PR DESCRIPTION
especially the macos workers are sometimes extremely slow.
