### PR TITLE
ci: add tag-based workflows and provenance attestation for GitHub-built binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   push:
     branches: [ 1.4-maint ]
+    tags:
+    - '1.*'
     paths:
     - '**.py'
     - '**.pyx'
@@ -40,9 +42,14 @@ jobs:
     - uses: actions/checkout@v4
     - uses: chartboost/ruff-action@v1
 
-  pytest:
 
-    needs: lint
+  posix_tests:
+
+    needs: [lint]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       # noinspection YAMLSchemaValidation
@@ -77,25 +84,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all
-        fetch-depth: 0
-        fetch-tags: true
-
-    - name: Detect if commit is tagged
-      id: detect_tag
-      run: |
-        tag="$(git describe --exact-match --tags HEAD 2>/dev/null || true)"
-        # If HEAD is a merge commit, the PR head is usually the second parent (HEAD^2).
-        if [ -z "$tag" ] && git rev-parse -q --verify HEAD^2 >/dev/null 2>&1; then
-          tag="$(git describe --exact-match --tags HEAD^2 2>/dev/null || true)"
-        fi
-        echo "Found tag: ${tag}"
-        echo "tagged=$tag" >> "$GITHUB_OUTPUT"
-
-    - name: Check out exact tag
-      if: ${{ steps.detect_tag.outputs.tagged }}
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ steps.detect_tag.outputs.tagged }}
         fetch-depth: 0
         fetch-tags: true
 
@@ -151,14 +139,14 @@ jobs:
         env_vars: OS, python
 
     - name: Build Borg fat binaries (${{ matrix.binary }})
-      if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
       run: |
         pip install 'pyinstaller==6.14.2'
         mkdir -p dist/binary
         pyinstaller --clean --distpath=dist/binary scripts/borg.exe.spec
 
     - name: Smoke-test the built binary (${{ matrix.binary }})
-      if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
       run: |
         pushd dist/binary
         echo "single-file binary"
@@ -171,7 +159,7 @@ jobs:
         popd
 
     - name: Prepare binaries (${{ matrix.binary }})
-      if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
       run: |
         mkdir -p artifacts
         if [ -f dist/binary/borg.exe ]; then
@@ -183,8 +171,14 @@ jobs:
         echo "binary files"
         ls -l artifacts/
 
+    - name: Attest binaries provenance (${{ matrix.binary }})
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: 'artifacts/*'
+
     - name: Upload binaries (${{ matrix.binary }})
-      if: ${{ matrix.binary && steps.detect_tag.outputs.tagged }}
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.binary }}

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -70,6 +70,24 @@ GPG key fingerprint: 6D5B EF9A DD20 7580 5747 B70F 9F88 FB52 FAF7 B393
 My fingerprint is also in the footer of all my BorgBackup mailing list posts.
 
 
+Provenance attestations for GitHub-built binaries
+-------------------------------------------------
+
+For binaries built on GitHub (files with a "-gh" suffix in the name), we publish
+an artifact provenance attestation that proves the binary was built by our
+GitHub Actions workflow from a specific commit or tag. You can verify this using
+the GitHub CLI (gh). Install it from https://cli.github.com/ and make sure you
+use a recent version that supports "gh attestation".
+
+Practical example (Linux, 1.4.3 tag):
+
+    curl -LO https://github.com/borgbackup/borg/releases/download/1.4.3/borg-linux-glibc235-x86_64-gh
+    gh attestation verify --repo borgbackup/borg --source-ref refs/tags/1.4.3 borg-linux-glibc235-x86_64-gh
+
+If verification succeeds, gh prints a summary stating the subject (your file),
+that it was attested by GitHub Actions, and the job/workflow reference.
+
+
 Installing
 ----------
 


### PR DESCRIPTION
backport of #9135 and #9136.
