### PR TITLE
blake2b_256: fix key passing, fixes #8867

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -248,7 +248,7 @@ class BenchmarkMixIn:
             else:
                 print(f"{spec:<24} {format_file_size(size):<10} {dt:.3f}s")
 
-        from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
+        from ..crypto.low_level import AES256_CTR_BLAKE2b_legacy, AES256_CTR_HMAC_SHA256
         from ..crypto.low_level import AES256_OCB, CHACHA20_POLY1305
 
         if not args.json:
@@ -266,7 +266,7 @@ class BenchmarkMixIn:
             ),
             (
                 "aes-256-ctr-blake2b",
-                lambda: AES256_CTR_BLAKE2b(key_256 * 4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
+                lambda: AES256_CTR_BLAKE2b_legacy(key_256 * 4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
                     random_10M, header=b"X"
                 ),
             ),

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -183,7 +183,7 @@ class KeyType:
     REPO = 0x03
     BLAKE2KEYFILE = 0x04
     BLAKE2REPO = 0x05
-    BLAKE2AUTHENTICATED = 0x06
+    BLAKE2AUTHENTICATEDLEGACY = 0x06
     AUTHENTICATED = 0x07
     # new crypto
     # upper 4 bits are ciphersuite, lower 4 bits are keytype
@@ -195,6 +195,7 @@ class KeyType:
     BLAKE2AESOCBREPO = 0x31
     BLAKE2CHPOKEYFILE = 0x40
     BLAKE2CHPOREPO = 0x41
+    BLAKE2AUTHENTICATED = 0x51
 
 
 CACHE_TAG_NAME = "CACHEDIR.TAG"


### PR DESCRIPTION
borg 1.x involved the key a bit unusually in the blake2b hash calculation (padding 64B of key material with another 64B of zeros to a total of 128B and then just prepending it to the data).

since a while, we use blake2b from python stdlib and they support passing the key as a separate argument. up to 64B keys are allowed here.

besides the way how the 64B of key material are passed, there are also other differences in how the key gets involved in the digest computation, thus the legacy blake2b hashes from borg 1.x are not compatible with the ones borg 2 will use. The hash is not the same for same key and data values.
