### PR TITLE
check: fix return code for index entry value discrepancies

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1029,10 +1029,10 @@ class Repository:
             raise ValueError(self.path + " is in append-only mode")
         error_found = False
 
-        def report_error(msg):
+        def report_error(msg, *args):
             nonlocal error_found
             error_found = True
-            logger.error(msg)
+            logger.error(msg, *args)
 
         logger.info("Starting repository check")
         assert not self._active_txn
@@ -1122,8 +1122,8 @@ class Repository:
                 # self.index = "as rebuilt in-memory from segments"
                 if len(current_index) != len(self.index):
                     report_error("Index object count mismatch.")
-                    logger.error("Committed index: %d objects", len(current_index))
-                    logger.error("Rebuilt index:   %d objects", len(self.index))
+                    report_error("committed index: %d objects", len(current_index))
+                    report_error("rebuilt index:   %d objects", len(self.index))
                 else:
                     logger.info("Index object count match.")
                 line_format = "ID: %-64s rebuilt index: %-16s committed index: %-16s"
@@ -1131,14 +1131,14 @@ class Repository:
                 for key, value in self.index.iteritems():
                     current_value = current_index.get(key, not_found)
                     if current_value != value:
-                        logger.warning(line_format, bin_to_hex(key), value, current_value)
+                        report_error(line_format, bin_to_hex(key), value, current_value)
                 self._send_log()
                 for key, current_value in current_index.iteritems():
                     if key in self.index:
                         continue
                     value = self.index.get(key, not_found)
                     if current_value != value:
-                        logger.warning(line_format, bin_to_hex(key), value, current_value)
+                        report_error(line_format, bin_to_hex(key), value, current_value)
                 self._send_log()
             if repair:
                 self.write_index()


### PR DESCRIPTION
Also: use ERROR loglevel for these (not WARNING).

A different amount of index entries was already logged as error and led to "error_found = True" in repository.check.

Different values in the rebuilt index vs. the on-disk index were only logged on warning level, but did not lead to error_found = True.

Guess there is no reason why these should not be errors and lead to error_found = True, so this was fixed in this commit.

Minor related change: change report_error function args, so it can be called like logger.error - including giving a format AND args.
