### PR TITLE
benchmark crud: add --json-lines output option, fixes #9165

### DIFF
--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -7,7 +7,42 @@ from . import cmd, RK_ENCRYPTION
 def test_benchmark_crud(archiver, monkeypatch):
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     monkeypatch.setenv("_BORG_BENCHMARK_CRUD_TEST", "YES")
-    cmd(archiver, "benchmark", "crud", archiver.input_path)
+    output = cmd(archiver, "benchmark", "crud", archiver.input_path)
+    # Verify human-readable output contains expected C/R/U/D lines with MB/s
+    for prefix in ("C-Z-TEST", "R-Z-TEST", "U-Z-TEST", "D-Z-TEST", "C-R-TEST", "R-R-TEST", "U-R-TEST", "D-R-TEST"):
+        assert prefix in output
+    assert "MB/s" in output
+
+
+def test_benchmark_crud_json_lines(archiver, monkeypatch):
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    monkeypatch.setenv("_BORG_BENCHMARK_CRUD_TEST", "YES")
+    output = cmd(archiver, "benchmark", "crud", "--json-lines", archiver.input_path)
+    # Filter for JSON lines only; the test harness merges stdout and stderr,
+    # so non-JSON messages (e.g. "Done. Run borg compact...") from inner
+    # commands may appear in the captured output.
+    lines = [line for line in output.splitlines() if line.strip().startswith("{")]
+    # 2 test samples (Z-TEST, R-TEST) x 4 operations (C, R, U, D) = 8 lines
+    assert len(lines) == 8
+    entries = [json.loads(line) for line in lines]
+    # Verify all expected id values are present
+    expected_ids = {"C-Z-TEST", "R-Z-TEST", "U-Z-TEST", "D-Z-TEST", "C-R-TEST", "R-R-TEST", "U-R-TEST", "D-R-TEST"}
+    actual_ids = {e["id"] for e in entries}
+    assert actual_ids == expected_ids
+    for entry in entries:
+        assert isinstance(entry["id"], str)
+        assert entry["command"] in ("create1", "extract", "create2", "delete")
+        assert isinstance(entry["sample"], str)
+        assert entry["sample"] in ("Z-TEST", "R-TEST")
+        assert isinstance(entry["sample_count"], int)
+        assert entry["sample_count"] == 1
+        assert isinstance(entry["sample_size"], int)
+        assert entry["sample_size"] == 1
+        assert isinstance(entry["sample_random"], bool)
+        assert isinstance(entry["time"], float)
+        assert entry["time"] > 0
+        assert isinstance(entry["io"], int)
+        assert entry["io"] > 0
 
 
 def test_benchmark_cpu(archiver):


### PR DESCRIPTION
 ## Description                                                                                                 
                                                                             
  Add `--json-lines` flag to `borg benchmark crud` for machine-readable output, as proposed in #9165.

  - Each benchmark result is printed as a single JSON object per line
  - Fields: `id`, `command`, `sample`, `sample_count`, `sample_size`, `sample_random`, `time` (seconds), `io` (bytes/sec)
  - Follows the existing `--json-lines` pattern used by `borg list` and `borg diff`
  - Without `--json-lines`, output is unchanged

  Closes #9165

  ## Checklist

  - [x] PR is against `master`
  - [ ] New code has tests and docs where appropriate - no new tests; docs are auto-generated from argparse      
  - [x] Tests pass
  - [x] Commit messages are clean and reference related issues