### PR TITLE
no_selinux -> filter_xattrs

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -225,13 +225,14 @@ def is_birthtime_fully_supported():
         return False
 
 
-def no_selinux(x):
-    # selinux fails our FUSE tests, thus ignore selinux xattrs
-    SELINUX_KEY = b"security.selinux"
+def filter_xattrs(x):
+    # selinux and com.apple.provenance fail our FUSE tests, thus ignore them
+    UNWANTED_KEYS = {b"security.selinux", b"com.apple.provenance"}
     if isinstance(x, dict):
-        return {k: v for k, v in x.items() if k != SELINUX_KEY}
+        return {k: v for k, v in x.items() if k not in UNWANTED_KEYS}
     if isinstance(x, list):
-        return [k for k in x if k != SELINUX_KEY]
+        return [k for k in x if k not in UNWANTED_KEYS]
+    raise ValueError("Unsupported type: %s" % type(x))
 
 
 class BaseTestCase(unittest.TestCase):

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -26,7 +26,7 @@ from ...manifest import Manifest
 from ...platform import get_flags
 from ...remote import RemoteRepository
 from ...repository import Repository
-from .. import has_lchflags, has_mknod, is_utime_fully_supported, have_fuse_mtime_ns, st_mtime_ns_round, no_selinux
+from .. import has_lchflags, has_mknod, is_utime_fully_supported, have_fuse_mtime_ns, st_mtime_ns_round, filter_xattrs
 from .. import changedir
 from .. import are_symlinks_supported, are_hardlinks_supported, are_fifos_supported, granularity_sleep
 from ..platform.platform_test import is_win32
@@ -407,8 +407,8 @@ def _assert_dirs_equal_cmp(diff, ignore_flags=False, ignore_xattrs=False, ignore
                 d1.append(round(s1.st_mtime_ns, st_mtime_ns_round))
                 d2.append(round(s2.st_mtime_ns, st_mtime_ns_round))
         if not ignore_xattrs:
-            d1.append(no_selinux(get_all(path1, follow_symlinks=False)))
-            d2.append(no_selinux(get_all(path2, follow_symlinks=False)))
+            d1.append(filter_xattrs(get_all(path1, follow_symlinks=False)))
+            d2.append(filter_xattrs(get_all(path2, follow_symlinks=False)))
         assert d1 == d2
     for sub_diff in diff.subdirs.values():
         _assert_dirs_equal_cmp(sub_diff, ignore_flags=ignore_flags, ignore_xattrs=ignore_xattrs, ignore_ns=ignore_ns)

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -10,7 +10,7 @@ from ...constants import *  # NOQA
 from ...storelocking import Lock
 from ...helpers import flags_noatime, flags_normal
 from .. import has_lchflags, llfuse
-from .. import changedir, no_selinux, same_ts_ns
+from .. import changedir, filter_xattrs, same_ts_ns
 from .. import are_symlinks_supported, are_hardlinks_supported, are_fifos_supported
 from ..platform.platform_test import fakeroot_detected
 from . import RK_ENCRYPTION, cmd, assert_dirs_equal, create_regular_file, create_src_archive, open_archive, src_file
@@ -147,11 +147,11 @@ def test_fuse(archivers, request):
             in_fn = "input/fusexattr"
             out_fn = os.fsencode(os.path.join(mountpoint, "archive", "input", "fusexattr"))
             if not xattr.XATTR_FAKEROOT and xattr.is_enabled(archiver.input_path):
-                assert sorted(no_selinux(xattr.listxattr(out_fn))) == [b"user.empty", b"user.foo"]
+                assert sorted(filter_xattrs(xattr.listxattr(out_fn))) == [b"user.empty", b"user.foo"]
                 assert xattr.getxattr(out_fn, b"user.foo") == b"bar"
                 assert xattr.getxattr(out_fn, b"user.empty") == b""
             else:
-                assert no_selinux(xattr.listxattr(out_fn)) == []
+                assert filter_xattrs(xattr.listxattr(out_fn)) == []
                 try:
                     xattr.getxattr(out_fn, b"user.foo")
                 except OSError as e:


### PR DESCRIPTION
Originally, we only wanted to get rid of selinux xattrs, but macOS also uses some xattr keys that disturb our test results, so we filter them also.
