### PR TITLE
compact: cache per-archive referenced objects to speed up analysis

### DIFF
--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -38,6 +38,7 @@ class ArchiveGarbageCollector:
         assert isinstance(repository, Repository)
         self.manifest = manifest
         self.chunks = None  # a ChunkIndex, here used for: id -> (is_used, stored_size)
+        self.missing_chunks: set[bytes] = set()  # ids of referenced objects not present in the repo
         self.total_size = None  # overall size of source file content data written to all archives
         self.archives_count = None  # number of archives
         self.stats = stats  # compute repo space usage before/after - lists all repo objects, can be slow.
@@ -120,7 +121,7 @@ class ArchiveGarbageCollector:
 
     def analyze_archives(self) -> tuple[set, int, int]:
         """Collect the objects all archives reference, then mark the used chunks and sum their size."""
-        self.missing_chunks: set[bytes] = set()
+        self.missing_chunks = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
         cached_hex_ids = self.list_archive_reference_caches()

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -107,19 +107,8 @@ class ArchiveGarbageCollector:
         logger.info(f"Removed {len(unused_files_cache_names)} unused files cache files.")
 
     def analyze_archives(self) -> tuple[set, int, int, int]:
-        """Iterate over all items in all archives, create the dicts id -> size of all used chunks."""
-
-        def use_it(id):
-            entry = self.chunks.get(id)
-            if entry is not None:
-                # the chunk is in the repo, mark it used.
-                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED)
-            else:
-                # with --stats: we do NOT have this chunk in the repository!
-                # without --stats: we do not have this chunk or the chunks index is incomplete.
-                missing_chunks.add(id)
-
-        missing_chunks: set[bytes] = set()
+        """Iterate over all archives, mark used chunks and add up the source files count and size."""
+        self.missing_chunks: set[bytes] = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
         pi = ProgressIndicatorPercent(
@@ -131,22 +120,40 @@ class ArchiveGarbageCollector:
                 f"Analyzing archive {info.name} {info.ts.astimezone()} {bin_to_hex(info.id)} ({i + 1}/{num_archives})"
             )
             archive = Archive(self.manifest, info.id, iec=self.iec)
-            # archive metadata size unknown, but usually small/irrelevant:
-            use_it(archive.id)
-            for id in archive.metadata.item_ptrs:
-                use_it(id)
-            for id in archive.metadata.items:
-                use_it(id)
-            # archive items content data:
-            for item in archive.iter_items():
-                total_files += 1  # every fs object counts, not just regular files
-                if "chunks" in item:
-                    for id, size in item.chunks:
-                        total_size += size  # original, uncompressed file content size
-                        use_it(id)
+            size, files = self.analyze_archive(archive)
+            total_size += size
+            total_files += files
             pi.show(i + 1)  # report after each archive, so the last one lands on 100%
         pi.finish()
-        return missing_chunks, total_files, total_size, num_archives
+        return self.missing_chunks, total_files, total_size, num_archives
+
+    def analyze_archive(self, archive: Archive) -> tuple[int, int]:
+        """Mark all chunks used by the archive; return its source files content size and count."""
+
+        def use_it(id):
+            entry = self.chunks.get(id)
+            if entry is not None:
+                # the chunk is in the repo, mark it used.
+                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED)
+            else:
+                # we do not have this chunk or the chunks index is incomplete.
+                self.missing_chunks.add(id)
+
+        total_size, total_files = 0, 0
+        # archive metadata size unknown, but usually small/irrelevant:
+        use_it(archive.id)
+        for id in archive.metadata.item_ptrs:
+            use_it(id)
+        for id in archive.metadata.items:
+            use_it(id)
+        # archive items content data:
+        for item in archive.iter_items():
+            total_files += 1  # every fs object counts, not just regular files
+            if "chunks" in item:
+                for id, size in item.chunks:
+                    total_size += size  # original, uncompressed file content size
+                    use_it(id)
+        return total_size, total_files
 
     def report_and_delete(self):
         if self.missing_chunks:

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -119,7 +119,7 @@ class ArchiveGarbageCollector:
         logger.info(f"Removed {len(unused_files_cache_names)} unused files cache files.")
 
     def analyze_archives(self) -> tuple[set, int, int]:
