### PR TITLE
docs: borg serve: recommend using a simple shell (closes #3818)

### DIFF
--- a/docs/usage/serve.rst
+++ b/docs/usage/serve.rst
@@ -48,6 +48,7 @@ Details about sshd usage: `sshd(8) <https://www.openbsd.org/cgi-bin/man.cgi/Open
 
 SSH Configuration
 ~~~~~~~~~~~~~~~~~
+
 ``borg serve``'s pipes (``stdin``/``stdout``/``stderr``) are connected to the ``sshd`` process on the server side. In the event that the SSH connection between ``borg serve`` and the client is disconnected or stuck abnormally (for example, due to a network outage), it can take a long time for ``sshd`` to notice the client is disconnected. In the meantime, ``sshd`` continues running, and as a result so does the ``borg serve`` process holding the lock on the repository. This can cause subsequent ``borg`` operations on the remote repository to fail with the error: ``Failed to create/acquire the lock``.
 
 In order to avoid this, it is recommended to perform the following additional SSH configuration:
@@ -74,3 +75,16 @@ This will cause the server to send a keep alive to the client every 10 seconds. 
 If you then run borg commands with ``--lock-wait 600``, this gives sufficient time for the borg serve processes to terminate after the SSH connection is torn down after the 300 second wait for the keepalives to fail.
 
 You may, of course, modify the timeout values demonstrated above to values that suit your environment and use case.
+
+When the client is untrusted, it is a good idea to set the backup
+user's shell to a simple implementation (``/bin/sh`` is only an example and may or may
+not be such a simple implementation)::
+
+  chsh -s /bin/sh BORGUSER
+
+Because the configured shell is used by `openssh <https://www.openssh.com/>`_
+to execute the command configured through the ``authorized_keys`` file
+using ``"$SHELL" -c "$COMMAND"``,
+setting a minimal shell implementation reduces the attack surface
+compared to when a feature-rich and complex shell implementation is
+used.


### PR DESCRIPTION
see https://github.com/borgbackup/borg/issues/8318

As a short summary of issue 8318:
openssh executes the user's configured shell with the whole command (either remote-command or forced-command) as a single argument like so: `"$SHELL" -c "$COMMAND"`.
This entails a larger attack surface, when a complex and feature-rich shell is configured for the user.

Because in the example configuration of a push backup server a complex and feature-rich shell is not needed, recommending the usage of a simple shell like /bin/sh will reduce the opportunity of yet-undiscovered security vulnerabilities to arise in the future.