### PR TITLE
Extract: Selective chunk extraction for regular files (#5638)

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -761,6 +761,125 @@ Duration: {0.duration}
                 # In this case, we *want* to extract twice, because there is no other way.
                 pass
 
+    def _fs_has_extended_acl(self, path, st):
+        """
+        Return True if the filesystem object at *path* (with stat *st*) has a non-trivial
+        (extended) ACL.
+
+        clear_attrs() deliberately does not reset ACLs. So if the existing file has an extended ACL that the archive item does not,
+        an in-place update would leave that stale ACL behind. We detect this here and let such
+        files take the normal extraction path (fresh inode) instead.
+        """
+        if is_win32 or self.noacls:
+            return False
+        probe = Item()
+        try:
+            # acl_get only sets acl_* keys when there is a non-trivial ACL; for plain mode-only
+            # permissions it sets nothing (it checks acl_extended_*() first on all platforms).
+            acl_get(path, probe, st, numeric_ids=self.numeric_ids)
+        except OSError:
+            # if we cannot even read ACLs (e.g. unsupported by the fs), none can survive: safe.
+            return False
+        return any(key.startswith("acl") for key in probe.as_dict())
+
+    def can_patch_in_place(self, item, path, st):
+        """
+        Can the existing filesystem object at *path* (described by *st*) be updated in place
+        from *item* by only fetching the chunks that differ (see compare_and_extract_chunks)?
+
+        We only do this for plain regular files (not hard links): the destination must already
+        exist as a regular file and the item must be a regular file, too. Hard links keep going
+        through the normal extraction path so the preloading bookkeeping stays correct.
+
+        Finally, we skip files that carry an extended ACL, see _fs_has_extended_acl().
+        """
+        if st is None:
+            return False
+        if "hlid" in item:
+            return False
+        if not (stat.S_ISREG(st.st_mode) and stat.S_ISREG(item.mode)):
+            return False
+        if st.st_nlink != 1:
+            return False
+        return not self._fs_has_extended_acl(path, st)
+
+    def will_patch_in_place(self, item):
+        """
+        Like can_patch_in_place(), but stats the destination itself.
+
+        Used by the extract command to decide whether to skip preloading this item's chunks.
+        """
+        if "hlid" in item or not stat.S_ISREG(item.mode):
+            return False
+        path = os.path.join(self.cwd, item.path)
+        try:
+            st = os.stat(path, follow_symlinks=False)
+        except OSError:
+            return False
+        return self.can_patch_in_place(item, path, st)
+
+    def compare_and_extract_chunks(self, item, path, *, st, pi=None):
+        """
+        Update the existing regular file at *path* in place from *item*, fetching only the
+        chunks whose content differs from what is already on disk.
+
+        *st* is the stat result of the existing file as determined by the caller. Returns True
+        if the file was updated in place, or False if the caller should fall back to a full
+        extraction.
+        """
+        if not self.can_patch_in_place(item, path, st):
+            return False
+
+        # First pass (read-only): hash the existing on-disk content using the archived chunk
+        # sizes, so we can compare it chunk-by-chunk with the archived chunk list.
+        with backup_io("open"):
+            fs_file = open(path, "rb+")
+        with fs_file:
+            fs_chunks = []
+            for item_chunk in item.chunks:
+                with backup_io("read"):
+                    data = fs_file.read(item_chunk.size)
+                fs_chunks.append(ChunkListEntry(id=self.key.id_hash(data), size=len(data)))
+
+            # Only the chunks that actually differ need to be fetched from the repository.
+            # These were not preloaded (see will_patch_in_place / the extract command), so we
+            # fetch them as regular, non-preloaded objects.
+            needed_chunks = [
+                item_chunk for fs_chunk, item_chunk in zip(fs_chunks, item.chunks) if fs_chunk != item_chunk
+            ]
+            fetched_chunks = self.pipeline.fetch_many(needed_chunks, ro_type=ROBJ_FILE_STREAM)
+
+            # Second pass: for each archived chunk, seek over the matching on-disk chunk or
+            # overwrite the differing one with the freshly fetched data.
+            with backup_io("seek"):
+                fs_file.seek(0)
+            for fs_chunk, item_chunk in zip(fs_chunks, item.chunks):
+                if fs_chunk == item_chunk:
+                    with backup_io("seek"):
+                        fs_file.seek(item_chunk.size, os.SEEK_CUR)
+                else:
+                    data = next(fetched_chunks)
+                    with backup_io("write"):
+                        fs_file.write(data)
+                if pi:
+                    pi.show(increase=item_chunk.size, info=[remove_surrogates(item.path)])
+
+            with backup_io("truncate_and_attrs"):
+                item_chunks_size = fs_file.tell()
+                fs_file.truncate(item_chunks_size)
+                fs_file.flush()
+                fd = fs_file.fileno()
+                # the file existed before, so it may carry stale metadata that
+                # restore_attrs() would not clear: wipe it first.
+                self.clear_attrs(path, fd=fd)
+                self.restore_attrs(path, item, fd=fd)
+
+        if "size" in item:
+            item_size = item.size
+            if item_size != item_chunks_size:
+                raise BackupError(f"Size inconsistency detected: size {item_size}, chunks size {item_chunks_size}")
+        return True
+
     def extract_item(
         self,
         item,
@@ -772,6 +891,7 @@ Duration: {0.duration}
         hlm=None,
         pi=None,
         continue_extraction=False,
+        preloaded=True,
     ):
         """
         Extract archive item.
@@ -784,6 +904,9 @@ Duration: {0.duration}
         :param hlm: maps hlid to link_target for extracting subtrees with hard links correctly
         :param pi: ProgressIndicatorPercent (or similar) for file extraction progress (in bytes)
         :param continue_extraction: continue a previously interrupted extraction of the same archive
+        :param preloaded: whether this item's chunks were preloaded (see preload_item_chunks).
+            Must be False if the caller skipped preloading (e.g. for in-place updates), so the
+            full-extraction fetch does not wait for preloaded chunks that were never requested.
         """
 
         def same_item(item, st):
@@ -817,7 +940,9 @@ Duration: {0.duration}
                     # it would get stuck.
                     if "chunks" in item:
                         item_chunks_size = 0
-                        for data in self.pipeline.fetch_many(item.chunks, is_preloaded=True, ro_type=ROBJ_FILE_STREAM):
+                        for data in self.pipeline.fetch_many(
+                            item.chunks, is_preloaded=preloaded, ro_type=ROBJ_FILE_STREAM
+                        ):
                             if pi:
                                 pi.show(increase=len(data), info=[remove_surrogates(item.path)])
                             if stdout:
@@ -837,13 +962,20 @@ Duration: {0.duration}
 
         dest = self.cwd
         path = os.path.join(dest, item.path)
+        st = None  # There is no file at path (or we could not stat it).
         # Attempt to remove existing files, ignore errors on failure
         try:
             st = os.stat(path, follow_symlinks=False)
             if continue_extraction and same_item(item, st):
                 return  # done! we already have fully extracted this file in a previous run.
-            if not stat.S_ISDIR(st.st_mode):
+            if self.can_patch_in_place(item, path, st):
+                # keep the existing regular file in place so it can be updated by only
+                # fetching the chunks that differ from what is already there.
+                # compare_and_extract_chunks() will use this st.
+                pass
+            elif not stat.S_ISDIR(st.st_mode):
                 os.unlink(path)
+                st = None
             elif stat.S_ISDIR(item.mode):
                 # if we have an existing directory and we want to extract a directory,
                 # we just use the existing one and do not remove it.
@@ -852,10 +984,11 @@ Duration: {0.duration}
                 pass
             else:
                 os.rmdir(path)  # only works for empty directories
+                st = None
         except UnicodeEncodeError:
             raise self.IncompatibleFilesystemEncodingError(path, sys.getfilesystemencoding()) from None
         except OSError:
-            pass
+            st = None
 
         def make_parent(path):
             parent_dir = os.path.dirname(path)
@@ -869,11 +1002,13 @@ Duration: {0.duration}
             with self.extract_helper(item, path, hlm) as hardlink_set:
                 if hardlink_set:
                     return
+                if self.compare_and_extract_chunks(item, path, st=st, pi=pi):
+                    return
                 with backup_io("open"):
                     fd = open(path, "wb")
                 with fd:
                     trailing_hole = False
-                    for data in self.pipeline.fetch_many(item.chunks, is_preloaded=True, ro_type=ROBJ_FILE_STREAM):
+                    for data in self.pipeline.fetch_many(item.chunks, is_preloaded=preloaded, ro_type=ROBJ_FILE_STREAM):
                         if pi:
                             pi.show(increase=len(data), info=[remove_surrogates(item.path)])
                         with backup_io("write"):
@@ -1030,6 +1165,31 @@ Duration: {0.duration}
             except OSError:
                 # some systems don't support calling utime on a symlink
                 pass
+
+    def clear_attrs(self, path, fd=None):
+        """
+        Remove pre-existing filesystem metadata (extended attributes and BSD-style flags) from
+        *path* (*fd*), bringing it to a "fresh" state for a subsequent restore_attrs().
+
+        restore_attrs() only *adds* the metadata stored in the archive item; it assumes a newly
+        created file. When updating an existing file in place (see compare_and_extract_chunks),
+        the file may carry xattrs or flags that are not present in the archive and that would
+        otherwise survive.
+
+        Note: ACLs are not cleared here. An access ACL present in the archive item is overwritten
+        by restore_attrs(); however, ACLs present only on the pre-existing file are not removed.
+        """
+        if is_win32:
+            return
+        # Clear flags first: a leftover immutable/append flag from the existing file must not
+        # survive, and restore_attrs() only sets flags when the archive item carries them.
+        if not self.noflags:
+            try:
+                set_flags(path, 0, fd=fd)
+            except OSError:
+                pass
+        if not self.noxattrs:
+            xattr.clear_all(fd if fd is not None else path, follow_symlinks=False)
 
     def set_meta(self, key, value):
         metadata = self._load_meta(self.id)

--- a/src/borg/archiver/extract_cmd.py
+++ b/src/borg/archiver/extract_cmd.py
@@ -72,7 +72,14 @@ class ExtractMixIn:
                 logging.getLogger("borg.output.list").info(f"{log_prefix} {remove_surrogates(item.path)}")
 
             if is_matched:
-                archive.preload_item_chunks(item, optimize_hardlinks=True)
+                # Skip preloading when we will update an existing regular file in place:
+                # that path only fetches the chunks that differ, so preloading all of them
+                # would leak the unfetched ones in the RemoteRepository (see preload_item_chunks).
+                preloaded = True
+                if not dry_run and not stdout and archive.will_patch_in_place(item):
+                    preloaded = False
+                else:
+                    archive.preload_item_chunks(item, optimize_hardlinks=True)
 
                 if not dry_run:
                     while dirs and not item.path.startswith(dirs[-1].path):
@@ -97,6 +104,7 @@ class ExtractMixIn:
                                 hlm=hlm,
                                 pi=pi,
                                 continue_extraction=continue_extraction,
+                                preloaded=preloaded,
                             )
                 except BackupError as e:
                     self.print_warning_instance(BackupWarning(remove_surrogates(orig_path), e))

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -18,7 +18,7 @@ from . import xattr  # noqa: F401
 platform_ug: ModuleType | None = None  # make mypy happy
 
 if is_linux:  # pragma: linux only
