### PR TITLE
docs: Fix grammar in borg mount docs

### DIFF
--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -120,7 +120,7 @@ class MountMixIn:
         Unmounting in these cases could cause an active rsync or similar process
         to delete data unintentionally.
 
-        When running in the foreground ^C/SIGINT unmounts cleanly, but other
+        When running in the foreground ^C/SIGINT unmounts clean, but other
         signals or crashes do not.
         """
         )


### PR DESCRIPTION
"clean" as adverb does not have suffix -ly.

Source: https://dict.leo.org/grammatik/englisch/adjv_usage_flat.php?lang=de#id=5.3.1.b