### PR TITLE
seen_chunk: do not use .refcount

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -719,14 +719,17 @@ class ChunksMixin:
         return self._chunks
 
     def seen_chunk(self, id, size=None):
-        entry = self.chunks.get(id, ChunkIndexEntry(0, None))
-        if entry.refcount and size is not None:
-            assert isinstance(entry.size, int)
-            if not entry.size:
+        entry = self.chunks.get(id)
+        entry_exists = entry is not None
+        if entry_exists and size is not None:
+            if entry.size == 0:
                 # AdHocWithFilesCache:
                 # Here *size* is used to update the chunk's size information, which will be zero for existing chunks.
                 self.chunks[id] = entry._replace(size=size)
-        return entry.refcount != 0
+            else:
+                # in case we already have a size information in the entry, check consistency:
+                assert size == entry.size
+        return entry_exists
 
     def reuse_chunk(self, id, size, stats):
         assert isinstance(size, int) and size > 0


### PR DESCRIPTION
If we have an entry for a chunk id in the ChunkIndex, it means that this chunk exists in the repository.

The code was a bit over-complicated and used entry.refcount only to detect whether .get(id, default) actually got something from the ChunkIndex or used the provided default value.

The code does the same now, but in a simpler way.
Additionally, it checks for size consistency if a size is provided by the caller and a size is already present in the entry.
