### PR TITLE
Add quarterly pruning strategy.

### DIFF
--- a/docs/misc/prune-example.txt
+++ b/docs/misc/prune-example.txt
@@ -100,3 +100,27 @@ example simple. They all work in basically the same way.
 
 The weekly rule is easy to understand roughly, but hard to understand in all
 details. If interested, read "ISO 8601:2000 standard week-based year".
+
+The 13weekly and 3monthly rules are two different strategies for keeping one
+every quarter of a year. There are `multiple ways` to define a quarter-year;
+borg prune recognizes two:
+
+* --keep-13weekly keeps one backup every 13 weeks using ISO 8601:2000's
+  definition of the week-based year. January 4th is always included in the
+  first week of a year, and January 1st to 3rd may be in week 52 or 53 of the
+  previous year. Week 53 is also in the fourth quarter of the year.
+* --keep-3monthly keeps one backup every 3 months. January 1st to
+  March 31, April 1st to June 30th, July 1st to September 30th, and October 1st
+  to December 31st form the quarters.
+
+If the subtleties of the definition of a quarter year don't matter to you, a
+short summary of behavior is:
+
+* --keep-13weekly favors keeping backups at the beginning of Jan, Apr, July,
+  and Oct.
+* --keep-3monthly favors keeping backups at the end of Dec, Mar, Jun, and Sept.
+* Both strategies will have some overlap in which backups are kept.
+* The differences are negligible unless backups considered for deletion were
+  created weekly or more frequently.
+
+.. _multiple ways: https://en.wikipedia.org/wiki/Calendar_year#Quarter_year

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4675,9 +4675,13 @@ class Archiver:
         the local timezone, and weeks go from Monday to Sunday. Specifying a
         negative number of archives to keep means that there is no limit. As of borg
         1.2.0, borg will retain the oldest archive if any of the secondly, minutely,
-        hourly, daily, weekly, monthly, or yearly rules was not otherwise able to meet
-        its retention target. This enables the first chronological archive to continue
-        aging until it is replaced by a newer archive that meets the retention criteria.
+        hourly, daily, weekly, monthly, quarterly, or yearly rules was not otherwise
+        able to meet its retention target. This enables the first chronological archive
+        to continue aging until it is replaced by a newer archive that meets the
+        retention criteria.
+
+        The ``--keep-13weekly`` and ``--keep-3monthly`` rules are two different
+        strategies for keeping archives every quarter year.
 
         The ``--keep-last N`` option is doing the same as ``--keep-secondly N`` (and it will
         keep the last N archives under the assumption that you do not create more than one

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1518,10 +1518,12 @@ class Archiver:
     def do_prune(self, args, repository, manifest, key):
         """Prune repository archives according to specified rules"""
         if not any((args.secondly, args.minutely, args.hourly, args.daily,
-                    args.weekly, args.monthly, args.yearly, args.within)):
+                    args.weekly, args.monthly, args.quarterly_13weekly,
+                    args.quarterly_3monthly, args.yearly, args.within)):
             raise CommandError('At least one of the "keep-within", "keep-last", '
                                '"keep-secondly", "keep-minutely", "keep-hourly", "keep-daily", '
-                               '"keep-weekly", "keep-monthly" or "keep-yearly" settings must be specified.')
+                               '"keep-weekly", "keep-monthly", "keep-13weekly", "keep-3monthly", '
+                               'or "keep-yearly" settings must be specified.')
         if args.prefix is not None:
             args.glob_archives = args.prefix + '*'
         checkpoint_re = r'\.checkpoint(\.\d+)?'
@@ -4715,6 +4717,11 @@ class Archiver:
                                help='number of weekly archives to keep')
         subparser.add_argument('-m', '--keep-monthly', dest='monthly', type=int, default=0,
                                help='number of monthly archives to keep')
+        quarterly_group = subparser.add_mutually_exclusive_group()
+        quarterly_group.add_argument('--keep-13weekly', dest='quarterly_13weekly', type=int, default=0,
+                                     help='number of quarterly archives to keep (13 week strategy)')
+        quarterly_group.add_argument('--keep-3monthly', dest='quarterly_3monthly', type=int, default=0,
+                                     help='number of quarterly archives to keep (3 month strategy)')
         subparser.add_argument('-y', '--keep-yearly', dest='yearly', type=int, default=0,
                                help='number of yearly archives to keep')
         define_archive_filters_group(subparser, sort_by=False, first_last=False)


### PR DESCRIPTION
This implements and would close #4750 as described. It works for my use case, but is not ready to be merged due to no tests and docs, and there are subtleties to be addressed wrt [what a quarter year actually means](https://en.wikipedia.org/wiki/Calendar_year#Quarter_year).

To do:
* [x] Split into `--keep-3monthly` (using the same logic `--keep-monthly` does) and `--keep-13weekly` (using the ISO 8601 week-based year), maybe get rid of the latter entirely.
* [x] Tests
* [x] Docs
