### PR TITLE
Fixes in `FilesCacheMixin`

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -559,6 +559,8 @@ class FilesCacheMixin:
                             except KeyError:
                                 # repo is missing a chunk referenced from entry
                                 logger.debug(f"compress_entry failed for {entry}, skipping.")
+                            else:
+                                self._newest_cmtime = max(self._newest_cmtime, timestamp_to_int(entry.ctime), timestamp_to_int(entry.mtime))
                     except (TypeError, ValueError) as exc:
                         msg = "The files cache seems invalid. [%s]" % str(exc)
                         break


### PR DESCRIPTION
This PR includes two fixes in `FilesCacheMixin`
- fix usage of `discard_after` in `_write_files_cache` (should be `<= discard_after` instead of `< discard_after`); without this it always discards the file with the latest cmtime; this is also implied by the naming of `discard_after` (if `<` was correct it should be called `keep_before`)
- update `_newest_cmtime` in `_read_files_cache`; `_read_files_cache`, unlike `_build_files_cache`, wasn't maintaining `_newest_cmtime`; I wasn't sure about maintaining `_newest_path_hashes` though, so I didn't include that
