### PR TITLE
Fix paper key import error message

### DIFF
--- a/src/borg/crypto/keymanager.py
+++ b/src/borg/crypto/keymanager.py
@@ -181,7 +181,7 @@ class KeyManager:
                     try:
                         (id_lines, id_repoid, id_complete_checksum) = data.split("/")
                     except ValueError:
-                        print("the id line must contain exactly three '/', try again")
+                        print("the id line must contain exactly two '/', try again")
                         continue
                     if sha256_truncated(data.lower().encode("ascii"), 2) != checksum:
                         print("line checksum did not match, try same line again")


### PR DESCRIPTION
I just experimented a bit with printable key ex/import and noticed the error message checking the number of slashes in the `id`  line being wrong.

This also applies to at least the 1.4 and 1.2 versions
