### PR TITLE
build: require setuptools>=78.1.1 (fixes #9042)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ where = ["src"]
 "*" = ["*.c", "*.h", "*.pyx"]
 
 [build-system]
-requires = ["setuptools>=77.0.0", "wheel", "pkgconfig", "Cython>=3.0.3", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=78.1.1", "wheel", "pkgconfig", "Cython>=3.0.3", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-setuptools >=77.0.0
+setuptools >=78.1.1
 setuptools_scm
 pip !=24.2
 wheel


### PR DESCRIPTION
This updates the minimum required setuptools version to >=78.1.1 in:
- pyproject.toml [build-system]
- requirements.d/development.txt

Motivation: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf

This should address the security advisory and fixes #9042.