### PR TITLE
work around sudden failure of sphinx ini lexer

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -968,7 +968,7 @@ The integrity data of the ``files`` cache is stored in the cache ``config``.
 
 The ``[integrity]`` section is used:
 
-.. code-block:: ini
+.. code-block:: none
 
     [cache]
     version = 1


### PR DESCRIPTION
/Users/tw/w/borg/docs/internals/data-structures.rst:971: WARNING: Lexing literal_block
'
[cache]
version = 1
repository = 3c4...e59
manifest = 10e...21c
timestamp = 2017-06-01T21:31:39.699514
key_type = 2
previous_location = /path/to/repo

[integrity]
manifest = 10e...21c
files = {"algorithm": "XXH64", "digests": {"HashHeader": "eab...39e3", "final": "e2a...b24"}} '
as "ini" resulted in an error at token: '}'.
Retrying in relaxed mode. [misc.highlighting_failure]

Note: this part of the docs didn't change for a long time, so I guess the sudden warning comes from a change in sphinx' lexers.

Main problem is that rc != 0 will abort our CI pipeline.
