### PR TITLE
 github: enhance pull request template (port from master)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,8 +1,0 @@
-Thank you for contributing code to Borg; your help is appreciated!
-
-Before you submit a pull request, please make sure it complies with the
-guidelines in our documentation:
-
-https://borgbackup.readthedocs.io/en/stable/development.html#contributions
-
-**Please remove the text above before submitting your pull request.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Thank you for contributing to BorgBackup!
+
+Please make sure your PR complies with our contribution guidelines:
+https://borgbackup.readthedocs.io/en/latest/development.html#contributions
+-->
+
+## Description
+
+<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->
+
+
+## Checklist
+
+- [ ] PR is against `master` (or maintenance branch if only applicable there)
+- [ ] New code has tests and docs where appropriate
+- [ ] Tests pass (run `tox` or the relevant test subset)
+- [ ] Commit messages are clean and reference related issues


### PR DESCRIPTION
## Description                                                                                                                                                
  
  Port the enhanced PR template from `master` (#9335) to `1.4-maint`, as requested by @ThomasWaldmann in
  https://github.com/borgbackup/borg/pull/9335#issuecomment-3915014582.

  Changes (identical to #9335):
  - Replace minimal plain-text template with a structured Markdown version
  - Add `## Description` and `## Checklist` sections
  - Move instructions into HTML comments
  - Rename to `.md` for consistency with `ISSUE_TEMPLATE.md`

  ## Checklist

  - [x] PR is against `1.4-maint`
  - [ ] New code has tests and docs where appropriate — not applicable, template-only change
  - [ ] Tests pass — not applicable, no code changes
  - [x] Commit messages are clean and reference related issues
