### PR TITLE
docs: clarify storage quota run-time settings (fixes #3948)

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -237,7 +237,7 @@ Storage quotas
 ~~~~~~~~~~~~~~
 
 Quotas are implemented at the Repository level. The active quota of a repository
-is determined by the ``storage_quota`` `config` entry or a run-time override (via :ref:`borg_serve`).
+is determined by the ``storage_quota`` `config` entry or a run-time setting (via :ref:`borg_serve`, which has priority over the config entry).
 The currently used quota is stored in the hints file. Operations (PUT and DELETE) during
 a transaction modify the currently used quota:
 

--- a/docs/usage/config.rst
+++ b/docs/usage/config.rst
@@ -19,4 +19,7 @@ Examples
     # make a repo append-only
     $ borg config /path/to/repo append_only 1
 
+    # set storage quota to 50 GB
+    $ borg config /path/to/repo storage_quota 50G
+
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -5265,7 +5265,8 @@ class Archiver:
                                     'See :ref:`append_only_mode` in Additional Notes for more details.')
         subparser.add_argument('--storage-quota', metavar='QUOTA', dest='storage_quota',
                                type=parse_storage_quota, default=None,
-                               help='Override storage quota of the repository (e.g. 5G, 1.5T). '
+                               help='Set storage quota of the repository (has priority over the '
+                                    'repository\'s own quota setting) (e.g. 5G, 1.5T). '
                                     'When a new repository is initialized, sets the storage quota on the new '
                                     'repository as well. Default: no quota.')
 


### PR DESCRIPTION
This PR clarifies the wording regarding repository storage quotas, specifically how run-time settings in 'borg serve' take priority over the repository's internal configuration. It also adds an example of how to adjust the storage quota using 'borg config'. This fixes #3948.