### PR TITLE
docs: fix broken :ref: references in man pages, fixes #7239

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -178,6 +178,7 @@ Other changes:
 
   - fix S3 url description, #9249
   - add a note that you need to install boto3 if you want to use S3/B2 URLs
+  - man pages: fix broken :ref: references (e.g. borg_patterns), #7239
 
 
 Version 2.0.0b20 (2025-12-24)

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -485,11 +485,17 @@ class BuildMan:
         from docutils.core import publish_string
         from docutils.nodes import inline
         from docutils.parsers.rst import roles
+        from borg.archiver._common import rst_plain_text_references
 
         def issue(name, rawtext, text, lineno, inliner, options={}, content=[]):
             return [inline(rawtext, "#" + text)], []
 
+        def ref_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+            replacement = rst_plain_text_references.get(text, text)
+            return [inline(rawtext, replacement)], []
+
         roles.register_local_role("issue", issue)
+        roles.register_local_role("ref", ref_role)
         # We give the source_path so that docutils can find relative includes
         # as-if the document where located in the docs/ directory.
         man_page = publish_string(source=rst, source_path="docs/%s.rst" % name, writer=manpage.Writer())


### PR DESCRIPTION
 ## Summary

  Register a custom `:ref:` role in the man page builder (`scripts/make.py`) so that references like  `:ref:`borg_patterns`` resolve to meaningful text instead of appearing as literal `borg_patterns` in man pages.

  Fixes #7239

  ## Problem

  Command epilogs use RST `:ref:` directives (e.g. `:ref:`borg_patterns``). These resolve correctly in two contexts:
  - **Terminal** (`--help`): `rst_plain_text_references` mapping substitutes them
  - **HTML docs**: Sphinx resolves them via document cross-references

  But for **man pages**, `gen_man_page()` passes the raw RST to docutils, which doesn't understand `:ref:` (a Sphinx-specific role). Result: literal `borg_patterns` in italics.

  Affected man pages: borg-create, borg-delete, borg-diff, borg-extract, borg-export-tar,borg-list, borg-undelete, borg-recreate, borg-repo-create.

  ## Fix

  Add a custom `:ref:` docutils role in `gen_man_page()` (same pattern as the existing `:issue:` role) that resolves references using the existing `rst_plain_text_references` mapping from `borg.archiver._common`.

  ## Changes

  | File | Change |
  |------|--------|
  | `scripts/make.py` | Add `ref_role` handler + register `:ref:` role in `gen_man_page()` |
  | `docs/changes.rst` | Add changelog entry under docs |
