### PR TITLE
chunks cache: invalidate old chunk index cache

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -701,7 +701,7 @@ def delete_chunkindex_cache(repository):
     logger.debug(f"cached chunk indexes deleted: {hashes}")
 
 
-CHUNKINDEX_HASH_SEED = 2
+CHUNKINDEX_HASH_SEED = 3
 
 
 def write_chunkindex_to_repo_cache(


### PR DESCRIPTION
guess we better invalidate the old repo-side cache of the chunk index and rebuild it with the current borg and borghash code.
