### PR TITLE
create: add --hostname/--username, fixes #9651

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -426,6 +426,8 @@ New features:
   and repository chunk statistics, #9579, #9757
 - prune: show total vs matching archives in output, #9262
 - create --exclude-dataless: macOS: skip cloud files not materialized locally, #9746
+- create: add --hostname and --username to explicitly set hostname/username
+  stored in the archive, #9651
 - Minimal implementation of "related repositories", #9645
 
   This feature allows multiple repositories to share deduplication-relevant secrets

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -119,6 +119,10 @@ borg create
     +-------------------------------------------------------+---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                       | ``-C COMPRESSION``, ``--compression COMPRESSION`` | select compression algorithm, see the output of the "borg help compression" command for details.                                                                  |
     +-------------------------------------------------------+---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                       | ``--hostname HOSTNAME``                           | explicitly set hostname for the archive (default: current hostname)                                                                                               |
+    +-------------------------------------------------------+---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                       | ``--username USERNAME``                           | explicitly set username for the archive (default: current username)                                                                                               |
+    +-------------------------------------------------------+---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
     .. raw:: html
 
@@ -193,6 +197,8 @@ borg create
         -c SECONDS, --checkpoint-interval SECONDS     write checkpoint every SECONDS seconds (Default: 1800)
         --chunker-params PARAMS                       specify the chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, HASH_MASK_BITS, HASH_WINDOW_SIZE). default: buzhash,19,23,21,4095
         -C COMPRESSION, --compression COMPRESSION     select compression algorithm, see the output of the "borg help compression" command for details.
+        --hostname HOSTNAME                           explicitly set hostname for the archive (default: current hostname)
+        --username USERNAME                           explicitly set username for the archive (default: current username)
 
 
 Description

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -49,7 +49,8 @@ from .helpers import utcnow
 from .lrucache import LRUCache
 from .patterns import PathPrefixPattern, FnmatchPattern, IECommand
 from .item import Item, ArchiveItem, ItemDiff
-from .platform import acl_get, acl_set, set_flags, get_flags, swidth, hostname
+from . import platform
+from .platform import acl_get, acl_set, set_flags, get_flags, swidth
 from .remote import cache_if_remote
 from .repository import Repository, LIST_SCAN_LIMIT
 
@@ -434,7 +435,8 @@ class Archive:
                  checkpoint_interval=1800, numeric_ids=False, noatime=False, noctime=False,
                  noflags=False, noacls=False, noxattrs=False,
                  progress=False, chunker_params=CHUNKER_PARAMS, start=None, start_monotonic=None, end=None,
-                 consider_part_files=False, log_json=False, iec=False):
+                 consider_part_files=False, log_json=False, iec=False,
+                 hostname=None, username=None):
         self.cwd = os.getcwd()
         self.key = key
         self.repository = repository
@@ -447,6 +449,8 @@ class Archive:
         self.name = name  # overwritten later with name from archive metadata
         self.name_in_manifest = name  # can differ from .name later (if borg check fixed duplicate archive names)
         self.comment = None
+        self.hostname = hostname if hostname is not None else platform.hostname
+        self.username = username if username is not None else getuser()
         self.tam_verified = False
         self.checkpoint_interval = checkpoint_interval
         self.numeric_ids = numeric_ids
@@ -632,8 +636,8 @@ Utilization of max. archive size: {csize_max:.0%}
             'comment': comment or '',
             'items': self.items_buffer.chunks,
             'cmdline': sys.argv,
-            'hostname': hostname,
-            'username': getuser(),
+            'hostname': self.hostname,
+            'username': self.username,
             'time': start.strftime(ISO_FORMAT),
             'time_end': end.strftime(ISO_FORMAT),
             'cwd': self.cwd,

--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -722,7 +722,8 @@ class Archiver:
                                   numeric_ids=args.numeric_ids, noatime=not args.atime, noctime=args.noctime,
                                   progress=args.progress,
                                   chunker_params=args.chunker_params, start=t0, start_monotonic=t0_monotonic,
-                                  log_json=args.log_json, iec=args.iec)
+                                  log_json=args.log_json, iec=args.iec,
+                                  hostname=args.hostname, username=args.username)
                 metadata_collector = MetadataCollector(noatime=not args.atime, noctime=args.noctime,
                     noflags=args.nobsdflags or args.noflags, noacls=args.noacls, noxattrs=args.noxattrs,
                     numeric_ids=args.numeric_ids, nobirthtime=args.nobirthtime)
@@ -4002,6 +4003,12 @@ class Archiver:
                                    type=CompressionSpec, default=CompressionSpec('lz4'),
                                    help='select compression algorithm, see the output of the '
                                         '"borg help compression" command for details.')
+        archive_group.add_argument('--hostname', metavar='HOSTNAME', dest='hostname',
+                                   type=str, default=None, action=Highlander,
+                                   help='explicitly set hostname for the archive (default: current hostname)')
+        archive_group.add_argument('--username', metavar='USERNAME', dest='username',
+                                   type=str, default=None, action=Highlander,
+                                   help='explicitly set username for the archive (default: current username)')
 
         subparser.add_argument('location', metavar='ARCHIVE',
                                type=location_validator(archive=True),

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -2251,6 +2251,16 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         assert len(archive['id']) == 64
         assert 'stats' in archive
 
+    def test_create_explicit_hostname_and_username(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', '--hostname', 'foo_host', '--username', 'bar_user',
+                 self.repository_location + '::test', 'input')
+        info = json.loads(self.cmd('info', '--json', self.repository_location + '::test'))
+        archive = info['archives'][0]
+        assert archive['hostname'] == 'foo_host'
+        assert archive['username'] == 'bar_user'
+
     def test_create_topical(self):
         self.create_regular_file('file1', size=1024 * 80)
         time.sleep(1)  # file2 must have newer timestamps than file1


### PR DESCRIPTION
Backport of #9402 (borg2/master commit 90f84e721) to 1.4-maint.

Adds `--hostname` and `--username` command-line options to `borg create`, allowing the hostname/username stored in the archive metadata to be set explicitly (e.g. when running borg in a container with a random hostname, or backing up a remotely mounted filesystem). Both default to the current system hostname / username when not given.

Fixes #9651.

## Changes
- `Archive.__init__` accepts optional `hostname`/`username`, stored on the instance and written by `save()`; falls back to `platform.hostname` / `getuser()`.
- `borg create` gains `--hostname HOSTNAME` and `--username USERNAME` (Highlander, default `None`).
- New test `test_create_explicit_hostname_and_username`.
- Usage docs + changelog updated.

## Scope note
This is the CLI-only part of #9651. The issue also requested an environment variable and notes that the `{hostname}` placeholder is used in prune globs / check; since this change only sets stored metadata (not the `{hostname}` placeholder resolved at arg-parse time), those aspects are intentionally **not** covered here and can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)