### PR TITLE
tests: restore coverage sigterm handling to investigate OpenBSD CI slowdown (#9463)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,7 @@ commands = [["bandit", "-r", "src/borg", "-c", "pyproject.toml"]]
 [tool.coverage.run]
 branch = true
 disable_warnings = ["module-not-measured", "no-ctracer"]
-patch = ["subprocess"]
+patch = []
 parallel = true
 sigterm = true
 source = ["src/borg"]


### PR DESCRIPTION
## Description

Restore `sigterm = true` under `[tool.coverage.run]` in `pyproject.toml`.

This follows the discussion in #9463 to test whether restoring the `sigterm` setting affects the OpenBSD CI runtime.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] Tests pass (run `tox` or the relevant test subset)
- [ ] New code has tests and docs where appropriate
- [x] Commit messages are clean and reference related issues