### PR TITLE
Fix OpenBSD Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,7 @@ end
 
 def packages_openbsd
   return <<-EOF
+    echo "https://ftp.eu.openbsd.org/pub/OpenBSD" > /etc/installurl
     pkg_add bash
     chsh -s bash vagrant
     pkg_add xxhash

--- a/src/borg/logger.py
+++ b/src/borg/logger.py
@@ -117,6 +117,12 @@ class JSONProgressFormatter(logging.Formatter):
 # warnings.filterwarnings('ignore', r'... regex for warning message to ignore ...')
 
 
+# we do not want that urllib spoils test output with LibreSSL related warnings on OpenBSD.
+# NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+,
+#                    currently the 'ssl' module is compiled with 'LibreSSL 3.8.2'.
+warnings.filterwarnings("ignore", message=r".*urllib3 v2 only supports OpenSSL.*")
+
+
 def _log_warning(message, category, filename, lineno, file=None, line=None):
     # for warnings, we just want to use the logging system, not stderr or other files
     msg = f"{filename}:{lineno}: {category.__name__}: {message}"


### PR DESCRIPTION
Fixes #8506.

#8506 is likely caused by the Vagrant box having a mirror in its `etc/installurl`, which does not offer 7.4 packages. There are other mirrors out there who do, e.g., https://ftp.openbsd.org/pub/OpenBSD/.
