### PR TITLE
binary build scripts: use /bin/sh

### DIFF
--- a/scripts/build-borg-using-nuitka.sh
+++ b/scripts/build-borg-using-nuitka.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 # Generate a single-file binary of borgbackup using Nuitka.
 
-set -euo pipefail
+set -eu
 
 OUTPUT_DIR="dist/binary"
 OUTPUT_FILENAME="borg-nuitka.exe"  # .exe does NOT mean windows here

--- a/scripts/build-borg-using-pyinstaller.sh
+++ b/scripts/build-borg-using-pyinstaller.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 # Generate a single-file binary of borgbackup using PyInstaller.
 
-set -euo pipefail
+set -eu
 
 OUTPUT_DIR="dist/binary"
 SPEC_FILE="scripts/borg.exe.spec"


### PR DESCRIPTION
there is no bash on some BSDs
