### PR TITLE
Backport BORG_USE_CHUNKS_ARCHIVE env var to 1.4-maint

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -840,18 +840,8 @@ will make the subsequent rebuilds faster (because it needs to transfer less data
 from the repository). While being faster, the cache needs quite some disk space,
 which might be unwanted.
 
-There is a temporary (but maybe long lived) hack to avoid using lots of disk
-space for chunks.archive.d (see :issue:`235` for details):
-
-::
-
-    # this assumes you are working with the same user as the backup.
-    cd ~/.cache/borg/$(borg config /path/to/repo id)
-    rm -rf chunks.archive.d ; touch chunks.archive.d
-
-This deletes all the cached archive chunk indexes and replaces the directory
-that kept them with a file, so borg won't be able to store anything "in" there
-in future.
+You can disable the cached archive chunk indexes by setting the environment
+variable ``BORG_USE_CHUNKS_ARCHIVE`` to ``no``.
 
 This has some pros and cons, though:
 

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -63,6 +63,9 @@ General:
         When set to a numeric value, this determines the maximum "time to live" for the files cache
         entries (default: 20). The files cache is used to quickly determine whether a file is unchanged.
         The FAQ explains this more detailed in: :ref:`always_chunking`
+    BORG_USE_CHUNKS_ARCHIVE
+        When set to no (default: yes), the ``chunks.archive.d`` folder will not be used. This reduces
+        disk space usage but slows down cache resyncs.
     BORG_SHOW_SYSINFO
         When set to no (default: yes), system information (like OS, Python version, ...) in
         exceptions is not shown.

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -478,6 +478,7 @@ class LocalCache(CacheStatsMixin):
         self.consider_part_files = consider_part_files
         self.timestamp = None
         self.txn_active = False
+        self.do_cache = os.environ.get("BORG_USE_CHUNKS_ARCHIVE", "yes").lower() in ["yes", "1", "true"]
 
         self.path = cache_dir(repository, path)
         self.security_manager = SecurityManager(repository)
@@ -907,9 +908,6 @@ class LocalCache(CacheStatsMixin):
         self.begin_txn()
         with cache_if_remote(self.repository, decrypted_cache=self.key) as decrypted_repository:
             legacy_cleanup()
-            # TEMPORARY HACK: to avoid archive index caching, create a FILE named ~/.cache/borg/REPOID/chunks.archive.d -
-            # this is only recommended if you have a fast, low latency connection to your repo (e.g. if repo is local disk)
-            self.do_cache = os.path.isdir(archive_path)
             self.chunks = create_master_idx(self.chunks)
 
     def check_cache_compatibility(self):


### PR DESCRIPTION
This is the backport of the pull request #8281 to fix #8280 on 1.4-maint