### PR TITLE
ci: add Python 3.15 to CI testing and tox configuration

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,8 +25,8 @@ jobs:
             python-version: '3.12'
             toxenv: py312-pyfuse3
           - os: ubuntu-24.04
-            python-version: '3.14'
-            toxenv: py314-mfusepy
+            python-version: '3.15-dev'
+            toxenv: py315-mfusepy
           - os: macos-15
             python-version: '3.14'
             toxenv: py314-none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
               {"os": "ubuntu-22.04", "python-version": "3.11", "toxenv": "docs"},
               {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-llfuse"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3"},
-              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"}
+              {"os": "ubuntu-24.04", "python-version": "3.15-dev", "toxenv": "py315-mfusepy"}
             ]
           }' || '{
             "include": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Security :: Cryptography",
     "Topic :: System :: Archiving :: Backup",
 ]
@@ -175,7 +176,7 @@ ignore_missing_imports = true
 requires = ["tox>=4.19", "pkgconfig", "cython", "wheel", "setuptools_scm"]
 # Important: when adding/removing Python versions here,
 #            also update the section "Test environments with different FUSE implementations" accordingly.
-env_list = ["py{310,311,312,313,314}-{none,llfuse,pyfuse3,mfusepy}", "docs", "ruff", "mypy", "bandit"]
+env_list = ["py{310,311,312,313,314,315}-{none,llfuse,pyfuse3,mfusepy}", "docs", "ruff", "mypy", "bandit"]
 
 [tool.tox.env_run_base]
 package = "editable-legacy"  # without this it does not find setup_docs when running under fakeroot
@@ -254,6 +255,20 @@ set_env = {BORG_FUSE_IMPL = "pyfuse3"}
 extras = ["pyfuse3", "sftp", "s3", "rclone"]
 
 [tool.tox.env.py314-mfusepy]
+set_env = {BORG_FUSE_IMPL = "mfusepy"}
+extras = ["mfusepy", "sftp", "s3", "rclone"]
+
+[tool.tox.env.py315-none]
+
+[tool.tox.env.py315-llfuse]
+set_env = {BORG_FUSE_IMPL = "llfuse"}
+extras = ["llfuse", "sftp", "s3", "rclone"]
+
+[tool.tox.env.py315-pyfuse3]
+set_env = {BORG_FUSE_IMPL = "pyfuse3"}
+extras = ["pyfuse3", "sftp", "s3", "rclone"]
+
+[tool.tox.env.py315-mfusepy]
 set_env = {BORG_FUSE_IMPL = "mfusepy"}
 extras = ["mfusepy", "sftp", "s3", "rclone"]
 

--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -11,6 +11,6 @@ pytest-xdist==3.8.0
 coverage[toml]==7.13.5
 pytest-cov==7.1.0
 pytest-benchmark==5.2.3
-Cython==3.2.4
+Cython==3.2.5
 pre-commit==4.5.1
 types-PyYAML==6.0.12.20260518


### PR DESCRIPTION
This PR adds Python 3.15 to the project classifiers, the tox environment matrix, and the GitHub Actions CI pipeline matrices.