### PR TITLE
remove_dotdot_prefixes: remove bad assert, fixes #9406

### DIFF
--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -328,7 +328,6 @@ def remove_dotdot_prefixes(path):
 
     `path` is expected to be normalized already (e.g. via `posixpath.normpath()`).
     """
-    assert "\\" not in path
     if is_win32:
         if len(path) > 1 and path[1] == ":":
             path = path.replace(":", "", 1)


### PR DESCRIPTION
## Description

remove bad assertion.

guess the assert was meant to make sure that we do not have backslashes as path separators, but did not consider that on linux a backslash can be part of a filename (without being a path separator).

## Checklist

- [X] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [X] Tests pass (run `tox` or the relevant test subset)
- [X] Commit messages are clean and reference related issues
