### PR TITLE
Enhance passphrase handling (Fixes #8496)

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -364,7 +364,6 @@ class FlexiKey:
         target = key.find_key()
         prompt = "Enter passphrase for key %s: " % target
         passphrase = Passphrase.env_passphrase()
-        debug_enabled = os.environ.get("BORG_DEBUG_PASSPHRASE") == "YES"
         if passphrase is None:
             passphrase = Passphrase()
             if not key.load(target, passphrase):
@@ -372,14 +371,12 @@ class FlexiKey:
                     passphrase = Passphrase.getpass(prompt)
                     if key.load(target, passphrase):
                         break
-                    elif debug_enabled:
-                        Passphrase.display_debug_info(passphrase)
+                    Passphrase.display_debug_info(passphrase)
                 else:
                     raise PasswordRetriesExceeded
         else:
             if not key.load(target, passphrase):
-                if debug_enabled:
-                    Passphrase.display_debug_info(passphrase)
+                Passphrase.display_debug_info(passphrase)
                 raise PassphraseWrong
         key.init_ciphers(manifest_data)
         key._passphrase = passphrase

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -375,7 +375,7 @@ class FlexiKey:
                     raise PasswordRetriesExceeded
         else:
             if not key.load(target, passphrase):
-                raise PassphraseWrong
+                raise PassphraseWrong(passphrase)
         key.init_ciphers(manifest_data)
         key._passphrase = passphrase
         return key

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -371,6 +371,8 @@ class FlexiKey:
                     passphrase = Passphrase.getpass(prompt)
                     if key.load(target, passphrase):
                         break
+                    else:
+                        Passphrase.display_debug_info(passphrase)
                 else:
                     raise PasswordRetriesExceeded
         else:

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -364,6 +364,7 @@ class FlexiKey:
         target = key.find_key()
         prompt = "Enter passphrase for key %s: " % target
         passphrase = Passphrase.env_passphrase()
+        debug_enabled = os.environ.get("BORG_DEBUG_PASSPHRASE") == "YES"
         if passphrase is None:
             passphrase = Passphrase()
             if not key.load(target, passphrase):
@@ -371,13 +372,15 @@ class FlexiKey:
                     passphrase = Passphrase.getpass(prompt)
                     if key.load(target, passphrase):
                         break
-                    else:
+                    elif debug_enabled:
                         Passphrase.display_debug_info(passphrase)
                 else:
                     raise PasswordRetriesExceeded
         else:
             if not key.load(target, passphrase):
-                raise PassphraseWrong(passphrase)
+                if debug_enabled:
+                    Passphrase.display_debug_info(passphrase)
+                raise PassphraseWrong
         key.init_ciphers(manifest_data)
         key._passphrase = passphrase
         return key

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -121,16 +121,21 @@ class Passphrase(str):
     @staticmethod
     def display_debug_info(passphrase):
         if os.environ.get("BORG_DEBUG_PASSPHRASE") == "YES":
-            print("Incorrect passphrase!", file=sys.stderr)
-            print(f'Passphrase used (between double-quotes): "{passphrase}"', file=sys.stderr)
-            print(f'Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode("utf-8"))}', file=sys.stderr)
-            print("Relevant Environment Variables:", file=sys.stderr)
+            env_vars_str = ""
             for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
                 env_var_value = os.environ.get(env_var)
                 if env_var_value is not None:
-                    print(f'{env_var} = "{env_var_value}"', file=sys.stderr)
+                    env_vars_str += f'{env_var} = "{env_var_value}"\n'
                 else:
-                    print(f"# {env_var} is not set", file=sys.stderr)
+                    env_vars_str += f"# {env_var} is not set\n"
+            passphrase_info = (
+                f"Incorrect passphrase!\n"
+                f'Passphrase used (between double-quotes): "{passphrase}"\n'
+                f"Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode('utf-8'))}\n"
+                f"Relevant Environment Variables:\n"
+                f"{env_vars_str}"
+            )
+            print(passphrase_info, file=sys.stderr)
 
     @classmethod
     def new(cls, allow_empty=False):

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -31,6 +31,10 @@ class PassphraseWrong(Error):
 
     exit_mcode = 52
 
+    def __init__(self, passphrase):
+        super().__init__(self)
+        Passphrase.display_debug_info(passphrase)
+
 
 class PasswordRetriesExceeded(Error):
     """exceeded the maximum password retries"""
@@ -111,18 +115,26 @@ class Passphrase(str):
         ):
             print('Your passphrase (between double-quotes): "%s"' % passphrase, file=sys.stderr)
             print("Make sure the passphrase displayed above is exactly what you wanted.", file=sys.stderr)