-    from .linux import listxattr, getxattr, setxattr
+    from .linux import listxattr, getxattr, setxattr, removexattr
     from .linux import acl_get, acl_set
     from .linux import set_flags, get_flags
     from .linux import SyncFile
@@ -27,7 +27,7 @@ if is_linux:  # pragma: linux only
     from .posix import getosusername
     from . import posix_ug as platform_ug
 elif is_freebsd:  # pragma: freebsd only
-    from .freebsd import listxattr, getxattr, setxattr
+    from .freebsd import listxattr, getxattr, setxattr, removexattr
     from .freebsd import acl_get, acl_set
     from .freebsd import set_flags
     from .base import get_flags
@@ -37,7 +37,7 @@ elif is_freebsd:  # pragma: freebsd only
     from .posix import getosusername
     from . import posix_ug as platform_ug
 elif is_netbsd:  # pragma: netbsd only
-    from .netbsd import listxattr, getxattr, setxattr
+    from .netbsd import listxattr, getxattr, setxattr, removexattr
     from .base import acl_get, acl_set
     from .base import set_flags, get_flags
     from .base import SyncFile
@@ -46,7 +46,7 @@ elif is_netbsd:  # pragma: netbsd only
     from .posix import getosusername
     from . import posix_ug as platform_ug
 elif is_darwin:  # pragma: darwin only
