### PR TITLE
repository: add max_size byte limit to PackWriter, OR-ed with max_count

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -104,51 +104,45 @@ def build_rest_backend(location):
 
 
 class PackWriter:
-    """Buffers chunks into a pack file and writes to the store when full.
+    """Buffers chunks into a pack file and writes it to the store when full.
 
-    Collects (chunk_id, cdata) pairs in a list and flushes once a limit is
-    reached.  PackWriter maintains the ChunkIndex directly: each add() marks the
-    chunk as pending (pack_id=UNKNOWN_BYTES32); flush() then assigns the real
-    pack_id, offset and size to every pending entry once the pack is on disk.
+    add() buffers a (chunk_id, cdata) pair and marks the chunk pending in the
+    ChunkIndex (pack_id=UNKNOWN_BYTES32); flush() writes the pack and sets each
+    entry's real pack_id and obj_offset.
 
-    The index is not owned here.  Construction requires either a repository or an
-    explicit chunks index; there is no silent default.  With a repository, the writer
-    uses that repository's single, authoritative index (see the chunks property), so
-    there is never a second copy to keep in sync.  Unit tests pass an explicit index.
+    The ChunkIndex comes from the repository, or from an explicit chunks index when
+    there is no repository (see the chunks property).
 
     max_count bounds how many chunks a pack holds; max_size bounds its byte size.
-    flush() fires when either limit is reached.  Each limit is disabled by setting it
-    to None; at least one must be set.
+    flush() fires when either limit is reached.  Set a limit to None to disable it;
+    at least one must be set, otherwise the pack buffer is unbounded.
     """
 
     def __init__(self, store, *, max_count=3, max_size=None, chunks=None, repository=None):
         if repository is None and chunks is None:
             raise ValueError("PackWriter requires either a repository or an explicit chunks index")
         if max_count is None and max_size is None:
-            raise ValueError("PackWriter requires at least one of max_count or max_size")
+            raise ValueError("PackWriter needs max_count or max_size, otherwise the pack buffer is unbounded")
         self.store = store
         self.max_count = max_count  # None = no count limit
         self.max_size = max_size  # None = no size limit
-        self.repository = repository  # when set, the one and only index lives there
-        self._chunks = chunks  # explicit index for repository-less use (tests)
+        self.repository = repository
+        self._chunks = chunks  # used when there is no repository
         self._pieces = []  # list of (chunk_id, cdata)
         self._size = 0  # byte size of buffered pieces
 
     @property
     def chunks(self):
-        """The ChunkIndex this writer updates.
-
-        With a repository, this is the repository's single index (shared, not copied).
-        Without one, it is the explicit index passed at construction.
-        """
+        """The ChunkIndex this writer updates: the repository's index, or the
+        explicit index passed at construction when there is no repository."""
         if self.repository is not None:
             return self.repository.chunks
         return self._chunks
 
     def add(self, chunk_id, cdata):
         """Buffer a chunk.  Returns flush results if the pack is now full, else None."""
-        # Mark the chunk as pending; flush() fills in the pack_id, offset and size.
-        self.chunks.add(chunk_id, 0)
+        self.chunks.add(chunk_id, 0)  # size: plaintext chunk size, set by the cache layer
+        # obj_size is final; pack_id and obj_offset get their real values in flush().
         self.chunks.update_pack_info([(chunk_id, UNKNOWN_BYTES32, 0, len(cdata))])
         self._pieces.append((chunk_id, cdata))
         self._size += len(cdata)
@@ -163,7 +157,7 @@ class PackWriter:
 
         Returns a list of (chunk_id, pack_id, obj_offset, obj_size) tuples --
         one entry per chunk that was written.  Returns None if there was nothing
-        to flush.  Always updates the ChunkIndex with the real pack_id.
+        to flush.  Always updates the ChunkIndex with the real pack_id and obj_offset.
         """
         if not self._pieces:
             return None
@@ -190,19 +184,15 @@ class PackWriter:
         try:
             self.store.store(key, pack_data)
         except Exception:
-            # The pack was not durably stored, so every entry add() pre-marked for it now
-            # points at data that does not exist.  Leaving them would make seen_chunk() report
-            # these ids as present, letting a later identical chunk dedup against bytes that were
-            # never written -- silent data loss.  These entries were created this session and never
-            # received a real pack_id, so dropping them restores the index to its pre-add() state
-            # (matching master, where the index only ever reflected successfully stored chunks).
+            # The pack is not stored, so drop the pending entries: keeping them would let
+            # seen_chunk() dedup later chunks against bytes that were never written.
             for chunk_id in pending_ids:
                 entry = self.chunks.get(chunk_id)
                 if entry is not None and entry.pack_id == UNKNOWN_BYTES32:
                     del self.chunks[chunk_id]
             raise
         finally:
-            self._pieces = []  # reset even on failure to prevent re-bundling a failed chunk
+            self._pieces = []  # cleared on success and on failure
             self._size = 0
         self.chunks.update_pack_info(results)  # replace UNKNOWN_BYTES32 with real pack_id
         return results

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -106,7 +106,7 @@ def build_rest_backend(location):
 class PackWriter:
     """Buffers chunks into a pack file and writes to the store when full.
 
-    Collects (chunk_id, cdata) pairs in a list and flushes once max_count is
+    Collects (chunk_id, cdata) pairs in a list and flushes once a limit is
     reached.  PackWriter maintains the ChunkIndex directly: each add() marks the
     chunk as pending (pack_id=UNKNOWN_BYTES32); flush() then assigns the real
     pack_id, offset and size to every pending entry once the pack is on disk.
@@ -116,18 +116,22 @@ class PackWriter:
     uses that repository's single, authoritative index (see the chunks property), so
     there is never a second copy to keep in sync.  Unit tests pass an explicit index.
 
-    max_count bounds how many chunks a pack accumulates before flush() writes it.
-    Raising it produces larger packs without changing this class's interface.
+    max_count bounds how many chunks a pack accumulates; max_size (if set) bounds its
+    byte size.  flush() fires when either limit is reached.  max_size=None disables the
+    size check, leaving count the only trigger.  Both can be tuned without changing this
+    class's interface.
     """
 
-    def __init__(self, store, *, max_count=1, chunks=None, repository=None):
+    def __init__(self, store, *, max_count=3, max_size=None, chunks=None, repository=None):
         if repository is None and chunks is None:
             raise ValueError("PackWriter requires either a repository or an explicit chunks index")
         self.store = store
         self.max_count = max_count
+        self.max_size = max_size  # None = no size limit; flush is then count-only
         self.repository = repository  # when set, the one and only index lives there
         self._chunks = chunks  # explicit index for repository-less use (tests)
         self._pieces = []  # list of (chunk_id, cdata)
+        self._size = 0  # running byte size of buffered pieces (== len of the pack-to-be)
 
     @property
     def chunks(self):
@@ -152,7 +156,10 @@ class PackWriter:
         self.chunks.add(chunk_id, 0)  # size filled in by cache layer
         self.chunks.update_pack_info([(chunk_id, UNKNOWN_BYTES32, 0, len(cdata))])
         self._pieces.append((chunk_id, cdata))
-        if len(self._pieces) >= self.max_count:
+        self._size += len(cdata)
+        # Flush when EITHER limit is hit: too many objects, or the pack is big enough.
+        # max_size is OR-ed with max_count; None disables the size check.
+        if len(self._pieces) >= self.max_count or (self.max_size is not None and self._size >= self.max_size):
             return self.flush()
         return None
 
@@ -201,6 +208,7 @@ class PackWriter:
             raise
         finally:
             self._pieces = []  # reset even on failure to prevent re-bundling a failed chunk
+            self._size = 0  # next pack starts empty
         self.chunks.update_pack_info(results)  # replace UNKNOWN_BYTES32 with real pack_id
         return results
 
@@ -507,7 +515,7 @@ class Repository:
         if lock:
             self.lock = Lock(self.store, exclusive, timeout=lock_wait).acquire()
         self._chunks = None
-        self._pack_writer = PackWriter(self.store, max_count=2, repository=self)
+        self._pack_writer = PackWriter(self.store, repository=self)
         self.opened = True
 
     @property

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -116,22 +116,23 @@ class PackWriter:
     uses that repository's single, authoritative index (see the chunks property), so
     there is never a second copy to keep in sync.  Unit tests pass an explicit index.
 