+            print(
+                "Your passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")), file=sys.stderr
+            )
             try:
                 passphrase.encode("ascii")
             except UnicodeEncodeError:
-                print(
-                    "Your passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")),
-                    file=sys.stderr,
-                )
                 print(
                     "As you have a non-ASCII passphrase, it is recommended to keep the "
                     "UTF-8 encoding in hex together with the passphrase at a safe place.",
                     file=sys.stderr,
                 )
+
+    @staticmethod
+    def display_debug_info(passphrase):
+        print(
+            "Incorrect passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")), file=sys.stderr
+        )
+        for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
+            env_var_value = os.environ.get(env_var)
+            print(f"{env_var} = {env_var_value}", file=sys.stderr)
 
     @classmethod
     def new(cls, allow_empty=False):

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -118,6 +118,11 @@ class Passphrase(str):
             print(
                 "Your passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")), file=sys.stderr
             )
+            print(
+                "It is recommended to keep the UTF-8 encoding in hex together with the passphrase at a safe place. "
+                "In case you should ever run into passphrase issues, it could sometimes help debugging them.\n",
+                file=sys.stderr,
+            )
             try:
                 passphrase.encode("ascii")
             except UnicodeEncodeError:
@@ -129,12 +134,16 @@ class Passphrase(str):
 
     @staticmethod
     def display_debug_info(passphrase):
-        print(
-            "Incorrect passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")), file=sys.stderr
-        )
+        print("Incorrect passphrase!", file=sys.stderr)
+        print(f'Passphrase used (between double-quotes): "{passphrase}"', file=sys.stderr)
+        print(f'Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode("utf-8"))}', file=sys.stderr)
+        print("Relevant Environment Variables:", file=sys.stderr)
         for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
             env_var_value = os.environ.get(env_var)
-            print(f"{env_var} = {env_var_value}", file=sys.stderr)
+            if env_var_value is not None:
+                print(f'{env_var} = "{env_var_value}"', file=sys.stderr)
+            else:
+                print(f"# {env_var} is not set", file=sys.stderr)
 
     @classmethod
     def new(cls, allow_empty=False):

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -31,10 +31,6 @@ class PassphraseWrong(Error):
 
     exit_mcode = 52
 
-    def __init__(self, passphrase):
-        super().__init__(self)
-        Passphrase.display_debug_info(passphrase)
-
 
 class PasswordRetriesExceeded(Error):
     """exceeded the maximum password retries"""
@@ -113,37 +109,28 @@ class Passphrase(str):
             retry=True,
             env_var_override="BORG_DISPLAY_PASSPHRASE",
         ):
-            print('Your passphrase (between double-quotes): "%s"' % passphrase, file=sys.stderr)
-            print("Make sure the passphrase displayed above is exactly what you wanted.", file=sys.stderr)
-            print(
-                "Your passphrase (UTF-8 encoding in hex): %s" % bin_to_hex(passphrase.encode("utf-8")), file=sys.stderr
-            )
-            print(
-                "It is recommended to keep the UTF-8 encoding in hex together with the passphrase at a safe place. "
-                "In case you should ever run into passphrase issues, it could sometimes help debugging them.\n",
-                file=sys.stderr,
-            )
-            try:
-                passphrase.encode("ascii")
-            except UnicodeEncodeError:
-                print(
-                    "As you have a non-ASCII passphrase, it is recommended to keep the "
-                    "UTF-8 encoding in hex together with the passphrase at a safe place.",
-                    file=sys.stderr,
-                )
+            pw_msg = f"""
+            Your passphrase (between double-quotes): "{passphrase}"
+            Make sure the passphrase displayed above is exactly what you wanted.
+            Your passphrase (UTF-8 encoding in hex): {bin_to_hex(passphrase.encode("utf-8"))}
+            It is recommended to keep the UTF-8 encoding in hex together with the passphrase at a safe place.
+            In case you should ever run into passphrase issues, it could sometimes help debugging them.
+            """
+            print(pw_msg, file=sys.stderr)
 
     @staticmethod
     def display_debug_info(passphrase):
