### PR TITLE
docs: drop redundant sphinxcontrib.jquery setup_extension call

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,6 @@ def set_rst_settings(app):
 
 
 def setup(app):
-    app.setup_extension("sphinxcontrib.jquery")
     app.add_css_file("css/borg.css")
     app.connect("builder-inited", set_rst_settings)
 


### PR DESCRIPTION
## Description

`sphinxcontrib.jquery` is already registered in the `extensions` list in `docs/conf.py`, so the explicit `app.setup_extension("sphinxcontrib.jquery")` call in `setup()` is redundant. This removes it.

This is the single substantive change extracted from #9780, without the unrelated cosmetic reformatting of `html_sidebars` / `extlinks`.

## Type of Change

- Documentation / code cleanup
- No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)