### PR TITLE
setup.py: fix import error reporting for cythonize import, see #8208

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ except ImportError as exc:
     # either there is no Cython installed or there is some issue with it.
     cythonize = None
     cythonize_import_error_msg = "ImportError: " + str(exc)
+    if "failed to map segment from shared object" in cythonize_import_error_msg:
+        cythonize_import_error_msg += " Check if the borg build uses a +exec filesystem."
 
 sys.path += [os.path.dirname(__file__)]
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,11 @@ from setuptools.command.sdist import sdist
 
 try:
     from Cython.Build import cythonize
-except ImportError:
+    cythonize_import_error_msg = None
+except ImportError as exc:
+    # either there is no Cython installed or there is some issue with it.
     cythonize = None
+    cythonize_import_error_msg = "ImportError: " + str(exc)
 
 sys.path += [os.path.dirname(__file__)]
 
@@ -79,7 +82,9 @@ else:
 
     cython_c_files = [fn.replace(".pyx", ".c") for fn in cython_sources]
     if not on_rtd and not all(os.path.exists(path) for path in cython_c_files):
-        raise ImportError("The GIT version of Borg needs Cython. Install Cython or use a released version.")
+        raise ImportError("The GIT version of Borg needs a working Cython. " +
+                          "Install or fix Cython or use a released borg version. " +
+                          "Importing cythonize failed with: " + cythonize_import_error_msg)
 
 
 cmdclass = {"build_ext": build_ext, "sdist": Sdist}


### PR DESCRIPTION
Looks like borg's setup.py has hidden the real cause of a cythonize ImportError.

There are basically 2 cases:
- either there is no Cython installed, then the import fails because the module can not be found, or
- there is some issue within Cython and the import fails due to that.

It's important not to hide the real cause, especially if we run into case 2.

case 1 is kind of expected and frequent, case 2 is rare.
