### PR TITLE
hashindex: fixed iteritems segfaulting with non-existent marker, fixes #9368

### DIFF
--- a/src/borg/hashindex.pyx
+++ b/src/borg/hashindex.pyx
@@ -237,7 +237,7 @@ cdef class NSIndex(IndexBase):
         iter.index = self.index
         if marker:
             key = hashindex_get(self.index, <unsigned char *>marker)
-            if marker is None:
+            if not key:
                 raise IndexError
             iter.key = key - self.key_size
         return iter
@@ -354,7 +354,7 @@ cdef class ChunkIndex(IndexBase):
         iter.index = self.index
         if marker:
             key = hashindex_get(self.index, <unsigned char *>marker)
-            if marker is None:
+            if not key:
                 raise IndexError
             iter.key = key - self.key_size
         return iter


### PR DESCRIPTION
Never happened in borg, because borg always gives existing markers to iteritems.
