### PR TITLE
feat: add progress indicator to repository check loop

### DIFF
--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -52,7 +52,7 @@ class CheckMixIn:
             except IntegrityError:
                 pass  # will try to make key later again
         if not args.archives_only:
-            if not repository.check(repair=args.repair, max_duration=args.max_duration):
+            if not repository.check(repair=args.repair, max_duration=args.max_duration, progress=args.progress):
                 set_ec(EXIT_WARNING)
         if not args.repo_only and not archive_checker.check(
             repository,

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -50,7 +50,7 @@ from .parseformat import Highlander, MakePathSafeAction
 from .process import daemonize, daemonizing, ThreadRunner
 from .process import signal_handler, raising_signal_handler, sig_int, ignore_sigint, SigHup, SigTerm
 from .process import popen_with_error_handling, is_terminal, prepare_subprocess_env, create_filter_process
-from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, ProgressIndicatorObjectCounter
+from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, ProgressIndicatorCounter
 from .time import parse_timestamp, timestamp, safe_timestamp, safe_s, safe_ns, MAX_S, SUPPORT_32BIT_PLATFORMS
 from .time import format_time, format_timedelta, OutputTimestamp, archive_ts_now
 from .yes_no import yes, TRUISH, FALSISH, DEFAULTISH

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -50,7 +50,7 @@ from .parseformat import Highlander, MakePathSafeAction
 from .process import daemonize, daemonizing, ThreadRunner
 from .process import signal_handler, raising_signal_handler, sig_int, ignore_sigint, SigHup, SigTerm
 from .process import popen_with_error_handling, is_terminal, prepare_subprocess_env, create_filter_process
-from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage
+from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, ProgressIndicatorObjectCounter
 from .time import parse_timestamp, timestamp, safe_timestamp, safe_s, safe_ns, MAX_S, SUPPORT_32BIT_PLATFORMS
 from .time import format_time, format_timedelta, OutputTimestamp, archive_ts_now
 from .yes_no import yes, TRUISH, FALSISH, DEFAULTISH

--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -9,7 +9,7 @@ logger = create_logger()
 
 class ProgressIndicatorBase:
     LOGGER = "borg.output.progress"
-    JSON_TYPE: str = None
+    JSON_TYPE: str = None  # type: ignore[assignment]
 
     operation_id_counter = 0
 
@@ -38,6 +38,38 @@ class ProgressIndicatorMessage(ProgressIndicatorBase):
 
     def output(self, msg):
         j = self.make_json(message=msg)
+        self.logger.info(j)
+
+
+class ProgressIndicatorObjectCounter(ProgressIndicatorBase):
+    JSON_TYPE = "progress_message"
+
+    def __init__(self, step=1000, msg="%d objects", msgid=None):
+        """
+        Activity-based progress indicator, simply tracking a changing count.
+
+        :param step: step size
+        :param msg: output message; must contain one %d placeholder for the count.
+        """
+        self.step = step
+        self.msg = msg
+        self.trigger_at = step
+        super().__init__(msgid=msgid)
+
+    def show(self, current=None):
+        """
+        Show and output the progress message if the step condition is met.
+
+        :param current: Set the current counter value.
+        """
+        if current is not None and current >= self.trigger_at:
+            # adjust trigger_at to the next step threshold
+            while self.trigger_at <= current:
+                self.trigger_at += self.step
+            return self.output(self.msg % current)
+
+    def output(self, message):
+        j = self.make_json(message=message)
         self.logger.info(j)
 
 

--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -41,8 +41,8 @@ class ProgressIndicatorMessage(ProgressIndicatorBase):
         self.logger.info(j)
 
 
-class ProgressIndicatorObjectCounter(ProgressIndicatorBase):
-    JSON_TYPE = "progress_message"
+class ProgressIndicatorCounter(ProgressIndicatorBase):
+    JSON_TYPE = "progress_counter"
 
     def __init__(self, step=1000, msg="%d objects", msgid=None):
         """

--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -9,7 +9,7 @@ logger = create_logger()
 
 class ProgressIndicatorBase:
     LOGGER = "borg.output.progress"
-    JSON_TYPE: str = None  # type: ignore[assignment]
+    JSON_TYPE: str | None = None
 
     operation_id_counter = 0
 
@@ -44,7 +44,7 @@ class ProgressIndicatorMessage(ProgressIndicatorBase):
 class ProgressIndicatorCounter(ProgressIndicatorBase):
     JSON_TYPE = "progress_counter"
 
-    def __init__(self, step=1000, msg="%d objects", msgid=None):
+    def __init__(self, step=1, msg="%d objects", msgid=None):
         """
         Activity-based progress indicator, simply tracking a changing count.
 
@@ -56,12 +56,18 @@ class ProgressIndicatorCounter(ProgressIndicatorBase):
         self.trigger_at = step
         super().__init__(msgid=msgid)
 
-    def show(self, current=None):
+    def show(self, current=None, increase=1, info=None):
         """
         Show and output the progress message if the step condition is met.
 
         :param current: Set the current counter value.
+        :param increase: Increase the current counter value.
         """
+        if current is not None:
+            self.counter = current
+        if hasattr(self, 'counter'):
+            self.counter += increase
+            current = self.counter
         if current is not None and current >= self.trigger_at:
             # adjust trigger_at to the next step threshold
             while self.trigger_at <= current:

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -957,7 +957,8 @@ class RemoteRepository:
     @api(
         since=parse_version("1.0.0"),
         max_duration={"since": parse_version("1.2.0a4"), "previously": 0},
-        progress={"since": parse_version("never"), "dontcare": True},
+        # NOTE: update version when next beta is released
+        progress={"since": parse_version("2.0.0b21"), "dontcare": True},
     )
     def check(self, repair=False, max_duration=0, progress=False):
         """actual remoting is done via self.call in the @api decorator"""

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -954,8 +954,12 @@ class RemoteRepository:
     def info(self):
         """actual remoting is done via self.call in the @api decorator"""
 
-    @api(since=parse_version("1.0.0"), max_duration={"since": parse_version("1.2.0a4"), "previously": 0})
-    def check(self, repair=False, max_duration=0):
+    @api(
+        since=parse_version("1.0.0"),
+        max_duration={"since": parse_version("1.2.0a4"), "previously": 0},
+        progress={"since": parse_version("never"), "dontcare": True},
+    )
+    def check(self, repair=False, max_duration=0, progress=False):
         """actual remoting is done via self.call in the @api decorator"""
 
     @api(

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -14,7 +14,7 @@ from .constants import *  # NOQA
 from .hashindex import ChunkIndex, ChunkIndexEntry
 from .helpers import Error, ErrorWithTraceback, IntegrityError
 from .helpers import Location
-from .helpers import bin_to_hex, hex_to_bin, ProgressIndicatorCounter
+from .helpers import bin_to_hex, hex_to_bin
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -317,15 +317,12 @@ class Repository:
             else:
                 log_error("too small.")
 
-        pi = (
-            ProgressIndicatorCounter(
-                step=1000,
-                msg="Checked objects: %d",
-                msgid="repository.check",
-            )
-            if progress
-            else None
-        )
+        if progress:
+            from .helpers.progress import ProgressIndicatorCounter
+
+            pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check")
+        else:
+            pi = None
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -14,7 +14,7 @@ from .constants import *  # NOQA
 from .hashindex import ChunkIndex, ChunkIndexEntry
 from .helpers import Error, ErrorWithTraceback, IntegrityError
 from .helpers import Location
-from .helpers import bin_to_hex, hex_to_bin, ProgressIndicatorObjectCounter
+from .helpers import bin_to_hex, hex_to_bin, ProgressIndicatorCounter
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -290,7 +290,7 @@ class Repository:
         info = dict(id=self.id, version=self.version)
         return info
 
-    def check(self, repair=False, max_duration=0):
+    def check(self, repair=False, max_duration=0, progress=False):
         """Check repository consistency"""
 
         def log_error(msg):
@@ -317,7 +317,7 @@ class Repository:
             else:
                 log_error("too small.")
 
-        pi = ProgressIndicatorObjectCounter(step=1000, msg="Checking objects: %d", msgid="repository.check")
+        pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check") if progress else None
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"
@@ -364,7 +364,8 @@ class Repository:
                 obj_corrupted = False
                 check_object(obj)
                 objs_checked += 1
-                pi.show(objs_checked)
+                if pi:
+                    pi.show(objs_checked)
                 if obj_corrupted:
                     objs_errors += 1
                     if repair:
@@ -394,11 +395,14 @@ class Repository:
                     logger.info(f"Checkpointing at key {key}.")
                     self.store.store(LAST_KEY_CHECKED, key.encode())
                 if partial and now > t_start + max_duration:
+                    if pi:
+                        pi.finish()
                     logger.info(f"Finished partial repository check, last key checked is {key}.")
                     self.store.store(LAST_KEY_CHECKED, key.encode())
                     break
             else:
-                pi.finish()
+                if pi:
+                    pi.finish()
                 logger.info("Finished repository check.")
                 try:
                     self.store.delete(LAST_KEY_CHECKED)
@@ -413,7 +417,8 @@ class Repository:
                     )
         except StoreObjectNotFound:
             # it can be that there is no "data/" at all, then it crashes when iterating infos.
-            pi.finish()
+            if pi:
+                pi.finish()
             pass
         logger.info(f"Checked {objs_checked} repository objects, {objs_errors} errors.")
         if objs_errors == 0:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -317,7 +317,15 @@ class Repository:
             else:
                 log_error("too small.")
 
-        pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check") if progress else None
+        pi = (
+            ProgressIndicatorCounter(
+                step=1000,
+                msg="Checked objects: %d",
+                msgid="repository.check",
+            )
+            if progress
+            else None
+        )
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -14,7 +14,7 @@ from .constants import *  # NOQA
 from .hashindex import ChunkIndex, ChunkIndexEntry
 from .helpers import Error, ErrorWithTraceback, IntegrityError
 from .helpers import Location
-from .helpers import bin_to_hex, hex_to_bin
+from .helpers import bin_to_hex, hex_to_bin, ProgressIndicatorObjectCounter
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -317,7 +317,7 @@ class Repository:
             else:
                 log_error("too small.")
 
-        # TODO: progress indicator, ...
+        pi = ProgressIndicatorObjectCounter(step=1000, msg="Checking objects: %d", msgid="repository.check")
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"
@@ -364,6 +364,7 @@ class Repository:
                 obj_corrupted = False
                 check_object(obj)
                 objs_checked += 1
+                pi.show(objs_checked)
                 if obj_corrupted:
                     objs_errors += 1
                     if repair:
@@ -397,6 +398,7 @@ class Repository:
                     self.store.store(LAST_KEY_CHECKED, key.encode())
                     break
             else:
+                pi.finish()
                 logger.info("Finished repository check.")
                 try:
                     self.store.delete(LAST_KEY_CHECKED)
@@ -411,6 +413,7 @@ class Repository:
                     )
         except StoreObjectNotFound:
             # it can be that there is no "data/" at all, then it crashes when iterating infos.