-    from .darwin import listxattr, getxattr, setxattr
+    from .darwin import listxattr, getxattr, setxattr, removexattr
     from .darwin import acl_get, acl_set
     from .darwin import is_darwin_feature_64_bit_inode, _get_birthtime_ns
     from .darwin import set_flags
@@ -59,7 +59,7 @@ elif is_darwin:  # pragma: darwin only
     from . import posix_ug as platform_ug
 elif not is_win32:  # pragma: posix only
     # Generic code for all other POSIX OSes
-    from .base import listxattr, getxattr, setxattr
+    from .base import listxattr, getxattr, setxattr, removexattr
     from .base import acl_get, acl_set
     from .base import set_flags, get_flags
     from .base import SyncFile
@@ -69,7 +69,7 @@ elif not is_win32:  # pragma: posix only
     from . import posix_ug as platform_ug
 else:  # pragma: win32 only
     # Win32-specific stuff
-    from .base import listxattr, getxattr, setxattr
+    from .base import listxattr, getxattr, setxattr, removexattr
     from .base import acl_get, acl_set
     from .base import set_flags, get_flags
     from .windows import SyncFile

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -69,6 +69,17 @@ def setxattr(path, name, value, *, follow_symlinks=False):
     """
 
 
+def removexattr(path, name, *, follow_symlinks=False):
+    """
+    Remove an xattr from *path*.
+
+    *path* can either be a path (bytes) or an open file descriptor (int).
+    *name* is the name of the xattr to remove (bytes).
+    *follow_symlinks* indicates whether symlinks should be followed
+    and only applies when *path* is not an open file descriptor.
+    """
+
+
 def acl_get(path, item, st, numeric_ids=False, fd=None):
     """
     Save ACL entries.

--- a/src/borg/platform/darwin.pyx
+++ b/src/borg/platform/darwin.pyx
@@ -6,7 +6,7 @@ from posix.time cimport timespec
 
 from . import posix_ug
 from ..helpers import safe_decode, safe_encode
-from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_string0
+from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, _removexattr_inner, split_string0
 
 
 
@@ -31,6 +31,9 @@ cdef extern from "sys/xattr.h":
 
     int c_setxattr "setxattr" (const char *path, const char *name, const void *value, size_t size, uint32_t pos, int flags)
     int c_fsetxattr "fsetxattr" (int filedes, const char *name, const void *value, size_t size, uint32_t pos, int flags)
