### PR TITLE
platform/linux: fetch flags before FS_IOC_SETFLAGS

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -29,7 +29,9 @@ have_fuse_mtime_ns = hasattr(llfuse.EntryAttributes, "st_mtime_ns") if llfuse el
 has_lchflags = hasattr(os, "lchflags") or sys.platform.startswith("linux")
 try:
     with tempfile.NamedTemporaryFile() as file:
-        platform.set_flags(file.name, stat.UF_NODUMP)
+        st = os.stat(file.name, follow_symlinks=False)
+        flags = platform.get_flags(file.name, st)
+        platform.set_flags(file.name, flags | stat.UF_NODUMP)
 except OSError:
     has_lchflags = False
 

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -226,7 +226,10 @@ def create_test_files(input_path, create_hardlinks=True):
     if are_fifos_supported():
         os.mkfifo(os.path.join(input_path, "fifo1"))
     if has_lchflags:
-        platform.set_flags(os.path.join(input_path, "flagfile"), stat.UF_NODUMP)
+        file = os.path.join(input_path, "flagfile")
+        st = os.stat(file, follow_symlinks=False)
+        flags = platform.get_flags(file, st)
+        platform.set_flags(file, flags | stat.UF_NODUMP)
 
     if is_win32:
         have_root = False

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -721,7 +721,10 @@ def test_file_status_excluded(archivers, request):
     create_regular_file(archiver.input_path, "file2", size=1024 * 80)
     if has_lchflags:
         create_regular_file(archiver.input_path, "file3", size=1024 * 80)
-        platform.set_flags(os.path.join(archiver.input_path, "file3"), stat.UF_NODUMP)
+        file = os.path.join(archiver.input_path, "file3")
+        st = os.stat(file, follow_symlinks=False)
+        flags = platform.get_flags(file, st)
+        platform.set_flags(file, flags | stat.UF_NODUMP)
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     output = cmd(archiver, "create", "--list", "test", "input")
     assert "A input/file1" in output
@@ -1075,7 +1078,10 @@ def test_exclude_nodump_dir_with_file(archivers, request):
 
     # Prepare input tree: input/nd directory (NODUMP) containing a file.
     create_regular_file(archiver.input_path, "nd/file_in_ndir", contents=b"hello")
-    platform.set_flags(os.path.join(archiver.input_path, "nd"), stat.UF_NODUMP)
+    file = os.path.join(archiver.input_path, "nd")
+    st = os.stat(file, follow_symlinks=False)
+    flags = platform.get_flags(file, st)
+    platform.set_flags(file, flags | stat.UF_NODUMP)
 
     # Create repo and archive
     cmd(archiver, "repo-create", RK_ENCRYPTION)


### PR DESCRIPTION
`FS_IOC_SETFLAGS` called without fetching flags first can remove for example an ext4 flag like `EXT4_EXTENTS_FL` which results in `EOPNOTSUPP`. That one is indeed handled in the code, but this is still incorrect. The flags should be fetched with `FS_IOC_GETFLAGS`, updated and only then stored back with `FS_IOC_SETFLAGS`.

Fixes #9039.
Closes: https://bugzilla.suse.com/show_bug.cgi?id=1251048

With the commit applied I now see:
```strace
newfstatat(AT_FDCWD, "/tmp/tmp5tlytc1a", {st_mode=S_IFREG|0600, st_size=0, ...}, AT_SYMLINK_NOFOLLOW) = 0 
openat(AT_FDCWD, "/tmp/tmp5tlytc1a", O_RDONLY|O_NONBLOCK|O_NOFOLLOW|O_CLOEXEC) = 4 
ioctl(4, FS_IOC_GETFLAGS, [FS_EXTENT_FL]) = 0 
ioctl(4, FS_IOC_SETFLAGS, [FS_NODUMP_FL|FS_EXTENT_FL]) = 0 
close(4)                          = 0 
```