### PR TITLE
repo-compress: reduce memory consumption

### DIFF
--- a/src/borg/hashindex.pyi
+++ b/src/borg/hashindex.pyi
@@ -13,6 +13,7 @@ CIE = Union[Tuple[int, int], Type[ChunkIndexEntry]]
 class ChunkIndex:
     F_NONE: int
     F_USED: int
+    F_COMPRESS: int
     F_NEW: int
     M_USER: int
     M_SYSTEM: int

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -47,6 +47,7 @@ class ChunkIndex(HTProxyMixin, MutableMapping):
     M_SYSTEM = 0xff000000  # mask for system flags
     # user flags:
     F_USED = 2 ** 0  # chunk is used/referenced
+    F_COMPRESS = 2 ** 1  # chunk shall get (re-)compressed
     # system flags (internal use, always 0 to user, not changeable by user):
     F_NEW = 2 ** 24  # a new chunk that is not present in repo/cache/chunks.* yet.
 


### PR DESCRIPTION
Worst (but frequent) case here is that all or most of the chunks in the repo need to get recompressed, thus storing all chunk ids in a python list would need significant amounts of memory for large repositories.

We already have all chunk ids stored in cache.chunks, so we now just flag the ones needing re-compression by setting the F_COMPRESS flag (that does not need any additional memory).
