### PR TITLE
docs: offer a PDF download and link offline formats in the sidebar

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,3 +31,4 @@ sphinx:
 
 formats:
     - htmlzip
+    - pdf

--- a/docs/_templates/downloads.html
+++ b/docs/_templates/downloads.html
@@ -1,0 +1,31 @@
+<div class="borg-downloads" id="borg-downloads" style="display:none;">
+  <p class="caption"><span class="caption-text">Download docs</span></p>
+  <ul id="borg-downloads-list"></ul>
+</div>
+<script type="text/javascript">
+  // Populate offline download links (PDF, HTMLzip, ...) using ReadTheDocs data if available.
+  function borgInitDownloads(data) {
+    var downloads = data && data.versions && data.versions.current && data.versions.current.downloads;
+    if (!downloads) return;
+    var labels = {pdf: "PDF", htmlzip: "HTML (zip)", epub: "ePub"};
+    var list = document.getElementById("borg-downloads-list");
+    if (!list) return;
+    var count = 0;
+    Object.keys(downloads).forEach(function(fmt) {
+      var url = downloads[fmt];
+      if (!url) return;
+      var li = document.createElement("li");
+      var a = document.createElement("a");
+      a.href = url;
+      a.textContent = labels[fmt] || fmt;
+      li.appendChild(a);
+      list.appendChild(li);
+      count++;
+    });
+    if (count) document.getElementById("borg-downloads").style.display = "";
+  }
+
+  document.addEventListener("readthedocs-addons-data-ready", function(event) {
+    borgInitDownloads(event.detail.data());
+  });
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,7 +161,7 @@ smartquotes_action = 'qe'  # no D in there means "do not transform -- and ---"
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    '**': ['logo-text.html', "versionselector.html", 'searchbox.html', 'globaltoc.html'],
+    '**': ['logo-text.html', "versionselector.html", 'searchbox.html', 'downloads.html', 'globaltoc.html'],
 }
 
 # Additional templates that should be rendered to pages, maps page names to


### PR DESCRIPTION
Fixes #9731.

## What

- Enable the `pdf` output format on Read the Docs (`.readthedocs.yaml`). The LaTeX build configuration already existed in `docs/conf.py` (`latex_documents`, `latex_logo`, `latex_elements`), so only the format needed to be declared. RTD provisions the LaTeX toolchain automatically.
- Add a **"Download docs"** section to the left sidebar (right below the search box, as suggested in the issue) that links the available offline formats (PDF, HTML zip, ePub).

## How

The new `docs/_templates/downloads.html` template populates the links from the Read the Docs addons data (`readthedocs-addons-data-ready` → `versions.current.downloads`), reusing the same mechanism as the existing version selector. This keeps the links version-correct and hides the block when no downloads are available (e.g. local/offline builds).

## Notes

Because the links come from the live RTD addons data, they only appear on the readthedocs.io-hosted docs (where the addons inject that data), not in local HTML builds. This matches the issue's intent of linking the formats from the Read the Docs UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)