### PR TITLE
tests: fix coverage collection for daemonized borg mount (fuse/hlfuse)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,8 +282,6 @@ commands = [["bandit", "-r", "src/borg", "-c", "pyproject.toml"]]
 branch = true
 disable_warnings = ["module-not-measured", "no-ctracer"]
 patch = ["subprocess", "_exit"]
-parallel = true
-sigterm = true
 source = ["src/borg"]
 omit = [
     "*/borg/__init__.py",


### PR DESCRIPTION
## Description

Fixes #9448.

This PR updates coverage settings in `pyproject.toml` to handle that case:

- `patch = ["subprocess", "_exit"]`

`subprocess` makes coverage instrumentation propagate into spawned helper processes, and `_exit` ensures coverage data is still written when a process terminates via `os._exit()`.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate (config-only change; no code-path changes)
- [ ] Tests pass (run `tox` or the relevant test subset) — CI pending
- [x] Commit messages are clean and reference related issues