### PR TITLE
Fix: Exclude platform-specific code from coverage, fixes #9351

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,11 @@ omit = [
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
+    "pragma: win32 only",
+    "pragma: posix only",
+    "pragma: linux only",
+    "pragma: darwin only",
+    "pragma: netbsd only",
     "pragma: freebsd only",
     "pragma: unknown platform only",
     "def __repr__",


### PR DESCRIPTION
## Description
This PR addresses missing coverage reports for platform-specific code (e.g., `# pragma: win32 only`) by explicitly excluding these pragmas in `pyproject.toml`. Fixes #9351.

Previously, `pyproject.toml` only excluded `pragma: freebsd only` and `pragma: unknown platform only`. This caused Codecov to report missing coverage for valid platform-specific imports (like `set_birthtime` on Windows) when running on Linux CI.

## Changes
- `pyproject.toml`: Added `win32`, `posix`, `linux`, `darwin`, and `netbsd` pragmas to the `exclude_lines` list in coverage configuration.

## Verification
- Verify that Codecov no longer reports missing coverage for lines marked with these pragmas.
