### PR TITLE
drop Python 3.9 (EOL'ed by python.org) (1.4-maint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,12 @@ jobs:
         ${{ fromJSON(
           github.event_name == 'pull_request' && '{
             "include": [
-              {"os": "ubuntu-22.04", "python-version": "3.9", "toxenv": "py39-fuse2"},
+              {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"}
             ]
           }' || '{
             "include": [
-              {"os": "ubuntu-22.04", "python-version": "3.9", "toxenv": "py39-fuse2"},
-              {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-fuse3"},
+              {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
               {"os": "ubuntu-22.04", "python-version": "3.11", "toxenv": "py311-fuse2", "binary": "borg-linux-glibc235-x86_64-gh"},
               {"os": "ubuntu-22.04-arm", "python-version": "3.11", "toxenv": "py311-fuse2", "binary": "borg-linux-glibc235-arm64-gh"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-fuse3"},

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,9 +129,11 @@ def packages_openindiana
   return <<-EOF
     pkg install gcc-13 git
     pkg install pkg-config libxxhash
-    ln -sf /usr/bin/python3.9 /usr/bin/python3
+    pkg install python-313
+    ln -sf /usr/bin/python3.13 /usr/bin/python3
+    ln -sf /usr/bin/python3.13-config /usr/bin/python3-config
     python3 -m ensurepip
-    ln -sf /usr/bin/pip3.9 /usr/bin/pip3
+    ln -sf /usr/bin/pip3.13 /usr/bin/pip3
     pip3 install virtualenv
     # let borg's pkg-config find openssl:
     pfexec pkg set-mediator -V 3 openssl

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -185,7 +185,7 @@ Some more advanced examples::
   # verify a changed tox.ini (run this after any change to tox.ini):
   fakeroot -u tox --recreate
 
-  fakeroot -u tox -e py39  # run all tests, but only on python 3.9
+  fakeroot -u tox -e py310  # run all tests, but only on python 3.10
 
   fakeroot -u tox borg.testsuite.locking  # only run 1 test module
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -158,7 +158,7 @@ To install Borg from a source package (including pip), you have to install the
 following dependencies first. For the libraries you will also need their
 development header files (sometimes in a separate `-dev` or `-devel` package).
 
-* `Python 3`_ >= 3.9.0
+* `Python 3`_ >= 3.10.0
 * OpenSSL_ >= 1.0.0
 * libacl_ (which depends on libattr_)
 * libxxhash_ >= 0.8.1
@@ -424,9 +424,9 @@ If you need to use a different version of Python you can install this using ``py
 
     ...
     # create a virtual environment
-    pyenv install 3.9.0  # minimum, preferably use something more recent!
-    pyenv global 3.9.0
-    pyenv local 3.9.0
+    pyenv install 3.10.0  # minimum, preferably use something more recent!
+    pyenv global 3.10.0
+    pyenv local 3.10.0
     virtualenv --python=${pyenv which python} borg-env
     source borg-env/bin/activate   # always before using!
     ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ maintainers = [
     {name="Thomas Waldmann", email="tw@waldmann-edv.de"},
 ]
 description = "Deduplicated, encrypted, authenticated and compressed backups"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["backup", "borgbackup"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -85,7 +84,7 @@ write_to_template = "__version__ = version = {version!r}\n"
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = ["E", "F"]
@@ -175,7 +174,7 @@ min_version = "4.19"
 requires = ["tox>=4.19", "pkgconfig", "cython", "wheel", "setuptools_scm"]
 # Important: when adding/removing Python versions here,
 #            also update the section "Test environments with different FUSE implementations" accordingly.
-env_list = ["py{39,310,311,312,313,314}-{none,fuse2,fuse3}", "ruff"]
+env_list = ["py{310,311,312,313,314}-{none,fuse2,fuse3}", "ruff"]
 
 # Base configuration for test environments
 [tool.tox.env_run_base]
@@ -193,16 +192,6 @@ labels = ["test"]
 pass_env = ["*"]  # needed by tox4, so env vars are visible for building borg
 
 # Test environments with different FUSE implementations
-[tool.tox.env.py39-none]
-
-[tool.tox.env.py39-fuse2]
-set_env = {BORG_FUSE_IMPL = "llfuse"}
-extras = ["llfuse"]
-
-[tool.tox.env.py39-fuse3]
-set_env = {BORG_FUSE_IMPL = "pyfuse3"}
-extras = ["pyfuse3"]
-
 [tool.tox.env.py310-none]
 
 [tool.tox.env.py310-fuse2]

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2702,11 +2702,11 @@ class Archiver:
 
         {now}
             The current local date and time, by default in ISO-8601 format.
-            You can also supply your own `format string <https://docs.python.org/3.9/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
+            You can also supply your own `format string <https://docs.python.org/3.10/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {now:%Y-%m-%d_%H:%M:%S}
 
         {utcnow}
             The current UTC date and time, by default in ISO-8601 format.
-            You can also supply your own `format string <https://docs.python.org/3.9/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
+            You can also supply your own `format string <https://docs.python.org/3.10/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
 
         {user}
             The user name (or UID, if no name is available) of the user running borg.
@@ -4896,7 +4896,7 @@ class Archiver:
         +++++++++++++++++++++++++++
 
         The ``--format`` option uses Python's `format string syntax
-        <https://docs.python.org/3.9/library/string.html#formatstrings>`_.
+        <https://docs.python.org/3.10/library/string.html#formatstrings>`_.
 
         Examples:
         ::


### PR DESCRIPTION
Fixes #9056.

borg 1.4.2 and 1.2.9 were the last borg releases with official py39 support.
