### PR TITLE
msgpack: support 1.2.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -472,6 +472,7 @@ Note: Many of the fixed issues listed below relate to rather rare or theoretical
 
 Other changes:
 
+- msgpack: allow 1.2.0
 - use F_FULLFSYNC on macOS for SyncFile data durability, #9383
 - mount: improve error msg when uid/gid cannot be resolved, #9574
 - docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # Please note:
     # Using any other msgpack version is not supported by Borg development and
     # any feedback related to issues caused by this will be ignored.
-    "msgpack >=1.0.3, <=1.1.2",
+    "msgpack >=1.0.3, <=1.2.0",
     "packaging",
 ]
 

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -145,7 +145,7 @@ def is_supported_msgpack():
     version_check = os.environ.get('BORG_MSGPACK_VERSION_CHECK', 'yes').strip().lower()
 
     return version_check == 'no' or (
-        (1, 0, 3) <= msgpack.version[:3] <= (1, 1, 2) and
+        (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 0) and
         msgpack.version not in []
     )
 


### PR DESCRIPTION
## Summary

- Update requirement from `msgpack <=1.1.2` to `<=1.2.0`
- Update `is_supported_msgpack()` version check upper bound to `(1, 2, 0)`
- Add changelog entry for Version 1.4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)