### PR TITLE
minor tox.ini improvements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@
 envlist = py{310,311,312,313}-{none,fuse2,fuse3},docs
 minversion = 3.2
 requires =
-	pkgconfig
-	cython
-	wheel
-	setuptools_scm
+    pkgconfig
+    cython
+    wheel
+    setuptools_scm
 
 [testenv]
 package = editable-legacy  # without this it does not find setup_docs when running under fakeroot
@@ -19,25 +19,21 @@ deps =
     fuse2: llfuse
     fuse3: pyfuse3
     -rrequirements.d/development.txt
-commands = py.test -v -n {env:XDISTN:1} -rs --cov=borg --cov-config=.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
+commands = pytest -v -n {env:XDISTN:1} -rs --cov=borg --cov-config=.coveragerc --benchmark-skip --pyargs {posargs:borg.testsuite}
 # fakeroot -u needs some env vars:
 passenv = *
-
 
 [testenv:.pkg]
 passenv = *  # needed by tox4, so env vars are visible for building borg
 
-
 [testenv:ruff]
 skip_sdist=true
 skip_install=true
-changedir =
 deps =
     ruff
 commands = ruff check .
 
 [testenv:mypy]
-changedir =
 deps =
     pytest
     mypy


### PR DESCRIPTION
- consistent indentation with spaces
- use pytest, not py.test
- consistent empty lines between sections
- remove empty changedir lines
