### PR TITLE
canary: downgrade 3.15-dev to 3.14

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,8 +25,8 @@ jobs:
             python-version: '3.12'
             toxenv: py312-pyfuse3
           - os: ubuntu-24.04
-            python-version: '3.15-dev'
-            toxenv: py315-mfusepy
+            python-version: '3.14'
+            toxenv: py314-mfusepy
           - os: macos-15
             python-version: '3.14'
             toxenv: py314-none


### PR DESCRIPTION
The canary workflow used Python `3.15-dev`, which is not compatible with some of our requirements yet.

Downgrade that matrix entry to Python `3.14` (toxenv `py314-mfusepy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)