### PR TITLE
to_key_filename: raise length limit to 120, fixes #8966

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -545,11 +545,11 @@ class Location:
         name = re.sub(r"[^\w]", "_", self.path.rstrip("/"))
         if self.proto not in ("file", "socket", "rclone"):
             name = re.sub(r"[^\w]", "_", self.host) + "__" + name
-        if len(name) > 100:
+        if len(name) > 120:
             # Limit file names to some reasonable length. Most file systems
             # limit them to 255 [unit of choice]; due to variations in unicode
             # handling we truncate to 100 *characters*.
-            name = name[:100]
+            name = name[:120]
         return os.path.join(get_keys_dir(), name)
 
     def __repr__(self):


### PR DESCRIPTION
it used to be 100, but that caused test failures on some systems with deep build directories.
