### PR TITLE
github: enhance pull request template, fixes #9334

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,8 +1,0 @@
-Thank you for contributing code to Borg; your help is appreciated!
-
-Before you submit a pull request, please make sure it complies with the
-guidelines in our documentation:
-
-https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-
-**Please remove the text above before submitting your pull request.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Thank you for contributing to BorgBackup!
+
+Please make sure your PR complies with our contribution guidelines:
+https://borgbackup.readthedocs.io/en/latest/development.html#contributions
+-->
+
+## Description
+
+<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->
+
+
+## Checklist
+
+- [ ] PR is against `master` (or maintenance branch if only applicable there)
+- [ ] New code has tests and docs where appropriate
+- [ ] Tests pass (run `tox` or the relevant test subset)
+- [ ] Commit messages are clean and reference related issues


### PR DESCRIPTION
## Description

  Replace the minimal PR template (unchanged since #1924, Dec 2016) with a structured version that aligns with the [contribution guidelines](https://borgbackup.readthedocs.io/en/latest/development.html#contributions).

  Changes:
  - Add `## Description` section prompting contributors to describe changes and reference issues
  - Add `## Checklist` derived from the contribution guidelines
  - Move instructions into HTML comments so contributors don't need to manually remove template text
  - Rename to `.md` for consistency with `ISSUE_TEMPLATE.md` and GitHub conventions

   ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate — not applicable, template-only change
  - [ ] Tests pass — not applicable, no code changes
  - [x] Commit messages are clean and reference related issues