### PR TITLE
backport(1.4): build: require setuptools>=78.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ where = ["src"]
 "*" = ["*.c", "*.h", "*.pyx"]
 
 [build-system]
-requires = ["setuptools>=77.0.0", "setuptools_scm>=8", "wheel", "pkgconfig", "Cython>=3.0.3"]
+requires = ["setuptools>=78.1.1", "setuptools_scm>=8", "wheel", "pkgconfig", "Cython>=3.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,4 @@
-setuptools>=77.0.0
+setuptools>=78.1.1
 setuptools_scm>=8
 pip
 virtualenv


### PR DESCRIPTION
Backport of #9045 to 1.4-maint.

This updates the minimum required setuptools version to >=78.1.1 in:

• pyproject.toml [build-system]
• requirements.d/development.txt

Motivation: https://github.com/advisories/GHSA-5rjg-fvgr-3xxf

This should address the security advisory (see #9042).