### PR TITLE
require borgstore~=0.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,12 @@ classifiers = [
 ]
 license = {text="BSD"}
 dependencies = [
+  "borgstore ~= 0.0.1",
   "msgpack >=1.0.3, <=1.1.0",
   "packaging",
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0,
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.
   "argon2-cffi",
-  "borgstore",
-
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
so we can do borgstore releases:

0.0.x == compatible fixes, would match
0.1.0 could be incompatible changes, would not match

