### PR TITLE
test_chunkpoints_unchanged: do not use blake2b_256

### DIFF
--- a/src/borg/testsuite/chunker_slow.py
+++ b/src/borg/testsuite/chunker_slow.py
@@ -1,11 +1,15 @@
+from hashlib import sha256
 from io import BytesIO
 from binascii import unhexlify
 
 from .chunker import cf
 from ..chunker import Chunker
-from ..crypto.low_level import blake2b_256
 from ..constants import *  # NOQA
 from . import BaseTestCase
+
+
+def H(data):
+    return sha256(data).digest()
 
 
 class ChunkerRegressionTestCase(BaseTestCase):
@@ -31,10 +35,10 @@ class ChunkerRegressionTestCase(BaseTestCase):
                         for seed in (1849058162, 1234567653):
                             fh = BytesIO(data)
                             chunker = Chunker(seed, minexp, maxexp, maskbits, winsize)
-                            chunks = [blake2b_256(b'', c) for c in cf(chunker.chunkify(fh, -1))]
-                            runs.append(blake2b_256(b'', b''.join(chunks)))
+                            chunks = [H(c) for c in cf(chunker.chunkify(fh, -1))]
+                            runs.append(H(b''.join(chunks)))
 
         # The "correct" hash below matches the existing chunker behavior.
         # Future chunker optimisations must not change this, or existing repos will bloat.
-        overall_hash = blake2b_256(b'', b''.join(runs))
-        self.assert_equal(overall_hash, unhexlify("b559b0ac8df8daaa221201d018815114241ea5c6609d98913cd2246a702af4e3"))
+        overall_hash = H(b''.join(runs))
+        self.assert_equal(overall_hash, unhexlify("a43d0ecb3ae24f38852fcc433a83dacd28fe0748d09cc73fc11b69cf3f1a7299"))


### PR DESCRIPTION
we want to get rid of legacy stuff(*) one day and sha256 is as good for this purpose (and might be even hw accelerated).

(*) considered legacy due to the way it gives the key to the blake2b function (just padding and prepending it to the data, instead of using the key parameter, see #8867 ).