-        """Iterate over all archives, mark used chunks and add up the source files content size."""
+        """Collect the objects all archives reference, then mark the used chunks and sum their size."""
         self.missing_chunks: set[bytes] = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
@@ -131,33 +131,25 @@ class ArchiveGarbageCollector:
         pi = ProgressIndicatorPercent(
             total=num_archives, msg="Computing used chunks %3.1f%%", step=0.1, msgid="compact.analyze_archives"
         )
-        total_size = 0
+        # merge every archive's referenced objects into one table, deduplicated across all archives.
+        # merging here (in borghash) and marking the chunk index once per unique object below is much
+        # cheaper than marking once per (archive, object) when archives share a lot of objects.
+        all_references = HashTableNT(
+            key_size=32, value_type=ArchiveReferenceEntry, value_format=ArchiveReferenceEntryFormat
+        )
         for i, info in enumerate(archive_infos):
             logger.info(
                 f"Analyzing archive {info.name} {info.ts.astimezone()} {bin_to_hex(info.id)} ({i + 1}/{num_archives})"
             )
             archive = Archive(self.manifest, info.id, iec=self.iec)
-            total_size += self.analyze_archive(archive, cached=bin_to_hex(info.id) in cached_hex_ids)
+            references = self.get_archive_references(archive, cached=bin_to_hex(info.id) in cached_hex_ids)
+            all_references.update(references)
             pi.show(i + 1)  # report after each archive, so the last one lands on 100%
         pi.finish()
-        return self.missing_chunks, total_size, num_archives
-
-    def analyze_archive(self, archive: Archive, *, cached: bool) -> int:
-        """Mark all objects the archive references as used; return its source files content size
-        (in-archive duplicated chunks are only counted once).
-
-        The set of referenced objects and their plaintext sizes is read from a per-archive cache in
-        the repo if present, else computed by scanning the archive and then cached for next time.
-        """
-        references = self.load_archive_references(archive.id) if cached else None
-        if references is None:
-            references = self.scan_archive_references(archive)
-            if not self.dry_run:
-                self.store_archive_references(archive.id, references)
-        # mark every referenced object used and add up the source content size. each object counts
-        # once (the references mapping is deduplicated); metadata objects carry size 0.
+        # mark every referenced object used and add up the source content size. each object counts once
+        # (all_references is deduplicated across archives); metadata objects carry size 0.
         total_size = 0
-        for id, entry in references.items():
+        for id, entry in all_references.items():
             existing = self.chunks.get(id)
             if existing is not None:
                 # the object is in the repo, mark it used.
@@ -166,7 +158,20 @@ class ArchiveGarbageCollector:
                 # we do not have this object or the chunks index is incomplete.
                 self.missing_chunks.add(id)
             total_size += entry.size
-        return total_size
+        return self.missing_chunks, total_size, num_archives
+
+    def get_archive_references(self, archive: Archive, *, cached: bool) -> HashTableNT:
+        """Return the table of objects the archive references (object id -> plaintext size).
+
+        It is read from a per-archive cache in the repo if present, else computed by scanning the
+        archive and then cached for next time.
+        """
+        references = self.load_archive_references(archive.id) if cached else None
+        if references is None:
+            references = self.scan_archive_references(archive)
+            if not self.dry_run:
+                self.store_archive_references(archive.id, references)
+        return references
 
     def scan_archive_references(self, archive: Archive) -> HashTableNT:
         """Scan the archive's items, collecting the object ids it references and their plaintext sizes."""
@@ -260,7 +265,9 @@ class ArchiveGarbageCollector:
 
         count = len(self.chunks)
         logger.info(f"Overall statistics, considering all {self.archives_count} archives in this repository:")
