### PR TITLE
fix: xattr xdg backup exclusion should be on 'false'

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1231,7 +1231,7 @@ def maybe_exclude_by_attr(item):
     if xattrs := item.get("xattrs"):
         apple_excluded = xattrs.get(b"com.apple.metadata:com_apple_backup_excludeItem")
         linux_excluded = xattrs.get(b"user.xdg.robots.backup")
-        if apple_excluded is not None or linux_excluded == b"true":
+        if apple_excluded is not None or linux_excluded == b"false":
             raise BackupItemExcluded
 
     if flags := item.get("bsdflags"):


### PR DESCRIPTION
## Description

According to the [freedesktop proposal](https://www.freedesktop.org/wiki/CommonExtendedAttributes/) the xattrs attribute `user.xdg.robots.backup` should be set to `false` to exclude files from backups.

The current implementation has it backwards, as files are excluded if `user.xdg.robots.backup` is set to `true`.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
