### PR TITLE
xattr: document fakeroot xattr as Linux-only, add missing fakeroot skip on FreeBSD, fixes #9394

### DIFF
--- a/src/borg/testsuite/platform/freebsd_test.py
+++ b/src/borg/testsuite/platform/freebsd_test.py
@@ -2,10 +2,10 @@ import os
 import tempfile
 
 from ...platform import acl_get, acl_set
-from .platform_test import skipif_not_freebsd, skipif_acls_not_working
+from .platform_test import skipif_not_freebsd, skipif_fakeroot_detected, skipif_acls_not_working
 
 # set module-level skips
-pytestmark = [skipif_not_freebsd]
+pytestmark = [skipif_not_freebsd, skipif_fakeroot_detected]
 
 
 ACCESS_ACL = """\

--- a/src/borg/testsuite/xattr_test.py
+++ b/src/borg/testsuite/xattr_test.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from ..platform.xattr import buffer, split_lstring
-from ..xattr import is_enabled, getxattr, setxattr, listxattr
+from ..xattr import is_enabled, getxattr, setxattr, listxattr, XATTR_FAKEROOT
 from ..platformflags import is_linux
 
 
@@ -82,3 +82,11 @@ def test_getxattr_buffer_growth(tempfile_symlink):
 )
 def test_split_lstring(lstring, expected):
     assert split_lstring(lstring) == expected
+
+
+def test_xattr_fakeroot_flag():
+    """XATTR_FAKEROOT must be False when not on Linux or when fakeroot is not active."""
+    if not is_linux:
+        assert XATTR_FAKEROOT is False
+    if "FAKEROOTKEY" not in os.environ:
+        assert XATTR_FAKEROOT is False

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -19,8 +19,9 @@ from .platform import listxattr, getxattr, setxattr, ENOATTR
 
 # If we are running with fakeroot on Linux, then use the xattr functions of fakeroot. This is needed by
 # the 'test_extract_capabilities' test, but also allows xattrs to work with fakeroot on Linux in normal use.
-# TODO: Check whether fakeroot supports xattrs on all platforms supported below.
-# TODO: If that's the case then we can make Borg fakeroot-xattr-compatible on these as well.
+# Note: fakeroot xattr support is Linux-only. fakeroot only wraps the Linux-style setxattr/getxattr API,
+# but FreeBSD/NetBSD use the extattr_* API instead, so fakeroot never intercepts xattr calls there.
+# On macOS, fakeroot explicitly disables xattr wrapping due to prototype incompatibilities.
 XATTR_FAKEROOT = False
 if sys.platform.startswith("linux"):
     LD_PRELOAD = os.environ.get("LD_PRELOAD", "")


### PR DESCRIPTION
 ### Summary                                                                                                                                                      
  - Resolved open TODOs in `src/borg/xattr.py` (lines 22-23) that asked whether fakeroot supports xattrs on non-Linux platforms                                          
  -  Added missing `skipif_fakeroot_detected` to `freebsd_test.py` for consistency with `linux_test.py` and `darwin_test.py`                                     
  - Added test verifying `XATTR_FAKEROOT` is `False` on non-Linux and without fakeroot active                                                                   
  
  Fixes #9394

  ### Background

  Investigation confirmed fakeroot xattr support is Linux-only:

  - **FreeBSD/NetBSD**: fakeroot only wraps the Linux-style `setxattr`/`getxattr` API, but these platforms use the `extattr_*` API instead — fakeroot never intercepts xattr calls there
  - **macOS**: fakeroot explicitly `#undef`s all xattr wrappers due to prototype incompatibilities with the Linux versions
  - **Vagrantfile** confirms: FreeBSD comments `"fakeroot causes lots of troubles"`, NetBSD/OpenBSD have `"no fakeroot"`

  ### Changes

  - `src/borg/xattr.py` — Replace TODO comments with documentation explaining why detection is Linux-only
  - `src/borg/testsuite/platform/freebsd_test.py` — Add `skipif_fakeroot_detected` to `pytestmark` (was missing, unlike `linux_test.py` and `darwin_test.py`)   
  - `src/borg/testsuite/xattr_test.py` — Add `test_xattr_fakeroot_flag()` test

  ### Test plan

  - [ ] CI passes on all platforms
  - [ ] `test_xattr_fakeroot_flag` runs and passes
  - [ ] FreeBSD ACL tests still run normally (skip only triggers under fakeroot)
