### PR TITLE
list additional help topics in main borg help, fixes #3432

### DIFF
--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -244,14 +244,27 @@ class Archiver(
             self.define_common_options(add_argument)
 
     def build_parser(self):
-        from ._common import define_common_options
+        from ._common import define_common_options, process_epilog
 
+        additional_help = process_epilog(
+            """
+        Description of additional help topics:
+
+        Use ``borg help <topic>`` to get help on:
+
+          patterns            selection patterns for including/excluding paths
+          match-archives      selection patterns for matching archives
+          placeholders        placeholders in repository URLs, archive names, etc.
+          compression         options and specifications for data compression
+        """
+        )
         parser = ArgumentParser(
             prog=self.prog,
             description="Borg - Deduplicated Backups",
             default_config_files=[os.path.join(get_config_dir(), "default.yaml")],
             default_env=True,
             env_prefix="BORG",
+            epilog=additional_help,
         )
         parser.add_argument("--config", action="config")
         # paths and patterns must have an empty list as default everywhere

--- a/src/borg/testsuite/archiver/help_cmd_test.py
+++ b/src/borg/testsuite/archiver/help_cmd_test.py
@@ -53,3 +53,12 @@ def test_help_formatting(command, parser):
 def test_help_formatting_helptexts(topic):
     helptext = Archiver.helptext[topic]
     assert str(rst_to_terminal(helptext))
+
+
+def test_main_help_epilog(archiver):
+    help_output = cmd(archiver, "-h")
+    assert "Description of additional help topics:" in help_output
+    assert "patterns" in help_output
+    assert "match-archives" in help_output
+    assert "placeholders" in help_output
+    assert "compression" in help_output


### PR DESCRIPTION
- Add an epilog to the main ArgumentParser in src/borg/archiver/__init__.py.
- Import process_epilog and use it to format and list additional help topics: patterns, match-archives, placeholders, compression.
- Add test_main_help_epilog to help_cmd_test.py.
