### PR TITLE
Document the impact of the slashdot hack to pattern matching

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -2445,6 +2445,10 @@ class Archiver:
           - When you back up relative paths like ``../../src``, the archived paths
             start with ``src``.
 
+        - When using the slashdot hack, patterns match against the unstripped path,
+          i.e., when you back up ``/this/gets/stripped/./this/gets/archived``,
+          patterns must match ``this/gets/stripped/this/gets/archived``.
+
         A directory exclusion pattern can end either with or without a slash ('/').
         If it ends with a slash, such as `some/path/`, the directory will be
         included but not its content. If it does not end with a slash, such as


### PR DESCRIPTION
When using the slashdot hack (e.g. `/this/gets/stripped/./this/gets/archived`), `--pattern` and `--exclude` match against the unstripped path (i.e. `this/gets/stripped/this/gets/archived`, **not** against `this/gets/archived`). Document this with `borg help patterns`. I thought about also adding a note to `borg create --help`, but don't think that this is necessary there.

PR is against `1.4-maint` because I tested with Borg 1.4. I assume it's the same with Borg 2.0, will open a backport PR later.

<details>
<summary>Verified with Borg 1.4.4 with the following, click to expand.</summary>

```
$ mkdir borg-test; cd borg-test
$ borg init -e none repo
$ # create some test data (see listing below)
$ find data/ -type f -exec ls -hl {} \;
-rw-r--r-- 1 daniel daniel 6 15. Mai 14:02 data/this/is/also/saved
-rw-r--r-- 1 daniel daniel 4 15. Mai 14:07 data/this/gets/stripped/this/is/too
-rw-r--r-- 1 daniel daniel 9 15. Mai 14:01 data/this/gets/stripped/this/gets/archived
-rw-r--r-- 1 daniel daniel 5 15. Mai 14:01 data/other/data
```

```
$ ( cd data; borg create ../repo::archive1 this/gets/stripped/./this/gets/archived this/gets/stripped/./this/is this/is other; )
$ borg list repo::archive1
-rw-r--r-- daniel daniel        9 Fri, 2026-05-15 14:01:18 this/gets/archived
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:07:30 this/is
-rw-r--r-- daniel daniel        4 Fri, 2026-05-15 14:07:30 this/is/too
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ ( cd data; borg create ../repo::archive2 --pattern '! this' this/gets/stripped/./this/gets/archived this/gets/stripped/./this/is this/is other; )
$ borg list repo::archive2
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ ( cd data; borg create ../repo::archive3 --pattern '! this/gets/stripped' this/gets/stripped/./this/gets/archived this/gets/stripped/./this/is this/is other; )
$ borg list repo::archive3
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ ( cd data; borg create ../repo::archive4 --pattern '! this/gets/archived' this/gets/stripped/./this/gets/archived this/gets/stripped/./this/is this/is other; )
$ borg list repo::archive4  # pattern excludes nothing
-rw-r--r-- daniel daniel        9 Fri, 2026-05-15 14:01:18 this/gets/archived
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:07:30 this/is
-rw-r--r-- daniel daniel        4 Fri, 2026-05-15 14:07:30 this/is/too
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ borg create repo::archive5 "$PWD"/data/this/gets/stripped/./this/gets/archived "$PWD"/data/this/gets/stripped/./this/is "$PWD"/data/./this/is "$PWD"/data/./other
$ borg list repo::archive5  # using the slashdot hack for everything yields the same result as archive1
-rw-r--r-- daniel daniel        9 Fri, 2026-05-15 14:01:18 this/gets/archived
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:07:30 this/is
-rw-r--r-- daniel daniel        4 Fri, 2026-05-15 14:07:30 this/is/too
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ borg create repo::archive6 --pattern "! $PWD/data/this" "$PWD"/data/this/gets/stripped/./this/gets/archived "$PWD"/data/this/gets/stripped/./this/is "$PWD"/data/./this/is "$PWD"/data/./other
$ borg list repo::archive5  # same as archive2
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ borg create repo::archive7 --pattern "! $PWD/data/this/gets/stripped" "$PWD"/data/this/gets/stripped/./this/gets/archived "$PWD"/data/this/gets/stripped/./this/is "$PWD"/data/./this/is "$PWD"/data/./other
$ borg list repo::archive5  # same as archive3
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ borg create repo::archive8 --pattern "! this/gets/archived" "$PWD"/data/this/gets/stripped/./this/gets/archived "$PWD"/data/this/gets/stripped/./this/is "$PWD"/data/./this/is "$PWD"/data/./other
$ borg list repo::archive8  # pattern isn't matched against resulting paths, so same as archive4
-rw-r--r-- daniel daniel        9 Fri, 2026-05-15 14:01:18 this/gets/archived
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:07:30 this/is
-rw-r--r-- daniel daniel        4 Fri, 2026-05-15 14:07:30 this/is/too
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

```
$ borg create repo::archive9 --pattern "! this" "$PWD"/data/this/gets/stripped/./this/gets/archived "$PWD"/data/this/gets/stripped/./this/is "$PWD"/data/./this/is "$PWD"/data/./other
$ borg list repo::archive9  # pattern isn't matched against resulting paths, so still the same as archive4
-rw-r--r-- daniel daniel        9 Fri, 2026-05-15 14:01:18 this/gets/archived
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:07:30 this/is
-rw-r--r-- daniel daniel        4 Fri, 2026-05-15 14:07:30 this/is/too
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:01 this/is
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:02:08 this/is/also
-rw-r--r-- daniel daniel        6 Fri, 2026-05-15 14:02:08 this/is/also/saved
drwxr-xr-x daniel daniel        0 Fri, 2026-05-15 14:01:37 other
-rw-r--r-- daniel daniel        5 Fri, 2026-05-15 14:01:37 other/data
```

</details>