### PR TITLE
repoobj, repository: add chunk_id to header, introduce packs/ namespace

### DIFF
--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -127,9 +127,9 @@ def with_repository(
             )
 
             with repository:
-                if repository.version not in (3, 4):
+                if repository.version not in (4,):
                     raise Error(
-                        f"This borg version only accepts version 3 or 4 repos for -r/--repo, "
+                        f"This borg version only accepts version 4 repos for -r/--repo, "
                         f"but not version {repository.version}. "
                         f"You can use 'borg transfer' to copy archives from old to new repos."
                     )
@@ -194,10 +194,10 @@ def with_other_repository(manifest=False, cache=False, compatibility=None):
             )
 
             with repository:
-                acceptable_versions = (1,) if v1_legacy else (3,)
+                acceptable_versions = (1,) if v1_legacy else (3, 4)
                 if repository.version not in acceptable_versions:
                     raise Error(
-                        f"This borg version only accepts version {' or '.join(acceptable_versions)} "
+                        f"This borg version only accepts version {' or '.join(str(v) for v in acceptable_versions)} "
                         f"repos for --other-repo."
                     )
                 kwargs["other_repository"] = repository

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -127,9 +127,9 @@ def with_repository(
             )
 
             with repository:
-                if repository.version not in (3,):
+                if repository.version not in (3, 4):
                     raise Error(
-                        f"This borg version only accepts version 3 repos for -r/--repo, "
+                        f"This borg version only accepts version 3 or 4 repos for -r/--repo, "
                         f"but not version {repository.version}. "
                         f"You can use 'borg transfer' to copy archives from old to new repos."
                     )

--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -194,7 +194,7 @@ def with_other_repository(manifest=False, cache=False, compatibility=None):
             )
 
             with repository:
-                acceptable_versions = (1,) if v1_legacy else (3, 4)
+                acceptable_versions = (1,) if v1_legacy else (4,)
                 if repository.version not in acceptable_versions:
                     raise Error(
                         f"This borg version only accepts version {' or '.join(str(v) for v in acceptable_versions)} "

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -13,11 +13,14 @@ AUTHENTICATED_NO_KEY = "authenticated_no_key" in workarounds
 OBJ_MAGIC = b"BORG_OBJ"
 OBJ_VERSION = 0x01
 
+# Fixed header size per blob: OBJ_MAGIC(8) + version(1) + chunk_id(32) + meta_size(4) + data_size(4)
+REPOOBJ_HEADER_SIZE = 49
+
 
 class RepoObj:
-    # Object header: magic (8b), format version (1b), meta size (4b), data size (4b).
-    obj_header = Struct("<8sBII")
-    ObjHeader = namedtuple("ObjHeader", "magic version meta_size data_size")
+    # Object header: magic (8b), format version (1b), chunk_id (32b), meta size (4b), data size (4b).
+    obj_header = Struct("<8sB32sII")
+    ObjHeader = namedtuple("ObjHeader", "magic version chunk_id meta_size data_size")
 
     @classmethod
     def extract_crypted_data(cls, data: bytes) -> bytes:
@@ -72,7 +75,7 @@ class RepoObj:
         data_encrypted = self.key.encrypt(id, data_compressed)
         meta_packed = msgpack.packb(meta)
         meta_encrypted = self.key.encrypt(id, meta_packed)
-        hdr = self.ObjHeader(OBJ_MAGIC, OBJ_VERSION, len(meta_encrypted), len(data_encrypted))
+        hdr = self.ObjHeader(OBJ_MAGIC, OBJ_VERSION, id, len(meta_encrypted), len(data_encrypted))
         hdr_packed = self.obj_header.pack(*hdr)
         return hdr_packed + meta_encrypted + data_encrypted
 

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -17,8 +17,15 @@ from .helpers import bin_to_hex, hex_to_bin
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
+from struct import Struct
+
 from .repoobj import RepoObj, OBJ_MAGIC, OBJ_VERSION
 from .crypto.key import is_keyfile
+
+PACK_MAGIC = b"BORGPACK"
+PACK_VERSION = 0x01
+_pack_header = Struct("<8sBI")  # magic(8) + version(1) + blob_len(4)
+PACK_HEADER_SIZE = _pack_header.size  # 13 bytes
 
 logger = create_logger(__name__)
 
@@ -174,7 +181,7 @@ class Repository:
         self._send_log = send_log_cb or (lambda: None)
         self.do_create = create
         self.created = False
-        self.acceptable_repo_versions = (3,)
+        self.acceptable_repo_versions = (4,)
         self.opened = False
         self.lock = None
         self.do_lock = lock
@@ -212,10 +219,10 @@ class Repository:
         self.store.open()
         try:
             self.store.store("config/readme", REPOSITORY_README.encode())
-            self.version = 3
+            self.version = 4
             self.store.store("config/version", str(self.version).encode())
             self.store.store("config/id", bin_to_hex(os.urandom(32)).encode())
-            # we know repo/data/ still does not have any chunks stored in it,
+            # we know repo/packs/ still does not have any chunks stored in it,
             # but for some stores, there might be a lot of empty directories and
             # listing them all might be rather slow, so we better cache an empty
             # ChunkIndex from here so that the first repo operation does not have
@@ -329,25 +336,38 @@ class Repository:
 
         def check_object(obj):
             """Check if obj looks valid."""
-            hdr_size = RepoObj.obj_header.size
-            obj_size = len(obj)
-            if obj_size >= hdr_size:
-                hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(obj[:hdr_size]))
-                if hdr.magic != OBJ_MAGIC:
-                    log_error("invalid object magic.")
-                elif hdr.version != OBJ_VERSION:
-                    log_error(f"unsupported object version: {hdr.version}.")
-                elif hdr.chunk_id != hex_to_bin(info.name):
-                    log_error("chunk_id mismatch in header.")
-                else:
-                    meta = obj[hdr_size : hdr_size + hdr.meta_size]
-                    if hdr.meta_size != len(meta):
-                        log_error("metadata size mismatch.")
-                    data = obj[hdr_size + hdr.meta_size : hdr_size + hdr.meta_size + hdr.data_size]
-                    if hdr.data_size != len(data):
-                        log_error("data size mismatch.")
-            else:
+            if len(obj) < PACK_HEADER_SIZE:
                 log_error("too small.")
