### PR TITLE
config: reject additional_free_space < 10M, fixes #6066

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1924,6 +1924,11 @@ class Archiver:
                         minimum = parse_file_size('10M')
                         if wanted != 0 and wanted < minimum:
                             raise ValueError('Invalid value: storage_quota < 10M')
+                    elif name == 'additional_free_space':
+                        wanted = parse_file_size(value)
+                        minimum = parse_file_size('10M')
+                        if wanted != 0 and wanted < minimum:
+                            raise ValueError('Invalid value: additional_free_space < 10M')
                     elif name == 'max_segment_size':
                         if parse_file_size(value) >= MAX_SEGMENT_SIZE_LIMIT:
                             raise ValueError('Invalid value: max_segment_size >= %d' % MAX_SEGMENT_SIZE_LIMIT)


### PR DESCRIPTION
Doesn't mean that 10M is very helpful in out of space conditions, but avoids wrong unit assumptions as in #6066.
