### PR TITLE
fix typos found by codespell (1.4-maint)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -741,7 +741,7 @@ These are your options to protect against that:
 How can I protect against theft, sabotage, lightning, fire, ...?
 ----------------------------------------------------------------
 
-In general: if your only backup medium is nearby the backupped machine and
+In general: if your only backup medium is nearby the backed-up machine and
 always connected, you can easily get into trouble: they likely share the same
 fate if something goes really wrong.
 
@@ -794,7 +794,7 @@ Common issues
 There can be many causes of this error. E.g. you have incorrectly specified the repository path.
 
 You will also get this error if you try to access a repository that uses the argon2 key algorithm using an old version of borg.
-We recommend upgrading to the latest stable version and trying again. We are sorry. We should have thought abount forward
+We recommend upgrading to the latest stable version and trying again. We are sorry. We should have thought about forward
 compatibility and implemented a more helpful error message.
 
 Why am I seeing idle borg serve processes on the repo server?
@@ -1413,7 +1413,7 @@ There are some caveats:
 Why is my backup bigger than with attic?
 ----------------------------------------
 
-Attic was rather unflexible when it comes to compression, it always
+Attic was rather inflexible when it comes to compression, it always
 compressed using zlib level 6 (no way to switch compression off or
 adjust the level or algorithm).
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -818,7 +818,7 @@ bucket is reached.
 This particular mode of operation is open addressing with linear probing.
 
 When the hash table is filled to 75%, its size is grown. When it's
-emptied to 25%, its size is shrinked. Operations on it have a variable
+emptied to 25%, its size is shrunk. Operations on it have a variable
 complexity between constant and linear with low factor, and memory overhead
 varies between 33% and 300%.
 

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1797,7 +1797,7 @@ class ArchiveChecker:
                 # if we kill the defect chunk here, subsequent actions within this "borg check"
                 # run will find missing chunks and replace them with all-zero replacement
                 # chunks and flag the files as "repaired".
-                # if another backup is done later and the missing chunks get backupped again,
+                # if another backup is done later and the missing chunks get backed up again,
                 # a "borg check" afterwards can heal all files where this chunk was missing.
                 logger.warning('Found defect chunks. They will be deleted now, so affected files can '
                                'get repaired now and maybe healed later.')

--- a/src/borg/testsuite/xattr.py
+++ b/src/borg/testsuite/xattr.py
@@ -75,11 +75,11 @@ class XattrTestCase(BaseTestCase):
         self.assert_equal(len(buffer), 128)
 
 
-@pytest.mark.parametrize('lstring, splitted', (
+@pytest.mark.parametrize('lstring, expected', (
     (b'', []),
     (b'\x00', [b'']),
     (b'\x01a', [b'a']),
     (b'\x01a\x02cd', [b'a', b'cd']),
 ))
-def test_split_lstring(lstring, splitted):
-    assert split_lstring(lstring) == splitted
+def test_split_lstring(lstring, expected):
+    assert split_lstring(lstring) == expected


### PR DESCRIPTION
Body:                                                                                                                                                         
  ## Summary
  Fix minor spelling mistakes found by running `codespell` on the `1.4-maint` branch.

  - `backupped` → `backed-up` (docs/faq.rst)
  - `abount` → `about` (docs/faq.rst)
  - `unflexible` → `inflexible` (docs/faq.rst)
  - `shrinked` → `shrunk` (docs/internals/data-structures.rst)
  - `backupped` → `backed up` (src/borg/archive.py)
  - `splitted` → `expected` (src/borg/testsuite/xattr.py)

  All changes are in docs, comments, or test parameter names — zero functional impact.

  Closes #9295