### PR TITLE
Update Borg 1.4 key.py for compatibility with Python 3.13

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -7,7 +7,12 @@ import shlex
 import sys
 import textwrap
 import subprocess
-from hashlib import sha256, sha512, pbkdf2_hmac
+from hashlib import sha256, sha512
+
+if sys.version_info >= (3, 13):
+    from _hashlib import pbkdf2_hmac
+else:
+    from hashlib import pbkdf2_hmac
 
 from ..logger import create_logger
 


### PR DESCRIPTION
Fix for #8691

Also FYI seems https://borgbackup.readthedocs.io/en/latest/development.html#contributions is out of date, as it states:
```
Contributions

… are welcome!

Some guidance for contributors:

    Discuss changes on the GitHub issue tracker, on IRC or on the mailing list.

    Make your PRs on the master branch (see [Branching Model](https://borgbackup.readthedocs.io/en/latest/development.html#branching-model) for details).
```

But this is slated for removal in Borg 2 according to other issues. I will make a separate PR for clearer language above. 