### PR TITLE
cockpit: fix subprocess invocation in frozen binaries

### DIFF
--- a/src/borg/cockpit/runner.py
+++ b/src/borg/cockpit/runner.py
@@ -28,7 +28,10 @@ class BorgRunner:
             self.logger.warning("Borg process already running.")
             return
 
-        cmd = [sys.executable, "-m", "borg"] + self.command
+        if getattr(sys, "frozen", False):
+            cmd = [sys.executable] + self.command  # executable == pyinstaller binary
+        else:
+            cmd = [sys.executable, "-m", "borg"] + self.command  # executable == python interpreter
 
         self.logger.info(f"Starting Borg process: {cmd}")
 


### PR DESCRIPTION
When running as a Pyinstaller-made binary, sys.executable points to the borg binary itself. Invoking it with "-m borg" resulted in an incorrect command line (e.g., "borg -m borg ..."), which confused the argument parser in the subprocess.

This change checks sys.frozen to determine the correct invocation:
- If frozen: [sys.executable, ...args]
- If not frozen: [sys.executable, "-m", "borg", ...args]

Fixes #9277.