### PR TITLE
ci: add top-level permissions for least-privilege security, fixes #9344

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
 ## Description

  Add a top-level `permissions: contents: read` to the CI workflow to restrict the default GITHUB_TOKEN to read-only for all jobs.

  Fixes #9344

  ## Changes

  Jobs that already have job-level permissions (`native_tests`, `vm_tests`) are unaffected — job-level overrides take precedence.

  Jobs that now gain an explicit read-only restriction:
  - `lint` — only uses `actions/checkout` + ruff
  - `security` — only uses `actions/checkout` + bandit
  - `asan_ubsan` — only uses `actions/checkout` + build + test
  - `windows_tests` — uses `actions/checkout` + build + test + upload-artifact

  ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate — not applicable, workflow-only change
  - [x] Tests pass — CI should remain green (no functional change)
  - [x] Commit messages are clean and reference related issues