### PR TITLE
CI: replace deprecated git.io shortlink in CodeQL workflow, fixes #9300

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         language: [ 'cpp', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        # Learn more about CodeQL language support at https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
 Description:
  Fixes #9300

  Replace the deprecated `git.io` shortlink in `.github/workflows/codeql-analysis.yml` with the full canonical URL.

  GitHub [deprecated the git.io URL shortener](https://github.blog/changelog/2022-04-25-git-io-deprecation/) in April 2022. The existing shortlink still redirects (301) but could stop working at any time in the upcoming future.

  **Change:**
  `https://git.io/codeql-language-support` → `https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/`

  Comment-only change, no functional impact.
