### PR TITLE
quickfix :  borg exits when assertions are disabled with Python optimizations

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3,6 +3,15 @@
 import sys
 import traceback
 
+# quickfix to disallow running borg with assertions switched off
+try:
+    assert False
+except AssertionError:
+    pass  # OK
+else:
+    print("Borg requires working assertions. Please run Python without -O and/or unset PYTHONOPTIMIZE.", file=sys.stderr)
+    sys.exit(2)  # == EXIT_ERROR
+
 try:
     import argparse
     import collections


### PR DESCRIPTION
Quick-workaround for #8649 
