### PR TITLE
Fix for Missing call to superclass `__init__` during object initialization

### DIFF
--- a/src/borg/testsuite/crypto/crypto_test.py
+++ b/src/borg/testsuite/crypto/crypto_test.py
@@ -282,7 +282,10 @@ def test_repo_key_detect_does_not_raise_integrity_error(getpass, monkeypatch):
 class TestDeriveKey(BaseTestCase):
     # Create a simple KeyBase subclass with a non-empty crypt_key
     class CustomKey(KeyBase):
+        TYPE = 0x42
+
         def __init__(self, crypt_key, id_key):
+            super().__init__(None)
             self.crypt_key = crypt_key
             self.id_key = id_key
 


### PR DESCRIPTION
To fix this, update `TestDeriveKey.CustomKey.__init__` to call `KeyBase.__init__` via `super().__init__(None)` before setting test-specific fields. This preserves existing test behavior while ensuring base initialization is not skipped.

In `src/borg/testsuite/crypto/crypto_test.py`, edit the nested `CustomKey` class around lines 284–288:
- In `__init__`, add `super().__init__(None)` as the first statement.
- Keep assignments to `self.crypt_key` and `self.id_key` unchanged so test semantics remain identical.

No new imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._