-        logger.info(f"Source data size was {format_file_size(self.total_size, precision=0, iec=self.iec)}.")
+        logger.info(
+            f"Deduplicated source data size was {format_file_size(self.total_size, precision=0, iec=self.iec)}."
+        )
         if self.stats:
             logger.info(
                 f"Repository size is {format_file_size(repo_size_after, precision=0, iec=self.iec)} "

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -4,7 +4,6 @@ import io
 from pathlib import Path
 
 from borghash import HashTableNT
-from borgstore.store import ItemInfo
 
 from ._common import with_repository
 from ..archive import Archive
@@ -201,8 +200,7 @@ class ArchiveGarbageCollector:
     def list_archive_reference_caches(self) -> set[str]:
         """Return the set of archive ids (hex) that currently have a reference cache in the repo."""
         hex_ids = set()
-        for info in self.repository.store_list("cache"):
-            info = ItemInfo(*info)  # RPC does not give a namedtuple
+        for info in self.repository.store_list("cache"):  # store_list yields ItemInfo namedtuples
             if info.name.startswith(REFERENCED_BY_ARCHIVE):
                 hex_ids.add(info.name[len(REFERENCED_BY_ARCHIVE) :])
         return hex_ids

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -1,5 +1,10 @@
-from collections import defaultdict
+from collections import defaultdict, namedtuple
+import hashlib
+import io
 from pathlib import Path
+
+from borghash import HashTableNT
+from borgstore.store import ItemInfo
 
 from ._common import with_repository
 from ..archive import Archive
@@ -12,11 +17,19 @@ from ..hashindex import ChunkIndex
 from ..helpers import set_ec, EXIT_ERROR, format_file_size, bin_to_hex
 from ..helpers import ProgressIndicatorPercent
 from ..manifest import Manifest
-from ..repository import Repository
+from ..repository import Repository, StoreObjectNotFound
 
 from ..logger import create_logger
 
 logger = create_logger()
+
+# per-archive cache of the objects an archive references, stored in the repo as
+# cache/referenced-by-archive.<archive id hex>. it is a serialized HashTableNT mapping object id
+# (32 bytes) -> plaintext object size (uint32), with a sha256 of that content appended for integrity.
+REFERENCED_BY_ARCHIVE = "referenced-by-archive."  # name prefix within the "cache" store namespace
+ArchiveReferenceEntry = namedtuple("ArchiveReferenceEntry", "size")
+ArchiveReferenceEntryFormatT = namedtuple("ArchiveReferenceEntryFormatT", "size")
+ArchiveReferenceEntryFormat = ArchiveReferenceEntryFormatT(size="I")  # uint32 plaintext size
 
 
 class ArchiveGarbageCollector:
@@ -110,6 +123,11 @@ class ArchiveGarbageCollector:
         self.missing_chunks: set[bytes] = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
+        cached_hex_ids = self.list_archive_reference_caches()
+        if not self.dry_run:
+            # drop the reference caches of archives that do not exist anymore.
+            valid_hex_ids = {bin_to_hex(info.id) for info in archive_infos}
+            self.cleanup_archive_reference_caches(cached_hex_ids - valid_hex_ids)
         pi = ProgressIndicatorPercent(
             total=num_archives, msg="Computing used chunks %3.1f%%", step=0.1, msgid="compact.analyze_archives"
         )
@@ -119,37 +137,106 @@ class ArchiveGarbageCollector:
                 f"Analyzing archive {info.name} {info.ts.astimezone()} {bin_to_hex(info.id)} ({i + 1}/{num_archives})"
             )
             archive = Archive(self.manifest, info.id, iec=self.iec)
-            total_size += self.analyze_archive(archive)
+            total_size += self.analyze_archive(archive, cached=bin_to_hex(info.id) in cached_hex_ids)
             pi.show(i + 1)  # report after each archive, so the last one lands on 100%
         pi.finish()
         return self.missing_chunks, total_size, num_archives
 
-    def analyze_archive(self, archive: Archive) -> int:
-        """Mark all chunks used by the archive; return its source files content size."""
+    def analyze_archive(self, archive: Archive, *, cached: bool) -> int:
+        """Mark all objects the archive references as used; return its source files content size
+        (in-archive duplicated chunks are only counted once).
 
-        def use_it(id):
-            entry = self.chunks.get(id)
-            if entry is not None:
-                # the chunk is in the repo, mark it used.
-                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED)
-            else:
-                # we do not have this chunk or the chunks index is incomplete.
-                self.missing_chunks.add(id)
-
+        The set of referenced objects and their plaintext sizes is read from a per-archive cache in
+        the repo if present, else computed by scanning the archive and then cached for next time.
+        """
+        references = self.load_archive_references(archive.id) if cached else None
+        if references is None:
+            references = self.scan_archive_references(archive)
+            if not self.dry_run:
+                self.store_archive_references(archive.id, references)
+        # mark every referenced object used and add up the source content size. each object counts
+        # once (the references mapping is deduplicated); metadata objects carry size 0.
         total_size = 0
