### PR TITLE
platform: fix fdatasync docstring, clarify OS-level vs HW-level flush

### DIFF
--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -271,9 +271,9 @@ import fcntl as fcntl_mod
 def fdatasync(fd):
     """macOS fdatasync using F_FULLFSYNC for true data durability.
 
-    On macOS, os.fsync() only flushes to the drive's write cache.
-    fcntl F_FULLFSYNC flushes to persistent storage.
-    Falls back to os.fsync() if F_FULLFSYNC is not supported.
+    os.fsync() is an OS-level flush (kernel page cache -> drive write buffer).
+    F_FULLFSYNC additionally issues a HW-level flush (drive write buffer -> persistent storage).
+    Falls back to os.fsync() if F_FULLFSYNC is not supported (e.g. network fs).
     """
     try:
         fcntl_mod.fcntl(fd, fcntl_mod.F_FULLFSYNC)


### PR DESCRIPTION
The `fdatasync()` docstring in `platform/darwin.pyx` described `os.fsync()` as "only flushes to the drive's write cache", which is inaccurate as `os.fsync()` is an OS-level flush (kernel page cache → drive write buffer), not a partial or incomplete operation.

This updates the docstring to describe the two-stage model explicitly:

- `os.fsync()` → OS-level flush (kernel page cache → drive write buffer)
- `F_FULLFSYNC` → additionally issues a HW-level flush (drive write buffer → persistent storage)

Follows up on #9592 where this wording was corrected for the 1.4-maint backport.