### PR TITLE
Fix for Missing call to superclass `__init__` during object initialization

### DIFF
--- a/src/borg/helpers/errors.py
+++ b/src/borg/helpers/errors.py
@@ -153,6 +153,7 @@ class BackupOSError(BackupError):
     exit_mcode = 104
 
     def __init__(self, op, os_error):
+        super().__init__(op, os_error)
         self.op = op
         self.os_error = os_error
         self.errno = os_error.errno


### PR DESCRIPTION
The fix is to call the superclass initializer in `BackupOSError.__init__`, passing the same logical message components this error represents (`op` and `os_error`). This preserves current functionality while ensuring proper initialization of the exception base classes (`BackupError` → `ErrorBase` → `Exception`), including consistent `args` population.

In `src/borg/helpers/errors.py`, edit only `BackupOSError.__init__` (lines around 155–161). Add `super().__init__(op, os_error)` as the first statement in that initializer, then keep the existing attribute assignments unchanged.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._