-        # archive metadata size unknown, but usually small/irrelevant:
-        use_it(archive.id)
+        for id, entry in references.items():
+            existing = self.chunks.get(id)
+            if existing is not None:
+                # the object is in the repo, mark it used.
+                self.chunks[id] = existing._replace(flags=existing.flags | ChunkIndex.F_USED)
+            else:
+                # we do not have this object or the chunks index is incomplete.
+                self.missing_chunks.add(id)
+            total_size += entry.size
+        return total_size
+
+    def scan_archive_references(self, archive: Archive) -> HashTableNT:
+        """Scan the archive's items, collecting the object ids it references and their plaintext sizes."""
+        references = HashTableNT(
+            key_size=32, value_type=ArchiveReferenceEntry, value_format=ArchiveReferenceEntryFormat
+        )
+        # archive metadata objects: only their ids matter for GC, their content size is not known here
+        # and not part of the source data size, so record them with size 0.
+        references[archive.id] = ArchiveReferenceEntry(size=0)
         for id in archive.metadata.item_ptrs:
-            use_it(id)
+            references[id] = ArchiveReferenceEntry(size=0)
         for id in archive.metadata.items:
-            use_it(id)
+            references[id] = ArchiveReferenceEntry(size=0)
         # archive items content data:
         for item in archive.iter_items():
             if "chunks" in item:
                 for id, size in item.chunks:
-                    total_size += size  # original, uncompressed file content size
-                    use_it(id)
-        return total_size
+                    references[id] = ArchiveReferenceEntry(size=size)  # original, uncompressed content size
+        return references
+
+    @staticmethod
+    def archive_reference_cache_name(archive_id: bytes) -> str:
+        """The store name of an archive's reference cache (well within borgstore's name length limit)."""
+        return f"cache/{REFERENCED_BY_ARCHIVE}{bin_to_hex(archive_id)}"
+
+    def list_archive_reference_caches(self) -> set[str]:
+        """Return the set of archive ids (hex) that currently have a reference cache in the repo."""
+        hex_ids = set()
+        for info in self.repository.store_list("cache"):
+            info = ItemInfo(*info)  # RPC does not give a namedtuple
+            if info.name.startswith(REFERENCED_BY_ARCHIVE):
+                hex_ids.add(info.name[len(REFERENCED_BY_ARCHIVE) :])
+        return hex_ids
+
+    def load_archive_references(self, archive_id: bytes) -> HashTableNT | None:
+        """Load and verify an archive's references table; return it, or None if it is missing/corrupted."""
+        try:
+            data = self.repository.store_load(self.archive_reference_cache_name(archive_id))
+        except StoreObjectNotFound:
+            return None
+        # the serialized table has a sha256 of its content appended (the store name cannot also carry it,
+        # as borgstore's name length limit is too small for archive id hex + sha256 hex). a mismatch means
+        # the cache is corrupted; we then return None so the caller falls back to scanning the archive.
+        hex_id = bin_to_hex(archive_id)
+        if len(data) < 32 or hashlib.sha256(data[:-32]).digest() != data[-32:]:
+            logger.warning(f"Ignoring corrupted references cache of archive {hex_id}.")
+            return None
+        try:
+            with io.BytesIO(data[:-32]) as f:
+                return HashTableNT.read(f)
+        except ValueError:
+            logger.warning(f"Ignoring unreadable references cache of archive {hex_id}.")
+            return None
+
+    def store_archive_references(self, archive_id: bytes, references: HashTableNT) -> None:
+        """Serialize the references table (with a sha256 of its content appended) and store it."""
+        with io.BytesIO() as f:
+            references.write(f)
+            data = f.getvalue()
+        data += hashlib.sha256(data).digest()
+        self.repository.store_store(self.archive_reference_cache_name(archive_id), data)
+
+    def cleanup_archive_reference_caches(self, stale_hex_ids: set[str]) -> None:
+        """Delete reference caches belonging to archives that are not in the archives list anymore."""
+        for hex_id in stale_hex_ids:
+            try:
+                self.repository.store_delete(f"cache/{REFERENCED_BY_ARCHIVE}{hex_id}")
+            except StoreObjectNotFound:
+                pass
+        logger.debug(f"Removed {len(stale_hex_ids)} stale archive references caches.")
 
     def report_and_delete(self):
         if self.missing_chunks:

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -25,7 +25,6 @@ class ArchiveGarbageCollector:
         assert isinstance(repository, Repository)
         self.manifest = manifest
         self.chunks = None  # a ChunkIndex, here used for: id -> (is_used, stored_size)
-        self.total_files = None  # overall number of source files written to all archives in this repo
         self.total_size = None  # overall size of source file content data written to all archives
         self.archives_count = None  # number of archives
         self.stats = stats  # compute repo space usage before/after - lists all repo objects, can be slow.
@@ -44,7 +43,7 @@ class ArchiveGarbageCollector:
         logger.info("Starting compaction / garbage collection...")
         self.chunks = self.get_repository_chunks()
         logger.info("Computing object IDs used by archives...")
-        (self.missing_chunks, self.total_files, self.total_size, self.archives_count) = self.analyze_archives()
+        (self.missing_chunks, self.total_size, self.archives_count) = self.analyze_archives()
         self.report_and_delete()
         if not self.dry_run:
             self.save_chunk_index()
@@ -106,29 +105,27 @@ class ArchiveGarbageCollector:
                 logger.warning(f"Could not access cache file: {e}")
         logger.info(f"Removed {len(unused_files_cache_names)} unused files cache files.")
 
-    def analyze_archives(self) -> tuple[set, int, int, int]:
-        """Iterate over all archives, mark used chunks and add up the source files count and size."""
+    def analyze_archives(self) -> tuple[set, int, int]:
+        """Iterate over all archives, mark used chunks and add up the source files content size."""
         self.missing_chunks: set[bytes] = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
         pi = ProgressIndicatorPercent(
             total=num_archives, msg="Computing used chunks %3.1f%%", step=0.1, msgid="compact.analyze_archives"
         )
-        total_size, total_files = 0, 0
+        total_size = 0
         for i, info in enumerate(archive_infos):
             logger.info(
                 f"Analyzing archive {info.name} {info.ts.astimezone()} {bin_to_hex(info.id)} ({i + 1}/{num_archives})"
             )
             archive = Archive(self.manifest, info.id, iec=self.iec)
-            size, files = self.analyze_archive(archive)
-            total_size += size
-            total_files += files
+            total_size += self.analyze_archive(archive)
             pi.show(i + 1)  # report after each archive, so the last one lands on 100%
         pi.finish()
-        return self.missing_chunks, total_files, total_size, num_archives
+        return self.missing_chunks, total_size, num_archives
 
-    def analyze_archive(self, archive: Archive) -> tuple[int, int]:
-        """Mark all chunks used by the archive; return its source files content size and count."""
+    def analyze_archive(self, archive: Archive) -> int:
+        """Mark all chunks used by the archive; return its source files content size."""
 
         def use_it(id):
             entry = self.chunks.get(id)
@@ -139,7 +136,7 @@ class ArchiveGarbageCollector:
                 # we do not have this chunk or the chunks index is incomplete.
                 self.missing_chunks.add(id)
 
-        total_size, total_files = 0, 0
+        total_size = 0
         # archive metadata size unknown, but usually small/irrelevant:
         use_it(archive.id)
         for id in archive.metadata.item_ptrs:
@@ -148,12 +145,11 @@ class ArchiveGarbageCollector:
             use_it(id)
         # archive items content data:
         for item in archive.iter_items():
-            total_files += 1  # every fs object counts, not just regular files
             if "chunks" in item:
                 for id, size in item.chunks:
                     total_size += size  # original, uncompressed file content size
                     use_it(id)
-        return total_size, total_files
+        return total_size
 
     def report_and_delete(self):
         if self.missing_chunks:
@@ -177,10 +173,7 @@ class ArchiveGarbageCollector:
 
         count = len(self.chunks)
         logger.info(f"Overall statistics, considering all {self.archives_count} archives in this repository:")
