### PR TITLE
Remove unnecessary check that Padmé overhead is at most 12%

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -613,11 +613,7 @@ class ObfuscateSize(CompressorBase):
 
         padded_size = (compr_size + bitMask) & ~bitMask  # Apply rounding
 
-        # Ensure max 12% overhead
-        max_allowed = int(compr_size * 1.12)
-        final_size = min(padded_size, max_allowed)
-
-        return final_size - compr_size  # Return only the additional padding size
+        return padded_size - compr_size  # Return only the additional padding size
 
 # Maps valid compressor names to their class
 COMPRESSOR_TABLE = {


### PR DESCRIPTION
It's easy enough to verify exhaustively for any plausible chunker params that Padmé always produces at most a 12% overhead. Checking that again at runtime is pointless.

A self-contained script to confirm the above for all data lengths between 2 bytes and 100 megabytes (takes about 2 minutes to run):

```python
#%%
import math
from math import floor

def log(x):                           # we use log in base 2
    return math.log(x, 2)

def padme(L):
    """
    Pads the length L using the Padmé algorithm
    Args:
        L (int): unpadded object length
    Returns:
        int: the padded object length
    """
    E = floor(log(L))
    S = floor(log(E))+1
    lastBits = E-S                    # we want those bits to be 0
    bitMask = (2 ** lastBits - 1)     # create a bitmask of 1's
    return (L + bitMask) & ~bitMask   # round up if necessary

def borg(compr_size):
    if compr_size < 2:
        return 0

    E = math.floor(math.log2(compr_size))  # Get exponent (power of 2)
    S = math.floor(math.log2(E)) + 1       # Second log component
    lastBits = E - S                       # Bits to be zeroed
    bitMask = (2 ** lastBits - 1)          # Mask for rounding

    padded_size = (compr_size + bitMask) & ~bitMask  # Apply rounding

    # Ensure max 12% overhead
    max_allowed = int(compr_size * 1.12)
    final_size = min(padded_size, max_allowed)

    #return final_size - compr_size  # Return only the additional padding size
    # we want to compare with the original implementation,
    # which returns the entire padded length:
    return final_size

#%%
for n in range(2, 100_000_000):
    a = padme(n)
    b = borg(n)
    if a != b:
        print(f"difference at {n}: {a} vs {b}")
        break
else:
    print("all good!")
```