### PR TITLE
debug format-obj: support all repo object types, fixes #9391

### DIFF
--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -265,8 +265,8 @@ class DebugMixIn:
             meta = json.load(f)
 
         repo_objs = manifest.repo_objs
-        # TODO: support misc repo object types other than ROBJ_FILE_STREAM
-        data_encrypted = repo_objs.format(id=id, meta=meta, data=data, ro_type=ROBJ_FILE_STREAM)
+        ro_type = meta.pop("type", ROBJ_FILE_STREAM)
+        data_encrypted = repo_objs.format(id=id, meta=meta, data=data, ro_type=ro_type)
 
         with open(args.object_path, "wb") as f:
             f.write(data_encrypted)


### PR DESCRIPTION
### Description

- `do_debug_format_obj` hardcodes `ro_type=ROBJ_FILE_STREAM`, ignoring the `"type"` field in the metadata JSON
- This breaks the debug round-trip (`get-obj → parse-obj → [edit] → format-obj → put-obj`) for non-file-stream objects (manifest, archive metadata, archive chunkids, archive stream)
  - `parse-obj` already outputs the `"type"` field in metadata JSON, and `RepoObj.format()` is fully generic
  - Fix: extract `ro_type` from metadata dict, matching the existing pattern in `repo_compress_cmd.py:46`

  Fixes #9391

  ## Changes

  | File | Change |
  |------|--------|
  | `src/borg/archiver/debug_cmd.py` | Replace hardcoded `ROBJ_FILE_STREAM` with `meta.pop("type", ROBJ_FILE_STREAM)` |
  | `src/borg/testsuite/archiver/debug_cmds_test.py` | Add `test_debug_format_obj_respects_type` — round-trip test with `ROBJ_ARCHIVE_STREAM` |

  ## Checklist
  - [x] PR is against `master`
  - [x] New code has tests
  - [x] Tests pass
  - [x] Commit message references related issue
  - [x] Code formatted with black