### PR TITLE
testsuite: corrupt archive metadata mid-object to fix flaky windows check test

### DIFF
--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -304,7 +304,9 @@ def test_manifest_rebuild_corrupted_chunk(archivers, request):
         corrupted_manifest = corrupt(manifest, 250)
         repository.put_manifest(corrupted_manifest)
         chunk = repository.get(archive.id)
-        corrupted_chunk = corrupt(chunk, -1)
+        # corrupt a byte in the middle of the object: the last byte can land on store-level
+        # framing rather than the authenticated payload, which made the repair flaky on Windows.
+        corrupted_chunk = corrupt(chunk, len(chunk) // 2)
         repository.put(archive.id, corrupted_chunk)
     cmd(archiver, "check", exit_code=1)
     output = cmd(archiver, "check", "-v", "--repair", exit_code=0)


### PR DESCRIPTION
test_manifest_rebuild_corrupted_chunk corrupts the last byte of an archive metadata object, which can land on store-level framing instead of the authenticated payload. This made the repair flow fail intermittently on Windows. Corrupt a byte in the middle of the object instead, so the integrity check fires consistently across platforms.