### PR TITLE
Add Arch Linux to installing from source docs (v1.4 backport)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -187,6 +187,19 @@ instructions, try to use your package manager to install the dependencies.
 After you have installed the dependencies, you can proceed with steps outlined
 under :ref:`pip-installation`.
 
+Arch Linux
+++++++++++
+
+Install the runtime and build dependencies::
+
+    pacman -S python python-pip python-virtualenv openssl acl xxhash lz4 zstd base-devel
+    pacman -S fuse2     # needed for llfuse
+    pacman -S fuse3     # needed for pyfuse3
+
+Note that Arch Linux specifically doesn't support
+`partial upgrades <https://wiki.archlinux.org/title/Partial_upgrade>`__,
+so in case some packages cannot be retrieved from the repo, run with ``pacman -Syu``.
+
 Debian / Ubuntu
 +++++++++++++++
 


### PR DESCRIPTION
Backport of #9018

By the way: There are GitHub actions (e.g. [here](https://github.com/marketplace/actions/backporting) and [here](https://github.com/marketplace/actions/backport-action)) that can automate this. Didn't use any myself before, so I can't really make a recommendation, but I've seen them in other projects, so might be worth a look :+1: