### PR TITLE
macos: fix broken brew pkg-config -> pkgconf transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,9 @@ jobs:
             ${{ runner.os }}-
 
     - name: Install macOS packages
-      run: brew bundle install
+      run: |
+        brew unlink pkg-config@0.29.2 || true
+        brew bundle install
 
     - name: Install Python requirements
       run: |

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-brew 'pkg-config'
+brew 'pkgconf'
 brew 'zstd'
 brew 'lz4'
 brew 'xxhash'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -170,7 +170,7 @@ def packages_macos
 
     # now brew, curl, ca-certificates, openssl@3 should be all ok.
     brew update
-    brew install pkg-config readline xxhash zstd lz4 xz
+    brew install pkgconf readline xxhash zstd lz4 xz
     brew install --cask macfuse
     # brew upgrade  # upgrade everything (takes rather long)
     # pyenv shall use the openssl@3 from homebrew:


### PR DESCRIPTION
it looks like in brew they removed pkg-config formula and added an alias to the pkgconf formula (which also provides a pkg-config cli command).

the transition was not seamless:

Installing pkg-config
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/manifests/2.3.0_1 ==> Fetching pkgconf
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/blobs/sha256:5f83615f295e78e593c767d84f3eddf61bfb0b849a1e6a5ea343506b30b2c620 ==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz Error: The `brew link` step did not complete successfully The formula built, but is not symlinked into /opt/homebrew Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config /opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4 /opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1 ==> Summary
🍺  /opt/homebrew/Cellar/pkgconf/2.3.0_1: 27 files, 474KB Installing pkg-config has failed!
