### PR TITLE
fix dependency issue related to chardet 6 release

### DIFF
--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -1,3 +1,4 @@
+chardet==5.2.0
 setuptools==80.9.0
 setuptools-scm==9.2.2
 pip==26.0.1

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,3 +1,4 @@
+chardet < 6
 setuptools >=78.1.1
 setuptools_scm
 pip !=24.2


### PR DESCRIPTION
requests wants < 6, but something else installs >= 6, triggering this warning on stderr that breaks our tests:
```
 /home/runner/work/borg/borg/.tox/py311-pyfuse3/lib/python3.11/site-packages/requests/__init__.py:113:
 RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0dev0)/charset_normalizer (3.4.4) doesn't match a supported version!
```