### PR TITLE
export-tar/import-tar: support for POSIX ACLs

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1566,6 +1566,12 @@ class TarfileObjectProcessors:
                         bkey = key.encode("utf-8", errors="surrogateescape")
                         bvalue = value.encode("utf-8", errors="surrogateescape")
                         xattrs[bkey] = bvalue
+                    elif key == SCHILY_ACL_ACCESS:
+                        # Process POSIX access ACL
+                        item.acl_access = value.encode("utf-8", errors="surrogateescape")
+                    elif key == SCHILY_ACL_DEFAULT:
+                        # Process POSIX default ACL
+                        item.acl_default = value.encode("utf-8", errors="surrogateescape")
                 if xattrs:
                     item.xattrs = xattrs
         yield item, status

--- a/src/borg/archiver/tar_cmds.py
+++ b/src/borg/archiver/tar_cmds.py
@@ -216,6 +216,13 @@ class TarMixIn:
                     key = SCHILY_XATTR + bkey.decode("utf-8", errors="surrogateescape")
                     value = bvalue.decode("utf-8", errors="surrogateescape")
                     ph[key] = value
+            # Add POSIX access and default ACL if present
+            acl_access = item.get("acl_access")
+            if acl_access is not None:
+                ph[SCHILY_ACL_ACCESS] = acl_access.decode("utf-8", errors="surrogateescape")
+            acl_default = item.get("acl_default")
+            if acl_default is not None:
+                ph[SCHILY_ACL_DEFAULT] = acl_default.decode("utf-8", errors="surrogateescape")
             if format == "BORG":  # BORG format additions
                 ph["BORG.item.version"] = "1"
                 # BORG.item.meta - just serialize all metadata we have:

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -125,6 +125,8 @@ TIME_DIFFERS2_NS = 3000000000
 
 # tar related
 SCHILY_XATTR = "SCHILY.xattr."  # xattr key prefix in tar PAX headers
+SCHILY_ACL_ACCESS = "SCHILY.acl.access"  # POSIX access ACL in tar PAX headers
+SCHILY_ACL_DEFAULT = "SCHILY.acl.default"  # POSIX default ACL in tar PAX headers
 
 # special tags
 # @PROT protects archives against accidential deletion or modification by delete, prune or recreate.


### PR DESCRIPTION
Implemented handling of POSIX access and default ACLs in tar files. New keys, `SCHILY.acl.access` and `SCHILY.acl.default`, are used to store these ACLs in the tar PAX headers.

See #2521.