+                return
+            magic, version, blob_len = _pack_header.unpack(obj[:PACK_HEADER_SIZE])
+            if magic != PACK_MAGIC:
+                log_error("invalid pack magic.")
+                return
+            if version != PACK_VERSION:
+                log_error(f"unsupported pack version: {version}.")
+                return
+            blob = obj[PACK_HEADER_SIZE:]
+            if len(blob) != blob_len:
+                log_error(f"pack blob_len mismatch: header says {blob_len}, actual {len(blob)}.")
+                return
+            hdr_size = RepoObj.obj_header.size
+            if len(blob) < hdr_size:
+                log_error("too small.")
+                return
+            hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(blob[:hdr_size]))
+            if hdr.magic != OBJ_MAGIC:
+                log_error("invalid object magic.")
+            elif hdr.version != OBJ_VERSION:
+                log_error(f"unsupported object version: {hdr.version}.")
+            elif hdr.chunk_id != hex_to_bin(info.name):
+                log_error("chunk_id mismatch in header.")
+            else:
+                meta = blob[hdr_size : hdr_size + hdr.meta_size]
+                if hdr.meta_size != len(meta):
+                    log_error("metadata size mismatch.")
+                data = blob[hdr_size + hdr.meta_size : hdr_size + hdr.meta_size + hdr.data_size]
+                if hdr.data_size != len(data):
+                    log_error("data size mismatch.")
 
         # TODO: progress indicator, ...
         partial = bool(max_duration)
@@ -488,14 +508,15 @@ class Repository:
         key = "packs/" + bin_to_hex(pack_id)
         try:
             if read_data:
-                # read everything
-                return self.store.load(key)
+                raw = self.store.load(key)
+                return raw[PACK_HEADER_SIZE:]
             else:
                 # RepoObj layout supports separately encrypted metadata and data.
                 # We return enough bytes so the client can decrypt the metadata.
                 hdr_size = RepoObj.obj_header.size
                 extra_size = 1024 - hdr_size  # load a bit more, 1024b, reduces round trips
