### PR TITLE
List more archive metadata

### DIFF
--- a/docs/usage/repo-list.rst
+++ b/docs/usage/repo-list.rst
@@ -5,9 +5,11 @@ Examples
 ::
 
     $ borg repo-list
-    Monday                               Mon, 2016-02-15 19:15:11
-    repo                                 Mon, 2016-02-15 19:26:54
-    root-2016-02-15                      Mon, 2016-02-15 19:36:29
-    newname                              Mon, 2016-02-15 19:50:19
+    151b1a57  Mon, 2024-09-23 22:57:11 +0200  docs             tw          MacBook-Pro  this is a comment
+    3387a079  Thu, 2024-09-26 09:07:07 +0200  scripts          tw          MacBook-Pro
+    ca774425  Thu, 2024-09-26 10:05:23 +0200  scripts          tw          MacBook-Pro
+    ba56c4a5  Thu, 2024-09-26 10:12:45 +0200  src              tw          MacBook-Pro
+    7567b79a  Thu, 2024-09-26 10:15:07 +0200  scripts          tw          MacBook-Pro
+    21ab3600  Thu, 2024-09-26 10:15:17 +0200  docs             tw          MacBook-Pro
     ...
 

--- a/src/borg/archiver/repo_list_cmd.py
+++ b/src/borg/archiver/repo_list_cmd.py
@@ -20,7 +20,7 @@ class RepoListMixIn:
         if args.format is not None:
             format = args.format
         elif args.short:
-            format = "{archive}{NL}"
+            format = "{id}{NL}"
         else:
             format = os.environ.get("BORG_RLIST_FORMAT", "{archive:<36} {time} [{id}]{NL}")
         formatter = ArchiveFormatter(format, repository, manifest, manifest.key, iec=args.iec)
