### PR TITLE
Update install docs to include `SETUPTOOLS_SCM_PRETEND_VERSION` (v1.4 backport)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -318,11 +318,11 @@ Use the Cygwin installer to install the dependencies::
 Using pip
 ~~~~~~~~~
 
-Ensure to install the dependencies as described within :ref:`source-install`.
-
 Virtualenv_ can be used to build and install Borg without affecting
 the system Python or requiring root access.  Using a virtual environment is
 optional, but recommended except for the most simple use cases.
+
+Ensure to install the dependencies as described within :ref:`source-install`.
 
 .. note::
     If you install into a virtual environment, you need to **activate** it
@@ -367,10 +367,10 @@ locally::
 Using git
 ~~~~~~~~~
 
-Ensure to install the dependencies as described within :ref:`source-install`.
-
 This uses latest, unreleased development code from git.
 While we try not to break master, there are no guarantees on anything.
+
+Ensure to install the dependencies as described within :ref:`source-install`.
 
 Version metadata is obtained dynamically at install time using ``setuptools-scm``.
 Please ensure that your git repo either has correct tags, or provide the version

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -372,6 +372,10 @@ Ensure to install the dependencies as described within :ref:`source-install`.
 This uses latest, unreleased development code from git.
 While we try not to break master, there are no guarantees on anything.
 
+Version metadata is obtained dynamically at install time using ``setuptools-scm``.
+Please ensure that your git repo either has correct tags, or provide the version
+manually using the ``SETUPTOOLS_SCM_PRETEND_VERSION`` environment variable.
+
 ::
 
     # get borg from github
@@ -381,11 +385,15 @@ While we try not to break master, there are no guarantees on anything.
     virtualenv --python=$(which python3) borg-env
     source borg-env/bin/activate   # always before using!
 
-    # install borg + dependencies into virtualenv
+    # install borg dependencies into virtualenv
     cd borg
     pip install -r requirements.d/development.txt
     pip install -r requirements.d/docs.txt  # optional, to build the docs
 
+    # set a borg version if setuptools-scm fails to do so automatically
+    export SETUPTOOLS_SCM_PRETEND_VERSION=
+
+    # install borg into virtualenv
     pip install -e .           # in-place editable mode
     or
     pip install -e .[pyfuse3]  # in-place editable mode, use pyfuse3


### PR DESCRIPTION
Backport of #9015

[465937f](https://github.com/borgbackup/borg/pull/9020/commits/465937f5a3f8ea45ff65f00f23fe361011af1887) unifies the paragraph order with `master` (it caused a merge conflict).