-        print("Incorrect passphrase!", file=sys.stderr)
-        print(f'Passphrase used (between double-quotes): "{passphrase}"', file=sys.stderr)
-        print(f'Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode("utf-8"))}', file=sys.stderr)
-        print("Relevant Environment Variables:", file=sys.stderr)
-        for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
-            env_var_value = os.environ.get(env_var)
-            if env_var_value is not None:
-                print(f'{env_var} = "{env_var_value}"', file=sys.stderr)
-            else:
-                print(f"# {env_var} is not set", file=sys.stderr)
+        if os.environ.get("BORG_DEBUG_PASSPHRASE") == "YES":
+            print("Incorrect passphrase!", file=sys.stderr)
+            print(f'Passphrase used (between double-quotes): "{passphrase}"', file=sys.stderr)
+            print(f'Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode("utf-8"))}', file=sys.stderr)
+            print("Relevant Environment Variables:", file=sys.stderr)
+            for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
+                env_var_value = os.environ.get(env_var)
+                if env_var_value is not None:
+                    print(f'{env_var} = "{env_var_value}"', file=sys.stderr)
+                else:
+                    print(f"# {env_var} is not set", file=sys.stderr)
 
     @classmethod
     def new(cls, allow_empty=False):

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import subprocess
 import sys
+import textwrap
 
 from . import bin_to_hex
 from . import Error
@@ -109,13 +110,15 @@ class Passphrase(str):
             retry=True,
             env_var_override="BORG_DISPLAY_PASSPHRASE",
         ):
