### PR TITLE
legacy: use borg 1.x keys dir for v1 repos

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -661,9 +661,18 @@ class FlexiKey:
             return keyfile
         return get_keys_dir()
 
+    def _keys_dir(self):
+        # v1 repos use the borg 1.x keys dir, which differs from the borg2 one on macOS
+        # (~/.config/borg/keys vs ~/Library/Application Support/borg/keys).
+        if self.repository.version == 1:
+            from ..legacy.fs import get_keys_dir as get_keys_dir_legacy
+
+            return get_keys_dir_legacy()
+        return get_keys_dir()
+
     def _find_key_in_keys_dir(self):
         id = self.repository.id
-        keys_path = Path(get_keys_dir())
+        keys_path = Path(self._keys_dir())
         for entry in keys_path.iterdir():
             filename = keys_path / entry.name
             try:
@@ -674,7 +683,7 @@ class FlexiKey:
     def _find_all_keys_in_keys_dir(self):
         # return all keyfiles in the keys dir that belong to this repository (multiple passphrases).
         id = self.repository.id
-        keys_path = Path(get_keys_dir())
+        keys_path = Path(self._keys_dir())
         found = []
         if not keys_path.exists():
             return found


### PR DESCRIPTION
## Description

Keyfile lookup always used the borg2 keys dir. On macOS that path (`~/Library/Application Support/borg/keys`) differs from the borg 1.x one (`~/.config/borg/keys`), so keyfiles of v1 repos were not found.

`_keys_dir()` now returns the borg 1.x keys dir when `repository.version == 1`, the same way `security._security_dir` picks the security dir. Both keyfile lookup paths use it. New key creation stays on the borg2 dir.

Part of #9556.

## Checklist
- [x] PR is against `master`
- [ ] New code has tests and docs where appropriate
- [x] Tests pass (relevant crypto/key and fs subsets)
- [x] Commit messages are clean and reference related issues