### PR TITLE
require Cython < 3.1 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ where = ["src"]
 "*" = ["*.c", "*.h", "*.pyx"]
 
 [build-system]
-requires = ["setuptools>=77.0.0", "wheel", "pkgconfig", "Cython>=3.0.3", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.0", "wheel", "pkgconfig", "Cython>=3.0.3,<3.1.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -10,5 +10,5 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-benchmark
-Cython
+Cython < 3.1
 pre-commit


### PR DESCRIPTION
This is a workaround for #8828.
