### PR TITLE
tests: fix diff cmd test on macOS HFS+, fixes #8860

### DIFF
--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -53,6 +53,7 @@ def test_basic_functionality(archivers, request):
     create_regular_file(archiver.input_path, "file_replaced", contents=b"0" * 4096)
     os.unlink("input/file_removed")
     os.unlink("input/file_removed2")
+    time.sleep(1)  # macOS HFS+ has a 1s timestamp granularity
     Path("input/file_touched").touch()
     os.rmdir("input/dir_replaced_with_file")
     create_regular_file(archiver.input_path, "dir_replaced_with_file", size=8192)


### PR DESCRIPTION
If we touch too quickly after file creation, it would not noticably update the timestamp.