+
+    int c_removexattr "removexattr" (const char *path, const char *name, int flags)
+    int c_fremovexattr "fremovexattr" (int filedes, const char *name, int flags)
 
     int XATTR_NOFOLLOW
 
@@ -98,6 +101,19 @@ def setxattr(path, name, value, *, follow_symlinks=False):
                 return c_setxattr(path, name, <char *> value, size, 0, XATTR_NOFOLLOW)
 
     _setxattr_inner(func, path, name, value)
+
+
+def removexattr(path, name, *, follow_symlinks=False):
+    def func(path, name):
+        if isinstance(path, int):
+            return c_fremovexattr(path, name, XATTR_NOFLAGS)
+        else:
+            if follow_symlinks:
+                return c_removexattr(path, name, XATTR_NOFLAGS)
+            else:
+                return c_removexattr(path, name, XATTR_NOFOLLOW)
+
+    _removexattr_inner(func, path, name)
 
 
 def _remove_numeric_id_if_possible(acl):

--- a/src/borg/platform/freebsd.pyx
+++ b/src/borg/platform/freebsd.pyx
@@ -5,7 +5,7 @@ from libc cimport errno
 
 from .posix import posix_acl_use_stored_uid_gid
 from ..helpers import safe_encode, safe_decode
-from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_lstring
+from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, _removexattr_inner, split_lstring
 
 
 
