### PR TITLE
windows: normalize drive letters fixes #9279

### DIFF
--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -252,6 +252,12 @@ def make_path_safe(path):
     if "\\.." in path or "..\\" in path:
         raise ValueError(f"unexpected '..' element in path {path!r}")
 
+    path = slashify(path)
+
+    if is_win32 and len(path) >= 2 and path[1] == ":":
+        # Handle drive letters: C:/path -> C/path
+        path = path[0].upper() + path[2:]
+
     path = map_chars(path)
 
     path = path.lstrip("/")

--- a/src/borg/testsuite/helpers/fs_test.py
+++ b/src/borg/testsuite/helpers/fs_test.py
@@ -318,6 +318,23 @@ def test_invalid_make_path_safe(path):
         make_path_safe(path)
 
 
+def test_make_path_safe_win32_drive_letters(monkeypatch):
+    monkeypatch.setattr("borg.helpers.fs.is_win32", True)
+    # Basic drive letter
+    assert make_path_safe("C:\\Users") == "C/Users"
+    assert make_path_safe("C:\\Users\\test") == "C/Users/test"
+    # Lowercase drive letter -> Uppercase
+    assert make_path_safe("c:\\windows") == "C/windows"
+    # Relative path with backslashes
+    assert make_path_safe("foo\\bar") == "foo/bar"
+    # Just drive letter
+    assert make_path_safe("D:") == "D"
+    # Drive letter with forward slash
+    assert make_path_safe("E:/test") == "E/test"
+    # Mixed separators
+    assert make_path_safe("F:\\Mixed/Separators") == "F/Mixed/Separators"
+
+
 def test_dir_is_tagged(tmpdir):
     """Test dir_is_tagged with both path-based and file descriptor-based operations."""
 


### PR DESCRIPTION
Implemented drive letter normalization in make_path_safe within src/borg/helpers/fs.py.

Windows drive letters (e.g. `C:\path`) are now mapped to portable path components (e.g. `C/path`) to ensure cross-platform compatibility and correct archiving.

Added regression test test_make_path_safe_win32_drive_letters to src/borg/testsuite/helpers/fs_test.py covering various drive letter scenarios.

Verified locally on Windows with MSYS2. Fixes #9279 