### PR TITLE
patterns: allow backslashes in paths, fixes #9518

### DIFF
--- a/src/borg/patterns.py
+++ b/src/borg/patterns.py
@@ -295,7 +295,6 @@ class RegexPattern(PatternBase):
         self.regex = re.compile(pattern)
 
     def _match(self, path):
-        assert "\\" not in path
         return self.regex.search(path) is not None
 
 


### PR DESCRIPTION
On all POSIX systems, a backslash is a normal character in filenames and not a path separator.
