### PR TITLE
Add Codecov Test Analytics 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,11 @@ jobs:
       run: |
         # do not use fakeroot, but run as root. avoids the dreaded EISDIR sporadic failures. see #2482.
         #sudo -E bash -c "tox -e py"
-        tox --skip-missing-interpreters
+        tox --skip-missing-interpreters -- --junitxml=test-results.xml
+    - name: Upload test results to Codecov
+      uses: codecov/test-results-action@v1
+      with:
+        files: test-results.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:
@@ -186,7 +190,11 @@ jobs:
       run: |
         # do not use fakeroot, but run as root. avoids the dreaded EISDIR sporadic failures. see #2482.
         #sudo -E bash -c "tox -e py"
-        tox --skip-missing-interpreters
+        tox --skip-missing-interpreters -- --junitxml=test-results.xml
+    - name: Upload test results to Codecov
+      uses: codecov/test-results-action@v1
+      with:
+        files: test-results.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:
@@ -236,4 +244,8 @@ jobs:
       - name: Run tests
         run: |
           ./dist/borg.exe -V
-          pytest -n4 --benchmark-skip -vv -rs -k "not remote"
+          pytest -n4 --benchmark-skip -vv -rs -k "not remote" --junitxml=test-results.xml
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        with:
+          files: test-results.xml


### PR DESCRIPTION
This PR sets up Codecov [Test Analytics](https://docs.codecov.com/docs/test-analytics), which enhances this project's existing Codecov coverage PR notification with details about failing, flaky, and slow tests. More details can be found [here](https://about.codecov.io/blog/find-failing-and-flaky-tests-with-codecov-test-analytics/), and below is an example screenshot.

![Test Results](https://private-user-images.githubusercontent.com/175655418/425226666-d74ba608-0cec-4e28-813d-38adb6b799a4.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ1ODQwNDksIm5iZiI6MTc0NDU4Mzc0OSwicGF0aCI6Ii8xNzU2NTU0MTgvNDI1MjI2NjY2LWQ3NGJhNjA4LTBjZWMtNGUyOC04MTNkLTM4YWRiNmI3OTlhNC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNDEzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDQxM1QyMjM1NDlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1hYmZmZjY1MWRmMWM5ZDZiYzE3OGJmYzdhNmQ0NzgzYmVkZGEyYTYwYTgyNmQxOGUxNDJiMGY3YTUwNTVmNjMwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.s69mLiFMZ3PjeDctT2VPHqWA1N6bzfKZTViVs97HZI8)

## Changes 
1. Updated test run command to include --junitxml=test-results.xml so Codecov can parse test analytics.
2. Added codecov/test-results-action@v1 step to upload the generated test-results.xml for Test Analytics.

Looking forward to your feedback!