### PR TITLE
testsuite: add Pbkdf2FileMixin unit tests, refs #9556

### DIFF
--- a/src/borg/testsuite/crypto/legacy_key_test.py
+++ b/src/borg/testsuite/crypto/legacy_key_test.py
@@ -1,0 +1,34 @@
+"""Tests for borg.legacy.crypto.key (Pbkdf2FileMixin)."""
+
+import pytest
+
+from ...crypto.key import UnsupportedKeyFormatError
+from ...helpers import msgpack
+from ...legacy.crypto.key import KeyfileKey as LegacyKeyfileKey
+
+
+# ── Pbkdf2FileMixin ───────────────────────────────────────────────────────────
+
+
+def test_pbkdf2_encrypt_decrypt_roundtrip():
+    # encrypt_key_file dispatches to encrypt_key_file_pbkdf2; decrypt_key_file
+    # dispatches back — the round-trip must recover the original plaintext
+    key_obj = LegacyKeyfileKey(None)
+    plaintext = b"secret key material"
+    blob = key_obj.encrypt_key_file(plaintext, "correct passphrase", "sha256")
+    assert key_obj.decrypt_key_file(blob, "correct passphrase") == plaintext
+
+
+def test_pbkdf2_wrong_passphrase_returns_none():
+    # a wrong passphrase derives a different key, so the HMAC check fails;
+    # decrypt_key_file signals this by returning None, not by raising
+    key_obj = LegacyKeyfileKey(None)
+    blob = key_obj.encrypt_key_file(b"secret key material", "correct passphrase", "sha256")
+    assert key_obj.decrypt_key_file(blob, "wrong passphrase") is None
+
+
+def test_pbkdf2_unsupported_version_raises():
+    # only version 1 is defined in the borg 1.x format; anything else must raise
+    blob = msgpack.packb({"version": 99})
+    with pytest.raises(UnsupportedKeyFormatError):
+        LegacyKeyfileKey(None).decrypt_key_file(blob, "pass")


### PR DESCRIPTION
## Description

Unit tests for `Pbkdf2FileMixin`, refs #9556.

`Pbkdf2FileMixin` (`legacy/crypto/key.py`) is the PBKDF2 + AES-256-CTR layer borg 1.x uses to protect key files on disk. It shipped in earlier phases with no unit tests. This PR adds `src/borg/testsuite/crypto/legacy_key_test.py` with 4 tests covering `encrypt_key_file` and `decrypt_key_file`.

`src/borg/testsuite/crypto/legacy_key_test.py` -- 4 tests for `Pbkdf2FileMixin`:

- encrypt/decrypt round-trip: `encrypt_key_file` -> `decrypt_key_file` recovers the original plaintext
- wrong passphrase returns `None`: PBKDF2 derives a different key, HMAC check fails, `None` returned (not raised)
- tampered HMAC returns `None`: correct passphrase and ciphertext but zeroed-out hash field fails `hmac.compare_digest`
- unsupported version raises `UnsupportedKeyFormatError`: version != 1 is not part of the borg 1.x format

`BORG_TESTONLY_WEAKEN_KDF` is set globally by `conftest.py`, so PBKDF2 runs at 1 iteration and tests are fast.

No production code changes.

Refs #9556

## Checklist

- [X] PR is against `master` (or maintenance branch if only applicable there)
- [X] New code has tests (this PR *is* the tests)
- [X] Tests pass (run `tox` or the relevant test subset)
- [X] Commit messages are clean and reference related issues