### PR TITLE
tests: cover borg transfer --from-borg1 from an ssh:// borg 1.x repo

### DIFF
--- a/src/borg/testsuite/archiver/transfer_cmd_test.py
+++ b/src/borg/testsuite/archiver/transfer_cmd_test.py
@@ -284,6 +284,42 @@ def test_transfer_upgrade(archivers, request, monkeypatch):
             assert chunks1 == chunks2
 
 
+def test_transfer_from_borg1_ssh(archivers, request, monkeypatch):
+    """transfer --from-borg1 from a borg 1.x repo reached via ssh:// (LegacyRemoteRepository + borg serve)."""
+    archiver = request.getfixturevalue(archivers)
+    if archiver.get_kind() != "local" or is_win32:
+        pytest.skip("legacy ssh:// transfer is exercised only locally (non-win32)")
+
+    # borg 1.2 repo dir contents, created by: scripts/make-testdata/test_transfer_upgrade.sh
+    repo12_tar = os.path.join(os.path.dirname(__file__), "repo12.tar.gz")
+    original_location = archiver.repository_location
+    extract_dir = f"{original_location}1"
+    os.makedirs(extract_dir)
+    with tarfile.open(repo12_tar) as tf:
+        tf.extractall(extract_dir)
+
+    # Reach the borg 1.x source repo via ssh://. The special host __testsuite__ makes the legacy
+    # client spawn a local "borg serve" (RepositoryServer) instead of using a real ssh connection.
+    # extract_dir is absolute, so this yields ssh://__testsuite__//abs/path (absolute-path form).
+    other_repo1 = f"--other-repo=ssh://__testsuite__/{extract_dir}"
+    archiver.repository_location = f"{original_location}2"
+
+    monkeypatch.setenv("BORG_PASSPHRASE", "pw2")
+    monkeypatch.setenv("BORG_OTHER_PASSPHRASE", "waytooeasyonlyfortests")
+    # must use the strong kdf here or borg2 can't decrypt the borg1 key
+    monkeypatch.setenv("BORG_TESTONLY_WEAKEN_KDF", "0")
+
+    cmd(archiver, "repo-create", RK_ENCRYPTION, other_repo1, "--from-borg1")
+    cmd(archiver, "transfer", other_repo1, "--from-borg1")
+    cmd(archiver, "check")
+
+    # The borg 1.2 testdata contains a known set of archives; ensure they all transferred.
+    with open(os.path.join(extract_dir, "test_meta", "repo_list.json")) as f:
+        expected_names = sorted(a["name"] for a in json.load(f)["archives"])
+    got_names = sorted(a["name"] for a in json.loads(cmd(archiver, "repo-list", "--json"))["archives"])
+    assert got_names == expected_names
+
+
 @contextmanager
 def setup_repos(archiver, mp):
     """


### PR DESCRIPTION
## What

Adds an end-to-end test for `borg transfer --from-borg1` reading the borg 1.x source repository over `ssh://`.

Follow-up to #9732, which removed the modern `ssh://`/`socket://` transport but deliberately kept `ssh://` working for legacy borg 1.x (v1) repositories via `LegacyRemoteRepository` + `borg serve` (`RepositoryServer`). That preserved client→server path had no end-to-end test:

- `test_transfer_upgrade` / `test_issue_9022` run `transfer --from-borg1` but only from a **local** v1 repo (they skip remote/binary) → they exercise `LegacyRepository`, never the ssh client/server.
- `_common_test.py` only unit-tests the `get_repository` dispatch.
- `legacyrepository_test.py` exercises `LegacyRemoteRepository` + `RepositoryServer` over `ssh://__testsuite__`, but only at the repo-operation level, never via `borg transfer`.

## The test

`test_transfer_from_borg1_ssh` extracts the existing `repo12.tar.gz` borg 1.2 repo and transfers from it via `--other-repo=ssh://__testsuite__/<abspath> --from-borg1`. The special `__testsuite__` host makes the legacy client spawn a local `borg serve` (no real ssh), so the full chain is driven: `LegacyRemoteRepository` → `borg serve` (`RepositoryServer.open(v1_legacy=True)`) → `LegacyRepository`. It then asserts all archives (archive1, archive2) transferred and `check` passes.

Local/non-win32 only, matching the sibling `--from-borg1` tests and the legacy remote fixture.

## Testing

`pytest src/borg/testsuite/archiver/transfer_cmd_test.py` → 15 passed, 3 skipped (the new test passes for the local kind, skips for remote). Verified with a venv that has `borgstore[rest]` so the spawned `borg serve` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)