### PR TITLE
fix: retrieve `birthtime` in nanosecond precision via system call (1.4-maint)

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -40,3 +40,16 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import API_VERSION as OS_API_VERSION
     from .darwin import listxattr, getxattr, setxattr
     from .darwin import acl_get, acl_set
+    from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
+
+
+def get_birthtime_ns(st, path, fd=None):
+    if hasattr(st, "st_birthtime_ns"):
+        # added in Python 3.12 but not always available.
+        return st.st_birthtime_ns
+    elif is_darwin and is_darwin_feature_64_bit_inode:
+        return _get_birthtime_ns(fd or path, follow_symlinks=False)
+    elif hasattr(st, "st_birthtime"):
+        return int(st.st_birthtime * 10**9)
+    else:
+        return None

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -2,12 +2,25 @@ import os
 
 from libc.stdint cimport uint32_t
 from libc cimport errno
+from posix.time cimport timespec
 
 from .posix import user2uid, group2gid
 from ..helpers import safe_decode, safe_encode
 from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_string0
 
 API_VERSION = '1.4_01'
+
+cdef extern from *:
+    """
+    #ifdef _DARWIN_FEATURE_64_BIT_INODE
+    #define DARWIN_FEATURE_64_BIT_INODE_DEFINED 1
+    #else
+    #define DARWIN_FEATURE_64_BIT_INODE_DEFINED 0
+    #endif
+    """
+    int DARWIN_FEATURE_64_BIT_INODE_DEFINED
+
+is_darwin_feature_64_bit_inode = DARWIN_FEATURE_64_BIT_INODE_DEFINED != 0
 
 cdef extern from "sys/xattr.h":
     ssize_t c_listxattr "listxattr" (const char *path, char *list, size_t size, int flags)
@@ -36,6 +49,14 @@ cdef extern from "sys/acl.h":
     acl_t acl_from_text(const char *buf)
     char *acl_to_text(acl_t acl, ssize_t *len_p)
     int ACL_TYPE_EXTENDED
+
+cdef extern from "sys/stat.h":
+    cdef struct stat:
+        timespec st_birthtimespec
+
+    int c_stat "stat" (const char *path, stat *buf)
+    int c_lstat "lstat" (const char *path, stat *buf)
+    int c_fstat "fstat" (int filedes, stat *buf)
 
 
 def listxattr(path, *, follow_symlinks=False):
@@ -159,3 +180,20 @@ def acl_set(path, item, numeric_ids=False, fd=None):
                     raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path))
         finally:
             acl_free(acl)
+
+
+def _get_birthtime_ns(path, follow_symlinks=False):
+    if isinstance(path, str):
+        path = os.fsencode(path)
+    cdef stat stat_info
+    cdef int result
+    if isinstance(path, int):
+        result = c_fstat(path, &stat_info)
+    else:
+        if follow_symlinks:
+            result = c_stat(path, &stat_info)
+        else:
+            result = c_lstat(path, &stat_info)
+    if result != 0:
+        raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path))
+    return stat_info.st_birthtimespec.tv_sec * 1_000_000_000 + stat_info.st_birthtimespec.tv_nsec

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1516,19 +1516,19 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         input_path = os.path.abspath('input/file')
         xa_key, xa_value = b'com.apple.ResourceFork', b'whatshouldbehere'  # issue #7234
         xattr.setxattr(input_path.encode(), xa_key, xa_value)
-        birthtime_expected = os.stat(input_path).st_birthtime
+        birthtime_expected = platform.get_birthtime_ns(os.stat(input_path), input_path)
         mtime_expected = os.stat(input_path).st_mtime_ns
         # atime_expected = os.stat(input_path).st_atime_ns
         self.cmd('create', self.repository_location + '::test', 'input')
         with changedir('output'):
             self.cmd('extract', self.repository_location + '::test')
             extracted_path = os.path.abspath('input/file')
-            birthtime_extracted = os.stat(extracted_path).st_birthtime
+            birthtime_extracted = platform.get_birthtime_ns(os.stat(extracted_path), extracted_path)
             mtime_extracted = os.stat(extracted_path).st_mtime_ns
             # atime_extracted = os.stat(extracted_path).st_atime_ns
             xa_value_extracted = xattr.getxattr(extracted_path.encode(), xa_key)
         assert xa_value_extracted == xa_value
-        assert same_ts_ns(birthtime_extracted * 1e9, birthtime_expected * 1e9)
+        assert same_ts_ns(birthtime_extracted, birthtime_expected)
         assert same_ts_ns(mtime_extracted, mtime_expected)
         # assert same_ts_ns(atime_extracted, atime_expected)  # still broken, but not really important.
 


### PR DESCRIPTION
Backport #8725 to 1.4-maint.