### PR TITLE
legacy: move pbkdf2 static method from FlexiKey to Pbkdf2FileMixin

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -2,7 +2,7 @@ import binascii
 import hmac
 import os
 import textwrap
-from hashlib import sha256, pbkdf2_hmac
+from hashlib import sha256
 from pathlib import Path
 from typing import Literal, ClassVar
 from collections.abc import Callable
@@ -442,12 +442,6 @@ class FlexiKey:
                 return self.decrypt_key_file_argon2(encrypted_key, passphrase)
             else:
                 raise UnsupportedKeyFormatError()
-
-    @staticmethod
-    def pbkdf2(passphrase, salt, iterations, output_len_in_bytes):
-        if os.environ.get("BORG_TESTONLY_WEAKEN_KDF") == "1":
-            iterations = 1
-        return pbkdf2_hmac("sha256", passphrase.encode("utf-8"), salt, iterations, output_len_in_bytes)
 
     @staticmethod
     def argon2(

--- a/src/borg/legacy/crypto/key.py
+++ b/src/borg/legacy/crypto/key.py
@@ -1,5 +1,6 @@
 import hmac
 import os
+from hashlib import pbkdf2_hmac
 
 from ...constants import *  # NOQA
 from ...crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b, hmac_sha256
@@ -11,6 +12,12 @@ from .low_level import AES
 
 class Pbkdf2FileMixin:
     """Mixin for borg 1.x key files encrypted with PBKDF2 + AES-CTR."""
+
+    @staticmethod
+    def pbkdf2(passphrase, salt, iterations, output_len_in_bytes):
+        if os.environ.get("BORG_TESTONLY_WEAKEN_KDF") == "1":
+            iterations = 1
+        return pbkdf2_hmac("sha256", passphrase.encode("utf-8"), salt, iterations, output_len_in_bytes)
 
     def decrypt_key_file(self, data, passphrase):
         unpacker = get_limited_unpacker("key")

--- a/src/borg/testsuite/crypto/crypto_test.py
+++ b/src/borg/testsuite/crypto/crypto_test.py
@@ -9,7 +9,7 @@ from ...crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes
 from ...crypto.low_level import hmac_sha256
 from ...legacy.crypto.low_level import AES
 from hashlib import sha256
-from ...crypto.key import CHPOKeyfileKey, AESOCBRepoKey, FlexiKey, KeyBase, PlaintextKey
+from ...crypto.key import CHPOKeyfileKey, AESOCBRepoKey, KeyBase, PlaintextKey
 from ...legacy.crypto.key import KeyfileKey as LegacyKeyfileKey
 from ...helpers import msgpack, bin_to_hex
 
@@ -228,7 +228,7 @@ def test_decrypt_key_file_pbkdf2_sha256_aes256_ctr_hmac_sha256():
     plain = b"hello"
     salt = b"salt" * 4
     passphrase = "hello, pass phrase"
-    key = FlexiKey.pbkdf2(passphrase, salt, 1, 32)
+    key = LegacyKeyfileKey.pbkdf2(passphrase, salt, 1, 32)
     hash = hmac_sha256(key, plain)
     data = AES(key, b"\0" * 16).encrypt(plain)
     encrypted = msgpack.packb(


### PR DESCRIPTION
## Description

Moves `pbkdf2` from `FlexiKey` into `Pbkdf2FileMixin`. The last piece of PBKDF2 logic now lives entirely in `borg.legacy`, refs #9556.

As in https://github.com/borgbackup/borg/pull/9664#issuecomment-4527557052, after #9665 dropped the KDF section from `benchmark_cmd.py`, there was no reason for `pbkdf2` to stay on `FlexiKey`.

- `pbkdf2` static method moves from `FlexiKey` (`crypto/key.py`) to `Pbkdf2FileMixin` (`legacy/crypto/key.py`)
- `pbkdf2_hmac` import removed from `crypto/key.py`, added to `legacy/crypto/key.py`
- Test updated: `FlexiKey.pbkdf2(...)` → `LegacyKeyfileKey.pbkdf2(...)`, `FlexiKey` removed from import

No logic changes. New key types (`CHPOKeyfileKey`, `AESOCBKeyfileKey`, etc.) no longer carry `pbkdf2` as they never needed it.

Refs #9556

## Checklist

- [X] PR is against master
- [ ] New code has tests
- [X] Tests pass
- [X] Commit message references related issue