### PR TITLE
ci: add concurrency groups to cancel stale workflow runs, fixes #9310

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,6 +5,10 @@ name: Lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
     - 'requirements.d/*'
     - '!docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '39 2 * * 5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
 ## Summary
  - Add `concurrency` groups to `ci.yml`, `codeql-analysis.yml`, and `black.yaml`
  - Groups runs by workflow + branch using `github.head_ref || github.ref`   
  - Only cancels in-progress runs for pull requests — push-to-master, tag builds, and scheduled CodeQL runs are never canceled
  - `backport.yml` excluded (triggered by PR close/comment, not branch pushes)

  Fixes #9310