### PR TITLE
hashindex_size: return int64_t, fixes #9423

### DIFF
--- a/src/borg/_hashindex.c
+++ b/src/borg/_hashindex.c
@@ -718,10 +718,10 @@ hashindex_len(HashIndex *index)
     return index->num_entries;
 }
 
-static int
+static int64_t
 hashindex_size(HashIndex *index)
 {
-    return sizeof(HashHeader) + index->num_buckets * index->bucket_size;
+    return sizeof(HashHeader) + (int64_t)index->num_buckets * index->bucket_size;
 }
 
 /*

--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -4,7 +4,7 @@ import locale
 import os
 
 cimport cython
-from libc.stdint cimport uint32_t, UINT32_MAX, uint64_t
+from libc.stdint cimport int64_t, uint32_t, UINT32_MAX, uint64_t
 from libc.errno cimport errno
 from libc.string cimport memcpy
 from cpython.exc cimport PyErr_SetFromErrnoWithFilename
@@ -26,7 +26,7 @@ cdef extern from "_hashindex.c":
     HashIndex *hashindex_init(int capacity, int key_size, int value_size)
     void hashindex_free(HashIndex *index)
     int hashindex_len(HashIndex *index)
-    int hashindex_size(HashIndex *index)
+    int64_t hashindex_size(HashIndex *index)
     void hashindex_write(HashIndex *index, object file_py) except *
     unsigned char *hashindex_get(HashIndex *index, unsigned char *key)
     unsigned char *hashindex_next_key(HashIndex *index, unsigned char *key)


### PR DESCRIPTION
## Description

Fix potential int32 overflow in hashindex_size computation.

## Checklist

- [X] PR is against `1.4-maint` (does not apply for master)
- [ ] New code has tests and docs where appropriate
- [X] Tests pass (run `tox` or the relevant test subset)
- [X] Commit messages are clean and reference related issues