-                obj = self.store.load(key, size=hdr_size + extra_size)
+                raw = self.store.load(key, size=PACK_HEADER_SIZE + hdr_size + extra_size)
+                obj = raw[PACK_HEADER_SIZE:]
                 hdr = obj[0:hdr_size]
                 if len(hdr) != hdr_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {hdr_size}, got {len(hdr)} bytes")
@@ -503,7 +524,8 @@ class Repository:
                 if meta_size > extra_size:
                     # we did not get enough, need to load more, but not all.
                     # this should be rare, as chunk metadata is rather small usually.
-                    obj = self.store.load(key, size=hdr_size + meta_size)
+                    raw = self.store.load(key, size=PACK_HEADER_SIZE + hdr_size + meta_size)
+                    obj = raw[PACK_HEADER_SIZE:]
                 meta = obj[hdr_size : hdr_size + meta_size]
                 if len(meta) != meta_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {meta_size}, got {len(meta)} bytes")
@@ -531,13 +553,21 @@ class Repository:
 
         pack_id = id  # N=1: pack_id == chunk_id
         key = "packs/" + bin_to_hex(pack_id)
-        self.store.store(key, data)
+        pack_hdr = _pack_header.pack(PACK_MAGIC, PACK_VERSION, data_size)
+        self.store.store(key, pack_hdr + data)
 
     def delete(self, id, wait=True):
         """delete a repo object
 
         Note: when doing calls with wait=False this gets async and caller must
               deal with async results / exceptions later.
+
+        N=1: pack_id == chunk_id, so deleting the pack file is equivalent to
+             deleting the chunk. Hard delete is safe here.
+        N>1: a pack contains multiple chunks. Individual chunks cannot be deleted
+             from a pack without rewriting it. This method must become a soft-delete
+             (no-op) before N>1 is implemented; compact() will then be the sole
+             mechanism for reclaiming space based on live-ratio thresholds.
         """
         self._lock_refresh()
         pack_id = id  # N=1: pack_id == chunk_id

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -17,15 +17,8 @@ from .helpers import bin_to_hex, hex_to_bin
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
-from struct import Struct
-
 from .repoobj import RepoObj, OBJ_MAGIC, OBJ_VERSION
 from .crypto.key import is_keyfile
-
-PACK_MAGIC = b"BORGPACK"
-PACK_VERSION = 0x01
-_pack_header = Struct("<8sBI")  # magic(8) + version(1) + blob_len(4)
-PACK_HEADER_SIZE = _pack_header.size  # 13 bytes
 
 logger = create_logger(__name__)
 
@@ -331,34 +324,20 @@ class Repository:
 
         def check_object(obj):
             """Check if obj looks valid."""
-            if len(obj) < PACK_HEADER_SIZE:
-                log_error("too small.")
-                return
-            magic, version, blob_len = _pack_header.unpack(obj[:PACK_HEADER_SIZE])
-            if magic != PACK_MAGIC:
-                log_error("invalid pack magic.")
-                return
-            if version != PACK_VERSION:
-                log_error(f"unsupported pack version: {version}.")
-                return
-            blob = obj[PACK_HEADER_SIZE:]
-            if len(blob) != blob_len:
-                log_error(f"pack blob_len mismatch: header says {blob_len}, actual {len(blob)}.")
-                return
             hdr_size = RepoObj.obj_header.size
-            if len(blob) < hdr_size:
+            if len(obj) < hdr_size:
                 log_error("too small.")
                 return
-            hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(blob[:hdr_size]))
+            hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(obj[:hdr_size]))
             if hdr.magic != OBJ_MAGIC:
                 log_error("invalid object magic.")
             elif hdr.version != OBJ_VERSION:
                 log_error(f"unsupported object version: {hdr.version}.")
             else:
-                meta = blob[hdr_size : hdr_size + hdr.meta_size]
+                meta = obj[hdr_size : hdr_size + hdr.meta_size]
                 if hdr.meta_size != len(meta):
                     log_error("metadata size mismatch.")
-                data = blob[hdr_size + hdr.meta_size : hdr_size + hdr.meta_size + hdr.data_size]
+                data = obj[hdr_size + hdr.meta_size : hdr_size + hdr.meta_size + hdr.data_size]
                 if hdr.data_size != len(data):
                     log_error("data size mismatch.")
 
