### PR TITLE
warn when replaying segments, fixes #9233

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -925,6 +925,7 @@ class Repository:
         remember_exclusive = self.exclusive
         self.exclusive = None
         self.prepare_txn(index_transaction_id, do_cleanup=False)
+        logger.warning('Replaying segments. Please wait, this can take a while...')
         try:
             segment_count = sum(1 for _ in self.io.segment_iterator())
             pi = ProgressIndicatorPercent(total=segment_count, msg='Replaying segments %3.0f%%',


### PR DESCRIPTION
If the repo index is not uptodate, any borg operation might trigger replay_segments and thus even operations that are usually quick can take rather long, leaving the user wondering about what's going on.

While there is already a progress indicator in replay_segments, it is logged at INFO level and thus not visible if borg runs at the default WARNING level.
