### PR TITLE
extract: fs flags: use get/set to influence only specific flags, #9039, macOS only

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -41,6 +41,7 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import listxattr, getxattr, setxattr
     from .darwin import acl_get, acl_set
     from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
+    from .darwin import set_flags
 
 
 def get_birthtime_ns(st, path, fd=None):


### PR DESCRIPTION
preserve UF_COMPRESSED and SF_DATALESS when restoring flags, get-modify-set in macOS set_flags, keeping system-managed read-only flags.
