### PR TITLE
docs: document error handling in borg create (fixes #4912)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3748,6 +3748,21 @@ class Archiver:
         Therefore, when using ``--one-file-system``, you should double-check that the backup works as intended.
 
 
+        Error handling
+        ++++++++++++++
+ 
+        When Borg encounters a file or directory it cannot read (e.g., due to permission
+        denied, or another process holding an exclusive lock on Windows), it will:
+ 
+        - Emit a warning message to stderr.
+        - Skip that file or directory and continue backing up the remaining files.
+        - Exit with return code 1 (Warning) at the end of the operation, instead of 0
+          (Success).
+ 
+        This ensures that a single problematic file does not abort your entire backup.
+        You should check your logs for these warnings to ensure that all important data
+        is being backed up.
+ 
         .. _list_item_flags:
 
         Item flags

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3754,10 +3754,9 @@ class Archiver:
         When Borg encounters a file or directory it cannot read (e.g., due to permission
         denied, or another process holding an exclusive lock on Windows), it will:
  
-        - Emit a warning message to stderr.
+        - Log a warning message.
         - Skip that file or directory and continue backing up the remaining files.
-        - Exit with return code 1 (Warning) at the end of the operation, instead of 0
-          (Success).
+        - Exit with a Warning RC at the end of the operation.
  
         This ensures that a single problematic file does not abort your entire backup.
         You should check your logs for these warnings to ensure that all important data


### PR DESCRIPTION
This PR adds a new 'Error handling' section to the 'borg create' help text. It explicitly documents that when Borg encounters unreadable files or directories (e.g., due to permissions or locks), it skips them with a warning, continues with the rest of the backup, and exits with return code 1. This fixes #4912.