### PR TITLE
CI: add GitHub artifact attestations for release binaries, fixes #9134 (master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
   posix_tests:
 
     needs: [lint, security]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: true
       # noinspection YAMLSchemaValidation
@@ -267,6 +271,12 @@ jobs:
         fi
         echo "binary files"
         ls -l artifacts/
+
+    - name: Attest binaries provenance (${{ matrix.binary }})
+      if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: 'artifacts/*'
 
     - name: Upload binaries (${{ matrix.binary }})
       if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -68,6 +68,24 @@ GPG key fingerprint: 6D5B EF9A DD20 7580 5747 B70F 9F88 FB52 FAF7 B393
 My fingerprint is also in the footer of all my BorgBackup mailing list posts.
 
 
+Provenance attestations for GitHub-built binaries
+-------------------------------------------------
+
+For binaries built on GitHub (files with a "-gh" suffix in the name), we publish
+an artifact provenance attestation that proves the binary was built by our
+GitHub Actions workflow from a specific commit or tag. You can verify this using
+the GitHub CLI (gh). Install it from https://cli.github.com/ and make sure you
+use a recent version that supports "gh attestation".
+
+Practical example (Linux, 2.0.0b20 tag):
+
+    curl -LO https://github.com/borgbackup/borg/releases/download/2.0.0b20/borg-linux-glibc235-x86_64-gh
+    gh attestation verify --repo borgbackup/borg --ref 2.0.0b20 ./borg-linux-glibc235-x86_64-gh
+
+If verification succeeds, gh prints a summary stating the subject (your file),
+that it was attested by GitHub Actions, and the job/workflow reference.
+
+
 Installing
 ----------
 


### PR DESCRIPTION
- grant id-token and attestations permissions to posix_tests job
- add actions/attest-build-provenance@v3 step for built artifacts

This publishes SLSA-style provenance for our tag builds (only when binaries are produced) so users can verify the origin of downloaded borg binaries.
