### PR TITLE
legacy: move legacy AES-CTR key classes into borg.legacy.crypto, refs #9556

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -29,7 +29,7 @@ from ..repoobj import RepoObj
 
 
 from .low_level import AES, bytes_to_int, num_cipher_blocks, hmac_sha256, blake2b_256
-from .low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b, AES256_OCB, CHACHA20_POLY1305
+from .low_level import AES256_OCB, CHACHA20_POLY1305
 from . import low_level
 
 # workaround for lost passphrase or key in "authenticated" or "authenticated-blake2" mode
@@ -729,40 +729,10 @@ class FlexiKey:
             raise TypeError("Unsupported borg key storage type")
 
 
-class KeyfileKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
-    TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
-    TYPE = KeyType.KEYFILE
-    NAME = "key file"
-    ARG_NAME = "keyfile"
-    STORAGE = KeyBlobStorage.KEYFILE
-    CIPHERSUITE = AES256_CTR_HMAC_SHA256
-
-
-class RepoKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
-    TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
-    TYPE = KeyType.REPO
-    NAME = "repokey"
-    ARG_NAME = "repokey"
-    STORAGE = KeyBlobStorage.REPO
-    CIPHERSUITE = AES256_CTR_HMAC_SHA256
-
-
-class Blake2KeyfileKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
-    TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
-    TYPE = KeyType.BLAKE2KEYFILE
-    NAME = "key file BLAKE2b"
-    ARG_NAME = "keyfile-blake2"
-    STORAGE = KeyBlobStorage.KEYFILE
-    CIPHERSUITE = AES256_CTR_BLAKE2b
-
-
-class Blake2RepoKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
-    TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
-    TYPE = KeyType.BLAKE2REPO
-    NAME = "repokey BLAKE2b"
-    ARG_NAME = "repokey-blake2"
-    STORAGE = KeyBlobStorage.REPO
-    CIPHERSUITE = AES256_CTR_BLAKE2b
+# legacy imports placed after FlexiKey/AESKeyBase/KeyBase so those names are already
+# in the partial module when legacy/crypto/key.py imports them back during circular load
+from ..legacy.crypto.key import KeyfileKey, RepoKey, Blake2KeyfileKey, Blake2RepoKey  # noqa: E402
+from ..legacy.crypto.key import LEGACY_KEY_TYPES  # noqa: E402
 
 
 class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
@@ -1001,14 +971,6 @@ class Blake2CHPORepoKey(ID_BLAKE2b_256, AEADKeyBase, FlexiKey):
     STORAGE = KeyBlobStorage.REPO
     CIPHERSUITE = CHACHA20_POLY1305
 
-
-LEGACY_KEY_TYPES = (
-    # legacy (AES-CTR based) crypto
-    KeyfileKey,
-    RepoKey,
-    Blake2KeyfileKey,
-    Blake2RepoKey,
-)
 
 AVAILABLE_KEY_TYPES = (
     # these are available encryption modes for new repositories

--- a/src/borg/legacy/crypto/key.py
+++ b/src/borg/legacy/crypto/key.py
@@ -3,7 +3,7 @@ from ...crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b
 from ...crypto.key import ID_HMAC_SHA_256, ID_BLAKE2b_256, AESKeyBase, FlexiKey
 
 
-class KeyfileKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
+class KeyfileKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):  # type: ignore[misc]
     TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
     TYPE = KeyType.KEYFILE
     NAME = "key file"
@@ -12,7 +12,7 @@ class KeyfileKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
     CIPHERSUITE = AES256_CTR_HMAC_SHA256
 
 
-class RepoKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
+class RepoKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):  # type: ignore[misc]
     TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
     TYPE = KeyType.REPO
     NAME = "repokey"
@@ -21,7 +21,7 @@ class RepoKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
     CIPHERSUITE = AES256_CTR_HMAC_SHA256
 
 
-class Blake2KeyfileKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
+class Blake2KeyfileKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):  # type: ignore[misc]
     TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
     TYPE = KeyType.BLAKE2KEYFILE
     NAME = "key file BLAKE2b"
@@ -30,7 +30,7 @@ class Blake2KeyfileKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
     CIPHERSUITE = AES256_CTR_BLAKE2b
 
 
-class Blake2RepoKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
+class Blake2RepoKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):  # type: ignore[misc]
     TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
     TYPE = KeyType.BLAKE2REPO
     NAME = "repokey BLAKE2b"

--- a/src/borg/legacy/crypto/key.py
+++ b/src/borg/legacy/crypto/key.py
@@ -1,0 +1,42 @@
+from ...constants import *  # NOQA
+from ...crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b
+from ...crypto.key import ID_HMAC_SHA_256, ID_BLAKE2b_256, AESKeyBase, FlexiKey
+
+
+class KeyfileKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
+    TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
+    TYPE = KeyType.KEYFILE
+    NAME = "key file"
+    ARG_NAME = "keyfile"
+    STORAGE = KeyBlobStorage.KEYFILE
+    CIPHERSUITE = AES256_CTR_HMAC_SHA256
+
+
+class RepoKey(ID_HMAC_SHA_256, AESKeyBase, FlexiKey):
+    TYPES_ACCEPTABLE = {KeyType.KEYFILE, KeyType.REPO, KeyType.PASSPHRASE}
+    TYPE = KeyType.REPO
+    NAME = "repokey"
+    ARG_NAME = "repokey"
+    STORAGE = KeyBlobStorage.REPO
+    CIPHERSUITE = AES256_CTR_HMAC_SHA256
+
+
+class Blake2KeyfileKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
+    TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
+    TYPE = KeyType.BLAKE2KEYFILE
+    NAME = "key file BLAKE2b"
+    ARG_NAME = "keyfile-blake2"
+    STORAGE = KeyBlobStorage.KEYFILE
+    CIPHERSUITE = AES256_CTR_BLAKE2b
+
+
+class Blake2RepoKey(ID_BLAKE2b_256, AESKeyBase, FlexiKey):
+    TYPES_ACCEPTABLE = {KeyType.BLAKE2KEYFILE, KeyType.BLAKE2REPO}
+    TYPE = KeyType.BLAKE2REPO
+    NAME = "repokey BLAKE2b"
+    ARG_NAME = "repokey-blake2"
+    STORAGE = KeyBlobStorage.REPO
+    CIPHERSUITE = AES256_CTR_BLAKE2b
+
+
+LEGACY_KEY_TYPES = (KeyfileKey, RepoKey, Blake2KeyfileKey, Blake2RepoKey)


### PR DESCRIPTION
## Description

Moves the four Borg 1.x AES-CTR key classes into `borg.legacy.crypto`, refs #9556.

- `KeyfileKey`, `RepoKey`, `Blake2KeyfileKey`, `Blake2RepoKey` → `legacy/crypto/key.py`
- `LEGACY_KEY_TYPES` moved with them
- `borg.crypto.key` re-exports all four classes and `LEGACY_KEY_TYPES` for backwards compatibility
- Shared base classes (`FlexiKey`, `AESKeyBase`, `ID_HMAC_SHA_256`, `ID_BLAKE2b_256`) remain in `borg.crypto.key` and are imported by the legacy module (no duplication)

No logic changes. The legacy import in `borg.crypto.key` is placed after `FlexiKey` is fully defined so the partial module already has all needed names during the circular load.

Refs #9556

## Checklist

- [X] PR is against master
- [ ] New code has tests
- [X] Tests pass
- [X] Commit message references related issue