### PR TITLE
changed insufficiently reserved length for log message 

### DIFF
--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -169,7 +169,7 @@ class PruneMixIn:
                     or (args.list_pruned and archive in to_delete)
                     or (args.list_kept and archive not in to_delete)
                 ):
-                    list_logger.info(f"{log_message:<40} {formatter.format_item(archive, jsonline=False)}")
+                    list_logger.info(f"{log_message:<42} {formatter.format_item(archive, jsonline=False)}")
             pi.finish()
             if sig_int:
                 # Ctrl-C / SIGINT: do not checkpoint (commit) again, we already have a checkpoint in this case.

--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -169,7 +169,7 @@ class PruneMixIn:
                     or (args.list_pruned and archive in to_delete)
                     or (args.list_kept and archive not in to_delete)
                 ):
-                    list_logger.info(f"{log_message:<42} {formatter.format_item(archive, jsonline=False)}")
+                    list_logger.info(f"{log_message:<44} {formatter.format_item(archive, jsonline=False)}")
             pi.finish()
             if sig_int:
                 # Ctrl-C / SIGINT: do not checkpoint (commit) again, we already have a checkpoint in this case.


### PR DESCRIPTION
During `borg prune` I've encountered a minor issue -- output was not properly aligned.

```
Keeping archive (rule: hourly #3):       2024-02-20-23:13:36                  Tue, 2024-02-20 23:13:38 [53dbb412a3d28b8d788cee0fe189d1ceefd4affd27866d23ffaee7cd45af5971]
Keeping archive (rule: hourly[oldest] #4): 2024-02-20-23:09:22                  Tue, 2024-02-20 23:09:24 [66392999b4cb3a71262f1bdff4ecd05bcb6b74c6dc1ae6a2c9903bcf4a8137b3]
```

This PR fixes this issue. Full command with output can be viewed [here](https://gist.github.com/galqiwi/4402da1a7eb46546c2973f574a261112).