### PR TITLE
docs: borg commands updated with --repo option

### DIFF
--- a/docs/deployment/pull-backup.rst
+++ b/docs/deployment/pull-backup.rst
@@ -301,7 +301,7 @@ ignore all arguments intended for the SSH command.
 All Borg commands can now be executed on *borg-client*. For example to create a
 backup execute the ``borg create`` command::
 
-   borg-client:~$ borg create ssh://borg-server/path/to/repo::archive /path_to_backup
+   borg-client:~$ borg create --repo ssh://borg-server/path/to/repo archive /path_to_backup
 
 When automating backup creation, the
 interactive ssh session may seem inappropriate. An alternative way of creating
@@ -312,7 +312,7 @@ a backup may be the following command::
       borgc@borg-client \
       borg create \
       --rsh "sh -c 'exec socat STDIO UNIX-CONNECT:/run/borg/reponame.sock'" \
-      ssh://borg-server/path/to/repo::archive /path_to_backup \
+      --repo ssh://borg-server/path/to/repo archive /path_to_backup \
       ';' rm /run/borg/reponame.sock
 
 This command also automatically removes the socket file after the ``borg

--- a/docs/deployment/pull-backup.rst
+++ b/docs/deployment/pull-backup.rst
@@ -98,7 +98,7 @@ create the backup, retaining the original paths, excluding the repository:
 
 ::
 
-    borg create --exclude borgrepo --files-cache ctime,size --repo borgrepo archive  /
+    borg create --exclude borgrepo --files-cache ctime,size --repo /borgrepo archive  /
 
 For the sake of simplicity only ``borgrepo`` is excluded here. You may want to
 set up an exclude file with additional files and folders to be excluded. Also

--- a/docs/deployment/pull-backup.rst
+++ b/docs/deployment/pull-backup.rst
@@ -98,7 +98,7 @@ create the backup, retaining the original paths, excluding the repository:
 
 ::
 
-    borg create --exclude borgrepo --files-cache ctime,size /borgrepo::archive /
+    borg create --exclude borgrepo --files-cache ctime,size --repo borgrepo archive  /
 
 For the sake of simplicity only ``borgrepo`` is excluded here. You may want to
 set up an exclude file with additional files and folders to be excluded. Also
@@ -159,7 +159,7 @@ Now we can run
 
 ::
 
-    borg extract /borgrepo::archive PATH
+    borg extract --repo /borgrepo archive PATH
 
 to restore whatever we like partially. Finally, do the clean-up:
 
@@ -187,7 +187,7 @@ and extract a backup, utilizing the ``--numeric-ids`` option:
 
     sshfs root@host:/ /mnt/sshfs
     cd /mnt/sshfs
-    borg extract --numeric-ids /path/to/repo::archive
+    borg extract --numeric-ids --repo /path/to/repo archive
     cd ~
     umount /mnt/sshfs
 
@@ -199,7 +199,7 @@ directly extract it without the need of mounting with SSHFS:
 
 ::
 
-    borg export-tar /path/to/repo::archive - | ssh root@host 'tar -C / -x'
+    borg export-tar --repo /path/to/repo archive - | ssh root@host 'tar -C / -x'
 
 Note that in this scenario the tar format is the limiting factor – it cannot
 restore all the advanced features that BorgBackup supports. See

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -11,7 +11,7 @@ Examples
     $ borg create --list my-documents ~/Documents
 
     # Backup /mnt/disk/docs, but strip path prefix using the slashdot hack
-    $ borg create /path/to/repo::docs /mnt/disk/./docs
+    $ borg create --repo /path/to/repo docs /mnt/disk/./docs
 
     # Backup ~/Documents and ~/src but exclude pyc files
     $ borg create my-files                \

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -329,14 +329,14 @@ Reading backup data from stdin
 There are two methods to read from stdin. Either specify ``-`` as path and
 pipe directly to borg::
 
-    backup-vm --id myvm --stdout | borg create REPO::ARCHIVE -
+    backup-vm --id myvm --stdout | borg create --repo REPO ARCHIVE -
 
 Or use ``--content-from-command`` to have Borg manage the execution of the
 command and piping. If you do so, the first PATH argument is interpreted
 as command to execute and any further arguments are treated as arguments
 to the command::
 
-    borg create --content-from-command REPO::ARCHIVE -- backup-vm --id myvm --stdout
+    borg create --content-from-command  --repo REPO ARCHIVE -- backup-vm --id myvm --stdout
 
 ``--`` is used to ensure ``--id`` and ``--stdout`` are **not** considered
 arguments to ``borg`` but rather ``backup-vm``.

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -118,7 +118,7 @@ General:
             This workaround is **only** for emergencies and **only** to extract data
             from an affected repository (read-only access)::
 
-                BORG_WORKAROUNDS=authenticated_no_key borg extract repo::archive
+                BORG_WORKAROUNDS=authenticated_no_key borg extract --repo repo archive
 
             After you have extracted all data you need, you MUST delete the repository::
 

