### PR TITLE
Automatic rebuild cache on exception, fixes #5213

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -531,7 +531,12 @@ class LocalCache(CacheStatsMixin):
             self.security_manager.assert_access_unknown(warn_if_unencrypted, manifest, self.key)
             self.create()
 
-        self.open()
+        try:
+            self.open()
+        except:
+            self.wipe_cache()
+            self.open()
+
         try:
             self.security_manager.assert_secure(manifest, self.key, cache_config=self.cache_config)
 
@@ -924,7 +929,7 @@ class LocalCache(CacheStatsMixin):
         return True
 
     def wipe_cache(self):
-        logger.warning("Discarding incompatible cache and forcing a cache rebuild")
+        logger.warning("Discarding incompatible or corrupted cache and forcing a cache rebuild")
         archive_path = os.path.join(self.path, "chunks.archive.d")
         if os.path.isdir(archive_path):
             shutil.rmtree(os.path.join(self.path, "chunks.archive.d"))

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -940,7 +940,7 @@ class LocalCache(CacheStatsMixin):
         self.cache_config.integrity["chunks"] = fd.integrity_data
         with IntegrityCheckedFile(path=os.path.join(self.path, files_cache_name()), write=True) as fd:
             pass  # empty file
-        self.cache_config.integrity["files"] = fd.integrity_data
+        self.cache_config.integrity[files_cache_name()] = fd.integrity_data
         self.cache_config.manifest_id = ""
         self.cache_config._config.set("cache", "manifest", "")
         if not self.cache_config._config.has_section("integrity"):

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -533,7 +533,7 @@ class LocalCache(CacheStatsMixin):
 
         try:
             self.open()
-        except:
+        except (FileNotFoundError, FileIntegrityError):
             self.wipe_cache()
             self.open()
 

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -947,6 +947,7 @@ class LocalCache(CacheStatsMixin):
             self.cache_config._config.add_section("integrity")
         for file, integrity_data in self.cache_config.integrity.items():
             self.cache_config._config.set("integrity", file, integrity_data)
+        # This is needed to pass the integrity check later on inside CacheConfig.load()
         self.cache_config._config.set("integrity", "manifest", "")
 
         self.cache_config.ignored_features = set()

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -943,10 +943,16 @@ class LocalCache(CacheStatsMixin):
         self.cache_config.integrity["files"] = fd.integrity_data
         self.cache_config.manifest_id = ""
         self.cache_config._config.set("cache", "manifest", "")
+        if not self.cache_config._config.has_section("integrity"):
+            self.cache_config._config.add_section("integrity")
+        for file, integrity_data in self.cache_config.integrity.items():
+            self.cache_config._config.set("integrity", file, integrity_data)
+        self.cache_config._config.set("integrity", "manifest", "")
 
         self.cache_config.ignored_features = set()
         self.cache_config.mandatory_features = set()
-        self.cache_config.save(self.manifest, self.key)
+        with SaveFile(self.cache_config.config_path) as fd:
+            self.cache_config._config.write(fd)
 
     def update_compatibility(self):
         operation_to_features_map = self.manifest.get_all_mandatory_features()

--- a/src/borg/testsuite/archiver/corruption.py
+++ b/src/borg/testsuite/archiver/corruption.py
@@ -45,6 +45,7 @@ def corrupt(file, amount=1):
 @pytest.mark.allow_cache_wipe
 def test_cache_chunks(archiver):
     corrupt_archiver(archiver)
+    create_src_archive(archiver, "test")
     corrupt(os.path.join(archiver.cache_path, "chunks"))
     if archiver.FORK_DEFAULT:
         out = cmd(archiver, "rinfo")

--- a/src/borg/testsuite/archiver/corruption.py
+++ b/src/borg/testsuite/archiver/corruption.py
@@ -6,7 +6,6 @@ from configparser import ConfigParser
 import pytest
 
 from ...constants import *  # NOQA
-from ...crypto.file_integrity import FileIntegrityError
 from ...helpers import bin_to_hex, Error
 from . import cmd, create_src_archive, create_test_files, RK_ENCRYPTION
 
@@ -43,15 +42,15 @@ def corrupt(file, amount=1):
         fd.write(corrupted)
 
 
+@pytest.mark.allow_cache_wipe
 def test_cache_chunks(archiver):
     corrupt_archiver(archiver)
     corrupt(os.path.join(archiver.cache_path, "chunks"))
     if archiver.FORK_DEFAULT:
-        out = cmd(archiver, "rinfo", exit_code=2)
-        assert "failed integrity check" in out
+        out = cmd(archiver, "rinfo")
     else:
-        with pytest.raises(FileIntegrityError):
-            cmd(archiver, "rinfo")
+        out = cmd(archiver, "rinfo")
+    assert "forcing a cache rebuild" in out
 
 
 def test_cache_files(archiver):


### PR DESCRIPTION
Here is a fix for #5213 by calling wipe_cache() if an exception is raised on LocalCache.open().