### PR TITLE
support msgpack 1.2.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -224,6 +224,7 @@ Fixes:
 
 Other changes:
 
+- msgpack: also allow 1.2.1
 - Location: simplify parsing/validation, #9678.
   For sftp/http(s)/s3/b2/rclone repositories, borg now only detects the scheme and hands the raw
   URL to borgstore, which parses and validates it (removing the duplicate parsing borg did before).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 dependencies = [
   "borghash ~= 0.1.0",
   "borgstore[rest] ~= 0.5.1",
-  "msgpack >=1.0.3, <=1.2.0",
+  "msgpack >=1.0.3, <=1.2.1",
   "packaging",
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -218,7 +218,7 @@ def is_supported_msgpack():
 
     if msgpack.version in []:  # < add bad releases here to deny list
         return False
-    return (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 0)
+    return (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 1)
 
 
 def get_limited_unpacker(kind):


### PR DESCRIPTION
Port of borgbackup/borg#9790 to master.

Note: the PR's second commit (Archive.delete: don't reuse msgpack Unpacker after an unpacking failure) does not apply here - on master Archive.delete no longer unpacks item metadata (it just removes the archive and lets "borg compact" reclaim space), so the reuse-after-failure code path does not exist. The streaming RobustUnpacker already creates a fresh Unpacker on resync.
