### PR TITLE
Location.canonical_path: some fixes, see #8446

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -616,7 +616,8 @@ class Location:
                 path = "/./" + self.path  # /./x = path x relative to cwd
             else:
                 path = self.path
-            return "ssh://{}{}{}{}".format(
+            return "{}://{}{}{}{}".format(
+                self.proto if self.proto else "???",
                 f"{self.user}@" if self.user else "",
                 self._host,  # needed for ipv6 addrs
                 f":{self.port}" if self.port else "",

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -619,7 +619,7 @@ class Location:
             return "{}://{}{}{}{}".format(
                 self.proto if self.proto else "???",
                 f"{self.user}@" if self.user else "",
-                self._host,  # needed for ipv6 addrs
+                self._host if self._host else "",  # needed for ipv6 addrs
                 f":{self.port}" if self.port else "",
                 path,
             )


### PR DESCRIPTION
1st commit: just fixing the protocol part:
```
% borg repo-info
Location: rclone://None/./pcloud:justtesting
```

2nd commit: do not display None, but rather empty host:
```
% borg repo-info    
Location: rclone:///./pcloud:justtesting
```