### PR TITLE
cache: remove try_upgrade_to_b14() legacy migration, fixes #9371

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -694,17 +694,6 @@ class FilesCacheMixin:
         )
 
 
-def try_upgrade_to_b14(repository):
-    # TODO: remove this before 2.0.0 release
-    # we just delete any present chunk index cache here, it is invalid due to the
-    # refcount -> flags change we did and due to the different CHUNKINDEX_HASH_SEED.
-    for name in "chunks_hash", "chunks":
-        try:
-            repository.store_delete(f"cache/{name}")
-        except (Repository.ObjectNotFound, StoreObjectNotFound):
-            pass  # likely already upgraded
-
-
 def list_chunkindex_hashes(repository):
     hashes = []
     for info in repository.store_list("cache"):
@@ -807,7 +796,6 @@ def read_chunkindex_from_repo_cache(repository, hash):
 
 
 def build_chunkindex_from_repo(repository, *, disable_caches=False, cache_immediately=False):
-    try_upgrade_to_b14(repository)
     # first, try to build a fresh, mostly complete chunk index from centrally cached chunk indexes:
     if not disable_caches:
         hashes = list_chunkindex_hashes(repository)


### PR DESCRIPTION
## Summary
  - Remove `try_upgrade_to_b14()` from `src/borg/cache.py` — a one-time migration function marked `# TODO: remove this before 2.0.0 release`
  - Added in b14 (d4310dd4c, Nov 2024) to invalidate old chunk index caches after the `refcount` → `flags` rename and `CHUNKINDEX_HASH_SEED` change
  - Any repo used since b14 has already been cleaned up — the function is now a no-op that always hits the `except` branch
  - It runs on every `build_chunkindex_from_repo()` call, issuing 2 unnecessary `store_delete()` RPCs per cache rebuild
  - Old caches are also rejected at the hash-validation level in `read_chunkindex_from_repo_cache()`, so this function provides no safety net

  Fixes #9371

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/cache.py` | Removed `try_upgrade_to_b14()` (lines 697–705) and its call in `build_chunkindex_from_repo()` (line 810) |

  ## Checklist
  - [x] PR is against `master`
  - [x] Single-topic changeset — removal only, no mixed refactoring
  - [x] Code formatted with black