### PR TITLE
testsuite: sweep stale borg FUSE mounts left by aborted runs

### DIFF
--- a/src/borg/conftest.py
+++ b/src/borg/conftest.py
@@ -1,5 +1,7 @@
+import getpass
 import os
 import shutil
+import tempfile
 
 import pytest
 
@@ -16,6 +18,62 @@ from borg.testsuite import has_lchflags, has_llfuse, has_pyfuse3, has_mfusepy  #
 from borg.testsuite import are_symlinks_supported, are_hardlinks_supported, is_utime_fully_supported  # noqa: E402
 from borg.testsuite.archiver import BORG_EXES
 from borg.testsuite.platform.platform_test import fakeroot_detected  # noqa: E402
+from borg.helpers import umount  # noqa: E402
+
+
+def _pytest_tmp_root():
+    # Mirror the parent of pytest's basetemp: <temproot>/pytest-of-<user>.
+    # Old (already-removed-from-retention) run dirs live here too, which is where
+    # FUSE mounts orphaned by aborted runs hide.
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = "unknown"
+    return os.path.join(tempfile.gettempdir(), f"pytest-of-{user}")
+
+
+def _looks_mounted(path):
+    # A live FUSE mount reports as a mount point; a dead/stale one makes the
+    # directory inaccessible (os.path.ismount swallows that and returns False).
+    if os.path.ismount(path):
+        return True
+    try:
+        os.listdir(path)
+    except OSError:
+        return True
+    return False
+
+
+def _sweep_stale_fuse_mounts():
+    # The fuse test helper always mounts at a directory named "mountpoint" under the
+    # pytest temp tree and unmounts it in a finally block.  If a run is aborted, that
+    # cleanup is skipped and the mount lingers, so the next run's temp-dir GC (rm_rf)
+    # trips over it ("Resource busy" etc.).  Walk the temp tree, find such leftover
+    # mountpoints and unmount them with borg's own (cross-platform) umount helper.
+    root = _pytest_tmp_root()
+    for dirpath, dirnames, filenames in os.walk(root, onerror=lambda err: None):
+        if "mountpoint" not in dirnames:
+            continue
+        dirnames.remove("mountpoint")  # never descend into a (possibly stale) mount
+        mountpoint = os.path.join(dirpath, "mountpoint")
+        if _looks_mounted(mountpoint):
+            try:
+                umount(mountpoint)
+            except Exception:  # nosec B110
+                pass  # best-effort: never let cleanup break the test session
+
+
+def pytest_sessionstart(session):
+    # Run once in the main process (not in each xdist worker), before any temp-dir
+    # GC, to clear mounts left behind by a previous, aborted session.
+    if not hasattr(session.config, "workerinput"):
+        _sweep_stale_fuse_mounts()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Safety net for anything stranded by this session (e.g. a hard interrupt).
+    if not hasattr(session.config, "workerinput"):
+        _sweep_stale_fuse_mounts()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

When a test run is aborted — Ctrl-C, a timeout, or a crashed `xdist` worker — the `fuse_mount` context manager's `finally: umount` does not run, leaving a live FUSE mount under the pytest temp dir. A later run then fails to `rm_rf` the old temp tree and emits noisy warnings:

```
PytestWarning: (rm_rf) error removing .../pytest-of-<user>/garbage-*/.../mountpoint
<class 'OSError'>: [Errno 16] Resource busy: 'mountpoint'
<class 'OSError'>: [Errno 30] Read-only file system: ...
<class 'OSError'>: [Errno 6] Device not configured: 'mountpoint'
```

These appear even on runs that *exclude* the fuse tests, because the orphan is left over from an earlier run and only gets tripped over later.

## Fix

Add `pytest_sessionstart` / `pytest_sessionfinish` hooks (run once on the xdist controller) that walk the pytest temp tree for leftover `mountpoint` directories and unmount them via borg's own cross-platform `helpers.umount`. Runs are thus self-healing across previously aborted sessions.

Deliberately avoids OS-specific code:
- **Discovery** is the well-known on-disk layout (`pytest-of-<user>/.../mountpoint`) found with stdlib `os.walk` + `os.path.ismount`, plus an `os.listdir` fallback to catch dead/stale mounts. The walk prunes `mountpoint` dirs so it never descends into a (possibly wedged) mount.
- **Unmounting** reuses borg's existing `helpers.umount` (`fusermount -u` → `umount` fallback) — no `/proc/mounts` or `mount`-output parsing, and no per-OS force/lazy/`diskutil` escalation.

The whole change is ~58 lines in `conftest.py`; no production code and no test teardown logic is changed.

Trade-off: borg's plain `umount` does not force-unmount a still-*busy* mount. In the orphan case the daemon is already dead, so a plain unmount clears it; this only degrades for the rare "killed run but daemon still alive and serving" case.

## Testing

- fuse/mount/migrate_lock tests pass single-threaded and under 12 xdist workers, leaving zero mounts (macOS + macFUSE, llfuse 1.5.2).
- Stranded a real `borgfs` mount to simulate an aborted run; a subsequent pytest session swept it at `sessionstart`, both with and without xdist.
- Repeated with the daemon hard-killed first (dead/stale mount) — `_looks_mounted` detects it and the sweep clears it.
- `ruff`, `black`, and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)