--- a/docs/usage/general/logging.rst.inc
+++ b/docs/usage/general/logging.rst.inc
@@ -10,7 +10,7 @@ If you want to capture the log output to a file, just redirect it:
 
 ::
 
-    borg create repo::archive myfiles 2>> logfile
+    borg create --repo repo archive myfiles 2>> logfile
 
 
 Custom logging configurations can be implemented via BORG_LOGGING_CONF.

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -712,14 +712,14 @@ class CreateMixIn:
         There are two methods to read from stdin. Either specify ``-`` as path and
         pipe directly to borg::
 
-            backup-vm --id myvm --stdout | borg create REPO ARCHIVE -
+            backup-vm --id myvm --stdout | borg create --repo REPO ARCHIVE -
 
         Or use ``--content-from-command`` to have Borg manage the execution of the
         command and piping. If you do so, the first PATH argument is interpreted
         as command to execute and any further arguments are treated as arguments
         to the command::
 
-            borg create --content-from-command REPO ARCHIVE -- backup-vm --id myvm --stdout
+            borg create --content-from-command --repo REPO ARCHIVE -- backup-vm --id myvm --stdout
 
         ``--`` is used to ensure ``--id`` and ``--stdout`` are **not** considered
         arguments to ``borg`` but rather ``backup-vm``.

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -712,14 +712,14 @@ class CreateMixIn:
         There are two methods to read from stdin. Either specify ``-`` as path and
         pipe directly to borg::
 
-            backup-vm --id myvm --stdout | borg create REPO::ARCHIVE -
+            backup-vm --id myvm --stdout | borg create --repo /path/to/repo ARCHIVE -
 
         Or use ``--content-from-command`` to have Borg manage the execution of the
         command and piping. If you do so, the first PATH argument is interpreted
         as command to execute and any further arguments are treated as arguments
         to the command::
 
-            borg create --content-from-command REPO::ARCHIVE -- backup-vm --id myvm --stdout
+            borg create --content-from-command --repo /path/to/repo ARCHIVE -- backup-vm --id myvm --stdout
 
         ``--`` is used to ensure ``--id`` and ``--stdout`` are **not** considered
         arguments to ``borg`` but rather ``backup-vm``.

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -712,14 +712,14 @@ class CreateMixIn:
         There are two methods to read from stdin. Either specify ``-`` as path and
         pipe directly to borg::
 
-            backup-vm --id myvm --stdout | borg create --repo /path/to/repo ARCHIVE -
+            backup-vm --id myvm --stdout | borg create REPO ARCHIVE -
 
         Or use ``--content-from-command`` to have Borg manage the execution of the
         command and piping. If you do so, the first PATH argument is interpreted
         as command to execute and any further arguments are treated as arguments
         to the command::
 
-            borg create --content-from-command --repo /path/to/repo ARCHIVE -- backup-vm --id myvm --stdout
+            borg create --content-from-command REPO ARCHIVE -- backup-vm --id myvm --stdout
 
         ``--`` is used to ensure ``--id`` and ``--stdout`` are **not** considered
         arguments to ``borg`` but rather ``backup-vm``.

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -362,12 +362,12 @@ class HelpMixIn:
 
         If literal curly braces need to be used, double them for escaping::
 
-            borg create /path/to/repo::{{literal_text}}
+            borg create --repo /path/to/repo {{literal_text}}
 
         Examples::
 
-            borg create /path/to/repo::{hostname}-{user}-{utcnow} ...
-            borg create /path/to/repo::{hostname}-{now:%Y-%m-%d_%H:%M:%S%z} ...
+            borg create --repo /path/to/repo {hostname}-{user}-{utcnow} ...
+            borg create --repo /path/to/repo {hostname}-{now:%Y-%m-%d_%H:%M:%S%z} ...
             borg prune -a 'sh:{hostname}-*' ...
 
         .. note::
@@ -472,12 +472,12 @@ class HelpMixIn:
 
         Examples::
 
-            borg create --compression lz4 REPO::ARCHIVE data
-            borg create --compression zstd REPO::ARCHIVE data
-            borg create --compression zstd,10 REPO::ARCHIVE data
-            borg create --compression zlib REPO::ARCHIVE data
-            borg create --compression zlib,1 REPO::ARCHIVE data
-            borg create --compression auto,lzma,6 REPO::ARCHIVE data
+            borg create --compression lz4 --repo REPO ARCHIVE data
+            borg create --compression zstd --repo REPO ARCHIVE data
+            borg create --compression zstd,10 --repo REPO ARCHIVE data
+            borg create --compression zlib --repo REPO ARCHIVE data
+            borg create --compression zlib,1 --repo REPO ARCHIVE data
+            borg create --compression auto,lzma,6 --repo REPO ARCHIVE data
             borg create --compression auto,lzma ...
             borg create --compression obfuscate,110,none ...
             borg create --compression obfuscate,3,auto,zstd,10 ...


### PR DESCRIPTION
REPO::ARCHIVE formatting has been replaced in the documentation with --repo 

Only python files have been updated 

All modified commands have been tested

This should replaces the initial PR 