### PR TITLE
Tests: save temp space

### DIFF
--- a/src/borg/testsuite/archiver/list_cmd_test.py
+++ b/src/borg/testsuite/archiver/list_cmd_test.py
@@ -35,11 +35,13 @@ def test_list_chunk_counts(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "empty_file", size=0)
     create_regular_file(archiver.input_path, "two_chunks")
-    with open(os.path.join(archiver.input_path, "two_chunks"), "wb") as fd:
+    filename = os.path.join(archiver.input_path, "two_chunks")
+    with open(filename, "wb") as fd:
         fd.write(b"abba" * 2000000)
         fd.write(b"baab" * 2000000)
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     cmd(archiver, "create", "test", "input")
+    os.unlink(filename)  # save space on TMPDIR
     output = cmd(archiver, "list", "test", "--format", "{num_chunks} {path}{NL}")
     assert "0 input/empty_file" in output
     assert "2 input/two_chunks" in output

--- a/src/borg/testsuite/archiver/repo_space_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_space_cmd_test.py
@@ -54,6 +54,8 @@ def test_repo_space_modify_reservation(archivers, request):
 
     # note: --reserve can only INCREASE the amount of reserved space.
 
+    cmd(archiver, "repo-space", "--free")  # save space on TMPDIR
+
 
 def test_repo_space_edge_cases(archivers, request):
     archiver = request.getfixturevalue(archivers)
@@ -78,3 +80,5 @@ def test_repo_space_edge_cases(archivers, request):
     # Check that space is reserved (should be 64MiB).
     output = cmd(archiver, "repo-space")
     assert "There is 67.11 MB reserved space in this repository." in output
+
+    cmd(archiver, "repo-space", "--free")  # save space on TMPDIR

--- a/src/borg/testsuite/archiver/transfer_cmd_test.py
+++ b/src/borg/testsuite/archiver/transfer_cmd_test.py
@@ -412,7 +412,7 @@ def test_transfer_rechunk(archivers, request, monkeypatch):
     """Test transfer with re-chunking"""
     archiver = request.getfixturevalue(archivers)
 
-    BLKSIZE = 4096
+    BLKSIZE = 512
     source_chunker_params = "buzhash,19,23,21,4095"  # default buzhash chunks
     dest_chunker_params = f"fixed,{BLKSIZE}"  # fixed chunk size
 

--- a/src/borg/testsuite/legacyrepository_test.py
+++ b/src/borg/testsuite/legacyrepository_test.py
@@ -229,6 +229,7 @@ def test_max_data_size(repo_fixtures, request):
         assert pdchunk(repository.get(H(0))) == max_data
         with pytest.raises(IntegrityError):
             repository.put(H(1), fchunk(max_data + b"x"))
+        repository.delete(H(0))
 
 
 def _assert_sparse(repository):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -143,6 +143,7 @@ def test_max_data_size(repo_fixtures, request):
         assert pdchunk(repository.get(H(0))) == max_data
         with pytest.raises(IntegrityError):
             repository.put(H(1), fchunk(max_data + b"x"))
+        repository.delete(H(0))
 
 
 def check(repository, repo_path, repair=False, status=True):


### PR DESCRIPTION
pytest likes to keep the temp files from the test for a while (the last 3 test runs).

if we want to be able to use a ramdisk of reasonable size for the temp files, we need to be a bit more careful about how much data we create there.

after this PR, we need ~500MB space per test run, so a ramdisk of 1.5-2.0GB works.