### PR TITLE
 Clarify excluded and included flags for dry-run in borg the docs #8563

### DIFF
--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -329,8 +329,8 @@ borg usually just stores their metadata:
 Other flags used include:
 
 - 'i' = backup data was read from standard input (stdin)
-- '-' = dry run, item was *not* backed up
-- 'x' = excluded, item was *not* backed up
+- '-' = item would be included in archive(s) (if not in dry-run mode)
+- 'x' = item was excluded - or would be excluded from archive(s) (if not in dry-run mode) 
 - '?' = missing status code (if you see this, please file a bug report!)
 
 Reading from stdin


### PR DESCRIPTION
Rewording of the "flags" description in the docs of borg 1.2. #8556
