### PR TITLE
CI: disable windows for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
 
   windows:
 
-    if: true  # can be used to temporary disable build
+    if: false  # can be used to temporary disable build
     runs-on: windows-latest
     timeout-minutes: 120
     needs: linux


### PR DESCRIPTION
The file:// repo URLs are still broken on windows.
