### PR TITLE
added stats to prune command, fixes #9262

### DIFF
--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -170,6 +170,8 @@ class PruneMixIn:
                 keep += prune_split(archives, rule, num, kept_because)
 
         to_delete = set(archives) - set(keep)
+        logger.info("Found %d archives.", len(archives))
+        logger.info("Keeping %d archives, pruning %d archives.", len(keep), len(to_delete))
         with Cache(repository, manifest, iec=args.iec) as cache:
             list_logger = logging.getLogger("borg.output.list")
             # set up counters for the progress display


### PR DESCRIPTION
-v / --info displays archive counts (total, kept, pruned).

fwd port of #9271.