+            pi.finish()
             pass
         logger.info(f"Checked {objs_checked} repository objects, {objs_errors} errors.")
         if objs_errors == 0:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -317,7 +317,8 @@ class Repository:
             else:
                 log_error("too small.")
 
-        pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check")
+        if progress:
+            pi = ProgressIndicatorCounter(step=1, msg="Checked objects: %d", msgid="repository.check")
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"
@@ -419,7 +420,6 @@ class Repository:
             # it can be that there is no "data/" at all, then it crashes when iterating infos.
             if progress:
                 pi.finish()
-            pass
         logger.info(f"Checked {objs_checked} repository objects, {objs_errors} errors.")
         if objs_errors == 0:
             logger.info(f"Finished {mode} repository check, no problems found.")

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -12,7 +12,7 @@ from borgstore.backends.errors import BackendAlreadyExists as StoreBackendAlread
 
 from .constants import *  # NOQA
 from .hashindex import ChunkIndex, ChunkIndexEntry
-from .helpers import Error, ErrorWithTraceback, IntegrityError
+from .helpers import Error, ErrorWithTraceback, IntegrityError, ProgressIndicatorCounter
 from .helpers import Location
 from .helpers import bin_to_hex, hex_to_bin
 from .storelocking import Lock
@@ -317,12 +317,7 @@ class Repository:
             else:
                 log_error("too small.")
 
