### PR TITLE
BORG_MSGPACK_VERSION_CHECK, fixes #9109

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -430,6 +430,8 @@ New features:
 - create: --files-changed=MODE option (controls how borg detects whether
   a file has changed while it is being backed up)
 - improved tty-less progress reporting (--progress)
+- BORG_MSGPACK_VERSION_CHECK=no to optionally disable the msgpack version
+  check; default is "yes", use at your own risk, #9109.
 
 Fixes:
 

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -70,6 +70,11 @@ General:
         When set to no (default: yes), system information (like OS, Python version, ...) in
         exceptions is not shown.
         Please only use for good reasons as it makes issues harder to analyze.
+    BORG_MSGPACK_VERSION_CHECK
+        Controls whether Borg checks the ``msgpack`` version.
+        The default is ``yes`` (strict check). Set to ``no`` to disable the version check and
+        allow any installed ``msgpack`` version. Use this at your own risk; malfunctioning or
+        incompatible ``msgpack`` versions may cause subtle bugs or repository data corruption.
     BORG_FUSE_IMPL
         Choose the lowlevel FUSE implementation borg shall use for ``borg mount``.
         This is a comma-separated list of implementation names, they are tried in the

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -1,3 +1,5 @@
+import os
+
 from .datastruct import StableDict
 from ..constants import *  # NOQA
 
@@ -136,9 +138,16 @@ def is_slow_msgpack():
 
 def is_supported_msgpack():
     # DO NOT CHANGE OR REMOVE! See also requirements and comments in pyproject.toml.
+    # This function now also respects the env var BORG_MSGPACK_VERSION_CHECK.
+    # Set BORG_MSGPACK_VERSION_CHECK=no to disable the version check on your own risk.
     import msgpack
-    return (1, 0, 3) <= msgpack.version[:3] <= (1, 1, 2) and \
-           msgpack.version not in []  # < add bad releases here to deny list
+
+    version_check = os.environ.get('BORG_MSGPACK_VERSION_CHECK', 'yes').strip().lower()
+
+    return version_check == 'no' or (
+        (1, 0, 3) <= msgpack.version[:3] <= (1, 1, 2) and
+        msgpack.version not in []
+    )
 
 
 def get_limited_unpacker(kind):


### PR DESCRIPTION
This PR implements an environment-variable controlled override for the strict msgpack version check.

Changes:
- Code: `helpers/msgpack.is_supported_msgpack()` now respects `BORG_MSGPACK_VERSION_CHECK`.
  - Default is "yes" (strict check enforced).
  - Set to `no` to disable the strict version check at your own risk.
- Docs:
  - Added `BORG_MSGPACK_VERSION_CHECK` to environment variables docs, stating default is "yes".
  - Updated changelog entry accordingly.

Rationale: addresses issue #9109 by allowing advanced users and packagers to temporarily relax the msgpack version constraint while still defaulting to safe behavior.
