### PR TITLE
delete: add --quick-stats option, fixes #9757

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -424,7 +424,7 @@ New features:
 
 - create/import-tar --quick-stats: faster than --stats by omitting "All archives"
   and repository chunk statistics, #9579
-- prune --quick-stats: faster than --stats by omitting "All archives" statistics, #9757
+- delete/prune --quick-stats: faster than --stats by omitting "All archives" statistics, #9757
 - prune: show total vs matching archives in output, #9262
 - Minimal implementation of "related repositories", #9645
 

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1421,11 +1421,11 @@ class Archiver:
                 raise Error("Got Ctrl-C / SIGINT.")
             elif uncommitted_deletes > 0:
                 checkpoint_func()
-            if args.stats:
+            if args.stats or args.quick_stats:
                 log_multi(DASHES,
                           STATS_HEADER,
                           stats.summary.format(label='Deleted data:', stats=stats),
-                          str(cache),
+                          *([] if args.quick_stats else [str(cache)]),
                           DASHES, logger=logging.getLogger('borg.output.stats'))
 
     def _delete_repository(self, args, repository):
@@ -4238,6 +4238,9 @@ class Archiver:
         deleted - the "Deleted data" deduplicated size there is most interesting as
         that is how much your repository will shrink.
         Please note that the "All archives" stats refer to the state after deletion.
+        ``--stats`` can be slow - if you want something faster, use ``--quick-stats``
+        (this skips the repository-wide "All archives" statistics).
+        The ``--stats`` / ``--quick-stats`` and ``--dry-run`` options are mutually exclusive.
 
         You can delete multiple archives by specifying a shell pattern to match
         multiple archives using the ``--glob-archives GLOB`` option (for more info on
@@ -4259,6 +4262,8 @@ class Archiver:
                                help='output verbose list of archives')
         subparser.add_argument('-s', '--stats', dest='stats', action='store_true',
                                help='print statistics for the deleted archive')
+        subparser.add_argument('--quick-stats', dest='quick_stats', action='store_true',
+                               help='print only deletion statistics, skipping repository-wide statistics')
         subparser.add_argument('--cache-only', dest='cache_only', action='store_true',
                                help='delete only the local cache for the given repository')
         subparser.add_argument('--force', dest='forced', action='count', default=0,

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1791,6 +1791,28 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         with Repository(self.repository_path) as repository:
             self.assert_equal(len(repository), 1)
 
+    def test_delete_quick_stats(self):
+        self.cmd('init', '--encryption=none', self.repository_location)
+        self.cmd('create', self.repository_location + '::test1', src_dir)
+        self.cmd('create', self.repository_location + '::test2', src_dir)
+        output = self.cmd('delete', '--quick-stats', self.repository_location + '::test1')
+        self.assert_in('Deleted data:', output)
+        assert 'All archives:' not in output
+        assert 'Chunk index:' not in output
+
+    def test_delete_stats_and_quick_stats_are_mutually_exclusive(self):
+        output = self.cmd('delete', '--stats', '--quick-stats',
+                          self.repository_location + '::test', exit_code=2)
+        self.assert_in('--stats and --quick-stats are mutually exclusive', output)
+
+    def test_delete_dry_run_ignores_quick_stats(self):
+        self.cmd('init', '--encryption=none', self.repository_location)
+        self.cmd('create', self.repository_location + '::test1', src_dir)
+        self.cmd('create', self.repository_location + '::test2', src_dir)
+        output = self.cmd('delete', '--dry-run', '--quick-stats', self.repository_location + '::test1')
+        self.assert_in('Ignoring --quick-stats', output)
+        assert 'Deleted data:' not in output
+
     def test_delete_multiple(self):
         self.create_regular_file('file1', size=1024 * 80)
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
## Summary

- Adds `--quick-stats` to `borg delete`, mirroring the same option already on `borg prune` (#9760) and `borg create`/`borg import-tar`
- Skips the slow repository-wide "All archives" and "Chunk index" statistics, printing only the "Deleted data:" row
- Updates the `delete` epilog to document the option and its mutual exclusivity with `--stats`/`--dry-run`
- Updates `docs/changes.rst` entry from `prune` to `delete/prune`

🤖 Generated with [Claude Code](https://claude.com/claude-code)