### PR TITLE
yes: deal with UnicodeDecodeError in input(), fixes #6984

### DIFF
--- a/src/borg/helpers/yes.py
+++ b/src/borg/helpers/yes.py
@@ -8,6 +8,9 @@ FALSISH = ('No', 'NO', 'no', 'N', 'n', '0', )
 TRUISH = ('Yes', 'YES', 'yes', 'Y', 'y', '1', )
 DEFAULTISH = ('Default', 'DEFAULT', 'default', 'D', 'd', '', )
 
+ERROR = "error"
+assert ERROR not in TRUISH + FALSISH + DEFAULTISH
+
 
 def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
         retry_msg=None, invalid_msg=None, env_msg='{} (from {})',
@@ -77,10 +80,14 @@ def yes(msg=None, false_msg=None, true_msg=None, default_msg=None,
             if not prompt:
                 return default
             try:
-                answer = input()
+                answer = input()  # this may raise UnicodeDecodeError, #6984
+                if answer == ERROR:  # for testing purposes
+                    raise UnicodeDecodeError("?", b"?", 0, 1, "?")  # args don't matter
             except EOFError:
                 # avoid defaultish[0], defaultish could be empty
                 answer = truish[0] if default else falsish[0]
+            except UnicodeDecodeError:
+                answer = ERROR
         if answer in defaultish:
             if default_msg:
                 output(default_msg, 'accepted_default')


### PR DESCRIPTION
if retry is True, it will just retry to get a valid answer. if retry is False, it will return the default.

the code can be tested by entering "error" (without the quotes).
