### PR TITLE
bugfix: remove superfluous repository.list() call

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -18,6 +18,18 @@ from .repoobj import RepoObj
 logger = create_logger(__name__)
 
 
+def repo_lister(repository, *, limit=None):
+    marker = None
+    finished = False
+    while not finished:
+        result = repository.list(limit=limit, marker=marker)
+        finished = (len(result) < limit) if limit is not None else (len(result) == 0)
+        if not finished:
+            marker = result[-1][0]
+        for id, stored_size in result:
+            yield id, stored_size
+
+
 class Repository:
     """borgstore based key value store"""
 


### PR DESCRIPTION
Because it ended the loop only when .list() returned an empty result, this always needed one call more than necessary.

We can also detect that we are finished, if .list() returns less than the limit we gave to it.

Also: reduce code duplication by using repo_lister func.
