### PR TITLE
benchmark cpu: drop KDF section

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 
 from ..constants import *  # NOQA
-from ..crypto.key import FlexiKey
 from ..helpers import format_file_size, CompressionSpec
 from ..helpers import json_print
 from ..helpers import msgpack
@@ -170,7 +169,6 @@ class BenchmarkMixIn:
         # Use minimal iterations and data size in test mode to keep CI fast.
         number_default = 1 if is_test else 100
         number_compression = 1 if is_test else 10
-        number_kdf = 1 if is_test else 5
         data_size = 100 * 1000 if is_test else 10 * 1000 * 1000
 
         random_10M = os.urandom(data_size)
@@ -287,20 +285,6 @@ class BenchmarkMixIn:
                 result["encryption"].append({"algo": spec, "size": size, "time": dt})
             else:
                 print(f"{spec:<24} {format_file_size(size):<10} {dt:.3f}s")
-
-        if not args.json:
-            print("KDFs (slow is GOOD, use argon2!) ===============================")
-        else:
-            result["kdf"] = []
-        for spec, func in [
-            ("pbkdf2", lambda: FlexiKey.pbkdf2("mypassphrase", b"salt" * 8, PBKDF2_ITERATIONS, 32)),
-            ("argon2", lambda: FlexiKey.argon2("mypassphrase", 64, b"S" * ARGON2_SALT_BYTES, **ARGON2_ARGS)),
-        ]:
-            dt = timeit(func, number=number_kdf)
-            if args.json:
-                result["kdf"].append({"algo": spec, "count": number_kdf, "time": dt})
-            else:
-                print(f"{spec:<24} {number_kdf:<10} {dt:.3f}s")
 
         if not args.json:
             print("Compression ====================================================")

--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -53,7 +53,6 @@ def test_benchmark_cpu(archiver, monkeypatch):
     assert "Non-cryptographic checksums / hashes" in output
     assert "Cryptographic hashes / MACs" in output
     assert "Encryption" in output
-    assert "KDFs" in output
     assert "Compression" in output
     assert "msgpack" in output
 
@@ -76,7 +75,7 @@ def test_benchmark_cpu_json(archiver, monkeypatch):
         for entry in result[category]:
             assert "algo_params" in entry
     # categories with "count" field
-    for category in ["kdf", "msgpack"]:
+    for category in ["msgpack"]:
         assert isinstance(result[category], list)
         assert len(result[category]) > 0
         for entry in result[category]:


### PR DESCRIPTION
Drops the KDF section from `do_benchmark_cpu`.

KDFs are supposed to be slow, that's the whole point. Timing them gives no useful signal, and the benchmark output already said so: `"KDFs (slow is GOOD, use argon2!)"`.

Suggested in https://github.com/borgbackup/borg/pull/9664#pullrequestreview-4350990208.

- Removed the KDF benchmark block (print header + for loop)
- Removed `number_kdf` and the `FlexiKey` import, both only used by that block

No logic changes.

## Checklist

- [X] PR is against master
- [ ] New code has tests
- [X] Tests pass
- [ ] Commit message references related issue