### PR TITLE
testsuite: remove deprecated manual cleanup in create_cmd_test

### DIFF
--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -962,10 +962,6 @@ def test_create_big_zeros_files(archivers, request):
             # Also verify the directory structure matches
             assert_dirs_equal(archiver.input_path, os.path.join(extract_path, "input"))
 
-    # Remove input files
-    for i in range(count):
-        os.unlink(os.path.join(archiver.input_path, f"zeros_{i}"))
-
 
 def test_create_big_random_files(archivers, request):
     """Test creating an archive from 10 files with 10MB random data each."""
@@ -997,10 +993,6 @@ def test_create_big_random_files(archivers, request):
 
             # Also verify the directory structure matches
             assert_dirs_equal(archiver.input_path, os.path.join(extract_path, "input"))
-
-    # Remove input files
-    for i in range(count):
-        os.unlink(os.path.join(archiver.input_path, f"random_{i}"))
 
 
 def test_create_with_compression_algorithms(archivers, request):
@@ -1063,11 +1055,6 @@ def test_create_with_compression_algorithms(archivers, request):
 
                 # Also verify the directory structure matches
                 assert_dirs_equal(archiver.input_path, os.path.join(extract_path, "input"))
-
-    # Remove input files
-    for i in range(count):
-        os.unlink(os.path.join(archiver.input_path, f"zeros_{i}"))
-        os.unlink(os.path.join(archiver.input_path, f"random_{i}"))
 
 
 def test_exclude_nodump_dir_with_file(archivers, request):


### PR DESCRIPTION
Manual cleanup is not needed anymore because of #9185 already being implemented.
So we can remove the #8980 code.

I have checked everything with the /tmp folder, the generated files are cleaned up safely after a test.