### PR TITLE
Version: do not access private attributes, fixes #9263

### DIFF
--- a/src/borg/__init__.py
+++ b/src/borg/__init__.py
@@ -5,8 +5,7 @@ from packaging.version import parse as parse_version
 from ._version import version as __version__
 
 
-_v = parse_version(__version__)
-__version_tuple__ = _v._version.release
+__version_tuple__ = parse_version(__version__).release
 
 # assert that all semver components are integers
 # this is mainly to show errors when people repackage poorly


### PR DESCRIPTION
DeprecationWarning: Version._version is private and will be removed soon
