### PR TITLE
freebsd: fix nfs4 acl processing, fixes #8756 (master)

### DIFF
--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -200,7 +200,7 @@ cdef _nfs4_use_stored_uid_gid(acl):
         if entry:
             if entry.startswith('user:') or entry.startswith('group:'):
                 fields = entry.split(':')
-                entries.append(':'.join(fields[0], fields[5], *fields[2:-1]))
+                entries.append(':'.join([fields[0], fields[5]] + fields[2:-1]))
             else:
                 entries.append(entry)
     return safe_encode('\n'.join(entries))


### PR DESCRIPTION
This only happened when:
- using borg extract --numeric-ids
- processing NFS4 ACLs

It didn't affect POSIX ACL processing.

This is rather old code, so it looks like nobody used that code or the bug was not reported.

The bug was discovered by PyCharm's "Junie" AI. \o/
