### PR TITLE
refactor: replace logging with structlog in helpers/yes_no.py (issue #9529)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
   "backports-zstd; python_version < '3.14'", # for python < 3.14.
   "xxhash>=2.0.0",
   "jsonargparse>=4.47.0",
-  "PyYAML>=6.0.2",  # we need to register our types with yaml, jsonargparse uses yaml for config files
+  "PyYAML>=6.0.2",
+  "structlog",
 ]
 
 [project.optional-dependencies]

--- a/src/borg/helpers/misc.py
+++ b/src/borg/helpers/misc.py
@@ -1,4 +1,3 @@
-import logging
 import io
 import os
 import platform  # python stdlib import - if this fails, check that cwd != src/borg/
@@ -58,7 +57,7 @@ def sysinfo():
     return "\n".join(info)
 
 
-def log_multi(*msgs, level=logging.INFO, logger=logger):
+def log_multi(*msgs, level=20, logger=logger):
     """
     Log multiple lines of text, emitting each line via a separate logging call for cosmetic reasons.
 

--- a/src/borg/helpers/yes_no.py
+++ b/src/borg/helpers/yes_no.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 import json
 import os
 import os.path
@@ -62,7 +62,7 @@ def yes(
     """
 
     def output(msg, msg_type, is_prompt=False, **kwargs):
-        json_output = getattr(logging.getLogger("borg"), "json", False)
+        json_output = getattr(structlog.get_logger("borg"), "json", False)
         if json_output:
             kwargs |= dict(type="question_%s" % msg_type, msgid=msgid, message=msg)
             print(json.dumps(kwargs), file=sys.stderr)


### PR DESCRIPTION
Closes #9529

Refactored log output in `helpers/` to use `structlog` instead of Python's built-in `logging` module.

**Changes:**
- `helpers/yes_no.py`: replaced `logging.getLogger` with `structlog.get_logger`
- `helpers/misc.py`: removed unused `logging` import, replaced `logging.INFO` with plain integer `20`

**Skipped for now:**
- `helpers/progress.py`: uses `setLevel()` which structlog doesn't support directly — needs discussion
- `helpers/__init__.py`: uses `logging.getLogger("borg.output.show-rc")` — needs discussion

All existing tests pass.