### PR TITLE
Update repository URLs in docs to use new syntax

### DIFF
--- a/docs/deployment/central-backup-server.rst
+++ b/docs/deployment/central-backup-server.rst
@@ -81,7 +81,7 @@ The options which are added to the key will perform the following:
 Due to the ``cd`` command we use, the server automatically changes the current
 working directory. Then client doesn't need to have knowledge of the absolute
 or relative remote repository path and can directly access the repositories at
-``<user>@<host>:<repo>``.
+``ssh://<user>@<host>/./<repo>``.
 
 .. note:: The setup above ignores all client given commandline parameters
           which are normally appended to the `borg serve` command.
@@ -93,21 +93,21 @@ The client needs to initialize the `pictures` repository like this:
 
 ::
 
- borg init backup@backup01.srv.local:pictures
+ borg init ssh://backup@backup01.srv.local/./pictures
 
 Or with the full path (should actually never be used, as only for demonstrational purposes).
 The server should automatically change the current working directory to the `<client fqdn>` folder.
 
 ::
 
-  borg init backup@backup01.srv.local:/home/backup/repos/johndoe.clnt.local/pictures
+  borg init ssh://backup@backup01.srv.local/home/backup/repos/johndoe.clnt.local/pictures
 
 When `johndoe.clnt.local` tries to access a not restricted path the following error is raised.
 John Doe tries to backup into the Web 01 path:
 
 ::
 
-  borg init backup@backup01.srv.local:/home/backup/repos/web01.srv.local/pictures
+  borg init ssh://backup@backup01.srv.local/home/backup/repos/web01.srv.local/pictures
 
 ::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -218,7 +218,7 @@ This is not a problem anymore.
 For more details, see :ref:`checkpoints_parts`.
 
 How can I switch append-only mode on and off?
------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------
 
 You could do that (via borg config REPO append_only 0/1), but using different
 ssh keys and different entries in ``authorized_keys`` is much easier and also

--- a/docs/usage/general/repository-urls.rst.inc
+++ b/docs/usage/general/repository-urls.rst.inc
@@ -14,12 +14,21 @@ Note: you may also prepend a ``file://`` to a filesystem path to get URL style.
 
 **Remote repositories** accessed via ssh user@host:
 
-``user@host:/path/to/repo`` - remote repo, absolute path
+``ssh://user@host:port/path/to/repo`` - remote repo, absolute path, port can be given
 
-``ssh://user@host:port/path/to/repo`` - same, alternative syntax, port can be given
+``user@host:/path/to/repo`` - remote repo, absolute path, deprecated syntax
 
 
-**Remote repositories with relative paths** can be given using this syntax:
+**Remote repositories with relative paths, URL style syntax with port**:
+
+``ssh://user@host:port/./path/to/repo`` - path relative to current directory
+
+``ssh://user@host:port/~/path/to/repo`` - path relative to user's home directory
+
+``ssh://user@host:port/~other/path/to/repo`` - path relative to other's home directory (deprecated)
+
+
+**Remote repositories with relative paths, deprecated SCP style syntax**:
 
 ``user@host:path/to/repo`` - path relative to current directory
 
@@ -29,15 +38,6 @@ Note: you may also prepend a ``file://`` to a filesystem path to get URL style.
 
 Note: giving ``user@host:/./path/to/repo`` or ``user@host:/~/path/to/repo`` or
 ``user@host:/~other/path/to/repo`` is also supported, but not required here.
-
-
-**Remote repositories with relative paths, alternative syntax with port**:
-
-``ssh://user@host:port/./path/to/repo`` - path relative to current directory
-
-``ssh://user@host:port/~/path/to/repo`` - path relative to user's home directory
-
-``ssh://user@host:port/~other/path/to/repo`` - path relative to other's home directory
 
 
 If you frequently need the same repo URL, it is a good idea to set the


### PR DESCRIPTION
Fixes #8361 (1.2 edition)

See also: 8371