### PR TITLE
[1.4-maint] Backport PR #9188: docs: some fixes/update to the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -210,8 +210,8 @@ sure you have an up-to-date version of borgbackup if you want to continue
 instead of retransferring a huge file. In some cases, there is only an outdated
 version shipped with your distribution (e.g. Debian). See :ref:`installation`.
 
-How can I backup huge file(s) over a unstable connection?
----------------------------------------------------------
+How can I back up huge file(s) over an unstable connection?
+-----------------------------------------------------------
 
 This is not a problem anymore.
 
@@ -381,9 +381,7 @@ Checking processors
   operate hardware outside its specifications for productive use.
 
   Tools to verify correct processor operation include Prime95 (mprime), linpack,
-  and the `Intel Processor Diagnostic Tool
-  <https://downloadcenter.intel.com/download/19792/Intel-Processor-Diagnostic-Tool>`_
-  (applies only to Intel processors).
+  and stress-ng.
 
 .. rubric:: Repairing a damaged repository
 
@@ -706,7 +704,7 @@ all your files/dirs data and metadata are stored in their encrypted form
 into the repository.
 
 Yes, as an attacker with access to the remote server could delete (or
-otherwise make unavailable) all your backups.
+otherwise make unavailable) all your backups on that server.
 
 How can I protect against a hacked backup client?
 -------------------------------------------------
@@ -962,7 +960,7 @@ Then you do the backup and look at the log output:
 
 When borg runs inside a virtual machine, there are some more things to look at:
 
-Some hypervisors (e.g. kvm on proxmox) give some broadly compatible CPU type to the
+Some hypervisors (e.g. kvm on older proxmox) give some broadly compatible CPU type to the
 VM (usually to ease migration between VM hosts of potentially different hardware CPUs).
 
 It is broadly compatible because they leave away modern CPU features that could be
@@ -970,8 +968,8 @@ not present in older or other CPUs, e.g. hardware acceleration for AES crypto, f
 sha2 hashes, for (P)CLMUL(QDQ) computations useful for crc32.
 
 So, basically you pay for compatibility with bad performance. If you prefer better
-performance, you should try to expose the host CPU's misc. hw acceleration features
-to the VM which runs borg.
+performance, you should try to use the x86-64-v2-AES VCPU or the "host" VCPU,
+exposing misc. hw acceleration features to the VM which runs borg.
 
 On Linux, check ``/proc/cpuinfo`` for the CPU flags inside the VM.
 For kvm check the docs about "Host model" and "Host passthrough".
@@ -1295,7 +1293,7 @@ Miscellaneous
 macOS: borg mounts not shown in Finder's side bar
 -------------------------------------------------
 
-https://github.com/osxfuse/osxfuse/wiki/Mount-options#local
+https://github.com/macfuse/macfuse/wiki/Mount-options#local
 
 Read the above first and use this on your own risk::
 


### PR DESCRIPTION
Backport of #9188 (commit 3642c7903b78c8f4f973762073b7606812c4a0f6) to 1.4-maint.

- Cherry-picked and resolved conflicts in docs/faq.rst manually.
- Kept 1.4-maint explanatory note about checkpoint part files.
- Applied grammar and header fixes from the original PR.
 
Please review.

Original PR: https://github.com/borgbackup/borg/pull/9188