### PR TITLE
testsuite: add argon2 wrong-passphrase test for decrypt_key_file, refs #9686

### DIFF
--- a/src/borg/testsuite/crypto/key_test.py
+++ b/src/borg/testsuite/crypto/key_test.py
@@ -318,3 +318,13 @@ def test_key_file_roundtrip(monkeypatch):
 
     assert to_dict(load_me) == to_dict(save_me)
     assert msgpack.unpackb(a2b_base64(saved))["algorithm"] == KEY_ALGORITHMS["argon2"]
+
+
+def test_argon2_wrong_passphrase_returns_none(monkeypatch):
+    # a wrong passphrase derives a different key, so the Argon2 integrity check fails;
+    # decrypt_key_file signals this by returning None, not by raising (refs #8036)
+    repository = MagicMock(id=b"repository_id")
+    monkeypatch.setenv("BORG_PASSPHRASE", "correct passphrase")
+    key = AESOCBRepoKey.create(repository, args=MagicMock(key_algorithm="argon2"))
+    saved = repository.save_key.call_args.args[0]
+    assert key.decrypt_key_file(a2b_base64(saved), "wrong passphrase") is None


### PR DESCRIPTION
## Description

One test for `decrypt_key_file_argon2`, refs #9686.

Follow-up to #9686, which added wrong-passphrase coverage for the PBKDF2 path. `decrypt_key_file` calls `decrypt_key_file_argon2` when the stored algorithm is `argon2 chacha20-poly1305`. Wrong passphrase, different derived key, Poly1305 auth fails, `None` back. Same contract as PBKDF2.

Added to `src/borg/testsuite/crypto/key_test.py`:

- wrong passphrase returns `None`: Argon2 derives a different key, Poly1305 check fails, `None` returned (not raised)

`BORG_TESTONLY_WEAKEN_KDF` is set globally in `conftest.py`, so Argon2 runs with minimal parameters.

No production code changes.

Refs #9686

## Checklist

- [X] PR is against `master` (or maintenance branch if only applicable there)
- [X] New code has tests (this PR *is* the test)
- [X] Tests pass (run `tox` or the relevant test subset)
- [X] Commit messages are clean and reference related issues