### PR TITLE
 upgrade http:// URLs to https:// and remove dead librelist.com link, fixes #9342

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
               netbsd)
                 arch="$(uname -m)"
                 sudo -E mkdir -p /usr/pkg/etc/pkgin
-                echo "http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/10.1/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
+                echo "https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/10.1/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
                 sudo -E pkgin update
                 sudo -E pkgin -y upgrade
                 sudo -E pkgin -y install zstd lz4 xxhash git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,7 +97,7 @@ end
 
 def packages_netbsd
   return <<-EOF
-    echo 'http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$arch/9.3/All' > /usr/pkg/etc/pkgin/repositories.conf
+    echo 'https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$arch/9.3/All' > /usr/pkg/etc/pkgin/repositories.conf
     pkgin update
     pkgin -y upgrade
     pkg_add zstd lz4 xxhash git

--- a/docs/global.rst.inc
+++ b/docs/global.rst.inc
@@ -26,6 +26,5 @@
 .. _mfusepy: https://pypi.org/project/mfusepy/
 .. _pyfuse3: https://pypi.org/project/pyfuse3/
 .. _userspace filesystems: https://en.wikipedia.org/wiki/Filesystem_in_Userspace
-.. _Cython: http://cython.org/
+.. _Cython: https://cython.org/
 .. _virtualenv: https://pypi.org/project/virtualenv/
-.. _mailing list discussion about internals: http://librelist.com/browser/attic/2014/5/6/questions-and-suggestions-about-inner-working-of-attic>

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -7,8 +7,8 @@ Data structures and file formats
 ================================
 
 This page documents the internal data structures and storage
-mechanisms of Borg. It is partly based on `mailing list
-discussion about internals`_ and also on static code analysis.
+mechanisms of Borg. It is partly based on mailing list
+discussions and also on static code analysis.
 
 .. todo:: Clarify terms, perhaps create a glossary.
           ID (client?) vs. key (repository?),

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -298,7 +298,7 @@ def define_exclude_and_patterns(add_option, *, tag_files=False, strip_components
             "--exclude-caches",
             dest="exclude_caches",
             action="store_true",
-            help="exclude directories that contain a CACHEDIR.TAG file " "(http://www.bford.info/cachedir/spec.html)",
+            help="exclude directories that contain a CACHEDIR.TAG file " "(https://www.bford.info/cachedir/spec.html)",
         )
         add_option(
             "--exclude-if-present",

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -150,7 +150,7 @@ def get_cache_dir(*, legacy=False, create=True):
                     """
             # This file is a cache directory tag created by Borg.
             # For information about cache directory tags, see:
-            #       http://www.bford.info/cachedir/spec.html
+            #       https://www.bford.info/cachedir/spec.html
             """
                 ).encode("ascii")
             )
@@ -184,7 +184,7 @@ def get_config_dir(*, legacy=False, create=True):
 def dir_is_cachedir(path=None, dir_fd=None):
     """Determines whether the specified directory is a cache directory (and
     therefore should potentially be excluded from the backup) according to
-    the CACHEDIR.TAG protocol (http://www.bford.info/cachedir/spec.html).
+    the CACHEDIR.TAG protocol (https://www.bford.info/cachedir/spec.html).
 
     If dir_fd is provided, operations will be based on the directory file descriptor.
     Otherwise (path is provided), operations will be based on the directory path.


### PR DESCRIPTION
## Description

  Upgrade 6 `http://` URLs to `https://` and remove one dead `librelist.com` link across 5 files.

  Fixes #9342

  ## Changes

  | File | Change |
  |------|--------|
  | `docs/global.rst.inc` | `http://cython.org/` → `https://cython.org/` |
  | `docs/global.rst.inc` | Remove dead `librelist.com` link (unused, never referenced) |
  | `src/borg/helpers/fs.py` (2 places) | `http://www.bford.info/cachedir/spec.html` → `https://` |
  | `src/borg/archiver/_common.py` | `http://www.bford.info/cachedir/spec.html` → `https://` |
  | `.github/workflows/ci.yml` | `http://ftp.NetBSD.org/...` → `https://ftp.NetBSD.org/...` |
  | `Vagrantfile` | `http://ftp.NetBSD.org/...` → `https://ftp.NetBSD.org/...` |

  All HTTPS replacements verified to return HTTP 200. Localhost test URLs excluded.

  ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate — not applicable, URL-only change
  - [x] Tests pass — no functional code changes
  - [x] Commit messages are clean and reference related issues