### PR TITLE
give borgstore.Store a complete levels configuration, fixes #8432

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -116,9 +116,18 @@ class Repository:
             url = "file://%s" % os.path.abspath(path_or_location)
             location = Location(url)
         self._location = location
-        # use a Store with flat config storage and 2-levels-nested data storage
+        # lots of stuff in data: use 2 levels by default (data/00/00/ .. data/ff/ff/ dirs)!
+        data_levels = int(os.environ.get("BORG_STORE_DATA_LEVELS", "2"))
+        levels_config = {
+            "archives/": [0],
+            "cache/": [0],
+            "config/": [0],
+            "data/": [data_levels],
+            "keys/": [0],
+            "locks/": [0],
+        }
         try:
-            self.store = Store(url, levels={"config/": [0], "data/": [2]})
+            self.store = Store(url, levels=levels_config)
         except StoreBackendError as e:
             raise Error(str(e))
         self.version = None

--- a/src/borg/testsuite/conftest.py
+++ b/src/borg/testsuite/conftest.py
@@ -30,6 +30,7 @@ def clean_env(tmpdir_factory, monkeypatch):
     monkeypatch.setenv("BORG_BASE_DIR", str(tmpdir_factory.mktemp("borg-base-dir")))
     # Speed up tests
     monkeypatch.setenv("BORG_TESTONLY_WEAKEN_KDF", "1")
+    monkeypatch.setenv("BORG_STORE_DATA_LEVELS", "0")  # flat storage for few objects
 
 
 def pytest_report_header(config, start_path):

--- a/src/borg/testsuite/storelocking.py
+++ b/src/borg/testsuite/storelocking.py
@@ -12,7 +12,7 @@ ID2 = "bar", 2, 2
 
 @pytest.fixture()
 def lockstore(tmpdir):
-    store = Store("file://" + str(tmpdir / "lockstore"))
+    store = Store("file://" + str(tmpdir / "lockstore"), levels={"locks/": [0]})
     store.create()
     with store:
         yield store


### PR DESCRIPTION
also:
- add BORG_STORE_DATA_LEVELS=2 env var
- use BORG_STORE_DATA_LEVELS=0 to speed up tests
