### PR TITLE
docs: add DoS warning for none encryption mode (fixes #6715)

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -805,6 +805,8 @@ b) with ``create --chunker-params buzhash,19,23,21,4095`` (default):
    You'll save some memory, but it will need to read / chunk all the files as
    it can not skip unmodified files then.
 
+.. _internals_hashindex:
+ 
 HashIndex
 ---------
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3058,6 +3058,7 @@ class Archiver:
             'borg_key_export': 'borg key export --help',
             'borg_key_change-passphrase': 'borg key change-passphrase',
             'environment-variables': 'Environment Variables',
+            'internals_hashindex': 'Internals -> Data structures and file formats -> HashIndex',
         }
 
         def process_epilog(epilog):

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4742,7 +4742,7 @@ class Archiver:
         compatible with Borg 1.1 and later.
 
         ``none`` mode uses no encryption and no authentication. It uses SHA256
-        (default) or BLAKE2b as a chunk ID hash. This mode is not recommended
+        as chunk ID hash. This mode is not recommended
         as it is vulnerable to DoS attacks by an attacker (for example,
         crafting content that causes hash index collisions). Do not use it if
         untrusted clients use the repository. See :ref:`internals_hashindex` for

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4742,11 +4742,11 @@ class Archiver:
         compatible with Borg 1.1 and later.
 
         ``none`` mode uses no encryption and no authentication. It uses SHA256
-        as chunk ID hash. This mode is not recommended. You should instead
-        consider using an authenticated or authenticated/encrypted mode. This
-        mode has possible denial-of-service issues when running ``borg create``
-        on contents controlled by an attacker. See above for alternatives.
-        This mode is compatible with all Borg versions.
+        (default) or BLAKE2b as a chunk ID hash. This mode is not recommended
+        as it is vulnerable to DoS attacks by an attacker (for example,
+        crafting content that causes hash index collisions). Do not use it if
+        untrusted clients use the repository. See :ref:`internals_hashindex` for
+        details. This mode is compatible with all Borg versions.
         """)
         subparser = subparsers.add_parser('init', parents=[common_parser], add_help=False,
                                           description=self.do_init.__doc__, epilog=init_epilog,


### PR DESCRIPTION
This PR adds a more explicit security warning for the 'none' encryption mode, highlighting its vulnerability to denial-of-service attacks via hash collisions (e.g., when backing up content controlled by an attacker). It also adds a reference to the 'HashIndex' internals documentation to provide technical context. This fixes #6715.