### PR TITLE
docs: clarify requirements when using command line options with special characters within a shell

### DIFF
--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -101,14 +101,14 @@ class HelpMixIn:
         from within a shell, the patterns should be quoted to protect them from
         expansion.
 
-        Pattern matching special characters, e.g. white space, within a shell may 
+        Patterns matching special characters, e.g. white space, within a shell may 
         require adjustments, such as putting quotation marks around the arguments.
         Example: 
         Using bash, the following command line option would match and exclude "item name":
         ``--pattern='-path/item name'``
-        Note that when a pattern file is read directly by borg, e.g. when using 
-        ``--exclude-from`` or ``--patterns-from`, there is no shell involved and thus 
-        no quotation marks are required.
+        Note that when patterns are used within a pattern file directly read by borg,  
+        e.g. when using ``--exclude-from`` or ``--patterns-from`, there is no shell 
+        involved and thus no quotation marks are required.
         
         The ``--exclude-from`` option permits loading exclusion patterns from a text
         file with one pattern per line. Lines empty or starting with the hash sign

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -107,7 +107,7 @@ class HelpMixIn:
         Using bash, the following command line option would match and exclude "item name":
         ``--pattern='-path/item name'``
         Note that when patterns are used within a pattern file directly read by borg,  
-        e.g. when using ``--exclude-from`` or ``--patterns-from`, there is no shell 
+        e.g. when using ``--exclude-from`` or ``--patterns-from``, there is no shell 
         involved and thus no quotation marks are required.
         
         The ``--exclude-from`` option permits loading exclusion patterns from a text

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -101,6 +101,15 @@ class HelpMixIn:
         from within a shell, the patterns should be quoted to protect them from
         expansion.
 
+        Pattern matching special characters, e.g. white space, within a shell may 
+        require adjustments, such as putting quotation marks around the arguments.
+        Example: 
+        Using bash, the following command line option would match and exclude "item name":
+        ``--pattern='-path/item name'``
+        Note that when a pattern file is read directly by borg, e.g. when using 
+        ``--exclude-from`` or ``--patterns-from`, there is no shell involved and thus 
+        no quotation marks are required.
+        
         The ``--exclude-from`` option permits loading exclusion patterns from a text
         file with one pattern per line. Lines empty or starting with the hash sign
         '#' after removing whitespace on both ends are ignored. The optional style


### PR DESCRIPTION
Clarify docs: 
Within a shell, command line options with special characters require adjustments, such as quotation marks.  
https://github.com/borgbackup/borg/issues/8578
