### PR TITLE
fix #6858: correct the signature of __set_name__ as cython 3.1 added support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ where = ["src"]
 "*" = ["*.c", "*.h", "*.pyx"]
 
 [build-system]
-requires = ["setuptools>=77.0.0", "wheel", "pkgconfig", "Cython>=3.0.3,<3.1.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.0", "wheel", "pkgconfig", "Cython>=3.0.3", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -10,5 +10,5 @@ pytest
 pytest-xdist
 pytest-cov
 pytest-benchmark
-Cython < 3.1
+Cython
 pre-commit

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -238,7 +238,7 @@ cdef class PropDictProperty:
         except KeyError:
             raise AttributeError(self.attr_error_msg) from None
 
-    cpdef __set_name__(self, name):
+    cpdef __set_name__(self, owner, name):
        self.key = name
        self.__doc__ = "%s (%s)" % (name, self.value_type_name)
        self.type_error_msg = "%s value must be %s" % (name, self.value_type_name)
@@ -613,12 +613,12 @@ cdef class ManifestItem(PropDict):
 
 cpdef _init_names():
     """
-    re-implements python __set_name__
+    re-implements python __set_name__ for Cython<3.1
     """
     for cls in PropDict.__subclasses__():
         for name, value in vars(cls).items():
             if isinstance(value, PropDictProperty):
-                value.__set_name__(name)
+                value.__set_name__(cls, name)
 
 _init_names()
 


### PR DESCRIPTION

uses the correct invocations for __set_name__ as cython now supports it

the code for manually calling is left in place to ensure support for older cython where needed

closes #8828 

