### PR TITLE
ci: add path filters to lint and codeql workflows, fixes #9328

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -8,10 +8,12 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
+      - '.github/workflows/black.yaml'
   pull_request:
     paths:
       - '**.py'
       - 'pyproject.toml'
+      - '.github/workflows/black.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,7 @@ on:
       - '**.pyx'
       - '**.c'
       - '**.h'
+      - '.github/workflows/codeql-analysis.yml'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
@@ -18,6 +19,7 @@ on:
       - '**.pyx'
       - '**.c'
       - '**.h'
+      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '39 2 * * 5'
 


### PR DESCRIPTION
 ## Summary

  - Add `paths` filter to `black.yaml` — only trigger on `**.py` and `pyproject.toml` changes
  - Add `paths` filter to `codeql-analysis.yml` — only trigger on source code changes (`**.py`, `**.pyx`, `**.c`, `**.h`); weekly schedule unaffected
  - `ci.yml` and `backport.yml` unchanged (ci.yml already has PR path filters; backport is event-driven)
  - Include each workflow file in its own `paths` filter so changes to the workflow config itself still trigger a run  

  Fixes #9328

  ## Details

  The Lint and CodeQL workflows currently run on every push/PR regardless of files changed, wasting CI minutes on docs-only changes (CHANGES.rst, README.rst, docs/**, etc.).

  Uses `paths` (whitelist) rather than `paths-ignore` — only triggers when files the tool actually processes are modified. Consistent with ci.yml which already filters PRs this way.

  | Workflow              | Paths filter                                              | Rationale                                                        |      
  |-----------------------|-----------------------------------------------------------|------------------------------------------------------------------|      
  | black.yaml            | `**.py`, `pyproject.toml`, `.github/workflows/black.yaml` | Black only formats Python; pyproject.toml has `[tool.black]` config |   
  | codeql-analysis.yml   | `**.py`, `**.pyx`, `**.c`, `**.h`, `.github/workflows/codeql-analysis.yml` | CodeQL analyzes Python + C/C++ source code |
