### PR TITLE
remove support for / testing on Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,17 +48,14 @@ jobs:
       matrix:
         include:
             - os: ubuntu-22.04
-              python-version: '3.9'
+              python-version: '3.10'
               toxenv: mypy
             - os: ubuntu-22.04
               python-version: '3.11'
               toxenv: docs
             - os: ubuntu-22.04
-              python-version: '3.9'
-              toxenv: py39-fuse2
-            - os: ubuntu-22.04
               python-version: '3.10'
-              toxenv: py310-fuse3
+              toxenv: py310-fuse2
             - os: ubuntu-22.04
               python-version: '3.11'
               toxenv: py311-fuse3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ maintainers = [
     {name="Thomas Waldmann", email="tw@waldmann-edv.de"},
 ]
 description = "Deduplicated, encrypted, authenticated and compressed backups"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["backup", "borgbackup"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -141,7 +140,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 markers = []
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict_optional = false
 local_partial_types = true
 show_error_codes = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # fakeroot -u tox --recreate
 
 [tox]
-envlist = py{39,310,311,312,313}-{none,fuse2,fuse3},docs
+envlist = py{310,311,312,313}-{none,fuse2,fuse3},docs
 minversion = 3.2
 requires =
 	pkgconfig


### PR DESCRIPTION
Python 3.9 will run out of upstream support 2025-10 anyway. So we can also drop it right now and have faster CI testing.

Fixes #8723.