### PR TITLE
cache: add seek()/tell() to SyncFile, use SaveFile in _write_files_cache, fixes #9390

### DIFF
--- a/src/borg/testsuite/platform/all_test.py
+++ b/src/borg/testsuite/platform/all_test.py
@@ -1,4 +1,6 @@
-from ...platform import swidth
+import io
+
+from ...platform import swidth, SyncFile
 
 
 def test_swidth_ascii():
@@ -11,3 +13,28 @@ def test_swidth_cjk():
 
 def test_swidth_mixed():
     assert swidth("borgバックアップ") == 4 + 6 * 2
+
+
+def test_syncfile_seek_tell(tmp_path):
+    """SyncFile exposes seek() and tell() from the underlying file object."""
+    path = tmp_path / "testfile"
+    with SyncFile(path, binary=True) as sf:
+        sf.write(b"hello world")
+        assert sf.tell() == 11
+        sf.seek(0, io.SEEK_SET)
+        assert sf.tell() == 0
+        sf.seek(0, io.SEEK_END)
+        assert sf.tell() == 11
+        sf.seek(5, io.SEEK_SET)
+        assert sf.tell() == 5
+        assert sf.read() == b" world"
+    assert path.read_bytes() == b"hello world"
+
+
+def test_syncfile_close_idempotent(tmp_path):
+    """Calling SyncFile.close() twice does not raise."""
+    path = tmp_path / "testfile"
+    sf = SyncFile(path, binary=True)
+    sf.write(b"data")
+    sf.close()
+    sf.close()  # must not raise


### PR DESCRIPTION
 ## Description

 - `_write_files_cache()` in `cache.py` has a TODO noting that `SaveFile` couldn't be used because `SyncFile` lacks `.seek()` and `.tell()`
  - Without `SaveFile`, the files cache is written directly to the final path — a crash mid-write can leave a corrupted file
  - `SaveFile` provides atomic writes (temp file + `os.replace`), but its `__enter__` returns a `SyncFile`, and `IntegrityCheckedFile` needs `.seek()`/`.tell()` on its backing fd for hash finalization (`hash_length` calls `seek(0, SEEK_END)` + `tell()`)
  - Fix: add the missing methods to `SyncFile`, make `close()` idempotent (needed because the `IntegrityCheckedFile` → hasher → `FileLikeWrapper` exit chain closes the `SyncFile` before `SaveFile.__exit__` tries to close it again), then refactor `_write_files_cache` to use `SaveFile`

  Fixes #9390

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/platform/base.py` | Add `seek()` and `tell()` to `SyncFile`, delegating to `self.f`; make `close()` idempotent with `if self.f.closed: return` guard |
  | `src/borg/cache.py` | Refactor `_write_files_cache` to wrap writes in `SaveFile` + `IntegrityCheckedFile(override_fd=...)` for atomic updates; remove TODO comment |
  | `src/borg/testsuite/platform/all_test.py` | Add tests for `seek`/`tell`, idempotent `close`, and `SaveFile` + `IntegrityCheckedFile` integration |
  | `src/borg/testsuite/crypto/file_integrity_test.py` | Add test for `IntegrityCheckedFile` with `SyncFile` as `override_fd` |

  ## Checklist

  - [x] PR is against `master`
  - [x] New code has tests
  - [x] Tests pass
  - [x] Commit messages are clean and reference related issues
  - [x] Code formatted with black
