### PR TITLE
format_timedelta: use 3 decimal digits (ms)

### DIFF
--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -100,7 +100,7 @@ def format_timedelta(td):
     s = ts % 60
     m = int(ts / 60) % 60
     h = int(ts / 3600) % 24
-    txt = "%.2f seconds" % s
+    txt = "%.3f seconds" % s
     if m:
         txt = "%d minutes %s" % (m, txt)
     if h:

--- a/src/borg/testsuite/archive.py
+++ b/src/borg/testsuite/archive.py
@@ -61,8 +61,8 @@ def test_stats_format(stats):
 Number of files: 1
 Original size: 20 B
 Deduplicated size: 20 B
-Time spent in hashing: 0.00 seconds
-Time spent in chunking: 0.00 seconds
+Time spent in hashing: 0.000 seconds
+Time spent in chunking: 0.000 seconds
 Added files: 0
 Unchanged files: 0
 Modified files: 0

--- a/src/borg/testsuite/helpers.py
+++ b/src/borg/testsuite/helpers.py
@@ -368,7 +368,7 @@ def test_text_invalid(text):
 def test_format_timedelta():
     t0 = datetime(2001, 1, 1, 10, 20, 3, 0)
     t1 = datetime(2001, 1, 1, 12, 20, 4, 100000)
-    assert format_timedelta(t1 - t0) == "2 hours 1.10 seconds"
+    assert format_timedelta(t1 - t0) == "2 hours 1.100 seconds"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
maybe this fixes the frequently failing test.
also, giving ms makes more sense than 10ms granularity.
