### PR TITLE
modernize: use Python 3.7+ features

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -6,7 +6,7 @@ import posixpath
 import stat
 import sys
 import time
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import partial
@@ -1036,8 +1036,8 @@ Duration: {0.duration}
                 can_compare_chunk_ids=can_compare_chunk_ids,
             )
 
-        orphans_archive1: OrderedDict[str, Item] = OrderedDict()
-        orphans_archive2: OrderedDict[str, Item] = OrderedDict()
+        orphans_archive1: dict[str, Item] = {}
+        orphans_archive2: dict[str, Item] = {}
 
         assert matcher is not None, "matcher must be set"
 

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -1,4 +1,3 @@
-import collections
 import textwrap
 
 from ..helpers.argparsing import ArgumentParser
@@ -7,7 +6,7 @@ from ..helpers.nanorst import rst_to_terminal
 
 
 class HelpMixIn:
-    helptext = collections.OrderedDict()
+    helptext = {}
     helptext["patterns"] = textwrap.dedent(
         """
         When specifying one or more file paths in a Borg command that supports

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -11,7 +11,6 @@ import stat
 import uuid
 from pathlib import Path
 from typing import ClassVar, Any, TYPE_CHECKING, Literal
-from collections import OrderedDict
 from datetime import UTC, datetime
 from functools import partial
 from hashlib import sha256
@@ -1376,7 +1375,7 @@ def prepare_dump_dict(d):
         return res
 
     def decode(d):
-        res = OrderedDict()
+        res = {}
         for key, value in d.items():
             if isinstance(value, dict):
                 value = decode(value)


### PR DESCRIPTION
Follow-up to the py38-modernize work (#9775), covering features available since Python 3.7. This branch is stacked on `py38-modernize` (and thus `py39-modernize` #9774), so it currently shows those commits too; it will resolve as the earlier PRs in the chain merge.

Most Python 3.7 features are already in use in the codebase (`time.time_ns()`/`monotonic_ns()`, `datetime.fromisoformat()`, `namedtuple(..., defaults=...)`), so the remaining lever is the **guaranteed dict insertion order** (3.7 language feature): `collections.OrderedDict` is only needed where `move_to_end()` / `popitem(last=...)` are used, so plain `dict` works everywhere else.

Converted four non-legacy sites that use no OrderedDict-specific API:

- `archive.compare_archives`: `orphans_archive1/2` (annotation + value)
- `prune_cmd.PRUNING_PATTERNS` (now a plain dict literal)
- `help_cmd.HelpMixIn.helptext`
- `parseformat` `prepare_dump_dict.decode`

Deliberately kept as `OrderedDict`: `helpers/lrucache.py` (uses `move_to_end()`/`popitem(last=False)`) and the `legacy/` code.

Verified locally: prune, help, parseformat and diff test suites pass; affected modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)