### PR TITLE
legacy: lazy-import legacy classes inside v1 branches only, refs #9556

### DIFF
--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -13,12 +13,9 @@ from ..helpers.argparsing import SUPPRESS, PositiveInt
 from ..helpers.nanorst import rst_to_terminal
 from ..manifest import Manifest, AI_HUMAN_SORT_KEYS
 from ..patterns import PatternMatcher
-from ..legacy.remote import LegacyRemoteRepository
 from ..remote import RemoteRepository
-from ..legacy.repository import LegacyRepository
 from ..repository import Repository
 from ..repoobj import RepoObj
-from ..legacy.repoobj import RepoObj1
 from ..patterns import (
     ArgparsePatternAction,
     ArgparseExcludeFileAction,
@@ -34,7 +31,12 @@ logger = create_logger(__name__)
 
 def get_repository(location, *, create, exclusive, lock_wait, lock, args, v1_or_v2):
     if location.proto in ("ssh", "socket"):
-        RemoteRepoCls = LegacyRemoteRepository if v1_or_v2 else RemoteRepository
+        if v1_or_v2:
+            from ..legacy.remote import LegacyRemoteRepository
+
+            RemoteRepoCls = LegacyRemoteRepository
+        else:
+            RemoteRepoCls = RemoteRepository
         repository = RemoteRepoCls(
             location, create=create, exclusive=exclusive, lock_wait=lock_wait, lock=lock, args=args
         )
@@ -45,7 +47,12 @@ def get_repository(location, *, create, exclusive, lock_wait, lock, args, v1_or_
         repository = Repository(location, create=create, exclusive=exclusive, lock_wait=lock_wait, lock=lock)
 
     else:
-        RepoCls = LegacyRepository if v1_or_v2 else Repository
+        if v1_or_v2:
+            from ..legacy.repository import LegacyRepository
+
+            RepoCls = LegacyRepository
+        else:
+            RepoCls = Repository
         repository = RepoCls(location.path, create=create, exclusive=exclusive, lock_wait=lock_wait, lock=lock)
     return repository
 
@@ -195,9 +202,13 @@ def with_other_repository(manifest=False, cache=False, compatibility=None):
                     )
                 kwargs["other_repository"] = repository
                 if manifest or cache:
-                    manifest_ = Manifest.load(
-                        repository, compatibility, other=True, ro_cls=RepoObj if repository.version > 1 else RepoObj1
-                    )
+                    if repository.version > 1:
+                        ro_cls = RepoObj
+                    else:
+                        from ..legacy.repoobj import RepoObj1
+
+                        ro_cls = RepoObj1
+                    manifest_ = Manifest.load(repository, compatibility, other=True, ro_cls=ro_cls)
                     assert_secure(repository, manifest_)
                     if manifest:
                         kwargs["other_manifest"] = manifest_

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -10,7 +10,6 @@ from ..helpers import ChunkerParams, ChunkIteratorFileWrapper, CompressionSpec
 from ..helpers.argparsing import ArgumentParser, ArgumentTypeError
 from ..item import ChunkListEntry
 from ..manifest import Manifest
-from ..legacy.repository import LegacyRepository
 from ..repository import Repository
 
 from ..logger import create_logger
@@ -35,6 +34,8 @@ def transfer_chunks(
 
     If chunker_params is provided, the chunks will be re-chunked using the specified parameters.
     """
+    from ..legacy.repository import LegacyRepository
+
     transfer = 0
     present = 0
     chunks = []

--- a/src/borg/remote.py
+++ b/src/borg/remote.py
@@ -36,7 +36,6 @@ from .fslocking import LockTimeout, NotLocked, NotMyLock, LockFailed
 from .logger import create_logger, borg_serve_log_queue
 from .manifest import NoManifestError
 from .helpers import msgpack
-from .legacy.repository import LegacyRepository
 from .repository import Repository, StoreObjectNotFound
 from .version import parse_version, format_version
 from .helpers.datastruct import EfficientCollectionQueue
@@ -358,7 +357,12 @@ class RepositoryServer:  # pragma: no cover
         return path
 
     def open(self, path, create=False, lock_wait=None, lock=True, exclusive=None, v1_or_v2=False):
-        self.RepoCls = LegacyRepository if v1_or_v2 else Repository
+        if v1_or_v2:
+            from .legacy.repository import LegacyRepository
+
+            self.RepoCls = LegacyRepository
+        else:
+            self.RepoCls = Repository
         self.rpc_methods = self._legacy_rpc_methods if v1_or_v2 else self._rpc_methods
         logging.debug("Resolving repository path %r", path)
         path = self._resolve_path(path)

--- a/src/borg/testsuite/archiver/_common_test.py
+++ b/src/borg/testsuite/archiver/_common_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_get_repository_ssh_v1_uses_legacy_remote():
+    """get_repository picks LegacyRemoteRepository when proto=ssh and v1_or_v2=True."""
+    from ...archiver._common import get_repository
+
+    location = MagicMock()
+    location.proto = "ssh"
+
+    with patch("borg.legacy.remote.LegacyRemoteRepository") as mock_cls:
+        get_repository(location, create=False, exclusive=False, lock_wait=None, lock=True, args=None, v1_or_v2=True)
+
+    mock_cls.assert_called_once_with(location, create=False, exclusive=False, lock_wait=None, lock=True, args=None)
+
+
+def test_get_repository_local_v1_uses_legacy_repository(tmp_path):
+    """get_repository picks LegacyRepository for a local-style path when v1_or_v2=True."""
+    from ...archiver._common import get_repository
+
+    # proto="file" with v1_or_v2=True skips the borgstore elif (which requires not v1_or_v2)
+    # and falls to the else branch where LegacyRepository is imported.
+    location = MagicMock()
+    location.proto = "file"
+    location.path = str(tmp_path)
+
+    with patch("borg.legacy.repository.LegacyRepository") as mock_cls:
+        get_repository(location, create=False, exclusive=False, lock_wait=None, lock=True, args=None, v1_or_v2=True)
+
+    mock_cls.assert_called_once_with(str(tmp_path), create=False, exclusive=False, lock_wait=None, lock=True)


### PR DESCRIPTION
Removes top-level `LegacyRepository`, `LegacyRemoteRepository`, and `RepoObj1` imports from three files, moving each to the branch that uses it, refs #9556.

- `borg.remote`: `LegacyRepository` imported inside `RepositoryServer.open()`, guarded by `v1_or_v2`
- `borg.archiver._common`: `LegacyRemoteRepository` and `LegacyRepository` imported inside `get_repository()` under the same guard; `RepoObj1` imported inside `with_other_repository()` under `repository.version == 1`
- `borg.archiver.transfer_cmd`: `LegacyRepository` imported at the top of `transfer_chunks()`, where it appears in the `except` tuple

No logic changes. None of these modules pull in `borg.legacy` at import time anymore, so a future phase can drop the package without them breaking at startup.

Unit tests added in `testsuite/archiver/_common_test.py` covering the `get_repository()` v1_or_v2 branches directly (SSH and local path), using mocks to avoid requiring a real legacy repository.

Refs #9556

Checklist

- [x] PR is against master
- [x] New code has tests
- [x] Tests pass
- [x] Commit message references related issue