### PR TITLE
ci: update CodeQL workflow runner to ubuntu-24.04, fixes #9386

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       actions: read


### PR DESCRIPTION
 ## Summary
  - Update `runs-on` in `.github/workflows/codeql-analysis.yml` from `ubuntu-22.04` to `ubuntu-24.04`
  - The main CI workflow (`ci.yml`) already uses `ubuntu-24.04` for security, asan_ubsan, and vm_tests jobs — this aligns the CodeQL workflow with the rest of the CI infrastructure

  Fixes #9386

  ## Checklist
  - [x] PR is against `master`
  - [x] Single-topic changeset — one-line runner update
  - [x] Tests pass — the workflow's `paths` filter includes itself, so CI will self-test the change