### PR TITLE
implement padme chunk size obfuscation (SPEC 250), fixes #8705

### DIFF
--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -470,6 +470,15 @@ class HelpMixIn:
               ...
               123: 8MiB (max.)
 
+            *Padmé padding* (deterministic)
+
+            ::
+
+              250: pads to sums of powers of 2, max 12% overhead
+
+            Uses the Padmé algorithm to deterministically pad the compressed size to a sum of
+            powers of 2, limiting overhead to 12%. See https://lbarman.ch/blog/padme/ for details.
+
         Examples::
 
             borg create --compression lz4 --repo REPO ARCHIVE data
@@ -481,7 +490,8 @@ class HelpMixIn:
             borg create --compression auto,lzma ...
             borg create --compression obfuscate,110,none ...
             borg create --compression obfuscate,3,auto,zstd,10 ...
-            borg create --compression obfuscate,2,zstd,6 ...\n\n"""
+            borg create --compression obfuscate,2,zstd,6 ...
+            borg create --compression obfuscate,250,zstd,3 ...\n\n"""
     )
 
     def do_help(self, parser, commands, args):

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -16,17 +16,15 @@ decompressor.
 """
 
 from argparse import ArgumentTypeError
+import math
 import random
 from struct import Struct
 import zlib
-
-import math
 
 try:
     import lzma
 except ImportError:
     lzma = None
-
 
 from .constants import MAX_DATA_SIZE
 from .helpers import Buffer, DecompressionError
@@ -605,7 +603,7 @@ class ObfuscateSize(CompressorBase):
         return self.compressor.decompress(meta, compressed_data)  # decompress data
 
     def _padme_obfuscate(self, compr_size):
-        if compr_size <= 0:
+        if compr_size < 2:
             return 0
 
         E = math.floor(math.log2(compr_size))  # Get exponent (power of 2)

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -20,6 +20,8 @@ import random
 from struct import Struct
 import zlib
 
+import math
+
 try:
     import lzma
 except ImportError:
@@ -556,6 +558,8 @@ class ObfuscateSize(CompressorBase):
         elif 110 <= level <= 123:
             self._obfuscate = self._random_padding_obfuscate
             self.max_padding_size = 2 ** (level - 100)  # 1kiB .. 8MiB
+        elif level == 250:  # Padmé
+            self._obfuscate = self._padme_obfuscate
 
     def _obfuscate(self, compr_size):
         # implementations need to return the size of obfuscation data,
@@ -600,6 +604,22 @@ class ObfuscateSize(CompressorBase):
             self.compressor = compressor_cls()
         return self.compressor.decompress(meta, compressed_data)  # decompress data
 
+    def _padme_obfuscate(self, compr_size):
+        if compr_size <= 0:
+            return 0
+
+        E = math.floor(math.log2(compr_size))  # Get exponent (power of 2)
+        S = math.floor(math.log2(E)) + 1       # Second log component
+        lastBits = E - S                       # Bits to be zeroed
+        bitMask = (2 ** lastBits - 1)          # Mask for rounding
+
+        padded_size = (compr_size + bitMask) & ~bitMask  # Apply rounding
+
+        # Ensure max 12% overhead
+        max_allowed = int(compr_size * 1.12)
+        final_size = min(padded_size, max_allowed)
+
+        return final_size - compr_size  # Return only the additional padding size
 
 # Maps valid compressor names to their class
 COMPRESSOR_TABLE = {

--- a/src/borg/testsuite/compress_test.py
+++ b/src/borg/testsuite/compress_test.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import zlib
-
+import math
 import pytest
 
 from ..compress import get_compressor, Compressor, CompressionSpec, CNONE, ZLIB, LZ4, LZMA, ZSTD, Auto
@@ -210,3 +210,32 @@ def test_specified_compression_level(c_type, c_name, c_levels):
 def test_invalid_compression_level(invalid_spec):
     with pytest.raises(argparse.ArgumentTypeError):
         CompressionSpec(invalid_spec)
+
+
+
+
+
+@pytest.mark.parametrize("data_length", [100, 500, 1000, 4000, 8192, 16384])
+def test_padme_obfuscation(data_length):
+    compressor = Compressor(name='obfuscate', level=250, compressor=Compressor('none'))
+    data = b"x" * data_length  # Varying data size
+    meta, compressed = compressor.compress({}, data)
+
+    # Ensure padded size is within the correct bounds
+    assert len(compressed) >= data_length  # Padded size is at least the original size
+    assert len(compressed) <= data_length * 1.12  # Max 12% overhead per Padmé spec
+
+    # Verify Padmé behavior: Ensure padded size is a valid Padmé padded value
+    padded_size = len(compressed)
+
+    # Compute expected Padmé padded size
+    E = math.floor(math.log2(data_length))
+    S = math.floor(math.log2(E)) + 1
+    lastBits = E - S
+    bitMask = (2 ** lastBits - 1)
+    expected_padded_size = (data_length + bitMask) & ~bitMask  # Apply rounding
+
+    max_allowed_size = int(data_length * 1.12)
+    expected_padded_size = min(expected_padded_size, max_allowed_size)
+
+    assert padded_size == expected_padded_size  # Ensure it follows Padmé's rule

--- a/src/borg/testsuite/xattr_test.py
+++ b/src/borg/testsuite/xattr_test.py
@@ -19,7 +19,7 @@ def tempfile_symlink(tmp_path):
 
 def assert_equal_se(is_x, want_x):
     # check 2 xattr lists for equality, but ignore security.selinux attr
-    is_x = set(is_x) - {b"security.selinux"}
+    is_x = set(is_x) - {b"security.selinux", b"com.apple.provenance"}
     want_x = set(want_x)
     assert is_x == want_x
 

--- a/src/borg/testsuite/xattr_test.py
+++ b/src/borg/testsuite/xattr_test.py
@@ -19,7 +19,7 @@ def tempfile_symlink(tmp_path):
 
 def assert_equal_se(is_x, want_x):
     # check 2 xattr lists for equality, but ignore security.selinux attr
-    is_x = set(is_x) - {b"security.selinux", b"com.apple.provenance"}
+    is_x = set(is_x) - {b"security.selinux"}
     want_x = set(want_x)
     assert is_x == want_x
 


### PR DESCRIPTION
Added Padmé padding as a new obfuscation option with SPEC=250.