### PR TITLE
borg2 - Support other OpenSSL versions on OpenBSD (#8553)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,7 @@ def packages_openbsd
     pkg_add openssl%3.0
     pkg_add py3-pip
     pkg_add py3-virtualenv
+    echo 'export BORG_OPENSSL_NAME=eopenssl30' >> ~vagrant/.bash_profile
   EOF
 end
 

--- a/docs/man/borg.1
+++ b/docs/man/borg.1
@@ -662,6 +662,9 @@ operations), see \fI\%tempfile\fP for details.
 .B Building:
 .INDENT 7.0
 .TP
+.B BORG_OPENSSL_NAME
+Defines the subdirectory name for OpenSSL (setup.py).
+.TP
 .B BORG_OPENSSL_PREFIX
 Adds given OpenSSL header file directory to the default locations (setup.py).
 .TP

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -198,6 +198,8 @@ Directories and files:
         operations), see tempfile_ for details.
 
 Building:
+    BORG_OPENSSL_NAME
+        Defines the subdirectory name for OpenSSL (setup.py).
     BORG_OPENSSL_PREFIX
         Adds given OpenSSL header file directory to the default locations (setup.py).
     BORG_LIBACL_PREFIX


### PR DESCRIPTION
`setup.py` hardcoded crypto library paths for OpenBSD, causing build issue when OpenBSD drops specific OpenSSL version. Solution is to make paths configurable.

Addresses #8553.