### PR TITLE
docs: document max_segment_size adjustment (fixes #7858)

### DIFF
--- a/docs/usage/config.rst
+++ b/docs/usage/config.rst
@@ -19,7 +19,7 @@ Examples
     # make a repo append-only
     $ borg config /path/to/repo append_only 1
 
-    # set maximum segment size (see "Adjusting segment size" in Usage Notes)
+    # set maximum segment size to 100 MiB (see "Adjusting segment size" in Usage Notes)
     $ borg config /path/to/repo max_segment_size 104857600
 
 

--- a/docs/usage/config.rst
+++ b/docs/usage/config.rst
@@ -19,4 +19,7 @@ Examples
     # make a repo append-only
     $ borg config /path/to/repo append_only 1
 
+    # set maximum segment size (see "Adjusting segment size" in Usage Notes)
+    $ borg config /path/to/repo max_segment_size 104857600
+
 

--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -199,35 +199,6 @@ This has some notable consequences:
 
 You can manually run compaction by invoking the ``borg compact`` command.
 
-See :ref:`rollback_transaction` for how to undo changes if you have not run
-compaction yet.
-
-.. _adjusting_segment_size:
-
-Adjusting segment size
-~~~~~~~~~~~~~~~~~~~~~~
-
-By default, Borg uses a maximum segment file size of 500 MB. This is a good balance
-for many use cases, but you can adjust it to better suit your environment:
-
-- **Smaller segments (e.g., 50 MB or 100 MB)**:
-  Recommended if you use tools like ``rsync`` or ``rclone`` to sync your
-  repository to another location. Smaller segments result in less data being
-  re-transmitted when a segment is updated (e.g., during compaction).
-- **Larger segments**:
-  Might slightly improve performance on some filesystems, but usually not
-  necessary.
-
-You can change this setting for an existing repository:
-
-::
-
-    # Set maximum segment size to 100 MB (in bytes)
-    borg config /path/to/repo max_segment_size 104857600
-
-Note that changing this setting **only affects new segments** created after the
-change. Already existing segments will only be rewritten to the new size when
-they are picked up by ``borg compact``.
 
 .. _append_only_mode:
 
@@ -367,3 +338,30 @@ When running Borg using an automated script, ``ssh`` might still ask for a passw
 even if there is an SSH key for the target server. Use this to make scripts more robust::
 
     export BORG_RSH='ssh -oBatchMode=yes'
+
+.. _adjusting_segment_size:
+
+Adjusting segment size
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Borg uses a maximum segment file size of 500 MiB. This is a good
+balance for many use cases, but you can adjust it to better suit your
+environment:
+
+- **Smaller segments (e.g., 50 MiB or 100 MiB)**:
+  Recommended if you use tools like ``rsync`` or ``rclone`` to sync your
+  repository to another location. Smaller segments result in less data being
+  re-transmitted when a segment is updated (e.g., during compaction).
+- **Larger segments**:
+  Usually not necessary, as 500 MiB is already quite large.
+
+You can change this setting for an existing repository:
+
+::
+
+    # Set maximum segment size to 100 MiB (in bytes)
+    borg config /path/to/repo max_segment_size 104857600
+
+Note that changing this setting **only affects new segments** created after the
+change. Already existing segments will only be rewritten to the new size when
+they are picked up by ``borg compact``.

--- a/docs/usage/notes.rst
+++ b/docs/usage/notes.rst
@@ -199,6 +199,36 @@ This has some notable consequences:
 
 You can manually run compaction by invoking the ``borg compact`` command.
 
+See :ref:`rollback_transaction` for how to undo changes if you have not run
+compaction yet.
+
+.. _adjusting_segment_size:
+
+Adjusting segment size
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Borg uses a maximum segment file size of 500 MB. This is a good balance
+for many use cases, but you can adjust it to better suit your environment:
+
+- **Smaller segments (e.g., 50 MB or 100 MB)**:
+  Recommended if you use tools like ``rsync`` or ``rclone`` to sync your
+  repository to another location. Smaller segments result in less data being
+  re-transmitted when a segment is updated (e.g., during compaction).
+- **Larger segments**:
+  Might slightly improve performance on some filesystems, but usually not
+  necessary.
+
+You can change this setting for an existing repository:
+
+::
+
+    # Set maximum segment size to 100 MB (in bytes)
+    borg config /path/to/repo max_segment_size 104857600
+
+Note that changing this setting **only affects new segments** created after the
+change. Already existing segments will only be rewritten to the new size when
+they are picked up by ``borg compact``.
+
 .. _append_only_mode:
 
 Append-only mode (forbid compaction)


### PR DESCRIPTION
This PR adds documentation on how to adjust the maximum segment size of a repository using 'borg config'. This is particularly useful for rsync-based syncing and remote repositories, where smaller segments can reduce data traffic. This fixes #7858 and #7189.