### PR TITLE
Fixed openSUSE dependencies in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -236,10 +236,10 @@ Install the dependencies automatically using zypper::
 Alternatively, you can enumerate all build dependencies in the command line::
 
     sudo zypper install python3 python3-devel \
-    libacl-devel openssl-devel libxxhash-devel \
+    libacl-devel openssl-devel xxhash-devel \
     python3-Cython python3-Sphinx python3-msgpack-python python3-pkgconfig pkgconf \
     python3-pytest python3-setuptools python3-setuptools_scm \
-    python3-sphinx_rtd_theme gcc gcc-c++
+    python3-sphinx_rtd_theme gcc gcc-c++ libzstd-devel liblz4-devel
     sudo zypper install python3-llfuse  # llfuse
 
 macOS

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -236,10 +236,10 @@ Install the dependencies automatically using zypper::
 Alternatively, you can enumerate all build dependencies in the command line::
 
     sudo zypper install python3 python3-devel \
-    libacl-devel openssl-devel xxhash-devel \
+    libacl-devel openssl-devel xxhash-devel libzstd-devel liblz4-devel \
     python3-Cython python3-Sphinx python3-msgpack-python python3-pkgconfig pkgconf \
     python3-pytest python3-setuptools python3-setuptools_scm \
-    python3-sphinx_rtd_theme gcc gcc-c++ libzstd-devel liblz4-devel
+    python3-sphinx_rtd_theme gcc gcc-c++
     sudo zypper install python3-llfuse  # llfuse
 
 macOS


### PR DESCRIPTION
Installing Borg from `pip` requires a few dependencies. Unfortunately, zypper can't find a few of those listed. Here's the fix.