### PR TITLE
compact: support --dry-run (do nothing), fixes #8300

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1893,11 +1893,12 @@ class Archiver:
     @with_repository(manifest=False, exclusive=True)
     def do_compact(self, args, repository):
         """compact segment files in the repository"""
-        # see the comment in do_with_lock about why we do it like this:
-        data = repository.get(Manifest.MANIFEST_ID)
-        repository.put(Manifest.MANIFEST_ID, data)
-        threshold = args.threshold / 100
-        repository.commit(compact=True, threshold=threshold, cleanup_commits=args.cleanup_commits)
+        if not args.dry_run:  # support --dry-run to simplify scripting
+            # see the comment in do_with_lock about why we do it like this:
+            data = repository.get(Manifest.MANIFEST_ID)
+            repository.put(Manifest.MANIFEST_ID, data)
+            threshold = args.threshold / 100
+            repository.commit(compact=True, threshold=threshold, cleanup_commits=args.cleanup_commits)
 
     @with_repository(exclusive=True, manifest=False)
     def do_config(self, args, repository):
@@ -3417,6 +3418,7 @@ class Archiver:
         subparser.add_argument('location', metavar='REPOSITORY', nargs='?', default='',
                                type=location_validator(archive=False),
                                help='repository to compact')
+        subparser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true', help='do nothing')
         subparser.add_argument('--cleanup-commits', dest='cleanup_commits', action='store_true',
                                help='cleanup commit-only 17-byte segment files')
         subparser.add_argument('--threshold', metavar='PERCENT', dest='threshold',


### PR DESCRIPTION
Sole purpose of this is to simplify scripting.