### PR TITLE
Remove unnecessary check that Padmé overhead is at most 12%

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -512,11 +512,7 @@ class ObfuscateSize(CompressorBase):
 
         padded_size = (compr_size + bitMask) & ~bitMask  # Apply rounding
 
-        # Ensure max 12% overhead
-        max_allowed = int(compr_size * 1.12)
-        final_size = min(padded_size, max_allowed)
-
-        return final_size - compr_size  # Return only the additional padding size
+        return padded_size - compr_size  # Return only the additional padding size
 
 # Maps valid compressor names to their class
 COMPRESSOR_TABLE = {


### PR DESCRIPTION
It's easy enough to verify exhaustively for any plausible chunker params that Padmé always produces at most a 12% overhead. Checking that again at runtime is pointless.

(backport from master)