### PR TITLE
docs: update SECURITY.md version table, fixes #9346

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ These Borg releases are currently supported with security updates.
 
 | Version | Supported          |
 |---------|--------------------|
-| 2.0.x   | :x: (not released) |
+| 2.0.x   | :x: (beta)         |
 | 1.4.x   | :white_check_mark: |
-| 1.2.x   | :white_check_mark: |
+| 1.2.x   | :x: (no new releases, critical fixes may still be backported) |
 | 1.1.x   | :x:                |
 | < 1.1   | :x:                |
 


### PR DESCRIPTION
## Description

Update the `SECURITY.md` version table to reflect current release status:

- **1.2.x**: Mark as `:x: (no new releases, critical fixes may still be backported)` — while no new releases are planned, critical fixes may still be backported to the 1.2-maint branch
- **2.0.x**: Change `(not released)` to `(beta)` — 20 beta releases exist (up to 2.0.0b20), so "(not released)" is misleading

Closes #9346

## Checklist

- [x] PR is against `master`
- [ ] New code has tests and docs where appropriate — not applicable, docs-only change
- [ ] Tests pass — not applicable, no code changes
- [x] Commit messages are clean and reference related issues