### PR TITLE
vagrant: drop debian buster VM / borg-linux-glibc228

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -348,22 +348,6 @@ Vagrant.configure(2) do |config|
     b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("bullseye", ".*none.*")
   end
 
-  config.vm.define "buster" do |b|
-    b.vm.box = "debian/buster64"
-    b.vm.provider :virtualbox do |v|
-      v.memory = 1024 + $wmem
-    end
-    b.vm.provision "fs init", :type => :shell, :inline => fs_init("vagrant")
-    b.vm.provision "packages debianoid", :type => :shell, :inline => packages_debianoid("vagrant")
-    b.vm.provision "install pyenv", :type => :shell, :privileged => false, :inline => install_pyenv("buster")
-    b.vm.provision "install pythons", :type => :shell, :privileged => false, :inline => install_pythons("buster")
-    b.vm.provision "build env", :type => :shell, :privileged => false, :inline => build_pyenv_venv("buster")
-    b.vm.provision "install borg", :type => :shell, :privileged => false, :inline => install_borg("llfuse")
-    b.vm.provision "install pyinstaller", :type => :shell, :privileged => false, :inline => install_pyinstaller()
-    b.vm.provision "build binary with pyinstaller", :type => :shell, :privileged => false, :inline => build_binary_with_pyinstaller("buster")
-    b.vm.provision "run tests", :type => :shell, :privileged => false, :inline => run_tests("buster", ".*none.*")
-  end
-
   config.vm.define "freebsd13" do |b|
     b.vm.box = "generic/freebsd13"
     b.vm.provider :virtualbox do |v|

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -14,7 +14,6 @@ AMD64/x86_64 architecture
 borg-linux-glibc241 Linux (built on Debian 13 "Trixie" with glibc 2.41)
 borg-linux-glibc236 Linux (built on Debian 12 "Bookworm" with glibc 2.36)
 borg-linux-glibc231 Linux (built on Debian 11 "Bullseye" with glibc 2.31)
-borg-linux-glibc228 Linux (built on Debian 10 "Buster" with glibc 2.28)
                     Note: You can also try them on other Linux distributions with different glibc
                     versions - as long as glibc is compatible, they will work.
                     If it doesn't work, try a Borg 1.2.x binary.

--- a/scripts/fetch-binaries
+++ b/scripts/fetch-binaries
@@ -12,7 +12,6 @@ check_and_copy () {
     echo ""
 }
 
-check_and_copy buster    borg-linux-glibc228
 check_and_copy bullseye  borg-linux-glibc231
 check_and_copy bookworm  borg-linux-glibc236
 check_and_copy trixie    borg-linux-glibc241


### PR DESCRIPTION
vagrant fails when trying to install rsync.

buster is EOL, even in LTS.

you can still use the binary from borg <= 1.4.1.
