### PR TITLE
[1.4-maint] No need to use OpenSSL 3.0 on OpenBSD

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -421,7 +421,6 @@ Other changes:
 - init: remove compatibility warning for borg <=1.0.8
   The warning refers to a compatibility issue not relevant any
   more since borg 1.0.9 (released 2016-12).
-- use OpenSSL 3.0 on OpenBSD
 - locate libacl via pkgconfig
 - scripts/make.py: move clean, build_man, build_usage to there,
   so we do not need to invoke setup.py directly, update docs

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ except ImportError:
 sys.path += [os.path.dirname(__file__)]
 
 is_win32 = sys.platform.startswith("win32")
-is_openbsd = sys.platform.startswith("openbsd")
 
 # Number of threads to use for cythonize, not used on windows
 cpu_threads = multiprocessing.cpu_count() if multiprocessing and multiprocessing.get_start_method() != "spawn" else None
@@ -124,12 +123,6 @@ if not on_rtd:
     crypto_extra_objects = []
     if is_win32:
         crypto_ext_lib = lib_ext_kwargs(pc, "BORG_OPENSSL_PREFIX", "libcrypto", "libcrypto", ">=1.1.1", lib_subdir="")
-    elif is_openbsd:
-        # Use openssl (not libressl) because we need AES-OCB via EVP api. Link
-        # it statically to avoid conflicting with shared libcrypto from the base
-        # OS pulled in via dependencies.
-        crypto_ext_lib = {"include_dirs": ["/usr/local/include/eopenssl30"]}
-        crypto_extra_objects += ["/usr/local/lib/eopenssl30/libcrypto.a"]
     else:
         crypto_ext_lib = lib_ext_kwargs(pc, "BORG_OPENSSL_PREFIX", "crypto", "libcrypto", ">=1.1.1")
 


### PR DESCRIPTION
borg-2.0 requires EVP_aes_256_ocb, which is not provided by LibreSSL. As such, OpenSSL-3.0 is needed on OpenBSD. borg-1.4 however does not use EVP_aes_256_ocb thus there is no need to use OpenSSL. Instead rely on LibreSSL.

Undo part of ccb1e92. Tested on OpenBSD -current.