### PR TITLE
Fix recreate function to handle archive None case

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2246,15 +2246,22 @@ class ArchiveRecreater:
         self.stats = stats
         self.progress = progress
         self.print_file_status = file_status_printer or (lambda *args: None)
-
+        
     def recreate(self, archive_id, target_name, delete_original, comment=None):
         archive = self.open_archive(archive_id)
+
+        if archive is None:
+            raise ValueError("Archive could not be opened")
+
         target = self.create_target(archive, target_name)
+
         if self.exclude_if_present or self.exclude_caches:
             self.matcher_add_tagged_dirs(archive)
+
         if self.matcher.empty() and not target.recreate_rechunkify and comment is None:
             # nothing to do
             return False
+
         self.process_items(archive, target)
         self.save(archive, target, comment, delete_original=delete_original)
         return True


### PR DESCRIPTION
Added a check to ensure the archive is opened correctly before continuing the recreate process.  This prevents errors when the archive cannot be opened.

<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description
Added a validation check in the recreate function to ensure that the archive is opened successfully before processing.

This prevents potential errors if the archive cannot be opened and improves the robustness of the recreate function.

<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->


## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [ ] Commit messages are clean and reference related issues