@@ -93,7 +93,7 @@ class RepoListMixIn:
         )
         subparser.set_defaults(func=self.do_repo_list)
         subparser.add_argument(
-            "--short", dest="short", action="store_true", help="only print the archive names, nothing else"
+            "--short", dest="short", action="store_true", help="only print the archive IDs, nothing else"
         )
         subparser.add_argument(
             "--format",

--- a/src/borg/archiver/repo_list_cmd.py
+++ b/src/borg/archiver/repo_list_cmd.py
@@ -22,7 +22,9 @@ class RepoListMixIn:
         elif args.short:
             format = "{id}{NL}"
         else:
-            format = os.environ.get("BORG_RLIST_FORMAT", "{archive:<36} {time} [{id}]{NL}")
+            format = os.environ.get(
+                "BORG_RLIST_FORMAT", "{id:.8}  {time}  {archive:<15}  {username:<10}  {hostname:<10}  {comment:.40}{NL}"
+            )
         formatter = ArchiveFormatter(format, repository, manifest, manifest.key, iec=args.iec)
 
         output_data = []

--- a/src/borg/testsuite/archiver/create_cmd.py
+++ b/src/borg/testsuite/archiver/create_cmd.py
@@ -63,7 +63,7 @@ def test_basic_functionality(archivers, request):
     with changedir("output"):
         cmd(archiver, "extract", "test")
 
-    list_output = cmd(archiver, "repo-list", "--short")
+    list_output = cmd(archiver, "repo-list")
     assert "test" in list_output
     assert "test.2" in list_output
 
@@ -532,7 +532,7 @@ def test_create_archivename_with_placeholder(archivers, request):
     name_given = "test-{now}"  # placeholder in archive name gets replaced by borg
     name_expected = f"test-{ts}"  # placeholder in f-string gets replaced by python
     cmd(archiver, "create", f"--timestamp={ts}", name_given, "input")
-    list_output = cmd(archiver, "repo-list", "--short")
+    list_output = cmd(archiver, "repo-list")
     assert name_expected in list_output
 
 

--- a/src/borg/testsuite/archiver/repo_list_cmd.py
+++ b/src/borg/testsuite/archiver/repo_list_cmd.py
@@ -25,13 +25,18 @@ def test_archives_format(archivers, request):
     cmd(archiver, "create", "--comment", "comment 1", "test-1", src_dir)
     cmd(archiver, "create", "--comment", "comment 2", "test-2", src_dir)
     output_1 = cmd(archiver, "repo-list")
-    output_2 = cmd(archiver, "repo-list", "--format", "{archive:<36} {time} [{id}]{NL}")
+    output_2 = cmd(
+        archiver,
+        "repo-list",
+        "--format",
+        "{id:.8}  {time}  {archive:<15}  {username:<10}  {hostname:<10}  {comment:.40}{NL}",
+    )
     assert output_1 == output_2
-    output_1 = cmd(archiver, "repo-list", "--short")
-    assert output_1 == "test-1" + os.linesep + "test-2" + os.linesep
-    output_3 = cmd(archiver, "repo-list", "--format", "{name} {comment}{NL}")
-    assert "test-1 comment 1" + os.linesep in output_3
-    assert "test-2 comment 2" + os.linesep in output_3
+    output = cmd(archiver, "repo-list", "--short")
+    assert len(output) == 2 * 64 + 2 * len(os.linesep)
+    output = cmd(archiver, "repo-list", "--format", "{name} {comment}{NL}")
+    assert "test-1 comment 1" + os.linesep in output
+    assert "test-2 comment 2" + os.linesep in output
 
 
 def test_size_nfiles(archivers, request):

--- a/src/borg/testsuite/archiver/transfer_cmd.py
+++ b/src/borg/testsuite/archiver/transfer_cmd.py
@@ -18,7 +18,7 @@ def test_transfer(archivers, request):
     original_location, input_path = archiver.repository_location, archiver.input_path
 
     def check_repo():
-        listing = cmd(archiver, "repo-list", "--short")
+        listing = cmd(archiver, "repo-list")
         assert "arch1" in listing
         assert "arch2" in listing
         listing = cmd(archiver, "list", "--short", "arch1")
@@ -93,6 +93,9 @@ def test_transfer_upgrade(archivers, request):
 
     for got_archive, expected_archive in zip(got["archives"], expected["archives"]):
         del got_archive["id"]
+        del got_archive["username"]  # we didn't have this in the 1.x default format
+        del got_archive["hostname"]  # we didn't have this in the 1.x default format
+        del got_archive["comment"]  # we didn't have this in the 1.x default format
         del expected_archive["id"]
         del expected_archive["barchive"]
         # timestamps:


### PR DESCRIPTION
Looks like this now:
```
(borg-env) tw@MacBook-Pro borg % borg repo-list                    
60e521ba  Mon, 2024-09-23 22:57:11 +0200  docs             tw          MacBook-Pro  a comment
211b5d10  Thu, 2024-09-26 09:07:07 +0200  scripts          tw          MacBook-Pro
d7ceb3f1  Thu, 2024-09-26 10:05:23 +0200  scripts          tw          MacBook-Pro
bc8d1d7a  Thu, 2024-09-26 10:12:45 +0200  src              tw          MacBook-Pro
cee1c7e5  Thu, 2024-09-26 10:15:07 +0200  scripts          tw          MacBook-Pro
a07b7cd7  Thu, 2024-09-26 10:15:17 +0200  docs             tw          MacBook-Pro
```

```
(borg-env) tw@MacBook-Pro borg % borg repo-list --short
60e521ba5d44d6fed6aa984ded9301821e85d594971986097f96dc5b55597ef2
211b5d10d61558d8d85eb25c5f5c3c2f14c694c240f206c84bc007c39c4890cd
d7ceb3f14fdbd5142db18e03c93c29ca0269845118c9ab8f5b929dbd66c5fc82
bc8d1d7a814938f96c59e6b71b874fe95d478425e9ba3d77de9667dbb569d3e5
cee1c7e5e08d24339bff8ac96c08303179fa9a0268fe7a9315f9fdb68fca7e2e
a07b7cd759ab47a45ef43c9dfc62cef5eaa984995ebfeef6b0e75eac5888f90e
```

See the commit comments for the reasoning.