### PR TITLE
ci: add missing timeout-minutes to codeql, backport, and lint workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,7 @@ jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -8,6 +8,7 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
`ci.yml` has `timeout-minutes` on every job, but three other workflows have no timeout configured. Without an explicit timeout, GitHub Actions defaults to 6    hours, wasting CI minutes if a job gets stuck.
Added timeouts consistent with existing `ci.yml` values:
  | Workflow | Job | Timeout | Rationale |                                                                                                                      
  |---|---|---|---|
  | `codeql-analysis.yml` | analyze | 20 min | Builds from source + CodeQL analysis (ci.yml Linux build is 25 min) |
  | `backport.yml` | backport | 5 min | Simple checkout + PR creation |
  | `black.yaml` | lint | 5 min | Matches ci.yml ruff lint job |

  No functional change — only adds a safety cap on job duration.

  Fixes #9298
