### PR TITLE
fix: retrieve `birthtime` in nanosecond precision via system call

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1072,7 +1072,9 @@ class MetadataCollector:
         if not self.noctime:
             attrs["ctime"] = safe_ns(st.st_ctime_ns)
         if not self.nobirthtime:
-            attrs["birthtime"] = safe_ns(get_birthtime_ns(st, path, fd=fd))
+            birthtime_ns = get_birthtime_ns(st, path, fd=fd)
+            if birthtime_ns is not None:
+                attrs["birthtime"] = safe_ns(birthtime_ns)
         attrs["uid"] = st.st_uid
         attrs["gid"] = st.st_gid
         if not self.numeric_ids:

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -4,8 +4,6 @@ Platform-specific APIs.
 Public APIs are documented in platform.base.
 """
 
-import os
-
 from ..platformflags import is_win32, is_linux, is_freebsd, is_darwin, is_cygwin
 
 from .base import ENOATTR, API_VERSION
@@ -75,4 +73,4 @@ def get_birthtime_ns(st, path, fd=None):
     elif hasattr(st, "st_birthtime"):
         return int(st.st_birthtime * 10**9)
     else:
-        raise OSError(ENOATTR, os.strerror(ENOATTR), path)
+        return None

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -4,6 +4,8 @@ Platform-specific APIs.
 Public APIs are documented in platform.base.
 """
 
+import os
+
 from ..platformflags import is_win32, is_linux, is_freebsd, is_darwin, is_cygwin
 
 from .base import ENOATTR, API_VERSION
@@ -34,7 +36,7 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import API_VERSION as OS_API_VERSION
     from .darwin import listxattr, getxattr, setxattr
     from .darwin import acl_get, acl_set
-    from .darwin import is_darwin_feature_64_bit_inode, get_birthtime_ns
+    from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
     from .base import set_flags, get_flags
     from .base import SyncFile
     from .posix import process_alive, local_pid_alive
@@ -62,3 +64,15 @@ else:  # pragma: win32 only
     from .windows import process_alive, local_pid_alive
     from .base import swidth
     from .windows import uid2user, user2uid, gid2group, group2gid, getosusername
+
+
+def get_birthtime_ns(st, path, fd=None):
+    if hasattr(st, "st_birthtime_ns"):
+        # added in Python 3.12 but not always available.
+        return st.st_birthtime_ns
+    elif is_darwin and is_darwin_feature_64_bit_inode:
+        return _get_birthtime_ns(fd or path, follow_symlinks=False)
+    elif hasattr(st, "st_birthtime"):
+        return int(st.st_birthtime * 10**9)
+    else:
+        raise OSError(ENOATTR, os.strerror(ENOATTR), path)

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -34,6 +34,7 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import API_VERSION as OS_API_VERSION
     from .darwin import listxattr, getxattr, setxattr
     from .darwin import acl_get, acl_set
+    from .darwin import is_darwin_feature_64_bit_inode, get_birthtime_ns
     from .base import set_flags, get_flags
     from .base import SyncFile
     from .posix import process_alive, local_pid_alive

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -184,7 +184,7 @@ def acl_set(path, item, numeric_ids=False, fd=None):
             acl_free(acl)
 
 
-def get_birthtime_ns(path, follow_symlinks=False):
+def _get_birthtime_ns(path, follow_symlinks=False):
     if isinstance(path, str):
         path = os.fsencode(path)
     cdef stat stat_info

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -10,6 +10,18 @@ from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_str
 
 API_VERSION = '1.2_05'
 
+cdef extern from *:
+    """
+    #ifdef _DARWIN_FEATURE_64_BIT_INODE
+    #define DARWIN_FEATURE_64_BIT_INODE_DEFINED 1
+    #else
+    #define DARWIN_FEATURE_64_BIT_INODE_DEFINED 0
+    #endif
+    """
+    int DARWIN_FEATURE_64_BIT_INODE_DEFINED
+
+is_darwin_feature_64_bit_inode = DARWIN_FEATURE_64_BIT_INODE_DEFINED != 0
+
 cdef extern from "sys/xattr.h":
     ssize_t c_listxattr "listxattr" (const char *path, char *list, size_t size, int flags)
     ssize_t c_flistxattr "flistxattr" (int filedes, char *list, size_t size, int flags)

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -44,6 +44,7 @@ cdef extern from "sys/stat.h":
 
     int c_stat64 "stat64" (const char *path, stat64 *buf)
     int c_lstat64 "lstat64" (const char *path, stat64 *buf)