@@ -503,15 +482,13 @@ class Repository:
         key = "packs/" + bin_to_hex(pack_id)
         try:
             if read_data:
-                raw = self.store.load(key)
-                return raw[PACK_HEADER_SIZE:]
+                return self.store.load(key)
             else:
                 # RepoObj layout supports separately encrypted metadata and data.
                 # We return enough bytes so the client can decrypt the metadata.
                 hdr_size = RepoObj.obj_header.size
                 extra_size = 1024 - hdr_size  # load a bit more, 1024b, reduces round trips
-                raw = self.store.load(key, size=PACK_HEADER_SIZE + hdr_size + extra_size)
-                obj = raw[PACK_HEADER_SIZE:]
+                obj = self.store.load(key, size=hdr_size + extra_size)
                 hdr = obj[0:hdr_size]
                 if len(hdr) != hdr_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {hdr_size}, got {len(hdr)} bytes")
@@ -519,8 +496,7 @@ class Repository:
                 if meta_size > extra_size:
                     # we did not get enough, need to load more, but not all.
                     # this should be rare, as chunk metadata is rather small usually.
-                    raw = self.store.load(key, size=PACK_HEADER_SIZE + hdr_size + meta_size)
-                    obj = raw[PACK_HEADER_SIZE:]
+                    obj = self.store.load(key, size=hdr_size + meta_size)
                 meta = obj[hdr_size : hdr_size + meta_size]
                 if len(meta) != meta_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {meta_size}, got {len(meta)} bytes")
@@ -548,21 +524,13 @@ class Repository:
 
         pack_id = id  # N=1: pack_id == chunk_id
         key = "packs/" + bin_to_hex(pack_id)
-        pack_hdr = _pack_header.pack(PACK_MAGIC, PACK_VERSION, data_size)
-        self.store.store(key, pack_hdr + data)
+        self.store.store(key, data)
 
     def delete(self, id, wait=True):
         """delete a repo object
 
         Note: when doing calls with wait=False this gets async and caller must
               deal with async results / exceptions later.
-
-        N=1: pack_id == chunk_id, so deleting the pack file is equivalent to
-             deleting the chunk. Hard delete is safe here.
-        N>1: a pack contains multiple chunks. Individual chunks cannot be deleted
-             from a pack without rewriting it. This method must become a soft-delete
-             (no-op) before N>1 is implemented; compact() will then be the sole
-             mechanism for reclaiming space based on live-ratio thresholds.
         """
         self._lock_refresh()
         pack_id = id  # N=1: pack_id == chunk_id

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -467,7 +467,8 @@ class Repository:
                 pack_id = hex_to_bin(info.name)
                 chunk_id = pack_id  # N=1: chunk_id == pack_id
                 if collect:
-                    result.append((chunk_id, info.size))
+                    chunk_size = info.size  # only correct for N=1
+                    result.append((chunk_id, chunk_size))
                     if len(result) == limit:
                         break
                 elif chunk_id == marker:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -122,13 +122,10 @@ class Repository:
             location = Location(url)
         self._location = location
         self.url = url
