### PR TITLE
 create: implement "file changed while backup" detection on Windows, fixes #9382

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1242,7 +1242,7 @@ class FilesystemObjectProcessors:
         log_json,
         iec,
         file_status_printer=None,
-        files_changed="ctime",
+        files_changed="mtime" if is_win32 else "ctime",
     ):
         self.metadata_collector = metadata_collector
         self.cache = cache
@@ -1471,40 +1471,35 @@ class FilesystemObjectProcessors:
                             )
                             self.stats.chunking_time = self.chunker.chunking_time
                         end_reading = time.time_ns()
-                        if not is_win32:  # TODO for win32
-                            with backup_io("fstat2"):
-                                st2 = os.fstat(fd)
-                            if self.files_changed == "disabled" or is_special_file:
-                                # special files:
-                                # - fifos change naturally, because they are fed from the other side. no problem.
-                                # - blk/chr devices don't change ctime anyway.
-                                pass
-                            elif self.files_changed == "ctime":
-                                if st.st_ctime_ns != st2.st_ctime_ns:
-                                    # ctime was changed, this is either a metadata or a data change.
-                                    changed_while_backup = True
-                                elif (
-                                    start_reading - TIME_DIFFERS1_NS < st2.st_ctime_ns < end_reading + TIME_DIFFERS1_NS
-                                ):
-                                    # this is to treat a very special race condition, see #3536.
-                                    # - file was changed right before st.ctime was determined.
-                                    # - then, shortly afterwards, but already while we read the file, the
-                                    #   file was changed again, but st2.ctime is the same due to ctime granularity.
-                                    # when comparing file ctime to local clock, widen interval by TIME_DIFFERS1_NS.
-                                    changed_while_backup = True
-                            elif self.files_changed == "mtime":
-                                if st.st_mtime_ns != st2.st_mtime_ns:
-                                    # mtime was changed, this is either a data change.
-                                    changed_while_backup = True
-                                elif (
-                                    start_reading - TIME_DIFFERS1_NS < st2.st_mtime_ns < end_reading + TIME_DIFFERS1_NS
-                                ):
-                                    # this is to treat a very special race condition, see #3536.
-                                    # - file was changed right before st.mtime was determined.
-                                    # - then, shortly afterwards, but already while we read the file, the
-                                    #   file was changed again, but st2.mtime is the same due to mtime granularity.
-                                    # when comparing file mtime to local clock, widen interval by TIME_DIFFERS1_NS.
-                                    changed_while_backup = True
+                        with backup_io("fstat2"):
+                            st2 = os.fstat(fd)
+                        if self.files_changed == "disabled" or is_special_file:
+                            # special files:
+                            # - fifos change naturally, because they are fed from the other side. no problem.
+                            # - blk/chr devices don't change ctime anyway.
+                            pass
+                        elif self.files_changed == "ctime":
+                            if st.st_ctime_ns != st2.st_ctime_ns:
+                                # ctime was changed, this is either a metadata or a data change.
+                                changed_while_backup = True
+                            elif start_reading - TIME_DIFFERS1_NS < st2.st_ctime_ns < end_reading + TIME_DIFFERS1_NS:
+                                # this is to treat a very special race condition, see #3536.
+                                # - file was changed right before st.ctime was determined.
+                                # - then, shortly afterwards, but already while we read the file, the
+                                #   file was changed again, but st2.ctime is the same due to ctime granularity.
+                                # when comparing file ctime to local clock, widen interval by TIME_DIFFERS1_NS.
+                                changed_while_backup = True
+                        elif self.files_changed == "mtime":
+                            if st.st_mtime_ns != st2.st_mtime_ns:
+                                # mtime was changed, this is either a data change.
+                                changed_while_backup = True
+                            elif start_reading - TIME_DIFFERS1_NS < st2.st_mtime_ns < end_reading + TIME_DIFFERS1_NS:
+                                # this is to treat a very special race condition, see #3536.
+                                # - file was changed right before st.mtime was determined.
+                                # - then, shortly afterwards, but already while we read the file, the
+                                #   file was changed again, but st2.mtime is the same due to mtime granularity.
+                                # when comparing file mtime to local clock, widen interval by TIME_DIFFERS1_NS.
+                                changed_while_backup = True
                         if changed_while_backup:
                             # regular file changed while we backed it up, might be inconsistent/corrupt!
                             if last_try:

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -687,6 +687,20 @@ def test_file_status_cs_cache_mode(archivers, request):
     assert "M input/file1" in output
 
 
+def test_files_changed_modes(archivers, request):
+    """test that all --files-changed modes are accepted and work"""
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=10)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    # test mtime mode (works on all platforms including Windows)
+    cmd(archiver, "create", "test_mtime", "input", "--files-changed=mtime")
+    # test disabled mode
+    cmd(archiver, "create", "test_disabled", "input", "--files-changed=disabled")
+    if not is_win32:
+        # test ctime mode (only meaningful on POSIX, where ctime = inode change time)
+        cmd(archiver, "create", "test_ctime", "input", "--files-changed=ctime")
+
+
 def test_file_status_ms_cache_mode(archivers, request):
     """test that a chmod'ed file with no content changes does not get chunked again in mtime,size cache_mode"""
     archiver = request.getfixturevalue(archivers)


### PR DESCRIPTION
## Summary
  - The "file changed while being backed up" detection (`fstat2` check) was entirely skipped on Windows via `if not is_win32:  # TODO for win32` since b3751b107 (March 2019, #1750)
  - On Windows, `st_ctime` is file creation time (not inode change time), so the default ctime-based detection was meaningless - but the `mtime` comparison path (added in b27df15b3, July 2025) works correctly on Windows since `st_mtime` updates
   on writes
  - Fix: remove the `is_win32` guard so the fstat2 + comparison logic runs on all platforms, and default `--files-changed` to `mtime` on Windows instead of `ctime`   
  - If a user explicitly passes `--files-changed=ctime` on Windows, borg now warns and falls back to `mtime` instead of silently disabling detection

  Fixes #9382

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/archive.py` | Remove `if not is_win32` guard at fstat2 check; default `files_changed` to `"mtime"` on win32 |
  | `src/borg/archiver/create_cmd.py` | Platform-aware argparse default; warn + fallback on `--files-changed=ctime` on Windows; update help text and docs |
  | `src/borg/testsuite/archiver/create_cmd_test.py` | Add `test_files_changed_mtime` — runs on all platforms including Windows |     

  **Related issues:** #1750, #7193, #8730

  ## Checklist
  - [x] PR is against `master`
  - [x] New code has tests
  - [x] Commit message references related issue
  - [x] Code formatted with black