### PR TITLE
docs: borg-serve: simplify example of env in authorized_keys

### DIFF
--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -29,10 +29,12 @@ locations like ``/etc/environment`` or in the forced command itself (example bel
 
     # Set a BORG_XXX environment variable on the "borg serve" side
     $ cat ~/.ssh/authorized_keys
-    command="export BORG_XXX=value; borg serve [...]",restrict ssh-rsa [...]
+    command="BORG_XXX=value borg serve [...]",restrict ssh-rsa [...]
 
 .. note::
-    The examples above use the ``restrict`` directive. This does automatically
+    The examples above use the ``restrict`` directive and assumes a POSIX
+    compliant shell set as the user's login shell.
+    This does automatically
     block potential dangerous ssh features, even when they are added in a future
     update. Thus, this option should be preferred.
     


### PR DESCRIPTION
see #8318

so long as it can be assumed that the user has configured a POSIX compliant login shell, using a simple command [1] looks cleaner, as no ``export`` or ``;`` are used.

[1] Section "2.9.1 Simple Commands" in volume "Shell & Utilities" of POSIX.1-2024