-            pw_msg = f"""
+            pw_msg = textwrap.dedent(
+                f"""
             Your passphrase (between double-quotes): "{passphrase}"
             Make sure the passphrase displayed above is exactly what you wanted.
             Your passphrase (UTF-8 encoding in hex): {bin_to_hex(passphrase.encode("utf-8"))}
             It is recommended to keep the UTF-8 encoding in hex together with the passphrase at a safe place.
             In case you should ever run into passphrase issues, it could sometimes help debugging them.
             """
+            )
             print(pw_msg, file=sys.stderr)
 
     @staticmethod

--- a/src/borg/helpers/passphrase.py
+++ b/src/borg/helpers/passphrase.py
@@ -111,7 +111,7 @@ class Passphrase(str):
             env_var_override="BORG_DISPLAY_PASSPHRASE",
         ):
             pw_msg = textwrap.dedent(
-                f"""
+                f"""\
             Your passphrase (between double-quotes): "{passphrase}"
             Make sure the passphrase displayed above is exactly what you wanted.
             Your passphrase (UTF-8 encoding in hex): {bin_to_hex(passphrase.encode("utf-8"))}
@@ -123,20 +123,24 @@ class Passphrase(str):
 
     @staticmethod
     def display_debug_info(passphrase):
+        def fmt_var(env_var):
+            env_var_value = os.environ.get(env_var)
+            if env_var_value is not None:
+                return f'{env_var} = "{env_var_value}"'
+            else:
+                return f"# {env_var} is not set"
+
         if os.environ.get("BORG_DEBUG_PASSPHRASE") == "YES":
-            env_vars_str = ""
-            for env_var in ["BORG_PASSPHRASE", "BORG_PASSCOMMAND", "BORG_PASSPHRASE_FD"]:
-                env_var_value = os.environ.get(env_var)
-                if env_var_value is not None:
-                    env_vars_str += f'{env_var} = "{env_var_value}"\n'
-                else:
-                    env_vars_str += f"# {env_var} is not set\n"
-            passphrase_info = (
-                f"Incorrect passphrase!\n"
-                f'Passphrase used (between double-quotes): "{passphrase}"\n'
-                f"Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode('utf-8'))}\n"
-                f"Relevant Environment Variables:\n"
-                f"{env_vars_str}"
+            passphrase_info = textwrap.dedent(
+                f"""\
+                Incorrect passphrase!
+                Passphrase used (between double-quotes): "{passphrase}"
+                Same, UTF-8 encoded, in hex: {bin_to_hex(passphrase.encode('utf-8'))}
+                Relevant Environment Variables:
+                {fmt_var("BORG_PASSPHRASE")}
+                {fmt_var("BORG_PASSCOMMAND")}
+                {fmt_var("BORG_PASSPHRASE_FD")}
+                """
             )
             print(passphrase_info, file=sys.stderr)
 

--- a/src/borg/testsuite/helpers_test.py
+++ b/src/borg/testsuite/helpers_test.py
@@ -1416,7 +1416,7 @@ class TestPassphrase:
 
         with pytest.raises(PassphraseWrong) as exc_info:
             Passphrase.display_debug_info("wrong_passphrase")
-            raise PassphraseWrong("wrong_passphrase")
+            raise PassphraseWrong()
 
         out, err = capsys.readouterr()
         assert "Incorrect passphrase!" in err
@@ -1435,7 +1435,7 @@ class TestPassphrase:
 
         with pytest.raises(PassphraseWrong):
             Passphrase.display_debug_info("wrong_passphrase")
-            raise PassphraseWrong("wrong_passphrase")
+            raise PassphraseWrong()
 
         out, err = capsys.readouterr()
         assert "Incorrect passphrase!" not in err

--- a/src/borg/testsuite/helpers_test.py
+++ b/src/borg/testsuite/helpers_test.py
@@ -1417,11 +1417,12 @@ class TestPassphrase:
             raise PassphraseWrong("wrong_passphrase")
 
         out, err = capsys.readouterr()
-        assert "Incorrect passphrase (UTF-8 encoding in hex)" in err
+        assert "Incorrect passphrase!" in err
+        assert 'Passphrase used (between double-quotes): "wrong_passphrase"' in err
         assert "77726f6e675f70617373706872617365" in err
-        assert "BORG_PASSPHRASE = wrong_passphrase" in err
-        assert "BORG_PASSCOMMAND = echo wrong_passphrase" in err
-        assert "BORG_PASSPHRASE_FD = 123" in err
+        assert "BORG_PASSPHRASE" in err
+        assert "BORG_PASSCOMMAND" in err
+        assert "BORG_PASSPHRASE_FD" in err
 
         assert str(exc_info.value) == (
             "passphrase supplied in BORG_PASSPHRASE, by BORG_PASSCOMMAND or via BORG_PASSPHRASE_FD is incorrect."
@@ -1457,11 +1458,12 @@ class TestPassphrase:
         Passphrase.display_debug_info(passphrase)
 
         out, err = capsys.readouterr()
-        assert "Incorrect passphrase (UTF-8 encoding in hex)" in err
+        assert "Incorrect passphrase!" in err
+        assert 'Passphrase used (between double-quotes): "debug_test"' in err
         assert "64656275675f74657374" in err  # UTF-8 hex encoding of 'debug_test'
-        assert "BORG_PASSPHRASE = debug_env_passphrase" in err
-        assert "BORG_PASSCOMMAND = command" in err
-        assert "BORG_PASSPHRASE_FD = fd_value" in err
+        assert "BORG_PASSPHRASE" in err
+        assert "BORG_PASSCOMMAND" in err
+        assert "BORG_PASSPHRASE_FD" in err
 
 
 @pytest.mark.parametrize(

--- a/src/borg/testsuite/helpers_test.py
+++ b/src/borg/testsuite/helpers_test.py
@@ -45,7 +45,7 @@ from ..helpers import eval_escapes
 from ..helpers import safe_unlink
 from ..helpers import text_to_json, binary_to_json
 from ..helpers import classify_ec, max_ec
-from ..helpers.passphrase import Passphrase, PasswordRetriesExceeded
+from ..helpers.passphrase import Passphrase, PasswordRetriesExceeded, PassphraseWrong
 from ..platform import is_cygwin, is_win32, is_darwin
 from . import FakeInputs, are_hardlinks_supported
 from . import rejected_dotdot_paths
@@ -1407,6 +1407,61 @@ class TestPassphrase:
 
     def test_passphrase_repr(self):
         assert "secret" not in repr(Passphrase("secret"))
+
+    def test_passphrase_wrong(self, capsys, monkeypatch):
+        monkeypatch.setenv("BORG_PASSPHRASE", "wrong_passphrase")
+        monkeypatch.setenv("BORG_PASSCOMMAND", "echo wrong_passphrase")
+        monkeypatch.setenv("BORG_PASSPHRASE_FD", "123")
+
+        with pytest.raises(PassphraseWrong) as exc_info:
+            raise PassphraseWrong("wrong_passphrase")
+
+        out, err = capsys.readouterr()
+        assert "Incorrect passphrase (UTF-8 encoding in hex)" in err
+        assert "77726f6e675f70617373706872617365" in err
+        assert "BORG_PASSPHRASE = wrong_passphrase" in err
+        assert "BORG_PASSCOMMAND = echo wrong_passphrase" in err
+        assert "BORG_PASSPHRASE_FD = 123" in err
+
+        assert str(exc_info.value) == (
+            "passphrase supplied in BORG_PASSPHRASE, by BORG_PASSCOMMAND or via BORG_PASSPHRASE_FD is incorrect."
+        )
+
+    def test_verification(self, capsys, monkeypatch):
+        passphrase = "test_passphrase"
+
+        monkeypatch.setenv("BORG_DISPLAY_PASSPHRASE", "no")
+        Passphrase.verification(passphrase)
+        out, err = capsys.readouterr()
+        assert "Your passphrase (between double-quotes)" not in err
+
+        monkeypatch.setenv("BORG_DISPLAY_PASSPHRASE", "yes")
+        Passphrase.verification(passphrase)
+        out, err = capsys.readouterr()
+        assert 'Your passphrase (between double-quotes): "test_passphrase"' in err
+        assert "UTF-8 encoding in hex" in err
+
+        # Case 3: Non-ASCII passphrase
+        passphrase = "tëst_päṩṩ"
+        hex_value = passphrase.encode("utf-8").hex()
+        Passphrase.verification(passphrase)
+        out, err = capsys.readouterr()
+        assert hex_value in err
+
+    def test_display_debug_info(self, capsys, monkeypatch):
+        passphrase = "debug_test"
+        monkeypatch.setenv("BORG_PASSPHRASE", "debug_env_passphrase")
+        monkeypatch.setenv("BORG_PASSCOMMAND", "command")
+        monkeypatch.setenv("BORG_PASSPHRASE_FD", "fd_value")
+
+        Passphrase.display_debug_info(passphrase)
+
+        out, err = capsys.readouterr()
+        assert "Incorrect passphrase (UTF-8 encoding in hex)" in err
+        assert "64656275675f74657374" in err  # UTF-8 hex encoding of 'debug_test'
+        assert "BORG_PASSPHRASE = debug_env_passphrase" in err
+        assert "BORG_PASSCOMMAND = command" in err
+        assert "BORG_PASSPHRASE_FD = fd_value" in err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This pull request improves the handling of passphrases and adds comprehensive debug information. The main changes include:

- Displaying hex bytes for passphrases in all cases, including ASCII and non-ASCII characters.
- Adding an option to display the hex bytes when the password is used and found incorrect.
- Showing which environment variables were used during passphrase operations.
- Preventing sensitive passphrase information from being logged unintentionally by directing it to sys.stderr.
- Adding tests to verify:
  - Handling of incorrect passphrases.
  - Passphrase verification logic.
  - Debug information display for passphrases.

