### PR TITLE
CI: speedup and better coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
               {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "mypy"},
               {"os": "ubuntu-22.04", "python-version": "3.11", "toxenv": "docs"},
               {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-llfuse"},
+              {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"},
-              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-arm64-gh"}
             ]
           }' || '{
             "include": [
@@ -154,6 +154,7 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-llfuse"},
               {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-pyfuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"},
+              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-arm64-gh"}
               {"os": "macos-15-intel", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-x86_64-gh"}
             ]
           }'


### PR DESCRIPTION
the macOS runner is just too slow - removed from PR jobs.

added pyfuse3 testing to PRs to improve coverage.
