### PR TITLE
doc(installation): add libffi-dev dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -168,6 +168,7 @@ following dependencies first:
   - liblz4_ >= 1.7.0 (r129)
   - libzstd_ >= 1.3.0
   - libxxhash >= 0.8.1 (0.8.0 might work also)
+  - libffi (required for argon2-cffi-bindings)
 * pkg-config (cli tool) and pkgconfig python package (borg uses these to
   discover header and library location - if it can't import pkgconfig and
   is not pointed to header/library locations via env vars [see setup.py],

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -203,6 +203,7 @@ Install the dependencies with development headers::
     libacl1-dev libacl1 \
     libssl-dev \
     liblz4-dev libzstd-dev libxxhash-dev \
+    libffi-dev \
     build-essential \
     pkg-config python3-pkgconfig
     sudo apt-get install libfuse-dev fuse    # needed for llfuse
@@ -221,6 +222,7 @@ Install the dependencies with development headers::
     libacl-devel libacl \
     openssl-devel \
     lz4-devel libzstd-devel xxhash-devel \
+    libffi-devel \
     pkgconf python3-pkgconfig
     sudo dnf install gcc gcc-c++ redhat-rpm-config
     sudo dnf install fuse-devel fuse         # needed for llfuse
@@ -237,6 +239,7 @@ Alternatively, you can enumerate all build dependencies in the command line::
 
     sudo zypper install python3 python3-devel \
     libacl-devel openssl-devel xxhash-devel libzstd-devel liblz4-devel \
+    libffi-devel \
     python3-Cython python3-Sphinx python3-msgpack-python python3-pkgconfig pkgconf \
     python3-pytest python3-setuptools python3-setuptools_scm \
     python3-sphinx_rtd_theme gcc gcc-c++


### PR DESCRIPTION
I was installing borg2 (`pip install borgbackup==2.0.0b14`) on Debian 12 (bookworm) armv7l and found the libffi header missing.

Was following along the instructions in that section (python virtual env), but libffi was not pulled in as a dependency so I had to install it manually.

I did a quick lookup on the corresponding packages for Fedora/OpenSuse, but I'm not quite sure about the right packages for MacOS/FreeBSD/Windows.

Maybe it's not needed at all?