### PR TITLE
docs: offer a PDF download and link offline formats in the sidebar

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -29,3 +29,4 @@ sphinx:
 
 formats:
     - htmlzip
+    - pdf

--- a/docs/_templates/downloads.html
+++ b/docs/_templates/downloads.html
@@ -1,0 +1,27 @@
+<p class="borg-downloads" id="borg-downloads" style="display:none;">Downloads: <span id="borg-downloads-list"></span></p>
+<script type="text/javascript">
+  // Populate offline download links (PDF, HTMLzip, ...) on a single line using ReadTheDocs data if available.
+  function borgInitDownloads(data) {
+    var downloads = data && data.versions && data.versions.current && data.versions.current.downloads;
+    if (!downloads) return;
+    var labels = {pdf: "PDF", htmlzip: "HTML", epub: "ePub"};
+    var span = document.getElementById("borg-downloads-list");
+    if (!span) return;
+    var first = true;
+    Object.keys(downloads).forEach(function(fmt) {
+      var url = downloads[fmt];
+      if (!url) return;
+      if (!first) span.appendChild(document.createTextNode(" | "));
+      var a = document.createElement("a");
+      a.href = url;
+      a.textContent = labels[fmt] || fmt;
+      span.appendChild(a);
+      first = false;
+    });
+    if (!first) document.getElementById("borg-downloads").style.display = "";
+  }
+
+  document.addEventListener("readthedocs-addons-data-ready", function(event) {
+    borgInitDownloads(event.detail.data());
+  });
+</script>

--- a/docs/borg_theme/css/borg.css
+++ b/docs/borg_theme/css/borg.css
@@ -221,3 +221,17 @@ readthedocs-flyout {
 .sphinxsidebar > .sidebar-block:has(#main-search):after {
     margin: 7px 22px 0 22px;
 }
+/* Downloads line in the sidebar: a single line, left-aligned with the boxes
+   above it and the table of contents below it. */
+.borg-downloads {
+    padding: 0 22px;
+    margin: 7px 0 7px 0;
+    font-size: 14px;
+    color: #000;
+}
+.borg-downloads:after {
+    content: '';
+    display: block;
+    border-top: 1px solid #ccc;
+    margin: 7px 0 0 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ html_use_smartypants = True
 smartquotes_action = "qe"  # no D in there means "do not transform -- and ---"
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {"**": ["logo-text.html", "versionselector.html", "searchbox.html", "globaltoc.html"]}
+html_sidebars = {"**": ["logo-text.html", "versionselector.html", "searchbox.html", "downloads.html", "globaltoc.html"]}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -218,7 +218,7 @@ latex_show_urls = "footnote"
 # latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-latex_appendices = ["support", "resources", "changes", "authors"]
+latex_appendices = ["support", "changes", "authors"]
 
 # If false, no module index is generated.
 # latex_domain_indices = True


### PR DESCRIPTION
Fixes #9731. Master counterpart of the changes already merged for `1.4-maint` (#9735, #9736, #9737, #9738), squashed into a single commit.

## What

- Enable the `pdf` output format on Read the Docs (`.readthedocs.yaml`). The LaTeX build config already existed in `docs/conf.py`, so only the format needed declaring; RTD provisions the LaTeX toolchain automatically.
- Add a **"Downloads"** line to the left sidebar that links the available offline formats (PDF, HTML zip, ePub). It is populated from the Read the Docs addons data (reusing the version-selector mechanism), so the links are version-correct and the line hides when no downloads are available (e.g. local builds).
- Style the line as a single, left-aligned line with a horizontal separator above (between the search box and the links) and below (between the links and the table of contents).
- Drop the stale `resources` entry from `latex_appendices` — that page was removed in #2088 and broke the now-enabled PDF build with a doctree `KeyError`.

## Sidebar layout on Read the Docs

```
[ version selector ]
─────────────────────
[ search box ]
─────────────────────
Downloads: PDF | HTML | ePub
─────────────────────
[ table of contents ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)