-        if progress:
-            from .helpers.progress import ProgressIndicatorCounter
-
-            pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check")
-        else:
-            pi = None
+        pi = ProgressIndicatorCounter(step=1000, msg="Checked objects: %d", msgid="repository.check")
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"
@@ -369,7 +364,7 @@ class Repository:
                 obj_corrupted = False
                 check_object(obj)
                 objs_checked += 1
-                if pi:
+                if progress:
                     pi.show(objs_checked)
                 if obj_corrupted:
                     objs_errors += 1
@@ -400,13 +395,13 @@ class Repository:
                     logger.info(f"Checkpointing at key {key}.")
                     self.store.store(LAST_KEY_CHECKED, key.encode())
                 if partial and now > t_start + max_duration:
-                    if pi:
+                    if progress:
                         pi.finish()
                     logger.info(f"Finished partial repository check, last key checked is {key}.")
                     self.store.store(LAST_KEY_CHECKED, key.encode())
                     break
             else:
-                if pi:
+                if progress:
                     pi.finish()
                 logger.info("Finished repository check.")
                 try:
@@ -422,7 +417,7 @@ class Repository:
                     )
         except StoreObjectNotFound:
             # it can be that there is no "data/" at all, then it crashes when iterating infos.
-            if pi:
+            if progress:
                 pi.finish()
             pass
         logger.info(f"Checked {objs_checked} repository objects, {objs_errors} errors.")


### PR DESCRIPTION
### Description

This PR adds a simple progress indicator to the Repository.check() loop.

Running borg check on large repositories can take a long time while objects are verified, but currently there is no visible progress apart from periodic key checkpoint logs. This can make it difficult to tell whether the process is still working or has stalled.

This change adds a lightweight progress indicator that reports ongoing activity as objects are processed.

Following the maintainer’s suggestion, this does not compute totals using store.list(), since that could be slow for large or remote repositories. Instead, it only shows ongoing progress without percentage or ETA.

Fixes #9443

<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->
## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
