### PR TITLE
benchmark cpu: add --json output option, fixes #9166

### DIFF
--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -1,3 +1,5 @@
+import json
+
 from ...constants import *  # NOQA
 from . import cmd, RK_ENCRYPTION
 
@@ -6,3 +8,44 @@ def test_benchmark_crud(archiver, monkeypatch):
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     monkeypatch.setenv("_BORG_BENCHMARK_CRUD_TEST", "YES")
     cmd(archiver, "benchmark", "crud", archiver.input_path)
+
+
+def test_benchmark_cpu(archiver):
+    output = cmd(archiver, "benchmark", "cpu")
+    # verify all section headers appear in the plain-text output
+    assert "Chunkers" in output
+    assert "Non-cryptographic checksums / hashes" in output
+    assert "Cryptographic hashes / MACs" in output
+    assert "Encryption" in output
+    assert "KDFs" in output
+    assert "Compression" in output
+    assert "msgpack" in output
+
+
+def test_benchmark_cpu_json(archiver):
+    output = cmd(archiver, "benchmark", "cpu", "--json")
+    result = json.loads(output)
+    assert isinstance(result, dict)
+    # categories with "size" field (bytes)
+    for category in ["chunkers", "checksums", "hashes", "encryption"]:
+        assert isinstance(result[category], list)
+        assert len(result[category]) > 0
+        for entry in result[category]:
+            assert isinstance(entry["algo"], str)
+            assert isinstance(entry["size"], int)
+            assert isinstance(entry["time"], float)
+    # chunkers and compression also have algo_params
+    for category in ["chunkers", "compression"]:
+        for entry in result[category]:
+            assert "algo_params" in entry
+    # categories with "count" field
+    for category in ["kdf", "msgpack"]:
+        assert isinstance(result[category], list)
+        assert len(result[category]) > 0
+        for entry in result[category]:
+            assert isinstance(entry["algo"], str)
+            assert isinstance(entry["count"], int)
+            assert isinstance(entry["time"], float)
+    # compression has size field too
+    for entry in result["compression"]:
+        assert isinstance(entry["size"], int)


### PR DESCRIPTION
## Description

  Add `--json` flag to `borg benchmark cpu` for machine-readable output, as proposed in #9166.

  - Outputs a single JSON object with keys: `chunkers`, `checksums`, `hashes`, `encryption`, `kdf`, `compression`, `msgpack`
  - Each key contains an array of benchmark entries with `algo`, `size`/`count`, `time`, and `algo_params` where applicable
  - Uses the existing `json_print()` helper (consistent with `repo-info --json`, `info --json`, etc.)
  - Without `--json`, output is unchanged
  
  Closes #9166

  ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate — no new tests; docs are auto-generated from argparse      
  - [x] Tests pass
  - [x] Commit messages are clean and reference related issues