### PR TITLE
docs: user@ and :port are optional in sftp and ssh URLs

### DIFF
--- a/docs/usage/general/repository-urls.rst.inc
+++ b/docs/usage/general/repository-urls.rst.inc
@@ -24,6 +24,8 @@ Note: you may also prepend a ``file://`` to a filesystem path to get URL style.
 
 ``sftp://user@host:port/path/to/repo`` - absolute path`
 
+For ssh and sftp URLs, the ``user@`` and ``:port`` parts are optional.
+
 If you frequently need the same repo URL, it is a good idea to set the
 ``BORG_REPO`` environment variable to set a default for the repo URL:
 


### PR DESCRIPTION
Fixes #8380.