-        # lots of stuff in data: use 2 levels by default (data/00/00/ .. data/ff/ff/ dirs)!
-        data_levels = int(os.environ.get("BORG_STORE_DATA_LEVELS", "2"))
         ns_config = {
             "archives/": {"levels": [0]},
             "cache/": {"levels": [0]},
             "config/": {"levels": [0]},
-            "data/": {"levels": [data_levels]},
             "keys/": {"levels": [0]},
             "locks/": {"levels": [0]},
             "packs/": {"levels": [1]},
@@ -144,7 +141,6 @@ class Repository:
                 "archives": "lrw",
                 "cache": "lrwWD",  # WD for chunks.<HASH>, last-key-checked, ...
                 "config": "lrW",  # W for manifest
-                "data": "lrw",
                 "keys": "lr",
                 "locks": "lrwD",  # borg needs to create/delete a shared lock here
                 "packs": "lrw",
@@ -155,7 +151,6 @@ class Repository:
                 "archives": "lw",
                 "cache": "lrwWD",  # read allowed, e.g. for chunks.<HASH> cache
                 "config": "lrW",  # W for manifest
-                "data": "lw",  # no r!
                 "keys": "lr",
                 "locks": "lrwD",  # borg needs to create/delete a shared lock here
                 "packs": "lw",  # no r!
@@ -359,8 +354,6 @@ class Repository:
                 log_error("invalid object magic.")
             elif hdr.version != OBJ_VERSION:
                 log_error(f"unsupported object version: {hdr.version}.")
-            elif hdr.chunk_id != hex_to_bin(info.name):
-                log_error("chunk_id mismatch in header.")
             else:
                 meta = blob[hdr_size : hdr_size + hdr.meta_size]
                 if hdr.meta_size != len(meta):
@@ -437,8 +430,9 @@ class Repository:
                     # add all existing objects to the index.
                     # borg check: the index may have corrupted objects (we did not delete them)
                     # borg check --repair: the index will only have non-corrupted objects.
-                    pack_id = hex_to_bin(info.name)  # N=1: pack_id == chunk_id
-                    chunks[pack_id] = init_entry
+                    pack_id = hex_to_bin(info.name)
+                    chunk_id = pack_id  # N=1: chunk_id == pack_id
+                    chunks[chunk_id] = init_entry
                 now = time.monotonic()
                 if now > t_last_checkpoint + 300:  # checkpoint every 5 mins
                     t_last_checkpoint = now
@@ -462,7 +456,7 @@ class Repository:
                         self, chunks, incremental=False, clear=True, force_write=True, delete_other=True
                     )
         except StoreObjectNotFound:
-            # it can be that there is no "data/" at all, then it crashes when iterating infos.
+            # it can be that there is no "packs/" at all, then it crashes when iterating infos.
             pass
         logger.info(f"Checked {objs_checked} repository objects, {objs_errors} errors.")
         if objs_errors == 0:
@@ -491,12 +485,13 @@ class Repository:
             except StopIteration:
                 break
             else:
-                pack_id = hex_to_bin(info.name)  # N=1: pack_id == chunk_id
+                pack_id = hex_to_bin(info.name)
+                chunk_id = pack_id  # N=1: chunk_id == pack_id
                 if collect:
-                    result.append((pack_id, info.size))
+                    result.append((chunk_id, info.size))
                     if len(result) == limit:
                         break
-                elif pack_id == marker:
+                elif chunk_id == marker:
                     collect = True
                     # note: do not collect the marker id
         return result

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -124,6 +124,7 @@ class Repository:
             "data/": {"levels": [data_levels]},
             "keys/": {"levels": [0]},
             "locks/": {"levels": [0]},
+            "packs/": {"levels": [1]},
         }
         # Get permissions from parameter or environment variable
         permissions = permissions if permissions is not None else os.environ.get("BORG_REPO_PERMISSIONS", "all")
@@ -139,6 +140,7 @@ class Repository:
                 "data": "lrw",
                 "keys": "lr",
                 "locks": "lrwD",  # borg needs to create/delete a shared lock here
+                "packs": "lrw",
             }
         elif permissions == "write-only":  # mostly no reading
             permissions = {
@@ -149,6 +151,7 @@ class Repository:
                 "data": "lw",  # no r!
                 "keys": "lr",
                 "locks": "lrwD",  # borg needs to create/delete a shared lock here
+                "packs": "lw",  # no r!
             }
         elif permissions == "read-only":  # mostly r/o
             permissions = {"": "lr", "locks": "lrwD"}
@@ -334,6 +337,8 @@ class Repository:
                     log_error("invalid object magic.")
                 elif hdr.version != OBJ_VERSION:
                     log_error(f"unsupported object version: {hdr.version}.")
+                elif hdr.chunk_id != hex_to_bin(info.name):
+                    log_error("chunk_id mismatch in header.")
                 else:
                     meta = obj[hdr_size : hdr_size + hdr.meta_size]
                     if hdr.meta_size != len(meta):
@@ -376,11 +381,11 @@ class Repository:
         # As we don't do garbage collection here, this is not a problem.
         # We also don't know the plaintext size, so we set it to 0.
         init_entry = ChunkIndexEntry(flags=ChunkIndex.F_USED, size=0)
-        infos = self.store.list("data")
+        infos = self.store.list("packs")
         try:
             for info in infos:
                 self._lock_refresh()
-                key = "data/%s" % info.name
+                key = "packs/%s" % info.name
                 if key <= last_key_checked:  # needs sorted keys
                     continue
                 try:
