### PR TITLE
docs: replace insecure http:// links with https://, fixes #9302

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -925,7 +925,7 @@ change rate-limit on the fly:
 
     pv -R $(pidof pv) -L 102400
 
-.. _pipeviewer: http://www.ivarch.com/programs/pv.shtml
+.. _pipeviewer: https://www.ivarch.com/programs/pv.shtml
 
 
 How can I avoid unwanted base directories getting stored into archives?

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,8 +70,8 @@ Ubuntu       `Ubuntu packages`_, `Ubuntu PPA`_             ``apt install borgbac
 .. _FreeBSD ports: https://www.freshports.org/archivers/py-borgbackup/
 .. _ebuild: https://packages.gentoo.org/packages/app-backup/borgbackup
 .. _GNU Guix: https://www.gnu.org/software/guix/package-list.html#borg
-.. _pkgsrc: http://pkgsrc.se/sysutils/py-borgbackup
-.. _cauldron: http://madb.mageia.org/package/show/application/0/release/cauldron/name/borgbackup
+.. _pkgsrc: https://pkgsrc.se/sysutils/py-borgbackup
+.. _cauldron: https://madb.mageia.org/package/show/application/0/release/cauldron/name/borgbackup
 .. _.nix file: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/borgbackup/default.nix
 .. _OpenBSD ports: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/sysutils/borgbackup/
 .. _OpenIndiana hipster repository: https://pkg.openindiana.org/hipster/en/search.shtml?token=borg&action=Search
@@ -138,7 +138,7 @@ environment variable before running Borg.
 If a new version is released, you will have to download it manually and replace
 the old version using the same steps as shown above.
 
-.. _pyinstaller: http://www.pyinstaller.org
+.. _pyinstaller: https://www.pyinstaller.org
 .. _releases: https://github.com/borgbackup/borg/releases
 
 .. _source-install:

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -280,7 +280,7 @@ and :ref:`borg_list` implement a ``--json`` option which turns their regular out
 
 Some commands, like :ref:`borg_list` and :ref:`borg_diff`, can produce *a lot* of JSON. Since many JSON implementations
 don't support a streaming mode of operation, which is pretty much required to deal with this amount of JSON, these
-commands implement a ``--json-lines`` option which generates output in the `JSON lines <http://jsonlines.org/>`_ format,
+commands implement a ``--json-lines`` option which generates output in the `JSON lines <https://jsonlines.org/>`_ format,
 which is simply a number of JSON objects separated by new lines.
 
 Dates are formatted according to ISO 8601 in local time. No explicit time zone is specified *at this time*


### PR DESCRIPTION
**Description**:

  Five documentation links still used `http://` for external sites that support HTTPS. Replaced them with `https://`:

  - `docs/faq.rst` — pipeviewer (`ivarch.com`)
  - `docs/installation.rst` — pkgsrc, Mageia, PyInstaller
  - `docs/internals/frontends.rst` — jsonlines.org

  All URLs verified to load correctly over HTTPS.

  Fixes #9302