### PR TITLE
CI: FUSE related fixes/improvements (master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-fuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-fuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"},
-              {"os": "macos-13", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-13-x86_64-gh"},
-              {"os": "macos-14", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-14-arm64-gh"}
+              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-x86_64-gh"},
+              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-arm64-gh"}
             ]
           }'
         ) }}

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -34,8 +34,8 @@ Binaries built on GitHub servers
 borg-linux-glibc235-x86_64-gh Linux AMD/Intel (built on Ubuntu 22.04 LTS with glibc 2.35)
 borg-linux-glibc235-arm64-gh  Linux ARM (built on Ubuntu 22.04 LTS with glibc 2.35)
 
-borg-macos-14-arm64-gh        macOS Apple Silicon (built on macOS 14 w/o FUSE support)
-borg-macos-13-x86_64-gh       macOS Intel (built on macOS 13 w/o FUSE support)
+borg-macos-15-arm64-gh        macOS Apple Silicon (built on macOS 15 w/o FUSE support)
+borg-macos-15-x86_64-gh       macOS Intel (built on macOS 15 w/o FUSE support)
 
 borg-freebsd-14-x86_64-gh     FreeBSD AMD/Intel (built on FreeBSD 14)
 


### PR DESCRIPTION
fixes #9182

- install OS fuse support packages as indicated by the tox env. on the macOS runners, we do not have any fuse support. on the linux runners, we may have fuse2 or fuse3. on FreeBSD, we have fuse2.
- install fuse python library for binary build
- first build/upload binaries, then run tests (including binary tests). early uploading makes inspection of a malfunctioning binary possible.
- for now, use llfuse, as there is an issue with pyinstaller and pyfuse3.

Also:
- remove || true - this just hides errors, not what we want.
