### PR TITLE
docs: add FAQ entry for bad backups and deduplication (fixes #4744)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -297,6 +297,32 @@ Yes, if you want to detect accidental data damage (like bit rot), use the
 If you want to be able to detect malicious tampering also, use an encrypted
 repo. It will then be able to check using CRCs and HMACs.
 
+Can a previous bad backup spoil future backups?
+-----------------------------------------------
+
+In general, no. If a backup was interrupted or failed for some reason, Borg's
+transactional nature and journaling system ensure that the repository remains
+consistent. Data that was successfully stored in a partial backup
+(checkpoints) will even be reused to speed up the next attempt.
+
+However, there is one specific case where a past "bad" backup can affect
+future ones due to how deduplication works:
+
+If data was corrupted **before** reaching Borg or while being processed by
+Borg (for example, due to a hardware failure like bad RAM), and this
+corrupted data was successfully stored in the repository with a valid
+checksum (MAC), Borg will assume this is the correct data for that chunk ID.
+Any future backup of the same content will then deduplicate against this
+corrupted version.
+
+This is not a Borg-specific issue, but a general property of deduplicating
+storage systems. To detect such issues, you should:
+
+- Use reliable hardware (ECC RAM is recommended).
+- Periodically run ``borg check --verify-data REPO`` to verify that the
+  stored data still matches its checksums. Note that this cannot detect
+  if the data was already "garbage" when it was first stored.
+
 Can I use Borg on SMR hard drives?
 ----------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -318,7 +318,7 @@ case the past bad backup affects the current or future backup due to
 deduplication.
 
 This is not a Borg-specific issue, but a general property of deduplicating
-storage systems. To detect such issues, you should:
+storage systems. To avoid or detect such issues, you should:
 
 - Use reliable hardware (ECC RAM is recommended).
 - Periodically run ``borg check --verify-data REPO`` to verify that the

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -322,8 +322,8 @@ storage systems. To detect such issues, you should:
 
 - Use reliable hardware (ECC RAM is recommended).
 - Periodically run ``borg check --verify-data REPO`` to verify that the
-  stored data still matches its checksums. Note that this cannot detect
-  if the data was already "garbage" when it was first stored.
+  stored data still matches its MAC (chunk id). Note that this cannot detect
+  if the data was already "garbage" when it was first processed and stored.
 
 Can I use Borg on SMR hard drives?
 ----------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -308,12 +308,14 @@ consistent. Data that was successfully stored in a partial backup
 However, there is one specific case where a past "bad" backup can affect
 future ones due to how deduplication works:
 
-If data was corrupted **before** reaching Borg or while being processed by
-Borg (for example, due to a hardware failure like bad RAM), and this
-corrupted data was successfully stored in the repository with a valid
-checksum (MAC), Borg will assume this is the correct data for that chunk ID.
-Any future backup of the same content will then deduplicate against this
-corrupted version.
+E.g. one could imagine that after computing the MAC (chunk id) of the correct
+chunk content data that data gets corrupted (e.g. due to a RAM issue). This
+issue will go unnoticed until the MAC is compared to the data again (e.g. when
+reading the data from the repo or doing a repo check with ``--verify-data``).
+As the MAC is correct, the deduplication "thinks" it already has the correct
+data while in fact it only has the corrupted version of that data. In that
+case the past bad backup affects the current or future backup due to
+deduplication.
 
 This is not a Borg-specific issue, but a general property of deduplicating
 storage systems. To detect such issues, you should:


### PR DESCRIPTION
This PR adds a new FAQ entry addressing whether a previous 'bad' backup (interrupted or containing corrupted data) can affect future backups. It explains that while Borg's transactional nature protects against interruptions, data corruption before storage (e.g., bad RAM) can lead to deduplication against corrupted chunks. It recommends ECC RAM and periodic 'borg check --verify-data'. This fixes #4744.