### PR TITLE
no_selinux -> filter_xattrs

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -199,13 +199,14 @@ def is_birthtime_fully_supported():
         return False
 
 
-def no_selinux(x):
-    # SELinux fails our FUSE tests; thus, ignore SELinux xattrs
-    SELINUX_KEY = b'security.selinux'
+def filter_xattrs(x):
+    # selinux and com.apple.provenance fail our FUSE tests, thus ignore them
+    UNWANTED_KEYS = {b"security.selinux", b"com.apple.provenance"}
     if isinstance(x, dict):
-        return {k: v for k, v in x.items() if k != SELINUX_KEY}
+        return {k: v for k, v in x.items() if k not in UNWANTED_KEYS}
     if isinstance(x, list):
-        return [k for k in x if k != SELINUX_KEY]
+        return [k for k in x if k not in UNWANTED_KEYS]
+    raise ValueError("Unsupported type: %s" % type(x))
 
 
 class BaseTestCase(unittest.TestCase):
@@ -279,8 +280,8 @@ class BaseTestCase(unittest.TestCase):
                     d1.append(round(s1.st_mtime_ns, st_mtime_ns_round))
                     d2.append(round(s2.st_mtime_ns, st_mtime_ns_round))
             if not ignore_xattrs:
-                d1.append(no_selinux(get_all(path1, follow_symlinks=False)))
-                d2.append(no_selinux(get_all(path2, follow_symlinks=False)))
+                d1.append(filter_xattrs(get_all(path1, follow_symlinks=False)))
+                d2.append(filter_xattrs(get_all(path2, follow_symlinks=False)))
             self.assert_equal(d1, d2)
         for sub_diff in diff.subdirs.values():
             self._assert_dirs_equal_cmp(sub_diff, ignore_flags=ignore_flags, ignore_xattrs=ignore_xattrs, ignore_ns=ignore_ns)

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -57,7 +57,7 @@ from ..logger import setup_logging
 from ..remote import RemoteRepository, PathNotAllowed
 from ..repository import Repository
 from . import has_lchflags, has_mknod, llfuse
-from . import BaseTestCase, changedir, environment_variable, no_selinux, same_ts_ns, granularity_sleep
+from . import BaseTestCase, changedir, environment_variable, filter_xattrs, same_ts_ns, granularity_sleep
 from . import are_symlinks_supported, are_hardlinks_supported, are_fifos_supported, is_utime_fully_supported, is_birthtime_fully_supported
 from .platform import fakeroot_detected, is_darwin, is_freebsd, is_netbsd, is_win32
 from .upgrader import make_attic_repo
@@ -2890,11 +2890,11 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 in_fn = 'input/fusexattr'
                 out_fn = os.fsencode(os.path.join(mountpoint, 'input', 'fusexattr'))
                 if not xattr.XATTR_FAKEROOT and xattr.is_enabled(self.input_path):
-                    assert sorted(no_selinux(xattr.listxattr(out_fn))) == [b'user.empty', b'user.foo', ]
+                    assert sorted(filter_xattrs(xattr.listxattr(out_fn))) == [b'user.empty', b'user.foo', ]
                     assert xattr.getxattr(out_fn, b'user.foo') == b'bar'
                     assert xattr.getxattr(out_fn, b'user.empty') == b''
                 else:
-                    assert no_selinux(xattr.listxattr(out_fn)) == []
+                    assert filter_xattrs(xattr.listxattr(out_fn)) == []
                     try:
                         xattr.getxattr(out_fn, b'user.foo')
                     except OSError as e:


### PR DESCRIPTION
Originally, we only wanted to get rid of selinux xattrs, but macOS also uses some xattr keys that disturb our test results, so we filter them also.
