### PR TITLE
platform: use F_FULLFSYNC on macOS for SyncFile data durability, fixes #9383

### DIFF
--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -43,6 +43,7 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import acl_get, acl_set
     from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
     from .darwin import set_flags
+    from .darwin import fdatasync, sync_dir  # type: ignore[no-redef]
 
 
 def get_birthtime_ns(st, path, fd=None):

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -143,7 +143,6 @@ class SyncFile:
 
     Calling SyncFile(path) for an existing path will raise FileExistsError, see comment in __init__.
 
-    TODO: Use F_FULLSYNC on macOS.
     TODO: A Windows implementation should use CreateFile with FILE_FLAG_WRITE_THROUGH.
     """
 

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -1,3 +1,4 @@
+import fcntl
 import os
 
 from libc.stdint cimport uint32_t
@@ -259,3 +260,30 @@ def set_flags(path, bsd_flags, fd=None):
         path_bytes = os.fsencode(path)
         if lchflags(path_bytes, c_flags) == -1:
             raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path_bytes))
+
+
+def fdatasync(fd):
+    """macOS fdatasync using F_FULLFSYNC for true data durability.
+
+    os.fsync() is an OS-level flush (kernel page cache -> drive write buffer).
+    F_FULLFSYNC additionally issues a HW-level flush (drive write buffer -> persistent storage).
+    Falls back to os.fsync() if F_FULLFSYNC is not supported (e.g. network fs).
+    """
+    try:
+        fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+    except OSError:
+        os.fsync(fd)
+
+
+def sync_dir(path):
+    """Sync a directory to persistent storage on macOS using F_FULLFSYNC."""
+    if isinstance(path, str):
+        path = os.fsencode(path)
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        fdatasync(fd)
+    except OSError as os_error:
+        if os_error.errno != errno.EINVAL:
+            raise
+    finally:
+        os.close(fd)

--- a/src/borg/testsuite/platform.py
+++ b/src/borg/testsuite/platform.py
@@ -9,6 +9,7 @@ import unittest
 from ..platformflags import is_win32, is_linux, is_freebsd, is_netbsd, is_darwin, is_haiku
 from ..platform import acl_get, acl_set, swidth
 from ..platform import get_process_id, process_alive
+from ..platform import fdatasync, sync_dir
 from . import BaseTestCase, unopened_tempfile
 from .locking import free_pid
 
@@ -219,6 +220,68 @@ class PlatformDarwinTestCase(BaseTestCase):
         self.set_acl(file2.name, b'!#acl 1\ngroup:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:staff:0:allow:read\nuser:FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000:root:0:allow:read\n', numeric_ids=True)
         self.assert_in(b'group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000:wheel:0:allow:read', self.get_acl(file2.name)['acl_extended'])
         self.assert_in(b'group:ABCDEFAB-CDEF-ABCD-EFAB-CDEF00000000::0:allow:read', self.get_acl(file2.name, numeric_ids=True)['acl_extended'])
+
+
+@unittest.skipUnless(is_darwin, 'macOS only test')
+def test_fdatasync_uses_f_fullfsync(monkeypatch):
+    import fcntl as fcntl_mod
+    from ..platform import darwin
+
+    calls = []
+    original_fcntl = fcntl_mod.fcntl
+
+    def mock_fcntl(fd, cmd, *args):
+        calls.append((fd, cmd))
+        return original_fcntl(fd, cmd, *args)
+
+    monkeypatch.setattr(fcntl_mod, 'fcntl', mock_fcntl)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b'test data')
+        tmp.flush()
+        darwin.fdatasync(tmp.fileno())
+
+    assert any(cmd == fcntl_mod.F_FULLFSYNC for _, cmd in calls), 'fdatasync should call fcntl with F_FULLFSYNC'
+
+
+@unittest.skipUnless(is_darwin, 'macOS only test')
+def test_fdatasync_falls_back_to_fsync(monkeypatch):
+    import fcntl as fcntl_mod
+    from ..platform import darwin
+
+    fsync_calls = []
+
+    def mock_fcntl(fd, cmd, *args):
+        if cmd == fcntl_mod.F_FULLFSYNC:
+            raise OSError('F_FULLFSYNC not supported')
+        return 0
+
+    def mock_fsync(fd):
+        fsync_calls.append(fd)
+
+    # Cython does runtime attribute lookup on module objects, so patching
+    # fcntl.fcntl and os.fsync here affects darwin.fdatasync as expected.
+    monkeypatch.setattr(fcntl_mod, 'fcntl', mock_fcntl)
+    monkeypatch.setattr(os, 'fsync', mock_fsync)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b'test data')
+        tmp.flush()
+        darwin.fdatasync(tmp.fileno())
+
+    assert len(fsync_calls) == 1, 'Should fall back to os.fsync when F_FULLFSYNC fails'
+
+
+def test_fdatasync_basic():
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b'test data for fdatasync')
+        tmp.flush()
+        fdatasync(tmp.fileno())
+
+
+def test_sync_dir_basic():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sync_dir(tmpdir)
 
 
 @unittest.skipUnless(sys.platform.startswith(('linux', 'freebsd', 'darwin')), 'POSIX only tests')


### PR DESCRIPTION
Backport of #9385 to `1.4-maint`.

`SyncFile.sync()` calls `platform.fdatasync(self.fd)`, which on macOS resolves to `os.fsync()`. `fsync()` only flushes to the drive's write cache as it does **not** guarantee data reaches persistent storage. A power loss could silently lose data
that `SyncFile` believed was safely persisted.

The fix was acknowledged with a TODO in `src/borg/platform/base.py`: `TODO: Use F_FULLSYNC on macOS.`

This backport implements the platform-specific override suggested in #9383: add `fdatasync()` and `sync_dir()` to `platform/darwin.pyx` using `fcntl(fd, F_FULLFSYNC)` with an `os.fsync()` fallback for network filesystems that do not support `F_FULLFSYNC`.

## Changes

| File | Change |
|------|--------|
| `src/borg/platform/darwin.pyx` | Add `fdatasync()` using `fcntl F_FULLFSYNC` with `os.fsync()` fallback; add `sync_dir()` using the same |
| `src/borg/platform/__init__.py` | Import `fdatasync`, `sync_dir` from `.darwin` in the darwin block |
| `src/borg/platform/base.py` | Remove resolved TODO comment |
| `src/borg/testsuite/platform.py` | Add 4 tests: F_FULLFSYNC usage, fsync fallback, fdatasync integration, sync_dir integration |
| `docs/changes.rst` | Add changelog entry for 1.4.x |

## Checklist

- [x] PR is against `1.4-maint` (maintenance branch as change is only applicable here as master is already fixed via #9385)
- [x] New code has tests and docs where appropriate
- [x] Tests pass
- [x] Commit message references related issue