### PR TITLE
docs: forward port DoS warning for none mode (fixes #6715)

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -614,6 +614,8 @@ b) with ``create --chunker-params buzhash,19,23,21,4095`` (default):
    You'll save some memory, but it will need to read / chunk all the files as
    it can not skip unmodified files then.
 
+.. _internals_hashindex:
+ 
 HashIndex
 ---------
 

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -252,6 +252,7 @@ rst_plain_text_references = {
     "borg_placeholders": '"borg help placeholders"',
     "key_files": "Internals -> Data structures and file formats -> Key files",
     "borg_key_export": "borg key export --help",
+    "internals_hashindex": "Internals -> Data structures and file formats -> HashIndex",
 }
 
 

--- a/src/borg/archiver/repo_create_cmd.py
+++ b/src/borg/archiver/repo_create_cmd.py
@@ -157,8 +157,9 @@ class RepoCreateMixIn:
         .. nanorst: inline-replace
 
         `none` mode uses no encryption and no authentication. You are advised NOT to use this mode
-        as it would expose you to all sorts of issues (DoS, confidentiality, tampering, ...) in
-        case of malicious activity in the repository.
+        as it would expose you to a Denial-of-Service risk (due to how the :ref:`internals_hashindex`
+        works) and other issues (confidentiality, tampering, ...) in case of malicious activity
+        in the repository.
 
         If you do **not** want to encrypt the contents of your backups, but still want to detect
         malicious tampering, use an `authenticated` mode. It is like `repokey` minus encryption.


### PR DESCRIPTION
Forward port of #9616 to master branch. This adds the security warning about DoS risks in 'none' encryption mode to the 'repo-create' command help.