### PR TITLE
repository: add write-only permissions mode, fixes #1165

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -498,6 +498,8 @@ class Archive:
         deleted=False,
     ):
         name_is_id = isinstance(name, bytes)
+        if not name_is_id:
+            assert len(name) <= 255
         self.cwd = os.getcwd()
         assert isinstance(manifest, Manifest)
         self.manifest = manifest

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -7,6 +7,8 @@ from collections import namedtuple
 from datetime import datetime, timezone, timedelta
 from time import perf_counter
 
+from borgstore.backends.errors import PermissionDenied
+
 from .logger import create_logger
 
 logger = create_logger()
@@ -443,7 +445,10 @@ class FilesCacheMixin:
         from .archive import Archive
 
         # get the latest archive with the IDENTICAL name, supporting archive series:
-        archives = self.manifest.archives.list(match=[self.archive_name], sort_by=["ts"], last=1)
+        try:
+            archives = self.manifest.archives.list(match=[self.archive_name], sort_by=["ts"], last=1)
+        except PermissionDenied:  # maybe repo is in write-only mode?
+            archives = None
         if not archives:
             # nothing found
             return

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -553,7 +553,6 @@ class Manifest:
             self.timestamp = max_ts.isoformat(timespec="microseconds")
         # include checks for limits as enforced by limited unpacker (used by load())
         assert self.archives.count() <= MAX_ARCHIVES
-        assert all(len(name) <= 255 for name in self.archives.names())
         assert len(self.item_keys) <= 100
         self.config["item_keys"] = tuple(sorted(self.item_keys))
         manifest_archives = self.archives.finish(self)

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -130,11 +130,22 @@ class Repository:
                 "keys": "lr",
                 "locks": "lrwD",  # borg needs to create/delete a shared lock here
             }
+        elif permissions == "write-only":  # mostly no reading
+            permissions = {
+                "": "l",
+                "archives": "lw",
+                "cache": "lrwWD",  # read allowed, e.g. for chunks.<HASH> cache
+                "config": "lrW",  # W for manifest
+                "data": "lw",  # no r!
+                "keys": "lr",
+                "locks": "lrwD",  # borg needs to create/delete a shared lock here
+            }
         elif permissions == "read-only":  # mostly r/o
             permissions = {"": "lr", "locks": "lrwD"}
         else:
             raise Error(
-                f"Invalid BORG_REPO_PERMISSIONS value: {permissions}, should be one of: all, no-delete, read-only"
+                f"Invalid BORG_REPO_PERMISSIONS value: {permissions}, should be one of: "
+                f"all, no-delete, write-only, read-only."
             )
 
         try:


### PR DESCRIPTION
Also: moved name length check to Archive.__init__, so it doesn't read all other archives main metadata when creating a new archive.

In write-only mode, the files cache can't be built from the repo from the latest archive of same series, we are not allowed to read that!

fixes #1165 

fixes #4071 
