### PR TITLE
Suppress modified changes for files which weren't actually modified in JSON output.

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1122,7 +1122,16 @@ class Archiver:
         """Diff contents of two archives"""
 
         def print_json_output(diff, path):
-            print(json.dumps({"path": path, "changes": [j for j, str in diff]}, sort_keys=True, cls=BorgJsonEncoder))
+            def actual_change(j):
+                if j["type"] == "modified":
+                    # It's useful to show 0 added and 0 removed for text output
+                    # but for JSON this is essentially noise. Additionally, the
+                    # JSON key is "changes", and this is not actually a change.
+                    return not (j["added"] == 0 and j["removed"] == 0)
+                else:
+                    return True
+
+            print(json.dumps({"path": path, "changes": [j for j, str in diff if actual_change(j)]}, sort_keys=True, cls=BorgJsonEncoder))
 
         def print_text_output(diff, path):
             print("{:<19} {}".format(' '.join([str for j, str in diff]), path))

--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -191,6 +191,9 @@ class BaseTestCase(unittest.TestCase):
     def assert_line_exists(self, lines, expected_regexpr):
         assert any(re.search(expected_regexpr, line) for line in lines), f"no match for {expected_regexpr} in {lines}"
 
+    def assert_line_not_exists(self, lines, expected_regexpr):
+        assert not any(re.search(expected_regexpr, line) for line in lines), f"unexpected match for {expected_regexpr} in {lines}"
+
     def _assert_dirs_equal_cmp(self, diff, ignore_flags=False, ignore_xattrs=False, ignore_ns=False):
         self.assert_equal(diff.left_only, [])
         self.assert_equal(diff.right_only, [])

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -23,6 +23,7 @@ from datetime import timedelta
 from hashlib import sha256
 from io import BytesIO, StringIO
 from unittest.mock import patch
+from pathlib import Path
 
 import pytest
 
@@ -4472,6 +4473,7 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
         self.create_regular_file('file_removed', size=256)
         self.create_regular_file('file_removed2', size=512)
         self.create_regular_file('file_replaced', size=1024)
+        self.create_regular_file('file_touched', size=128)
         os.mkdir('input/dir_replaced_with_file')
         os.chmod('input/dir_replaced_with_file', stat.S_IFDIR | 0o755)
         os.mkdir('input/dir_removed')
@@ -4500,6 +4502,7 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
         self.create_regular_file('file_replaced', contents=b'0' * 4096)
         os.unlink('input/file_removed')
         os.unlink('input/file_removed2')
+        Path('input/file_touched').touch()
         os.rmdir('input/dir_replaced_with_file')
         self.create_regular_file('dir_replaced_with_file', size=8192)
         os.chmod('input/dir_replaced_with_file', stat.S_IFREG | 0o755)
@@ -4562,6 +4565,13 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
             change = '0 B' if can_compare_ids else '{:<19}'.format('modified')
             self.assert_line_exists(lines, f"{change}.*input/empty")
 
+            # Show a 0 byte change for a file whose contents weren't modified
+            # for text output.
+            if content_only:
+                assert "input/file_touched" not in output
+            else:
+                self.assert_line_exists(lines, f"{change}.*input/file_touched")
+
             if are_hardlinks_supported():
                 self.assert_line_exists(lines, f"{change}.*input/hardlink_contents_changed")
             if are_symlinks_supported():
@@ -4609,6 +4619,16 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
 
             # File unchanged
             assert not any(get_changes('input/file_unchanged', joutput))
+
+            # Do NOT show a 0 byte change for a file whose contents weren't
+            # modified for JSON output.
+            unexpected = {'type': 'modified', 'added': 0, 'removed': 0}
+            assert unexpected not in get_changes('input/file_touched', joutput)
+            if not content_only:
+                assert {"ctime", "mtime"}.issubset({c["type"] for c in get_changes('input/file_touched', joutput)})
+            else:
+                # And if we're doing content-only, don't show the file at all.
+                assert not any(get_changes('input/file_touched', joutput))
 
             # Directory replaced with a regular file
             if 'BORG_TESTS_IGNORE_MODES' not in os.environ and not content_only:

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -4565,12 +4565,14 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
             change = '0 B' if can_compare_ids else '{:<19}'.format('modified')
             self.assert_line_exists(lines, f"{change}.*input/empty")
 
-            # Show a 0 byte change for a file whose contents weren't modified
-            # for text output.
-            if content_only:
-                assert "input/file_touched" not in output
+            # Do not show a 0 byte change for a file whose contents weren't
+            # modified.
+            self.assert_line_not_exists(lines, '0 B.*input/file_touched')
+            if not content_only:
+                self.assert_line_exists(lines, "[cm]time:.*input/file_touched")
             else:
-                self.assert_line_exists(lines, f"{change}.*input/file_touched")
+                # And if we're doing content-only, don't show the file at all.
+                assert "input/file_touched" not in output
 
             if are_hardlinks_supported():
                 self.assert_line_exists(lines, f"{change}.*input/hardlink_contents_changed")
@@ -4620,8 +4622,8 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
             # File unchanged
             assert not any(get_changes('input/file_unchanged', joutput))
 
-            # Do NOT show a 0 byte change for a file whose contents weren't
-            # modified for JSON output.
+            # Do not show a 0 byte change for a file whose contents weren't
+            # modified.
             unexpected = {'type': 'modified', 'added': 0, 'removed': 0}
             assert unexpected not in get_changes('input/file_touched', joutput)
             if not content_only:


### PR DESCRIPTION
Right now, if `borg diff` is run with the `--json-lines` parameter (and without `--content-only`, files whose content have _not_ been modified will still be given a `modified` entry of `{"added": 0, "removed": 0, "type": "modified"}`, e.g.:

```
 {"changes": [{"added": 0, "removed": 0, "type": "modified"}, {"new_ctime": "2024-07-22T20:13:59.352959", "old_ctime": "2020-01-06T02:21:13.955255", "type": "ctime"}], "path": ".areca/workspace/.log/areca.12-06-24.log"}
```

Per IRC discussion, this is considered a bug, as the file's content was not actually _changed_, and thus shouldn't be in the `changes` JSON array. This PR fixes the behavior so that JSON entries no longer get a `"type": "modified"` object for files whose contents weren't changed, but `ctime`, `mtime`, etc _were_ changed. E.g.:

```
{"changes": [{"new_ctime": "2024-07-22T20:13:59.352959", "old_ctime": "2020-01-06T02:21:13.955255", "type": "ctime"}], "path": ".areca/workspace/.log/areca.12-06-24.log"}
```

_Text output (without `--json-lines`) is unaffected_; I feel that the  `      0 B       0 B` is more useful for humans looking at output, compared to JSON processors :):

```
      0 B       0 B [ctime: Mon, 2020-01-06 02:21:13 -> Mon, 2024-07-22 20:13:59] .areca/workspace/.log/areca.12-06-24.log
```