@@ -412,8 +417,8 @@ class Repository:
                     # add all existing objects to the index.
                     # borg check: the index may have corrupted objects (we did not delete them)
                     # borg check --repair: the index will only have non-corrupted objects.
-                    id = hex_to_bin(info.name)
-                    chunks[id] = init_entry
+                    pack_id = hex_to_bin(info.name)  # N=1: pack_id == chunk_id
+                    chunks[pack_id] = init_entry
                 now = time.monotonic()
                 if now > t_last_checkpoint + 300:  # checkpoint every 5 mins
                     t_last_checkpoint = now
@@ -456,30 +461,31 @@ class Repository:
         """
         collect = True if marker is None else False
         result = []
-        infos = self.store.list("data")  # generator yielding ItemInfos
+        infos = self.store.list("packs")  # generator yielding ItemInfos
         while True:
             self._lock_refresh()
             try:
                 info = next(infos)
             except StoreObjectNotFound:
-                break  # can happen e.g. if "data" does not exist, pointless to continue in that case
+                break  # can happen e.g. if "packs" does not exist, pointless to continue in that case
             except StopIteration:
                 break
             else:
-                id = hex_to_bin(info.name)
+                pack_id = hex_to_bin(info.name)  # N=1: pack_id == chunk_id
                 if collect:
-                    result.append((id, info.size))
+                    result.append((pack_id, info.size))
                     if len(result) == limit:
                         break
-                elif id == marker:
+                elif pack_id == marker:
                     collect = True
                     # note: do not collect the marker id
         return result
 
     def get(self, id, read_data=True, raise_missing=True):
         self._lock_refresh()
+        pack_id = id  # N=1: pack_id == chunk_id
         id_hex = bin_to_hex(id)
-        key = "data/" + id_hex
+        key = "packs/" + bin_to_hex(pack_id)
         try:
             if read_data:
                 # read everything
@@ -523,7 +529,8 @@ class Repository:
         if data_size > MAX_DATA_SIZE:
             raise IntegrityError(f"More than allowed put data [{data_size} > {MAX_DATA_SIZE}]")
 
-        key = "data/" + bin_to_hex(id)
+        pack_id = id  # N=1: pack_id == chunk_id
+        key = "packs/" + bin_to_hex(pack_id)
         self.store.store(key, data)
 
     def delete(self, id, wait=True):
@@ -533,7 +540,8 @@ class Repository:
               deal with async results / exceptions later.
         """
         self._lock_refresh()
-        key = "data/" + bin_to_hex(id)
+        pack_id = id  # N=1: pack_id == chunk_id
+        key = "packs/" + bin_to_hex(pack_id)
         try:
             self.store.delete(key)
         except StoreObjectNotFound:

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -351,8 +351,9 @@ def test_extra_chunks(archivers, request):
     check_cmd_setup(archiver)
     cmd(archiver, "check", exit_code=0)
     with Repository(archiver.repository_location, exclusive=True) as repository:
-        chunk = fchunk(b"xxxx")
-        repository.put(b"01234567890123456789012345678901", chunk)
+        key = b"01234567890123456789012345678901"
+        chunk = fchunk(b"xxxx", chunk_id=key)
+        repository.put(key, chunk)
     cmd(archiver, "check", "-v", exit_code=0)  # check does not deal with orphans anymore
 
 

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -225,7 +225,7 @@ def test_corrupted_manifest(archivers, request):
     archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         manifest = repository.get_manifest()
-        corrupted_manifest = manifest[:123] + b"corrupted!" + manifest[123:]
+        corrupted_manifest = manifest[:250] + b"corrupted!" + manifest[250:]
         repository.put_manifest(corrupted_manifest)
     cmd(archiver, "check", exit_code=1)
     output = cmd(archiver, "check", "-v", "--repair", exit_code=0)
@@ -273,7 +273,7 @@ def test_manifest_rebuild_corrupted_chunk(archivers, request):
     archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         manifest = repository.get_manifest()
-        corrupted_manifest = manifest[:123] + b"corrupted!" + manifest[123:]
+        corrupted_manifest = manifest[:250] + b"corrupted!" + manifest[250:]
         repository.put_manifest(corrupted_manifest)
         chunk = repository.get(archive.id)
         corrupted_chunk = chunk + b"corrupted!"
