### PR TITLE
Bugfix: local path regex should not match s3 and b2 urls

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -451,7 +451,7 @@ class Location:
     # path may contain any chars. to avoid ambiguities with other regexes,
     # it must not start with "//" nor with "scheme://" nor with "rclone:".
     local_path_re = r"""
-        (?!(//|(ssh|socket|sftp|file)://|rclone:))
+        (?!(//|(ssh|socket|sftp|file)://|(rclone|s3|b2):))
         (?P<path>.+)
     """
 


### PR DESCRIPTION
There was an issue for matching the s3 and b2 urls because of an not updated regex for local repository paths. The local path was matching the s3 and b2 urls so the repository was created locally and not on s3/b2. Now it is possible to create and use s3 and b2 repositories.
