### PR TITLE
ci: expand Dependabot config to monitor pip dependencies, fixes #9349

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "pip"
+    directory: "/requirements.d"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
 Add `pip` package ecosystem to `.github/dependabot.yml`, scoped to `/requirements.d` (dev/build dependencies only).

  - Enable **version updates** for dev/build tools (pytest, Cython, coverage, tox, pre-commit, pyinstaller, etc.), not just security patches
  - **Group** all pip bumps into a single weekly PR, reducing noise matches the existing `github-actions` pattern from #9309
  - Intentionally excludes `pyproject.toml` runtime deps (strict version constraints would produce noisy PRs)

  ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate - not applicable, config-only change
  - [ ] Tests pass - not applicable, no code changes
  - [x] Commit messages are clean and reference related issues