-    max_count bounds how many chunks a pack accumulates; max_size (if set) bounds its
-    byte size.  flush() fires when either limit is reached.  max_size=None disables the
-    size check, leaving count the only trigger.  Both can be tuned without changing this
-    class's interface.
+    max_count bounds how many chunks a pack holds; max_size bounds its byte size.
+    flush() fires when either limit is reached.  Each limit is disabled by setting it
+    to None; at least one must be set.
     """
 
     def __init__(self, store, *, max_count=3, max_size=None, chunks=None, repository=None):
         if repository is None and chunks is None:
             raise ValueError("PackWriter requires either a repository or an explicit chunks index")
+        if max_count is None and max_size is None:
+            raise ValueError("PackWriter requires at least one of max_count or max_size")
         self.store = store
-        self.max_count = max_count
-        self.max_size = max_size  # None = no size limit; flush is then count-only
+        self.max_count = max_count  # None = no count limit
+        self.max_size = max_size  # None = no size limit
         self.repository = repository  # when set, the one and only index lives there
         self._chunks = chunks  # explicit index for repository-less use (tests)
         self._pieces = []  # list of (chunk_id, cdata)
-        self._size = 0  # running byte size of buffered pieces (== len of the pack-to-be)
+        self._size = 0  # byte size of buffered pieces
 
     @property
     def chunks(self):
@@ -146,20 +147,14 @@ class PackWriter:
 
     def add(self, chunk_id, cdata):
         """Buffer a chunk.  Returns flush results if the pack is now full, else None."""
-        # Mark the chunk as pending (pack_id=UNKNOWN_BYTES32).  flush() assigns the real
-        # pack_id and offset for every piece, so the placeholder offset 0 here is never read:
-        # get() refuses a pending entry (PackLocationUnknown) before any offset would matter.
-        # Precondition: callers add only chunks not already stored (the cache dedups via
-        # seen_chunk() first), so add(chunk_id, 0) never resets a real size on an existing entry.
-        # This is also what keeps ChunkIndex.add's "v.size == 0 or v.size == size" assertion happy:
-        # a fresh id has no entry, so the size=0 we pass here is never compared against a real size.
-        self.chunks.add(chunk_id, 0)  # size filled in by cache layer
+        # Mark the chunk as pending; flush() fills in the pack_id, offset and size.
+        self.chunks.add(chunk_id, 0)
         self.chunks.update_pack_info([(chunk_id, UNKNOWN_BYTES32, 0, len(cdata))])
         self._pieces.append((chunk_id, cdata))
         self._size += len(cdata)
-        # Flush when EITHER limit is hit: too many objects, or the pack is big enough.
-        # max_size is OR-ed with max_count; None disables the size check.
-        if len(self._pieces) >= self.max_count or (self.max_size is not None and self._size >= self.max_size):
+        if (self.max_count is not None and len(self._pieces) >= self.max_count) or (
+            self.max_size is not None and self._size >= self.max_size
+        ):
             return self.flush()
         return None
 
@@ -208,7 +203,7 @@ class PackWriter:
             raise
         finally:
             self._pieces = []  # reset even on failure to prevent re-bundling a failed chunk
-            self._size = 0  # next pack starts empty
+            self._size = 0
         self.chunks.update_pack_info(results)  # replace UNKNOWN_BYTES32 with real pack_id
         return results
 

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -248,6 +248,7 @@ def test_list(repo_fixtures, request):
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         for x in range(100):
             repository.put(H(x), fchunk(b"SOMEDATA", chunk_id=H(x)))  # unique bytes -> unique pack id
+        repository.flush()  # flush the last partial pack so all 100 objects are listable
         repo_list = repository.list()
         assert len(repo_list) == 100
         first_half = repository.list(limit=50)
@@ -343,6 +344,24 @@ def test_pack_writer_n2_flush():
     expected_pack_id = sha256(pack_data).digest()
     assert results[0] == (id1, expected_pack_id, 0, len(data1))
     assert results[1] == (id2, expected_pack_id, len(data1), len(data2))
+
+
+def test_pack_writer_flushes_on_max_size():
+    # max_count kept high so ONLY the size limit can trigger the flush.
+    store = MockStore()
+    pw = PackWriter(store, max_count=100, max_size=10, chunks=ChunkIndex())
+    assert pw.add(b"a" * 32, b"12345") is None  # _size = 5 < 10, no flush yet
+    results = pw.add(b"b" * 32, b"67890")  # _size = 10 >= 10 -> flush
+    assert results is not None
+    assert len(results) == 2
+
+
+def test_pack_writer_max_size_none_is_count_only():
+    # max_size=None must disable the size check entirely (count is the only trigger).
+    store = MockStore()
+    pw = PackWriter(store, max_count=2, max_size=None, chunks=ChunkIndex())
+    assert pw.add(b"a" * 32, b"x" * 10_000) is None  # huge, but the size check is off
+    assert pw.add(b"b" * 32, b"y" * 10_000) is not None  # flush on count == 2
 
 
 def test_pack_writer_rolls_back_index_on_failed_store():

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -347,21 +347,32 @@ def test_pack_writer_n2_flush():
 
 
 def test_pack_writer_flushes_on_max_size():
-    # max_count kept high so ONLY the size limit can trigger the flush.
+    # max_count is high, so the flush is driven by max_size alone.
     store = MockStore()
     pw = PackWriter(store, max_count=100, max_size=10, chunks=ChunkIndex())
-    assert pw.add(b"a" * 32, b"12345") is None  # _size = 5 < 10, no flush yet
-    results = pw.add(b"b" * 32, b"67890")  # _size = 10 >= 10 -> flush
+    assert pw.add(b"a" * 32, b"12345") is None
+    results = pw.add(b"b" * 32, b"67890")
     assert results is not None
     assert len(results) == 2
 
 
 def test_pack_writer_max_size_none_is_count_only():
-    # max_size=None must disable the size check entirely (count is the only trigger).
     store = MockStore()
     pw = PackWriter(store, max_count=2, max_size=None, chunks=ChunkIndex())
-    assert pw.add(b"a" * 32, b"x" * 10_000) is None  # huge, but the size check is off
-    assert pw.add(b"b" * 32, b"y" * 10_000) is not None  # flush on count == 2
+    assert pw.add(b"a" * 32, b"x" * 10_000) is None
+    assert pw.add(b"b" * 32, b"y" * 10_000) is not None
+
+
+def test_pack_writer_max_count_none_is_size_only():
+    store = MockStore()
+    pw = PackWriter(store, max_count=None, max_size=10, chunks=ChunkIndex())
+    assert pw.add(b"a" * 32, b"12345") is None
+    assert pw.add(b"b" * 32, b"67890") is not None
+
+
+def test_pack_writer_requires_a_limit():
+    with pytest.raises(ValueError):
+        PackWriter(MockStore(), max_count=None, max_size=None, chunks=ChunkIndex())
 
 
 def test_pack_writer_rolls_back_index_on_failed_store():


### PR DESCRIPTION
## What

`PackWriter` previously decided a pack was full by object count alone (`max_count`). This adds an optional `max_size` limit so a pack can also be closed once it reaches a target byte size. A flush happens as soon as either the count or the size limit is reached, whichever comes first.

`max_size` defaults to `None`, which leaves the size check off and keeps the current count-only behaviour. A caller opts in by passing a byte limit.

## Why

Object count says nothing about the resulting file size: the same number of chunks gives a tiny pack for small chunks and a very large one for big chunks. Limiting by byte size gives direct control over how large packs grow on disk, which is the next step toward size-controlled packs.

## Also in this PR

- The default `max_count` is raised to 3, and the explicit `max_count=2` at the `Repository.open()` call site is removed so the repository relies on PackWriter's own default. Running with a higher default exposed tests that only passed because packs happened to tile evenly at a count of 2.
- `test_list` now flushes its last partial pack before listing, instead of depending on the object count dividing evenly into whole packs.

## Tests

- `test_pack_writer_flushes_on_max_size`: confirms the size limit triggers a flush, with the count kept high so only size can fire.
- `test_pack_writer_max_size_none_is_count_only`: confirms `max_size=None` leaves the size check off and count remains the only trigger.
- Full suite passes at the new default (1750 passed, 97 skipped).
