### PR TITLE
Clean up Sphinx configuration and remove redundant code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,6 @@ def set_rst_settings(app):
 
 
 def setup(app):
-    app.setup_extension("sphinxcontrib.jquery")
     app.add_css_file("css/borg.css")
     app.connect("builder-inited", set_rst_settings)
 
@@ -156,7 +155,16 @@ html_use_smartypants = True
 smartquotes_action = "qe"  # no D in there means "do not transform -- and ---"
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {"**": ["logo-text.html", "versionselector.html", "searchbox.html", "downloads.html", "globaltoc.html"]}
+
+html_sidebars = {
+    "**": [
+        "logo-text.html",
+        "versionselector.html",
+        "searchbox.html",
+        "downloads.html",
+        "globaltoc.html",
+    ]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -248,4 +256,9 @@ extensions = [
     "guzzle_sphinx_theme",  # register the theme as an extension to generate a sitemap.xml
 ]
 
-extlinks = {"issue": ("https://github.com/borgbackup/borg/issues/%s", "#%s")}
+extlinks = {
+    "issue": (
+        "https://github.com/borgbackup/borg/issues/%s",
+        "#%s",
+    )
+}


### PR DESCRIPTION
<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description

<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->


## Checklist

- [ ] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [ ] Commit messages are clean and reference related issues

## Summary

This PR performs minor cleanup in the Sphinx configuration file:

- Removed redundant `app.setup_extension("sphinxcontrib.jquery")` call.
- Removed the unused initial `extensions = []` assignment.
- Reformatted `html_sidebars` for better readability.
- Reformatted `extlinks` dictionary for consistency.

## Type of Change

- Documentation
- Code cleanup
- No functional changes

## Testing

- No functional changes were made.
- Configuration remains valid.
