### PR TITLE
changed insufficiently reserved length for log message (copy of #8152 for 1.2)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1619,7 +1619,7 @@ class Archiver:
                             rule=kept_because[archive.id][0], num=kept_because[archive.id][1]
                         )
                 if args.output_list:
-                    list_logger.info("{message:<40} {archive}".format(
+                    list_logger.info("{message:<44} {archive}".format(
                         message=log_message, archive=format_archive(archive)
                     ))
             pi.finish()


### PR DESCRIPTION
This PR fixes bug described in https://github.com/borgbackup/borg/pull/8152 for 1.2 branch