### PR TITLE
tests: suppress RequestsDependencyWarning from requests/chardet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,12 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.pytest.ini_options]
 markers = []
+filterwarnings = [
+    # requests <= 2.32.5 emits RequestsDependencyWarning when chardet >= 6 is installed.
+    # Keep the chardet < 6 pin in requirements.d/development.txt until the upstream fix
+    # in requests is released; suppress the noisy warning during tests in the meantime.
+    "ignore::requests.exceptions.RequestsDependencyWarning",
+]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
requests <= 2.32.5 emits RequestsDependencyWarning when chardet >= 6 is installed. The upstream fix is not released yet, so the chardet < 6 pin remains.

Suppress the warning in pytest configuration to avoid noisy test output.

fix: #9433

<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description

<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->
This PR suppresses the RequestsDependencyWarning emitted by requests when chardet >= 6 is installed.

Currently, requests <= 2.32.5 raises this warning because it expects chardet < 6. The upstream fix has not been released yet, so the existing chardet < 6 constraint in requirements.d/development.txt remains unchanged.

To avoid noisy test output, this change adds a filterwarnings rule in the pytest configuration (pyproject.toml) to ignore requests.exceptions.RequestsDependencyWarning during tests.

No dependency constraints were modified.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
