### PR TITLE
platform: use F_FULLSYNC on macOS for SyncFile data durability, fixes #9383

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -50,6 +50,7 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import acl_get, acl_set
     from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
     from .darwin import set_flags
+    from .darwin import fdatasync, sync_dir  # type: ignore[no-redef]
     from .base import get_flags
     from .base import SyncFile
     from .posix import process_alive, local_pid_alive

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -151,7 +151,6 @@ class SyncFile:
 
     Calling SyncFile(path) for an existing path will raise FileExistsError. See the comment in __init__.
 
-    TODO: Use F_FULLSYNC on macOS.
     TODO: A Windows implementation should use CreateFile with FILE_FLAG_WRITE_THROUGH.
     """
 


### PR DESCRIPTION
- `SyncFile.sync()` calls `platform.fdatasync(self.fd)`, which resolves to `os.fdatasync` or `os.fsync` - On macOS, `fsync()` only flushes data to the drive's write cache, not to persistent storage                                                         
  - True durability requires `fcntl(fd, F_FULLFSYNC)` — without it, a power loss could lose data that `SyncFile` believed was safely persisted
  - This was acknowledged with a TODO at `src/borg/platform/base.py:154`: `TODO: Use F_FULLSYNC on macOS.`
  - Implements a platform-specific sync wrapper as suggested in #9383

  Fixes #9383

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/platform/darwin.pyx` | Add `fdatasync()` using `fcntl F_FULLFSYNC` with `os.fsync()` fallback; add `sync_dir()` using the same | 
  | `src/borg/platform/__init__.py` | Import `fdatasync`, `sync_dir` from `.darwin` in the darwin block |
  | `src/borg/platform/base.py` | Remove resolved TODO comment |
  | `src/borg/testsuite/platform/darwin_test.py` | Add 4 tests: F_FULLFSYNC usage, fsync fallback, fdatasync integration, sync_dir integration |       

  ## Checklist
  - [x] PR is against `master`
  - [x] New code has tests
  - [x] Tests pass
  - [x] Commit message references related issue
  - [x] Code formatted with black