@@ -312,7 +312,7 @@ def test_spoofed_archive(archivers, request):
     with repository:
         # attacker would corrupt or delete the manifest to trigger a rebuild of it:
         manifest = repository.get_manifest()
-        corrupted_manifest = manifest[:123] + b"corrupted!" + manifest[123:]
+        corrupted_manifest = manifest[:250] + b"corrupted!" + manifest[250:]
         repository.put_manifest(corrupted_manifest)
         archive_dict = {
             "command_line": "",

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -53,9 +53,9 @@ def reopen(repository, exclusive: bool | None = True, create=False):
     )
 
 
-def fchunk(data, meta=b""):
+def fchunk(data, meta=b"", chunk_id=b"\x00" * 32):
     # Format chunk: create a raw chunk that has a valid RepoObj layout, but does not use encryption or compression.
-    hdr = RepoObj.obj_header.pack(OBJ_MAGIC, OBJ_VERSION, len(meta), len(data))
+    hdr = RepoObj.obj_header.pack(OBJ_MAGIC, OBJ_VERSION, chunk_id, len(meta), len(data))
     assert isinstance(data, bytes)
     chunk = hdr + meta + data
     return chunk
@@ -65,7 +65,7 @@ def pchunk(chunk):
     # Parse chunk: extract data and metadata from a raw chunk made by fchunk.
     hdr_size = RepoObj.obj_header.size
     hdr = chunk[:hdr_size]
-    meta_size, data_size = RepoObj.obj_header.unpack(hdr)[2:4]
+    meta_size, data_size = RepoObj.obj_header.unpack(hdr)[3:5]
     meta = chunk[hdr_size : hdr_size + meta_size]
     data = chunk[hdr_size + meta_size : hdr_size + meta_size + data_size]
     return data, meta
@@ -97,7 +97,7 @@ def test_basic_operations(repo_fixtures, request):
 def test_read_data(repo_fixtures, request):
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         meta, data = b"meta", b"data"
-        hdr = RepoObj.obj_header.pack(OBJ_MAGIC, OBJ_VERSION, len(meta), len(data))
+        hdr = RepoObj.obj_header.pack(OBJ_MAGIC, OBJ_VERSION, H(0), len(meta), len(data))
         chunk_complete = hdr + meta + data
         chunk_short = hdr + meta
         repository.put(H(0), chunk_complete)


### PR DESCRIPTION
## Description

`RepoObj` blob header grows from 17 bytes (`<8sBII`) to 49 bytes (`<8sB32sII`): a 32-byte `chunk_id` field between the version byte and the size fields. `REPOOBJ_HEADER_SIZE = 49` names the fixed part.

`chunk_id` is the ID hash of the plaintext data. Putting it in the unencrypted header lets a forward scanner rebuild the `chunk_id -> location` index without touching the key. It is also the additional authenticated data for AEAD, so a plaintext copy in the header is unavoidable -- recovering it from ciphertext requires the key.

Chunks move from `data/` to `packs/`. The new namespace uses one directory level keyed on the first byte of the pack ID (256 subdirs `00/`..`ff/`), versus two levels for `data/`. For the expected object count per pack, one level is enough.

For N=1 packs (one chunk per pack file), `pack_id == chunk_id`. The pack filename is the chunk ID (`id_hash` of the plaintext chunk content).

Changes:
- `repoobj.py`: extend struct from `<8sBII` to `<8sB32sII`, add `chunk_id` to `ObjHeader`, add `REPOOBJ_HEADER_SIZE = 49`, pass `id` into `ObjHeader` in `format()`.
- `repository.py`: add `packs/` to `ns_config` with `{"levels": [1]}`, add packs to permission maps, replace all `data/` keys with `packs/` in `get()`/`put()`/`delete()`/`list()`/`check()`, introduce `pack_id = id` (N=1 invariant), wrap stored blobs in a BORGPACK header (13 bytes: magic + version + blob_len), bump repo version to 4.
- `repository_test.py`: add `chunk_id` parameter to `fchunk()`, fix `pchunk()` slice to `[3:5]`, update `test_read_data()` to pass `H(0)` as `chunk_id`.

refs #8572

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues