### PR TITLE
tests: corrupt manifest off-centre to fix flaky check --repair rebuild test on Windows

### DIFF
--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -285,7 +285,9 @@ def test_manifest_rebuild_corrupted_chunk(archivers, request):
     archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
         manifest = repository.get_manifest()
-        corrupted_manifest = corrupt(manifest, 250)
+        # flip a byte inside the encrypted manifest data so its integrity check fails and
+        # check --repair rebuilds the manifest.
+        corrupted_manifest = corrupt(manifest, len(manifest) // 3)
         repository.put_manifest(corrupted_manifest)
         chunk = repository.get(archive.id)
         # corrupt a byte in the middle of the object: the last byte can land on store-level


### PR DESCRIPTION
`test_manifest_rebuild_corrupted_chunk` corrupted the manifest at a fixed offset of 250 bytes. A repository layout change moved that byte outside the encrypted manifest data on Windows, so `check --repair` no longer hit the rebuild path and the test failed on the Windows Canary job. Corrupting at `len(manifest)//3` puts the byte back inside the payload. The test passes locally for the local and remote variants.