### PR TITLE
Fixes cleanup of append-only test tempfiles on macOS/BSD

### DIFF
--- a/src/borg/conftest.py
+++ b/src/borg/conftest.py
@@ -133,7 +133,21 @@ def archiver(tmp_path, set_env_variables):
     os.chdir(archiver.tmpdir)
     yield archiver
     os.chdir(old_wd)
-    shutil.rmtree(archiver.tmpdir, ignore_errors=True)  # clean up
+
+    def maybe_clear_flags_and_retry(func, path, _exc_info):
+        if has_lchflags:
+            # Clear any BSD flags (e.g. UF_APPEND) that may have prevented removal, then retry once.
+            try:
+                os.lchflags(path, 0)
+                func(path)
+            except OSError:
+                pass
+        else:
+            # Do nothing (equivalent to `ignore_errors=True`) if flags aren't supported on this platform.
+            pass
+
+    # Clean up archiver temp files
+    shutil.rmtree(archiver.tmpdir, onerror=maybe_clear_flags_and_retry)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Description

The `test_extract_restores_append_flag` test leaves append-only tempfiles around on macOS and FreeBSD that cannot be removed cleanly. This was previously just ignored by the cleanup func but those files occasionally caused lots of warning output on subsequent test runs. Fixed by attempting to clear flags and retry whenever the cleanup function fails.

I am not entirely sure what triggers the warnings, I can usually do a couple of test runs before the warnings start showing even though the files would have been left around after the first test run. Cleaning them up properly is the right thing to do anyway.


## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
