### PR TITLE
docs: modify docs for automated backup to append to SYSTEMD_WANTS

### DIFF
--- a/docs/deployment/automated-local.rst
+++ b/docs/deployment/automated-local.rst
@@ -34,7 +34,7 @@ Find out the ID of the partition table of your backup disk (here assumed to be /
 
 Then, create ``/etc/backups/40-backup.rules`` with the following content (all on one line)::
 
-    ACTION=="add", SUBSYSTEM=="block", ENV{ID_PART_TABLE_UUID}=="<the PTUUID you just noted>", TAG+="systemd", ENV{SYSTEMD_WANTS}="automatic-backup.service"
+    ACTION=="add", SUBSYSTEM=="block", ENV{ID_PART_TABLE_UUID}=="<the PTUUID you just noted>", TAG+="systemd", ENV{SYSTEMD_WANTS}+="automatic-backup.service"
 
 The "systemd" tag in conjunction with the SYSTEMD_WANTS environment variable has systemd
 launch the "automatic-backup" service, which we will create next, as the


### PR DESCRIPTION
backport, fixes #8641
In the example, setting SYSTEMD_WANTS instead of appending may prevent other autostart services attached by earlier udev rules from launching. This commit changes = to += to fix this behavior.
