### PR TITLE
requirements: remove chardet < 6 pin, no longer needed with requests >= 2.32.6

### DIFF
--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -1,4 +1,3 @@
-chardet==5.2.0
 setuptools==80.10.2
 setuptools-scm==9.2.2
 pip==26.0.1

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,4 +1,3 @@
-chardet < 6
 setuptools >=78.1.1
 setuptools_scm
 pip !=24.2


### PR DESCRIPTION
## Description

Remove the `chardet < 6` pin from `requirements.d/development.txt` and 
`requirements.d/development.lock.txt`.

This constraint was added as a workaround because `requests <= 2.32.5` 
emitted `RequestsDependencyWarning` when `chardet >= 6` was installed, 
which caused noisy test output. Since `requests >= 2.32.6` has now been 
released with the upstream fix, this workaround pin is no longer needed.

Borg does not directly use `chardet` — it was only pinned to silence 
warnings from `requests`. Removing it allows the package manager to 
freely resolve `chardet` without the artificial constraint.

Fixes #9433

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues