### PR TITLE
repository.list: refresh lock more frequently

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -336,11 +336,11 @@ class Repository:
         list <limit> infos starting from after id <marker>.
         each info is a tuple (id, storage_size).
         """
-        self._lock_refresh()
         collect = True if marker is None else False
         result = []
         infos = self.store.list("data")  # generator yielding ItemInfos
         while True:
+            self._lock_refresh()
             try:
                 info = next(infos)
             except StoreObjectNotFound:


### PR DESCRIPTION
under all circumstances, we must avoid that the lock gets stale due to not being refreshed in time.

there is some internal rate limiting in _lock_refresh, so calling it often should be no problem.

fixes #8390.