@@ -21,6 +21,10 @@ cdef extern from "sys/extattr.h":
     int c_extattr_set_file "extattr_set_file" (const char *path, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
     int c_extattr_set_link "extattr_set_link" (const char *path, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
     int c_extattr_set_fd "extattr_set_fd" (int fd, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
+
+    int c_extattr_delete_file "extattr_delete_file" (const char *path, int attrnamespace, const char *attrname)
+    int c_extattr_delete_link "extattr_delete_link" (const char *path, int attrnamespace, const char *attrname)
+    int c_extattr_delete_fd "extattr_delete_fd" (int fd, int attrnamespace, const char *attrname)
 
     int EXTATTR_NAMESPACE_USER
 
@@ -122,6 +126,25 @@ def setxattr(path, name, value, *, follow_symlinks=False):
         pass
     else:
         _setxattr_inner(func, path, name, value)
+
+
+def removexattr(path, name, *, follow_symlinks=False):
+    def func(path, name):
+        if isinstance(path, int):
+            return c_extattr_delete_fd(path, ns_id, name)
+        else:
+            if follow_symlinks:
+                return c_extattr_delete_file(path, ns_id, name)
+            else:
+                return c_extattr_delete_link(path, ns_id, name)
+
+    ns, name = split_ns(name, b"user")
+    try:
+        ns_id = NS_ID_MAP[ns]  # this will raise a KeyError it the namespace is unsupported
+    except KeyError:
+        pass
+    else:
+        _removexattr_inner(func, path, name)
 
 
 cdef _get_acl(p, type, item, attribute, flags, fd=None):

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -8,7 +8,7 @@ from ..helpers import workarounds
 from ..helpers import safe_decode, safe_encode
 from .base import SyncFile as BaseSyncFile
 from .base import safe_fadvise
-from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_string0
+from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, _removexattr_inner, split_string0
 try:
     from .syncfilerange import sync_file_range, SYNC_FILE_RANGE_WRITE, SYNC_FILE_RANGE_WAIT_BEFORE, SYNC_FILE_RANGE_WAIT_AFTER
     SYNC_FILE_RANGE_LOADED = True
@@ -31,6 +31,10 @@ cdef extern from "sys/xattr.h":
     int c_setxattr "setxattr" (const char *path, const char *name, const void *value, size_t size, int flags)
     int c_lsetxattr "lsetxattr" (const char *path, const char *name, const void *value, size_t size, int flags)
     int c_fsetxattr "fsetxattr" (int filedes, const char *name, const void *value, size_t size, int flags)
+
+    int c_removexattr "removexattr" (const char *path, const char *name)
+    int c_lremovexattr "lremovexattr" (const char *path, const char *name)
+    int c_fremovexattr "fremovexattr" (int filedes, const char *name)
 
 cdef extern from "sys/types.h":
     int ACL_TYPE_ACCESS
@@ -119,6 +123,19 @@ def setxattr(path, name, value, *, follow_symlinks=False):
                 return c_lsetxattr(path, name, <char *> value, size, flags)
 
     _setxattr_inner(func, path, name, value)
+
+
+def removexattr(path, name, *, follow_symlinks=False):
+    def func(path, name):
+        if isinstance(path, int):
+            return c_fremovexattr(path, name)
+        else:
+            if follow_symlinks:
+                return c_removexattr(path, name)
+            else:
+                return c_lremovexattr(path, name)
+
+    _removexattr_inner(func, path, name)
 
 
 BSD_TO_LINUX_FLAGS = {

--- a/src/borg/platform/netbsd.pyx
+++ b/src/borg/platform/netbsd.pyx
@@ -1,4 +1,4 @@
-from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, split_lstring
+from .xattr import _listxattr_inner, _getxattr_inner, _setxattr_inner, _removexattr_inner, split_lstring
 
 
 
@@ -14,6 +14,10 @@ cdef extern from "sys/extattr.h":
     int c_extattr_set_file "extattr_set_file" (const char *path, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
     int c_extattr_set_link "extattr_set_link" (const char *path, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
     int c_extattr_set_fd "extattr_set_fd" (int fd, int attrnamespace, const char *attrname, const void *data, size_t nbytes)
+
+    int c_extattr_delete_file "extattr_delete_file" (const char *path, int attrnamespace, const char *attrname)
+    int c_extattr_delete_link "extattr_delete_link" (const char *path, int attrnamespace, const char *attrname)
+    int c_extattr_delete_fd "extattr_delete_fd" (int fd, int attrnamespace, const char *attrname)
 
     int EXTATTR_NAMESPACE_USER
 
@@ -87,3 +91,22 @@ def setxattr(path, name, value, *, follow_symlinks=False):
         pass
     else:
         _setxattr_inner(func, path, name, value)
+
+
+def removexattr(path, name, *, follow_symlinks=False):
+    def func(path, name):
+        if isinstance(path, int):
+            return c_extattr_delete_fd(path, ns_id, name)
+        else:
+            if follow_symlinks:
+                return c_extattr_delete_file(path, ns_id, name)
+            else:
+                return c_extattr_delete_link(path, ns_id, name)
+
+    ns, name = split_ns(name, b"user")
+    try:
+        ns_id = NS_ID_MAP[ns]  # this will raise a KeyError it the namespace is unsupported
+    except KeyError:
+        pass
+    else:
+        _removexattr_inner(func, path, name)

--- a/src/borg/platform/xattr.py
+++ b/src/borg/platform/xattr.py
@@ -87,3 +87,9 @@ def _setxattr_inner(func, path, name, value):
     assert isinstance(name, bytes)
     assert isinstance(value, bytes)
     _check(func(path, name, value, len(value)), path, detect_buffer_too_small=False)
+
+
+def _removexattr_inner(func, path, name):
+    assert isinstance(path, (bytes, int))
+    assert isinstance(name, bytes)
+    _check(func(path, name), path, detect_buffer_too_small=False)

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import stat
 from collections import OrderedDict
 from datetime import datetime, timezone
 from io import StringIO
@@ -10,9 +11,9 @@ import pytest
 from . import rejected_dotdot_paths
 from ..crypto.key import PlaintextKey
 from ..archive import Archive, CacheChunkBuffer, RobustUnpacker, valid_msgpacked_dict, ITEM_KEYS, Statistics
-from ..archive import BackupOSError, backup_io, backup_io_iter, get_item_uid_gid
+from ..archive import BackupError, BackupOSError, backup_io, backup_io_iter, get_item_uid_gid
 from ..helpers import msgpack
-from ..item import Item, ArchiveItem
+from ..item import Item, ArchiveItem, ChunkListEntry
 from ..manifest import Archives, Manifest
 from ..platform import uid2user, gid2group, is_win32
 
@@ -435,3 +436,210 @@ def test_archives_get_by_id_missing_returns_none():
     manifest = Mock()
     archives = Archives(repo, manifest)
     assert archives.get_by_id(b"\x01" * 32) is None
+
+
+# ---- borg extract: in-place chunk comparison / selective extraction (#5638) ----
+
+CHUNK_SIZE = 4
+
+
+class FetchManyPipeline:
+    """Minimal pipeline stand-in that records which chunk ids fetch_many() requested."""
+
+    def __init__(self, objects):
+        self.objects = objects  # id -> data
+        self.fetched = []
+
+    def fetch_many(self, chunks, ro_type=None):
+        assert ro_type is not None
+        for chunk in chunks:
+            self.fetched.append(chunk.id)
+            yield self.objects[chunk.id]
+
+
+@pytest.fixture
+def extractor(tmpdir):
+    repository = Mock()
+    key = PlaintextKey(repository)
+    manifest = Manifest(key, repository)
+    archive = Archive(manifest=manifest, name="test", create=True)
+    archive.key = key
+    archive.cwd = str(tmpdir)
+    return archive
+
+
+def make_item(key, objects, data):
+    """Chunk *data* into CHUNK_SIZE pieces, register them in *objects*, return an Item."""
+    chunks = []
+    for i in range(0, len(data), CHUNK_SIZE):
+        piece = data[i : i + CHUNK_SIZE]
+        cid = key.id_hash(piece)
+        chunks.append(ChunkListEntry(id=cid, size=len(piece)))
+        objects[cid] = piece
+    item = Item(path="test", mode=stat.S_IFREG | 0o644, size=len(data))
+    item.chunks = chunks
+    return item
+
+
+@pytest.mark.parametrize(
+    "name, item_data, fs_data, expected_fetched",
+    [
+        ("no_change", b"11112222", b"11112222", 0),
+        ("first_chunk", b"11112222", b"33332222", 1),
+        ("second_chunk", b"11112222", b"11113333", 1),
+        ("both_chunks", b"11112222", b"33334444", 2),
+        ("cross_boundary", b"11112222", b"11333322", 2),
+        ("partial_last_chunk", b"1111222233", b"1111222244", 1),
+        ("fs_shorter", b"11112222", b"111122", 1),
+        ("fs_longer", b"11112222", b"1111222233", 0),
+        ("empty_item", b"", b"11112222", 0),
+        ("empty_fs", b"11112222", b"", 2),
+    ],
+)
+def test_compare_and_extract_chunks(extractor, tmpdir, name, item_data, fs_data, expected_fetched):
+    objects = {}
+    item = make_item(extractor.key, objects, item_data)
+    pipeline = FetchManyPipeline(objects)
+    extractor.pipeline = pipeline
+    # we only exercise the data path here; attribute (re)storing is covered elsewhere.
+    extractor.clear_attrs = Mock()
+    extractor.restore_attrs = Mock()
+
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(fs_data)
+    st = os.stat(path)
+
+    assert extractor.compare_and_extract_chunks(item, path, st=st)
+    assert len(pipeline.fetched) == expected_fetched
+    with open(path, "rb") as f:
+        assert f.read() == item_data
+
+
+def test_compare_and_extract_chunks_fetches_only_differing(extractor, tmpdir):
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    pipeline = FetchManyPipeline(objects)
+    extractor.pipeline = pipeline
+    extractor.clear_attrs = Mock()
+    extractor.restore_attrs = Mock()
+
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(b"1111XXXX")  # only the second chunk differs
+
+    extractor.compare_and_extract_chunks(item, path, st=os.stat(path))
+    # exactly the (differing) second chunk should have been fetched, not the first.
+    assert pipeline.fetched == [item.chunks[1].id]
+
+
+@pytest.mark.parametrize("st_is_none", [True, False])
+def test_compare_and_extract_chunks_skips_non_regular(extractor, tmpdir, st_is_none):
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    extractor.pipeline = FetchManyPipeline(objects)
+    if st_is_none:
+        st = None
+    else:
+        st = os.stat(str(tmpdir))  # a directory, not a regular file
+    assert extractor.compare_and_extract_chunks(item, str(tmpdir.join("test")), st=st) is False
+
+
+def test_compare_and_extract_chunks_size_inconsistency(extractor, tmpdir):
+    # if the archived item.size does not match the size implied by its chunks, we must raise
+    # rather than silently produce a wrong file (parity with the normal extraction path).
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    item.size = 9999  # deliberately wrong (the chunks add up to 8 bytes)
+    extractor.pipeline = FetchManyPipeline(objects)
+    extractor.clear_attrs = Mock()
+    extractor.restore_attrs = Mock()
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(b"1111XXXX")
+    with pytest.raises(BackupError):
+        extractor.compare_and_extract_chunks(item, path, st=os.stat(path))
+
+
+def test_will_patch_in_place(extractor, tmpdir):
+    objects = {}
+
+    # no file at the destination yet -> normal extraction
+    item = make_item(extractor.key, objects, b"11112222")  # item.path == "test", regular file
+    assert extractor.will_patch_in_place(item) is False
+
+    # an existing regular file at the destination -> patch in place
+    with open(str(tmpdir.join("test")), "wb") as f:
+        f.write(b"11112222")
+    assert extractor.will_patch_in_place(item) is True
+
+    # a hard-linked archive item is never patched in place (even if the file exists)
+    hl_item = make_item(extractor.key, objects, b"11112222")
+    hl_item.hlid = b"\x00" * 32
+    assert extractor.will_patch_in_place(hl_item) is False
+
+    # a non-regular archive item (e.g. a directory) is never patched in place
+    dir_item = make_item(extractor.key, objects, b"11112222")
+    dir_item.mode = stat.S_IFDIR | 0o755
+    assert extractor.will_patch_in_place(dir_item) is False
+
+
+def test_compare_and_extract_chunks_skips_hardlinks(extractor, tmpdir):
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    item.hlid = b"\x00" * 32  # a hard link must use the normal (preloaded) extraction path
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(b"11112222")
+    assert extractor.compare_and_extract_chunks(item, path, st=os.stat(path)) is False
+
+
+def test_compare_and_extract_chunks_skips_hardlinked_file(extractor, tmpdir):
+    # a destination file with other hard links (st_nlink > 1) must not be patched in place,
+    # as that would change the content seen through those other links.
+    # We synthesize st_nlink=2 instead of calling os.link(), because whether a hard link
+    # actually bumps st_nlink (or is supported at all) depends on the filesystem.
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    extractor.pipeline = FetchManyPipeline(objects)
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(b"11112222")
+    fields = list(os.stat(path))  # the 10 standard stat fields
+    fields[3] = 2  # st_nlink
+    st = os.stat_result(fields)
+    assert extractor.compare_and_extract_chunks(item, path, st=st) is False
+
+
+def test_compare_and_extract_chunks_skips_file_with_extended_acl(extractor, tmpdir):
+    # a file carrying an extended ACL must not be patched in place, because clear_attrs() does
+    # not reset ACLs; such files fall back to normal extraction (fresh inode, clean metadata).
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    extractor.pipeline = FetchManyPipeline(objects)
+    extractor._fs_has_extended_acl = Mock(return_value=True)
+    path = str(tmpdir.join("test"))
+    with open(path, "wb") as f:
+        f.write(b"11112222")
+    assert extractor.compare_and_extract_chunks(item, path, st=os.stat(path)) is False
+
+
+@pytest.mark.skipif(is_win32, reason="xattrs/clear_attrs are POSIX-only")
+def test_compare_and_extract_chunks_clears_stale_xattr(extractor, tmpdir):
+    from .. import xattr as xattr_mod
+
+    path = str(tmpdir.join("test")).encode()
+    with open(path, "wb") as f:
+        f.write(b"oldcontent")
+    if not xattr_mod.is_enabled(str(tmpdir)):
+        pytest.skip("xattrs not supported on this filesystem")
+    xattr_mod.set_all(path, {b"user.stale": b"1"})
+
+    objects = {}
+    item = make_item(extractor.key, objects, b"11112222")
+    extractor.pipeline = FetchManyPipeline(objects)
+    extractor.restore_attrs = Mock()  # real clear_attrs, but skip restoring archived attrs
+
+    assert extractor.compare_and_extract_chunks(item, path.decode(), st=os.stat(path))
+    # the stale xattr that was not part of the archive item must be gone.
+    assert b"user.stale" not in xattr_mod.get_all(path)

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -771,6 +771,32 @@ def test_extract_continue(archivers, request):
             assert f.read() == CONTENTS3
 
 
+def test_extract_patches_existing_file_in_place(archivers, request):
+    # when extracting over an existing regular file, borg updates it in place (only fetching
+    # the chunks that differ, see #5638) instead of unlinking and recreating it.
+    archiver = request.getfixturevalue(archivers)
+    # use a reasonably large, chunkable content so multiple chunks exist.
+    contents = os.urandom(4 * 1024 * 1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file", contents=contents)
+    cmd(archiver, "create", "arch", "input")
+
+    with changedir("output"):
+        cmd(archiver, "extract", "arch")
+        st_before = os.stat("input/file")
+        # locally modify a few bytes near the start, leaving the rest identical.
+        with open("input/file", "rb+") as f:
+            f.seek(5)
+            f.write(b"DIFFERENT")
+        # extract again (no --continue): the existing file should be patched in place.
+        cmd(archiver, "extract", "arch")
+        st_after = os.stat("input/file")
+        if not is_win32:
+            assert st_before.st_ino == st_after.st_ino  # same inode -> updated in place
+        with open("input/file", "rb") as f:
+            assert f.read() == contents  # content fully restored
+
+
 def test_dry_run_extraction_flags(archivers, request):
     archiver = request.getfixturevalue(archivers)
     cmd(archiver, "repo-create", RK_ENCRYPTION)

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -15,7 +15,7 @@ from .logger import create_logger
 
 logger = create_logger()
 
-from .platform import listxattr, getxattr, setxattr, ENOATTR
+from .platform import listxattr, getxattr, setxattr, removexattr, ENOATTR
 
 # If we are running with fakeroot on Linux, then use the xattr functions of fakeroot. This is needed by
 # the 'test_extract_capabilities' test, but also allows xattrs to work with fakeroot on Linux in normal use.
@@ -130,3 +130,37 @@ def set_all(path, xattrs, follow_symlinks=False):
                 err_str = str(e)
             logger.warning("When setting extended attribute %s: %s", k.decode(errors="replace"), err_str)
     return warning
+
+
+def clear_all(path, follow_symlinks=False):
+    """
+    Remove all (removable) extended attributes from *path*.
+
+    *path* can either be a path (str or bytes) or an open file descriptor (int).
+    *follow_symlinks* indicates whether symlinks should be followed
+    and only applies when *path* is not an open file descriptor.
+
+    This is best-effort: xattrs that cannot be removed (e.g. attributes in a
+    protected namespace such as "security.selinux", or on filesystems without
+    xattr support) are silently skipped rather than raising. It is used to bring
+    an existing file to a "fresh" state before re-applying archived metadata.
+    """
+    if isinstance(path, str):
+        path = os.fsencode(path)
+    try:
+        names = listxattr(path, follow_symlinks=follow_symlinks)
+    except OSError as e:
+        if e.errno in (errno.ENOTSUP, errno.EOPNOTSUPP, errno.EPERM):
+            # xattrs not supported on this filesystem (or not permitted to list): nothing to clear.
+            return
+        raise
+    for name in names:
+        try:
+            removexattr(path, name, follow_symlinks=follow_symlinks)
+        except OSError as e:
+            # ENOATTR: race, the xattr was already removed between list and remove.
+            # ENOTSUP/EOPNOTSUPP: filesystem does not support xattrs.
+            # EPERM/EACCES: protected namespace (e.g. "security.*") we are not allowed to drop.
+            if e.errno in (ENOATTR, errno.ENOTSUP, errno.EOPNOTSUPP, errno.EPERM, errno.EACCES):
+                continue
+            raise


### PR DESCRIPTION
Supersedes #8632 (which stalled as a draft). This is a clean re-implementation off current master that addresses all of the review feedback from that PR.

### Description

This PR makes extraction of an **existing regular file** update it in place: it hashes the on-disk content using the archived chunk sizes, compares chunk-by-chunk against the archive's chunk list, and fetches only the chunks that actually differ.

### Changes (`Archive.compare_and_extract_chunks`)

1. Read pass: read each archived chunk's `size` bytes from the existing file and build a parallel `fs_chunks` list of `ChunkListEntry(id=id_hash(data), size=...)`.
2. `zip(fs_chunks, item.chunks)` → the chunks whose ids differ are the ones to fetch.
3. `fetch_many()` only those (non-preloaded) chunks.
4. Write pass: for each archived chunk, `seek(size, SEEK_CUR)` if it already matches, otherwise `write()` the freshly fetched data. Truncate to the archived length.
5. Clear stale metadata, then `restore_attrs()`.

There is **no new CLI option**: the behavior is driven purely by the filesystem state, as requested in review.

#### Safety: in-place updating is a pure optimization that never changes observable semantics

It is only used when it is provably safe, otherwise we fall back to the normal unlink+recreate path (which behaves exactly as before). `can_patch_in_place()` requires:

- destination is a regular file **and** the archive item is a regular file.
- not a hard-linked archive item (`hlid`): keeps preload bookkeeping correct.
- `st_nlink == 1`, otherwise an in-place write would alter content seen through other hard links to the same inode; unlink+recreate gives this path its own fresh inode.
- no extended ACL on the existing file (see "metadata" below).

#### Preloading

Since in-place updating fetches only the differing chunks, the command now **skips preloading** for patch candidates (`will_patch_in_place()`), and a new `preloaded` flag on `extract_item()` ensures the full-extraction fallback does not wait on preloaded chunks that were never requested.

#### Metadata of the existing file

For an in-place update, a new `clear_attrs()` (next to `restore_attrs()`) wipes pre-existing extended attributes and BSD flags first. xattr removal required a new `removexattr` platform primitive (added across linux/darwin/freebsd/netbsd + the base fallback), and a resilient `xattr.clear_all()` that skips attributes it isn't allowed to drop (e.g. `security.*` namespaces, or filesystems without xattr support) rather than aborting the extraction.

ACLs are intentionally **not** cleared. Instead, files that carry an extended ACL fall back to the normal extraction path, so they always get a clean metadata state. This is irrelevant for the big-file/block-device target of #5638.

### Resolution of the #8632 review comments

| Review comment | Resolution |
|---|---|
| "not sure we need an option … determined by the fs state, not by an option" | No CLI option; decision is purely fs-state based. |
| "read-only pass → build fs chunks → zip → fetch_many → write/seek pass" | Implemented in exactly that order. |
| "if one preloads some chunks, one must fetch all of them" | Preload skipped for patch candidates; `preloaded` flag prevents a deadlock on fallback. |
| "don't catch Exception … notice how backup_io() is used" | All I/O wrapped in `backup_io(...)`; no broad `except`. |
| "seek in if-block, write in else-block" / "don't track offset" / "use os.SEEK_CUR" | Done; no offset variable. |
| "progress is made in the if-block also → do it after if/else" (+ unbound `chunk_data`) | `pi.show(increase=item_chunk.size)` after the if/else; no unbound variable. |
| "caller already determined st; don't do unneeded os calls" | `can_patch_in_place(item, path, st)` reuses the caller's `st`. |
| "remove default value for st" | `st` is keyword-only and required. |
| "create a clear_attrs method close to restore_attrs" | Added. |
| "setting an xattr to empty is not the same as removing an xattr" | Real `removexattr` primitive, not set-to-empty. |
| "you didn't read the acl_set code" / "there can be already acls or xattrs that don't match" | xattrs+flags cleared; ACL-bearing files fall back to normal extraction. |
| "close the fs_file (you removed the with)" / "fileno() called too often" | `with fs_file:`; `fileno()` taken once. |
| "use small chunk size & visual contents; add these edge cases" | Tests use `chunk_size=4`, literal contents, and all four requested cases. |
| "no prints / move test code out of archive.py" | No prints; tests live in the test modules. |

The old draft's extra `chunks_healthy` check was deliberately dropped. The normal extract path does not have it, so adding it only here would introduce an inconsistency.

### Testing

- Unit tests for `compare_and_extract_chunks` (parametrized: no-change, single/both/cross-boundary changes, partial last chunk, fs shorter/longer, empty fs, empty item) asserting both the resulting content and that only the differing chunks were fetched.
- Unit tests for the safety fallbacks (non-regular, `st=None`, hard-linked item, `st_nlink > 1`, extended ACL) and for stale-xattr clearing.
- End-to-end archiver test: extract → modify bytes on disk → extract again → content fully restored and the inode preserved (proving in-place update), passing for both the local and remote archiver.

### Notes

- I could only compile/test the macOS (darwin) `removexattr` binding locally. The linux/freebsd/netbsd bindings were written by mirroring the existing `setxattr` patterns.
- Block-device contents (the broader #5638 goal) build on this regular-file foundation and could be a follow-up.

Closes #5638 (regular-file case).


## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
