### PR TITLE
docs: add sphinxcontrib.jquery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,15 +104,13 @@ import guzzle_sphinx_theme
 html_theme_path = guzzle_sphinx_theme.html_theme_path()
 html_theme = "guzzle_sphinx_theme"
 
-# Register the theme as an extension to generate a sitemap.xml
-extensions.append("guzzle_sphinx_theme")
-
 
 def set_rst_settings(app):
     app.env.settings.update({"field_name_limit": 0, "option_limit": 0})
 
 
 def setup(app):
+    app.setup_extension("sphinxcontrib.jquery")
     app.add_css_file("css/borg.css")
     app.connect("builder-inited", set_rst_settings)
 
@@ -246,6 +244,8 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
+    "sphinxcontrib.jquery",  # jquery is not included anymore by default
+    "guzzle_sphinx_theme",  # register the theme as an extension to generate a sitemap.xml
 ]
 
 extlinks = {

--- a/requirements.d/docs.txt
+++ b/requirements.d/docs.txt
@@ -1,2 +1,3 @@
 sphinx
+sphinxcontrib-jquery
 guzzle_sphinx_theme

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands = mypy --ignore-missing-imports
 changedir = docs
 deps =
     sphinx
+    sphinxcontrib-jquery
     guzzle_sphinx_theme
 commands =
     sphinx-build -n -v -W --keep-going -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
The html generated uses jquery ($(...)),
but sphinx does not include it anymore since a while.

also: correctly add guzzle_sphinx_theme to extensions.
