### PR TITLE
docs: left-align the sidebar downloads line and add separators

### DIFF
--- a/docs/borg_theme/css/borg.css
+++ b/docs/borg_theme/css/borg.css
@@ -236,3 +236,17 @@ readthedocs-flyout {
 .sphinxsidebar > .sidebar-block:has(#main-search):after {
     margin: 7px 22px 0 22px;
 }
+/* Downloads line in the sidebar: a single line, left-aligned with the boxes
+   above it and the table of contents below it. */
+.borg-downloads {
+    padding: 0 22px;
+    margin: 7px 0 7px 0;
+    font-size: 14px;
+    color: #000;
+}
+.borg-downloads:after {
+    content: '';
+    display: block;
+    border-top: 1px solid #ccc;
+    margin: 7px 0 0 0;
+}


### PR DESCRIPTION
Follow-up to #9735 / #9737 (sidebar PDF/HTML/ePub downloads line).

Refines the appearance of the "Downloads" line in the left sidebar:

- Left-align the line at 22px so it lines up with the version selector and
  search box above it and the table of contents below it.
- Add a horizontal separator both above the line (between the search box and
  the downloads) and below it (between the downloads and the table of
  contents).

Sidebar layout on Read the Docs:

```
[ version selector ]
─────────────────────
[ search box ]
─────────────────────
Downloads: PDF | HTML | ePub
─────────────────────
[ table of contents ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)