### PR TITLE
compact: add --stats option

### DIFF
--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -1,35 +1,48 @@
+import pytest
+
 from ...constants import *  # NOQA
 from . import cmd, create_src_archive, generate_archiver_tests, RK_ENCRYPTION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
 
 
-def test_compact_empty_repository(archivers, request):
+@pytest.mark.parametrize("stats", (True, False))
+def test_compact_empty_repository(archivers, request, stats):
     archiver = request.getfixturevalue(archivers)
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
 
-    output = cmd(archiver, "compact", "-v", exit_code=0)
+    args = ("-v", "--stats") if stats else ("-v",)
+    output = cmd(archiver, "compact", *args, exit_code=0)
     assert "Starting compaction" in output
-    assert "Repository size is 0 B in 0 objects." in output
+    if stats:
+        assert "Repository size is 0 B in 0 objects." in output
+    else:
+        assert "Repository has data stored in 0 objects." in output
     assert "Finished compaction" in output
 
 
-def test_compact_after_deleting_all_archives(archivers, request):
+@pytest.mark.parametrize("stats", (True, False))
+def test_compact_after_deleting_all_archives(archivers, request, stats):
     archiver = request.getfixturevalue(archivers)
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     create_src_archive(archiver, "archive")
     cmd(archiver, "delete", "-a", "archive", exit_code=0)
 
-    output = cmd(archiver, "compact", "-v", exit_code=0)
+    args = ("-v", "--stats") if stats else ("-v",)
+    output = cmd(archiver, "compact", *args, exit_code=0)
     assert "Starting compaction" in output
     assert "Deleting " in output
-    assert "Repository size is 0 B in 0 objects." in output
+    if stats:
+        assert "Repository size is 0 B in 0 objects." in output
+    else:
+        assert "Repository has data stored in 0 objects." in output
     assert "Finished compaction" in output
 
 
-def test_compact_after_deleting_some_archives(archivers, request):
+@pytest.mark.parametrize("stats", (True, False))
+def test_compact_after_deleting_some_archives(archivers, request, stats):
     archiver = request.getfixturevalue(archivers)
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
@@ -37,8 +50,12 @@ def test_compact_after_deleting_some_archives(archivers, request):
     create_src_archive(archiver, "archive2")
     cmd(archiver, "delete", "-a", "archive1", exit_code=0)
 
-    output = cmd(archiver, "compact", "-v", exit_code=0)
+    args = ("-v", "--stats") if stats else ("-v",)
+    output = cmd(archiver, "compact", *args, exit_code=0)
     assert "Starting compaction" in output
     assert "Deleting " in output
-    assert "Repository size is 0 B in 0 objects." not in output
+    if stats:
+        assert "Repository size is 0 B in 0 objects." not in output
+    else:
+        assert "Repository has data stored in 0 objects." not in output
     assert "Finished compaction" in output


### PR DESCRIPTION
with --stats it will be as slow as before, listing all repo objs.

without --stats, it will be faster by using the cached chunks index.
