### PR TITLE
remote: fix StoreObjectNotFound exception lost over RPC, fixes #9380

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -712,8 +712,7 @@ def delete_chunkindex_cache(repository):
         cache_name = f"cache/chunks.{hash}"
         try:
             repository.store_delete(cache_name)
-        except (Repository.ObjectNotFound, StoreObjectNotFound):
-            # TODO: ^ seem like RemoteRepository raises Repository.ONF instead of StoreONF
+        except StoreObjectNotFound:
             pass
     logger.debug(f"cached chunk indexes deleted: {hashes}")
 
@@ -769,8 +768,7 @@ def write_chunkindex_to_repo_cache(
             cache_name = f"cache/chunks.{hash}"
             try:
                 repository.store_delete(cache_name)
-            except (Repository.ObjectNotFound, StoreObjectNotFound):
-                # TODO: ^ seem like RemoteRepository raises Repository.ONF instead of StoreONF
+            except StoreObjectNotFound:
                 pass
         if delete_these:
             logger.debug(f"cached chunk indexes deleted: {delete_these}")
@@ -782,8 +780,7 @@ def read_chunkindex_from_repo_cache(repository, hash):
     logger.debug(f"trying to load {cache_name} from the repo...")
     try:
         chunks_data = repository.store_load(cache_name)
-    except (Repository.ObjectNotFound, StoreObjectNotFound):
-        # TODO: ^ seem like RemoteRepository raises Repository.ONF instead of StoreONF
+    except StoreObjectNotFound:
         logger.debug(f"{cache_name} not found in the repository.")
     else:
         if xxh64(chunks_data, seed=CHUNKINDEX_HASH_SEED) == hex_to_bin(hash):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -9,7 +9,7 @@ from ..helpers import Location
 from ..helpers import IntegrityError
 from ..platformflags import is_win32
 from ..remote import RemoteRepository, InvalidRPCMethod, PathNotAllowed
-from ..repository import Repository, MAX_DATA_SIZE
+from ..repository import Repository, StoreObjectNotFound, MAX_DATA_SIZE
 from ..repoobj import RepoObj
 from .hashindex_test import H
 
@@ -213,6 +213,12 @@ def test_remote_rpc_exception_transport(remote_repository):
             assert len(e.args) == 2
             assert e.args[0] == s1
             assert e.args[1] == remote_repository.location.processed
+
+        try:
+            remote_repository.call("inject_exception", {"kind": "StoreObjectNotFound"})
+        except StoreObjectNotFound as e:
+            assert len(e.args) == 1
+            assert e.args[0] == s1
 
         try:
             remote_repository.call("inject_exception", {"kind": "InvalidRPCMethod"})


### PR DESCRIPTION
## Summary
  - `RemoteRepository` RPC layer serializes exceptions using `e.__class__.__name__`, but both `borgstore.store.ObjectNotFound` and `Repository.ObjectNotFound` share `__name__ == "ObjectNotFound"`
  - Client-side `handle_error` always reconstructs `Repository.ObjectNotFound`, even when the server actually raised `StoreObjectNotFound` from a `store_load()`/`store_delete()` call
  - This was already acknowledged with TODO comments at 3 sites in `cache.py`: `# TODO: ^ seem like RemoteRepository raises Repository.ONF instead of StoreONF`
  - Fix: distinguish `StoreObjectNotFound` during server-side serialization and reconstruct it correctly on the client side

  Fixes #9380

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/remote.py` | Import `StoreObjectNotFound`; serialize it as `"StoreObjectNotFound"` (not ambiguous `"ObjectNotFound"`) on the server side; add client-side `handle_error` branch to reconstruct it; add `inject_exception` test hook |
  | `src/borg/cache.py` | Simplify 3 `except` clauses from `(Repository.ObjectNotFound, StoreObjectNotFound)` to `StoreObjectNotFound`; remove TODO comments |  
  | `src/borg/testsuite/repository_test.py` | Add `StoreObjectNotFound` round-trip test in `test_remote_rpc_exception_transport` |

  ## Backward compatibility note

  This changes the RPC wire format for `StoreObjectNotFound`:
  - **Old server → new client**: old server sends `"ObjectNotFound"`, new client raises `Repository.ObjectNotFound` - `cache.py` callers would miss it. In practice, `store_*` methods are borg2-only and borg2 is in beta, so mixed-version deployments are not a supported scenario.
  - **New server → old client**: old client falls through to `RPCError` fallback.

  ## Checklist
  - [x] PR is against `master`
  - [x] New code has tests
  - [x] Tests pass
  - [x] Commit message references related issue
  - [x] Code formatted with black