-        logger.info(
-            f"Source data size was {format_file_size(self.total_size, precision=0, iec=self.iec)} "
-            f"in {self.total_files} files."
-        )
+        logger.info(f"Source data size was {format_file_size(self.total_size, precision=0, iec=self.iec)}.")
         if self.stats:
             logger.info(
                 f"Repository size is {format_file_size(repo_size_after, precision=0, iec=self.iec)} "

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -203,6 +203,48 @@ def test_compact_dry_run_reports_and_changes_nothing(archivers, request):
     assert "Deleting 0 unused objects" not in out2
 
 
+def test_compact_archive_reference_cache(archivers, request):
+    """compact caches each archive's referenced objects and drops caches of archives that are gone."""
+    archiver = request.getfixturevalue(archivers)
+
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_src_archive(archiver, "archive1")
+    create_src_archive(archiver, "archive2")
+
+    prefix = "referenced-by-archive."
+
+    def cached_archive_ids():
+        repository = open_repository(archiver)
+        with repository:
+            return {info.name[len(prefix) :] for info in repository.store_list("cache") if info.name.startswith(prefix)}
+
+    def archive_ids():
+        repository = open_repository(archiver)
+        with repository:
+            manifest = Manifest.load(repository, (Manifest.Operation.READ,))
+            return {bin_to_hex(info.id) for info in manifest.archives.list(sort_by=["ts"])}
+
+    # no reference caches exist before the first compact
+    assert cached_archive_ids() == set()
+
+    # the first compact builds one reference cache per archive
+    cmd(archiver, "compact", "-v", exit_code=0)
+    assert cached_archive_ids() == archive_ids()
+
+    # a second compact reuses the caches and the garbage collection stays correct (no missing objects)
+    output = cmd(archiver, "compact", "-v", "--stats", exit_code=0)
+    assert "missing objects" not in output
+    assert cached_archive_ids() == archive_ids()
+
+    # deleting an archive drops its reference cache on the next compact
+    ids_before = archive_ids()
+    cmd(archiver, "delete", "-a", "archive1", exit_code=0)
+    cmd(archiver, "compact", "-v", exit_code=0)
+    remaining = archive_ids()
+    assert remaining < ids_before  # archive1 is gone
+    assert cached_archive_ids() == remaining
+
+
 def test_compact_files_cache_cleanup(archivers, request):
     """Test that files cache files for deleted archives are removed during compact."""
     archiver = request.getfixturevalue(archivers)


### PR DESCRIPTION
## What

Speed up `borg compact`'s "Computing object IDs used by archives" phase by caching, per archive, the set of objects it references.

## How

- **Refactor** `analyze_archives` into a per-archive `analyze_archive`/`get_archive_references` split.
- **Drop the `total_files` statistic**
- **Per-archive reference cache**: for each archive, store `cache/referenced-by-archive.<archive id hex>` in the repo — a serialized `HashTableNT` mapping every referenced object id (32 bytes) to its plaintext size (uint32); metadata objects are recorded with size 0. On the next compact we load this table instead of decoding the whole item-metadata stream, then mark the objects used.
  - Archives are immutable, so a cache stays valid until the archive is deleted; caches of archives that no longer exist are removed during compact.
  - borgstore's name length limit is too small to also carry a content hash in the name, so a sha256 of the serialized table is **appended to the stored content** and verified on load. Any mismatch or read error is treated as a cache miss and falls back to scanning the archive, so garbage collection stays safe.
- **Merge before marking**: every archive's references are merged into one `HashTableNT`, deduplicated across archives, so the chunk index is marked once per unique object instead of once per (archive, object).

## Behavior change

Because the merged table is deduplicated across all archives, the reported **"Source data size" is now deduplicated across archives** (each referenced object counts once) rather than summed per archive.

## Benchmark

10 archives × 100,000 files, `borg compact -v`, local fs:

| | no cache | cache hit |
|---|---|---|
| before | 8.6 s | N/A |
| after | 6.7 s | ~2 s |

## Tests

Added `test_compact_archive_reference_cache` (cache is created, reused, and removed for deleted archives). Existing `compact` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
