### PR TITLE
allow msgpack 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 license = {text="BSD"}
 dependencies = [
-  "msgpack >=1.0.3, <=1.0.8",
+  "msgpack >=1.0.3, <=1.1.0",
   "packaging",
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0,
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -209,7 +209,7 @@ def is_supported_msgpack():
 
     if msgpack.version in []:  # < add bad releases here to deny list
         return False
-    return (1, 0, 3) <= msgpack.version <= (1, 0, 8)
+    return (1, 0, 3) <= msgpack.version <= (1, 1, 0)
 
 
 def get_limited_unpacker(kind):


### PR DESCRIPTION
tests with 1.1.0rc1 were successful, thus I assume 1.1.0 will also work ok.
