### PR TITLE
Improved tty-less progress reporting

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -146,7 +146,7 @@ Bytes sent to remote: {stats.tx_bytes}
     def usize_fmt(self):
         return format_file_size(self.usize, iec=self.iec)
 
-    def show_progress(self, item=None, final=False, stream=None, dt=None):
+    def show_progress(self, item=None, final=False, stream=sys.stderr, dt=None):
         now = time.monotonic()
         if dt is None or now - self.last_progress > dt:
             self.last_progress = now
@@ -159,6 +159,13 @@ Bytes sent to remote: {stats.tx_bytes}
                     data = {}
                 data.update({"time": time.time(), "type": "archive_progress", "finished": final})
                 msg = json.dumps(data)
+                end = "\n"
+            elif not stream.isatty():
+                if not final:
+                    msg = "{0.osize_fmt} O {0.csize_fmt} C {0.usize_fmt} D {0.nfiles} N ".format(self)
+                    msg += remove_surrogates(item.path) if item else ""
+                else:
+                    msg = ""
                 end = "\n"
             else:
                 columns, lines = get_terminal_size()
@@ -174,7 +181,7 @@ Bytes sent to remote: {stats.tx_bytes}
                 else:
                     msg = " " * columns
                 end = "\r"
-            print(msg, end=end, file=stream or sys.stderr, flush=True)
+            print(msg, end=end, file=stream, flush=True)
 
 
 def is_special(mode):


### PR DESCRIPTION
Previously when running borg in a systemd service (and similar when piping to a file and co.), these problems occurred:
- The carriage return both made it so that journald interpreted the output as binary, therefore not printing the text, while also not buffering correctly, so that log output was only available every once in a while in the form [40k blob data]. This can partially be worked around by using `journalctl -a` to view the logs, which at least prints the text, though only sporadically
- The path was getting truncated to a short length, since the default get_terminal_size returns a column width of 80, which isn't relevant when printing to e.g. journald

This commit fixes this by introducing a new code path for when stderr is a tty, which always prints the full paths and never ends with a carriage return.

Unfortunately I don't have the time right now to make the tests work nor add new ones to cover this, but I figured at least getting this patch out of my local repository is better than keeping it for myself, it definitely works in my deployment. Because of this I'll mark this PR a draft for now, feel free to close it if neither me nor anybody else manages to make the tests satisfactory in a reasonable time.