### PR TITLE
fix typos found by codespell

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -136,7 +136,7 @@ Start by checking out the appropriate branch:
     git checkout master
 
 It is best practice for a developer to keep local ``master`` branch as an
-uptodate copy of the upstream ``master`` branch and always do own work in a
+up-to-date copy of the upstream ``master`` branch and always do own work in a
 separate feature or bugfix branch.
 This is useful to be able to rebase own branches onto the upstream branches
 they were branched from, if necessary.
@@ -194,7 +194,7 @@ Rebase feature branch onto updated master branch
 ------------------------------------------------
 
 After updating the local ``master`` branch from upstream, the feature branch
-can be checked out and rebased onto (the now uptodate) ``master`` branch.
+can be checked out and rebased onto (the now up-to-date) ``master`` branch.
 ::
 
     git checkout MYCONTRIB-master

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -592,7 +592,7 @@ These are your options to protect against that:
 How can I protect against theft, sabotage, lightning, fire, ...?
 ----------------------------------------------------------------
 
-In general: if your only backup medium is nearby the backupped machine and
+In general: if your only backup medium is nearby the backed-up machine and
 always connected, you can easily get into trouble: they likely share the same
 fate if something goes really wrong.
 

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -402,7 +402,7 @@ class Repository:
                 except StoreObjectNotFound:
                     pass
                 if not partial:
-                    # if we did a full pass in one go, we built a complete, uptodate ChunkIndex, cache it!
+                    # if we did a full pass in one go, we built a complete, up-to-date ChunkIndex, cache it!
                     from .cache import write_chunkindex_to_repo_cache
 
                     write_chunkindex_to_repo_cache(

--- a/src/borg/testsuite/xattr_test.py
+++ b/src/borg/testsuite/xattr_test.py
@@ -78,7 +78,7 @@ def test_getxattr_buffer_growth(tempfile_symlink):
 
 
 @pytest.mark.parametrize(
-    "lstring, splitted", [(b"", []), (b"\x00", [b""]), (b"\x01a", [b"a"]), (b"\x01a\x02cd", [b"a", b"cd"])]
+    "lstring, expected", [(b"", []), (b"\x00", [b""]), (b"\x01a", [b"a"]), (b"\x01a\x02cd", [b"a", b"cd"])]
 )
-def test_split_lstring(lstring, splitted):
-    assert split_lstring(lstring) == splitted
+def test_split_lstring(lstring, expected):
+    assert split_lstring(lstring) == expected


### PR DESCRIPTION
## Summary
  - Fix minor spelling mistakes found by running `codespell` on the codebase
  - `backupped` → `backed-up` (docs/faq.rst)
  - `splitted` → `expected` (src/borg/testsuite/xattr_test.py)
  - `uptodate` → `up-to-date` (docs/development.rst, src/borg/repository.py)

  All changes are in docs, comments, or test parameter names — zero functional impact.

  Closes #9295 