### PR TITLE
fix: Error/CommandError have a output format for 1 argument

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -547,7 +547,7 @@ class Archiver:
                         if rc != 0:
                             raise CommandError(f'Command {args.paths[0]!r} exited with status {rc}')
                     except BackupError as e:
-                        raise Error('%s: %s', path, e)
+                        raise Error(f'{path!r}: {e}')
                 else:
                     status = '-'
                 self.print_file_status(status, path)


### PR DESCRIPTION
(backport from master, only thing todo here was that one place)
