### PR TITLE
improve borg check --repair healing tests, see #8302 (1.4-maint)

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -282,6 +282,8 @@ class DownloadPipeline:
             for item in items:
                 if 'chunks' in item:
                     item.chunks = [ChunkListEntry(*e) for e in item.chunks]
+                if 'chunks_healthy' in item:
+                    item.chunks_healthy = [ChunkListEntry(*e) for e in item.chunks_healthy]
 
             if filter:
                 items = [item for item in items if filter(item)]


### PR DESCRIPTION
test the healing more thoroughly:
- preservation of correct chunks list in .chunks_healthy
- check that .chunks_healthy is removed after healing
- check that doing another borg check --repair run does not find something to heal, again.

also did a datatype consistency fix for item.chunks_healthy list members: they are now post processed in the same way as item.chunks, so they have type ChunkListEntry rather than simple tuple.