+    int c_fstat64 "fstat64" (int filedes, stat64 *buf)
 
 
 def listxattr(path, *, follow_symlinks=False):
@@ -176,10 +177,13 @@ def get_birthtime_ns(path, follow_symlinks=False):
         path = os.fsencode(path)
     cdef stat64 stat_info
     cdef int result
-    if follow_symlinks:
-        result = c_stat64(path, &stat_info)
+    if isinstance(path, int):
+        result = c_fstat64(path, &stat_info)
     else:
-        result = c_lstat64(path, &stat_info)
+        if follow_symlinks:
+            result = c_stat64(path, &stat_info)
+        else:
+            result = c_lstat64(path, &stat_info)
     if result != 0:
         raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path))
     return stat_info.st_birthtimespec.tv_sec * 1_000_000_000 + stat_info.st_birthtimespec.tv_nsec

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -39,12 +39,12 @@ cdef extern from "sys/acl.h":
     int ACL_TYPE_EXTENDED
 
 cdef extern from "sys/stat.h":
-    cdef struct stat64:
+    cdef struct stat:
         timespec st_birthtimespec
 
-    int c_stat64 "stat64" (const char *path, stat64 *buf)
-    int c_lstat64 "lstat64" (const char *path, stat64 *buf)
-    int c_fstat64 "fstat64" (int filedes, stat64 *buf)
+    int c_stat "stat" (const char *path, stat *buf)
+    int c_lstat "lstat" (const char *path, stat *buf)
+    int c_fstat "fstat" (int filedes, stat *buf)
 
 
 def listxattr(path, *, follow_symlinks=False):
@@ -175,15 +175,15 @@ def acl_set(path, item, numeric_ids=False, fd=None):
 def get_birthtime_ns(path, follow_symlinks=False):
     if isinstance(path, str):
         path = os.fsencode(path)
-    cdef stat64 stat_info
+    cdef stat stat_info
     cdef int result
     if isinstance(path, int):
-        result = c_fstat64(path, &stat_info)
+        result = c_fstat(path, &stat_info)
     else:
         if follow_symlinks:
-            result = c_stat64(path, &stat_info)
+            result = c_stat(path, &stat_info)
         else:
-            result = c_lstat64(path, &stat_info)
+            result = c_lstat(path, &stat_info)
     if result != 0:
         raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path))
     return stat_info.st_birthtimespec.tv_sec * 1_000_000_000 + stat_info.st_birthtimespec.tv_nsec

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -27,7 +27,7 @@ from . import (
 )
 
 if is_darwin:
-    from ...platform.darwin import get_birthtime_ns
+    from ...platform import get_birthtime_ns, is_darwin_feature_64_bit_inode
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
 
@@ -579,20 +579,32 @@ def test_extract_xattrs_errors(archivers, request):
 
 @pytest.mark.skipif(not is_darwin, reason="only for macOS")
 def test_extract_xattrs_resourcefork(archivers, request):
+
+    def darwin_get_birthtime_ns(path):
+        st = os.stat(input_path)
+        if hasattr(st, "st_birthtime_ns"):
+            return st.st_birthtime_ns
+        elif is_darwin_feature_64_bit_inode:
+            return get_birthtime_ns(path, follow_symlinks=False)
+        elif hasattr(st, "st_birthtime"):
+            return int(st.st_birthtime * 10**9)
+        else:
+            return None
+
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file")
     cmd(archiver, "repo-create", "-e" "none")
     input_path = os.path.abspath("input/file")
     xa_key, xa_value = b"com.apple.ResourceFork", b"whatshouldbehere"  # issue #7234
     xattr.setxattr(input_path.encode(), xa_key, xa_value)
-    birthtime_expected = get_birthtime_ns(input_path)
+    birthtime_expected = darwin_get_birthtime_ns(input_path)
     mtime_expected = os.stat(input_path).st_mtime_ns
     # atime_expected = os.stat(input_path).st_atime_ns
     cmd(archiver, "create", "test", "input")
     with changedir("output"):
         cmd(archiver, "extract", "test")
         extracted_path = os.path.abspath("input/file")
-        birthtime_extracted = get_birthtime_ns(extracted_path)
+        birthtime_extracted = darwin_get_birthtime_ns(extracted_path)
         mtime_extracted = os.stat(extracted_path).st_mtime_ns
         # atime_extracted = os.stat(extracted_path).st_atime_ns
         xa_value_extracted = xattr.getxattr(extracted_path.encode(), xa_key)


### PR DESCRIPTION
Related to #8724.