### PR TITLE
ci: add dependabot config for github actions, fixes  #9308

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

  - Adds `.github/dependabot.yml` with GitHub Actions ecosystem monitoring
  - Weekly schedule with grouping — all action updates land in a single PR per week
  - Scoped to Actions only; pip security updates already work without a config file

  Fixes #9308

  ## Details

  The repository uses ~12 third-party Actions across 4 workflows but has no Dependabot configuration. While pip       
  security updates run automatically on public repos, GitHub Actions have no version or security monitoring at all.   

  Actions pinned to specific minor versions (e.g., `cross-platform-actions/action@v0.29.0`) won't receive updates     
  without explicit configuration. The `groups` setting with a `"*"` pattern consolidates all action updates into a    
  single weekly PR to minimize noise.

  Pip version updates are intentionally excluded — borg's strict dependency pins (e.g., `msgpack >=1.0.3, <=1.1.2`)   
  would generate noisy PRs that conflict with the project's manual dependency management approach.