### PR TITLE
Do not assert on diff if hard link sources are not found due to exclusions

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1162,7 +1162,7 @@ class Archiver:
 
         matcher = self.build_matcher(args.patterns, args.paths)
 
-        diffs = Archive.compare_archives_iter(archive1, archive2, matcher, can_compare_chunk_ids=can_compare_chunk_ids, content_only=args.content_only)
+        diffs = Archive.compare_archives_iter(self.print_warning, archive1, archive2, matcher, can_compare_chunk_ids=can_compare_chunk_ids, content_only=args.content_only)
         # Conversion to string and filtering for diff.equal to save memory if sorting
         diffs = ((path, diff.changes()) for path, diff in diffs if not diff.equal)
 


### PR DESCRIPTION
Per IRC, `borg diff` will assert if a multiply-linked file is selected for compare, but its hard link source was _not_ selected for compare. Print a warning and allow the diff to continue.

Example failure:

```
william@xubuntu-dtrain:/shares/wjones/work/browser-hist$ borg diff --content-only ::WD3200BEVT-userprofile-2021-10-17-120019 WD3200BEVT-userprofile-2021-10-24-120006 --pattern="+ pf:" --pattern="+ pp:Downloads" --pattern="! **/" > /dev/null
Local Exception
Traceback (most recent call last):
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 5412, in main
    exit_code = archiver.run(args)
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 5330, in run
    rc = func(args)
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 191, in wrapper
    return method(self, args, repository=repository, **kwargs)
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 206, in wrapper
    return method(self, args, repository=repository, manifest=manifest, key=key, archive=archive, **kwargs)
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 1172, in do_diff
    for path, diff in diffs:
  File "/home/william/Projects/borg/borg/src/borg/archiver.py", line 1167, in <genexpr>
    diffs = ((path, diff.changes()) for path, diff in diffs if not diff.equal)
  File "/home/william/Projects/borg/borg/src/borg/archive.py", line 1120, in compare_archives_iter
    assert hardlink_master_seen(item1)
AssertionError

Platform: Linux xubuntu-dtrain 5.15.0-112-generic #122-Ubuntu SMP Thu May 23 07:48:21 UTC 2024 x86_64
Linux: Unknown Linux
Borg: 1.4.1.dev26+gad502848  Python: CPython 3.10.12 msgpack: 1.0.8 fuse: pyfuse3 3.2.0 [pyfuse3,llfuse]
PID: 3004014  CWD: /shares/wjones/work/browser-hist
sys.argv: ['/home/william/.local/bin/borg', 'diff', '--content-only', '::WD3200BEVT-userprofile-2021-10-17-120019', 'WD3200BEVT-userprofile-2021-10-24-120006', '--pattern=+ pf:', '--pattern=+ pp:Downloads', '--pattern=! **/']
SSH_ORIGINAL_COMMAND: None
```
