### PR TITLE
test: repository path

### DIFF
--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -95,6 +95,12 @@ def test_basic_operations(repo_fixtures, request):
                 continue
             assert pdchunk(repository.get(H(x))) == b"SOMEDATA"
 
+def test_repository_path(tmp_path):
+    location = os.fspath(tmp_path / "@repo")
+    repository = Repository(location)
+    assert repository.url.endswith("@repo")
+    
+    repository.open(exclusive=False)
 
 def test_read_data(repo_fixtures, request):
     with get_repository_from_fixture(repo_fixtures, request) as repository:


### PR DESCRIPTION
<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description

I found a bug, where a repository with a path containing `@` can't be used.
This adds a test which reproduces the issue.
<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->


## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [ ] Commit messages are clean and reference related issues
