### PR TITLE
use macos-14 for the intel binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-fuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-fuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"},
-              {"os": "macos-13", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-13-x86_64-gh"},
+              {"os": "macos-14-intel", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-14-x86_64-gh"},
               {"os": "macos-14", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-14-arm64-gh"}
             ]
           }'

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -35,7 +35,7 @@ borg-linux-glibc235-x86_64-gh Linux AMD/Intel (built on Ubuntu 22.04 LTS with gl
 borg-linux-glibc235-arm64-gh  Linux ARM (built on Ubuntu 22.04 LTS with glibc 2.35)
 
 borg-macos-14-arm64-gh        macOS Apple Silicon (built on macOS 14 w/o FUSE support)
-borg-macos-13-x86_64-gh       macOS Intel (built on macOS 13 w/o FUSE support)
+borg-macos-14-x86_64-gh       macOS Intel (built on macOS 14 w/o FUSE support)
 
 
 Binaries built locally


### PR DESCRIPTION
the macOS 13 runner is already deprecated and going away in 2 months already.
