### PR TITLE
tests: fix ZeroDivisionError msg test for py314 (for borg 1.4)

### DIFF
--- a/src/borg/testsuite/repository.py
+++ b/src/borg/testsuite/repository.py
@@ -977,7 +977,7 @@ class RemoteRepositoryTestCase(RepositoryTestCase):
             self.repository.call('inject_exception', {'kind': 'divide'})
         except RemoteRepository.RPCError as e:
             assert e.unpacked
-            assert e.get_message() == 'ZeroDivisionError: integer division or modulo by zero\n'
+            assert e.get_message().startswith("ZeroDivisionError:")
             assert e.exception_class == 'ZeroDivisionError'
             assert len(e.exception_full) > 0
 


### PR DESCRIPTION
This is a backport of eaca4a6c4a07bffb412588c8bf602fb29553dc16 (#8913) to 1.4-maint. I added this patch to Fedora to get borg 1.4 building for the upcoming Fedora 43 which will use Python 3.14.