### PR TITLE
compact: invalidate cached chunk indexes before deleting objects, #9748

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -185,6 +185,10 @@ New features:
 
 Fixes:
 
+- compact: invalidate cached chunk indexes before deleting objects, #9748.
+  An interrupted compact no longer leaves a stale cache/chunks.* that claims
+  deleted objects still exist, which could cause a later create to skip
+  re-uploading data and silently produce an archive with dangling references.
 - files cache: fix no-change backup emptying the files cache, #9749
 - fix canonical_path() missing ':' before port number
 - fix: xattr xdg backup exclusion should be on 'false'

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from ._common import with_repository
 from ..archive import Archive
-from ..cache import write_chunkindex_to_repo_cache, build_chunkindex_from_repo
+from ..cache import write_chunkindex_to_repo_cache, build_chunkindex_from_repo, delete_chunkindex_cache
 from ..cache import files_cache_name, discover_files_cache_names
 from ..helpers import get_cache_dir
 from ..helpers.argparsing import ArgumentParser
@@ -177,6 +177,15 @@ class ArchiveGarbageCollector:
             if not (entry.flags & ChunkIndex.F_USED):
                 unused.add(id)
         logger.info(f"Deleting {len(unused)} unused objects...")
+        if unused:
+            # Before deleting any repository object, invalidate all centrally cached chunk indexes.
+            # Otherwise, if we get interrupted within the deletion loop, the still-existing cache/chunks.*
+            # would claim that already-deleted objects are still present. A later "borg create" would then
+            # trust that stale index, not re-upload the affected chunks and silently create an archive with
+            # dangling object references (see issue #9748). By removing the cached indexes first, an
+            # interruption is conservative: clients must rebuild the index from actual repository contents
+            # and will re-upload any deleted data. save_chunk_index() writes a fresh, valid index afterwards.
+            delete_chunkindex_cache(self.repository)
         pi = ProgressIndicatorPercent(
             total=len(unused), msg="Deleting unused objects %3.1f%%", step=0.1, msgid="compact.report_and_delete"
         )

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -1,11 +1,14 @@
+import os
 from pathlib import Path
 
 import pytest
 
 from ...constants import *  # NOQA
 from ...helpers import get_cache_dir
-from ...cache import files_cache_name, discover_files_cache_names
-from . import cmd, create_src_archive, generate_archiver_tests, RK_ENCRYPTION
+from ...cache import files_cache_name, discover_files_cache_names, list_chunkindex_hashes
+from ...manifest import Manifest
+from . import cmd, create_regular_file, create_src_archive, generate_archiver_tests, open_repository, RK_ENCRYPTION
+from . import changedir
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
 
@@ -83,6 +86,61 @@ def test_compact_index_corruption(archivers, request):
 
     output = cmd(archiver, "compact", "-v", "--stats", exit_code=0)
     assert "missing objects" not in output
+
+
+@pytest.mark.parametrize("stats", (True, False))
+def test_compact_interrupted_does_not_poison_chunk_index(archivers, request, monkeypatch, stats):
+    """Regression test for issue #9748.
+
+    If a compact is interrupted after it deleted repository objects but before it wrote the
+    updated chunk index, the still-existing cache/chunks.* must not claim that the deleted
+    objects are still present. Otherwise a later "borg create" trusts the stale index, does
+    not re-upload the affected chunks and silently produces an archive with dangling object
+    references (which extracts to zero bytes).
+
+    The fix invalidates all cached chunk indexes before the first delete, so an interruption
+    is conservative: the next client rebuilds the index from actual repository contents and
+    re-uploads any deleted data. This is tested for both compact paths (default and --stats).
+    """
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    archiver = request.getfixturevalue(archivers)
+
+    # Unique content, so the chunk(s) become unused once we delete the only archive referencing them.
+    content = os.urandom(1024 * 1024)
+    create_regular_file(archiver.input_path, "file1", contents=content)
+
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "archive1", "input")
+    cmd(archiver, "delete", "-a", "archive1")
+
+    # Simulate an interruption inside compact: run the real garbage collection (which deletes the
+    # unused objects), but force it to abort right before it writes the fresh, updated chunk index.
+    repository = open_repository(archiver)
+    with repository:
+        manifest = Manifest.load(repository, (Manifest.Operation.DELETE,))
+        gc = ArchiveGarbageCollector(repository, manifest, stats=stats, iec=False)
+
+        def interrupt():
+            raise KeyboardInterrupt("simulated interruption before save_chunk_index")
+
+        monkeypatch.setattr(gc, "save_chunk_index", interrupt)
+        with pytest.raises(KeyboardInterrupt):
+            gc.garbage_collect()
+
+    # The objects were deleted, so no readable cached chunk index may still list them.
+    repository = open_repository(archiver)
+    with repository:
+        assert list_chunkindex_hashes(repository) == []
+
+    # A later backup of identical content must re-upload the deleted chunks, ...
+    cmd(archiver, "create", "archive2", "input")
+    # ... and extracting it must reproduce the original bytes without missing-object warnings.
+    with changedir("output"):
+        output = cmd(archiver, "extract", "archive2")
+        assert "missing" not in output
+        with open(os.path.join("input", "file1"), "rb") as fd:
+            assert fd.read() == content
 
 
 def test_compact_files_cache_cleanup(archivers, request):


### PR DESCRIPTION
Fixes #9748.

## Problem

If `borg compact` is interrupted after it has deleted repository objects but before it writes the updated chunk index, the existing `cache/chunks.*` files still claim that the deleted objects exist.

A later `borg create` loads this stale index, treats the matching chunks as already present, and does not upload their data. The command exits successfully but creates an archive that references nonexistent repository objects. Extraction then substitutes zero bytes — a silent data-loss issue, with both `create` and `extract` returning exit code 0.

This violates the invariant documented in `cache.py`:

> when some functionality is DELETING chunks from the repository, it has to delete all existing cache/chunks.* and maybe write a new, valid cache/chunks.<hash>, so that all clients will discard any client-local chunks index caches.

`ArchiveGarbageCollector` only wrote/cleaned the index in `save_chunk_index()` *after* the whole deletion loop, leaving a crash window where deleted objects are still listed by a readable cached index.

## Fix

Invalidate all centrally cached chunk indexes (`delete_chunkindex_cache()`) right before the first object is deleted, in `report_and_delete()`. This makes an interruption conservative: later clients must rebuild the chunk index from actual repository contents and will re-upload any deleted data instead of creating dangling references. The post-deletion `save_chunk_index()` still writes a fresh, valid index for performance in the normal (uninterrupted) case.

This follows the issue's suggested fix direction.

## Test

Added `test_compact_interrupted_does_not_poison_chunk_index`, covering both compact paths (default and `--stats`). It runs the real garbage collection but forces an interruption right before `save_chunk_index()`, then asserts that no cached chunk index survives and that a subsequent `create` + `extract` of identical content reproduces the original bytes without missing-object warnings.

Verified the test fails without the fix and passes with it; the full `compact_cmd_test.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)