### PR TITLE
ci: pin psf/black action to commit SHA, fixes #9317

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: psf/black@stable
+      - uses: psf/black@6305bf1ae645ab7541be4f5028a86239316178eb  # 26.1.0
         with:
             version: "~= 24.0"


### PR DESCRIPTION
## Summary

  Pin `psf/black` from the mutable `@stable` branch reference to a specific commit SHA (26.1.0).

  - `@stable` is a branch that moves with every new release — the action code can change without notice
  - The `# 26.1.0` comment enables Dependabot (already configured) to automatically propose SHA update PRs
  - The `version: "~= 24.0"` formatter constraint is unchanged — this only pins the action wrapper

  Fixes #9317

  ## Details

  GitHub recommends [pinning third-party actions to full-length commit SHAs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for supply-chain security. The March 2025 `tj-actions/changed-files` incident demonstrated how mutable action refs can be exploited.

  **Change:** One line in `.github/workflows/black.yaml`.

  ```yaml
  # before
  - uses: psf/black@stable

  # after
  - uses: psf/black@6305bf1ae645ab7541be4f5028a86239316178eb  # 26.1.0