### PR TITLE
repository: cache whole packs in get_many, replacing adjacent-read grouping

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -829,7 +829,7 @@ class Repository:
             self._lock_refresh()
             entry = self.chunks.get(id_)
             if entry is None or self.chunks.is_pending(id_):
-                # id is unknown or still buffered, not yet in a pack: read it with get()
+                # id unknown or still buffered: get() raises or returns None accordingly
                 yield self.get(id_, read_data=True, raise_missing=raise_missing)
                 continue
             try:
@@ -838,8 +838,8 @@ class Repository:
                 if raise_missing:
                     raise self.ObjectNotFound(id_, str(self._location)) from None
                 yield None
-                continue
-            yield reader.read(entry.obj_offset, entry.obj_size)
+            else:
+                yield reader.read(entry.obj_offset, entry.obj_size)
 
     def put(self, id, data):
         """put a repo object

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -18,6 +18,7 @@ from .helpers import Location
 from .helpers import bin_to_hex, hex_to_bin
 from .helpers import get_cache_dir
 from .helpers import ProgressIndicatorPercent
+from .helpers.lrucache import LRUCache
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -206,7 +207,7 @@ class PackReader:
         self.key = "packs/" + bin_to_hex(pack_id) if pack_id is not None else None
         self.pack_contents = pack_contents
 
-    def _read(self, offset, size):
+    def read(self, offset, size):
         # read from the in-memory pack if we have it, else range-read from the store
         if self.pack_contents is not None:
             return self.pack_contents[offset : offset + size]
@@ -221,7 +222,7 @@ class PackReader:
         hdr_size = RepoObj.obj_header.size
         offset = 0
         while True:
-            hdr_data = self._read(offset, hdr_size)
+            hdr_data = self.read(offset, hdr_size)
             if len(hdr_data) < hdr_size:
                 break  # clean EOF, or trailing partial bytes
             hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(hdr_data))
@@ -303,9 +304,9 @@ class Repository:
 
         exit_mcode = 21
 
-    # Max bytes one grouped read in get_many() covers; a run reaching this size is split into
-    # multiple reads.
-    GET_MANY_GROUP_SIZE_LIMIT = 64 * 1024 * 1024
+    # Whole packs kept in memory for reads; the least recently used is evicted first.
+    # Memory use is this count times the pack size.
+    PACK_READER_CACHE_SIZE = 3
 
     def __init__(
         self,
@@ -391,6 +392,7 @@ class Repository:
         self.exclusive = exclusive
         self._pack_writer = None
         self._chunks = None  # ChunkIndex; loaded lazily on first access to .chunks
+        self._pack_cache = LRUCache(capacity=self.PACK_READER_CACHE_SIZE)  # pack_id -> PackReader
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self._location}>"
@@ -598,6 +600,7 @@ class Repository:
             self.store.close()
             self.store_opened = False
         self.opened = False
+        self._pack_cache.clear()
 
     def info(self):
         """return some infos about the repo (must be opened first)"""
@@ -801,6 +804,16 @@ class Repository:
             else:
                 return None
 
+    def _cached_pack_reader(self, pack_id):
+        """Return a PackReader holding the whole pack, fetching it from the store on a cache miss."""
+        reader = self._pack_cache.get(pack_id)
+        if reader is not None:
+            return reader
+        key = "packs/" + bin_to_hex(pack_id)
+        reader = PackReader(pack_id=pack_id, pack_contents=self.store.load(key))
+        self._pack_cache[pack_id] = reader
+        return reader
+
     def get_many(self, ids, read_data=True, raise_missing=True):
         if not read_data:
             # read_data=False returns only each object's header+meta, sized per object by get().
@@ -808,57 +821,21 @@ class Repository:
                 yield self.get(id_, read_data=read_data, raise_missing=raise_missing)
             return
 
-        # A pack stores its objects back-to-back. Fetch a run of ids that are byte-contiguous in
-        # one pack (each obj_offset == the previous obj_offset + obj_size) with one store.load and
-        # slice each object out of it. Objects are yielded in ids order.
-        run = []  # (id, obj_size) of the objects in the current run, in read order
-        run_key = None  # store key "packs/<pack_id>" the run reads from
-        run_start = 0  # obj_offset of the run's first object
-        run_end = 0  # obj_offset just past the run's last object
-
-        def flush_run():
-            # read the whole run with one store.load and yield each object's slice
-            if not run:
-                return
-            try:
-                blob = self.store.load(run_key, offset=run_start, size=run_end - run_start)
-            except StoreObjectNotFound:
-                if raise_missing:
-                    raise self.ObjectNotFound(run[0][0], str(self._location)) from None
-                for _ in run:
-                    yield None
-                return
-            pos = 0
-            for _id, obj_size in run:
-                yield blob[pos : pos + obj_size]
-                pos += obj_size
-
         for id_ in ids:
             self._lock_refresh()
             entry = self.chunks.get(id_)
             if entry is None or self.chunks.is_pending(id_):
-                # not a flushed pack object: end the run and let get() read it or raise.
-                yield from flush_run()
-                run, run_key = [], None
+                # id is unknown or still buffered, not yet in a pack: read it with get()
                 yield self.get(id_, read_data=True, raise_missing=raise_missing)
                 continue
-            key = "packs/" + bin_to_hex(entry.pack_id)
-            contiguous = (
-                run
-                and key == run_key
-                and entry.obj_offset == run_end
-                and (run_end - run_start) + entry.obj_size <= self.GET_MANY_GROUP_SIZE_LIMIT
-            )
-            if contiguous:
-                run.append((id_, entry.obj_size))
-                run_end += entry.obj_size
-            else:
-                yield from flush_run()
-                run = [(id_, entry.obj_size)]
-                run_key = key
-                run_start = entry.obj_offset
-                run_end = entry.obj_offset + entry.obj_size
-        yield from flush_run()
+            try:
+                reader = self._cached_pack_reader(entry.pack_id)
+            except StoreObjectNotFound:
+                if raise_missing:
+                    raise self.ObjectNotFound(id_, str(self._location)) from None
+                yield None
+                continue
+            yield reader.read(entry.obj_offset, entry.obj_size)
 
     def put(self, id, data):
         """put a repo object

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -303,6 +303,10 @@ class Repository:
 
         exit_mcode = 21
 
+    # Max bytes one grouped read in get_many() covers; a run reaching this size is split into
+    # multiple reads.
+    GET_MANY_GROUP_SIZE_LIMIT = 64 * 1024 * 1024
+
     def __init__(
         self,
         path_or_location,
@@ -798,8 +802,63 @@ class Repository:
                 return None
 
     def get_many(self, ids, read_data=True, raise_missing=True):
+        if not read_data:
+            # read_data=False returns only each object's header+meta, sized per object by get().
+            for id_ in ids:
+                yield self.get(id_, read_data=read_data, raise_missing=raise_missing)
+            return
+
+        # A pack stores its objects back-to-back. Fetch a run of ids that are byte-contiguous in
+        # one pack (each obj_offset == the previous obj_offset + obj_size) with one store.load and
+        # slice each object out of it. Objects are yielded in ids order.
+        run = []  # (id, obj_size) of the objects in the current run, in read order
+        run_key = None  # store key "packs/<pack_id>" the run reads from
+        run_start = 0  # obj_offset of the run's first object
+        run_end = 0  # obj_offset just past the run's last object
+
+        def flush_run():
+            # read the whole run with one store.load and yield each object's slice
+            if not run:
+                return
+            try:
+                blob = self.store.load(run_key, offset=run_start, size=run_end - run_start)
+            except StoreObjectNotFound:
+                if raise_missing:
+                    raise self.ObjectNotFound(run[0][0], str(self._location)) from None
+                for _ in run:
+                    yield None
+                return
+            pos = 0
+            for _id, obj_size in run:
+                yield blob[pos : pos + obj_size]
+                pos += obj_size
+
         for id_ in ids:
-            yield self.get(id_, read_data=read_data, raise_missing=raise_missing)
+            self._lock_refresh()
+            entry = self.chunks.get(id_)
+            if entry is None or self.chunks.is_pending(id_):
+                # not a flushed pack object: end the run and let get() read it or raise.
+                yield from flush_run()
+                run, run_key = [], None
+                yield self.get(id_, read_data=True, raise_missing=raise_missing)
+                continue
+            key = "packs/" + bin_to_hex(entry.pack_id)
+            contiguous = (
+                run
+                and key == run_key
+                and entry.obj_offset == run_end
+                and (run_end - run_start) + entry.obj_size <= self.GET_MANY_GROUP_SIZE_LIMIT
+            )
+            if contiguous:
+                run.append((id_, entry.obj_size))
+                run_end += entry.obj_size
+            else:
+                yield from flush_run()
+                run = [(id_, entry.obj_size)]
+                run_key = key
+                run_start = entry.obj_offset
+                run_end = entry.obj_offset + entry.obj_size
+        yield from flush_run()
 
     def put(self, id, data):
         """put a repo object

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 import time
@@ -18,7 +19,6 @@ from .helpers import Location
 from .helpers import bin_to_hex, hex_to_bin
 from .helpers import get_cache_dir
 from .helpers import ProgressIndicatorPercent
-from .helpers.lrucache import LRUCache
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -392,7 +392,8 @@ class Repository:
         self.exclusive = exclusive
         self._pack_writer = None
         self._chunks = None  # ChunkIndex; loaded lazily on first access to .chunks
-        self._pack_cache = LRUCache(capacity=self.PACK_READER_CACHE_SIZE)  # pack_id -> PackReader
+        # pack_id -> PackReader, per repository so close() can free the cached packs
+        self._cached_pack_reader = functools.lru_cache(maxsize=self.PACK_READER_CACHE_SIZE)(self._load_pack_reader)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self._location}>"
@@ -600,7 +601,7 @@ class Repository:
             self.store.close()
             self.store_opened = False
         self.opened = False
-        self._pack_cache.clear()
+        self._cached_pack_reader.cache_clear()
 
     def info(self):
         """return some infos about the repo (must be opened first)"""
@@ -804,15 +805,10 @@ class Repository:
             else:
                 return None
 
-    def _cached_pack_reader(self, pack_id):
-        """Return a PackReader holding the whole pack, fetching it from the store on a cache miss."""
-        reader = self._pack_cache.get(pack_id)
-        if reader is not None:
-            return reader
+    def _load_pack_reader(self, pack_id):
+        """Return a PackReader holding the whole pack, loaded from the store."""
         key = "packs/" + bin_to_hex(pack_id)
-        reader = PackReader(pack_id=pack_id, pack_contents=self.store.load(key))
-        self._pack_cache[pack_id] = reader
-        return reader
+        return PackReader(pack_id=pack_id, pack_contents=self.store.load(key))
 
     def get_many(self, ids, read_data=True, raise_missing=True):
         if not read_data:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import sys
 import time
@@ -19,6 +18,7 @@ from .helpers import Location
 from .helpers import bin_to_hex, hex_to_bin
 from .helpers import get_cache_dir
 from .helpers import ProgressIndicatorPercent
+from .helpers.lrucache import LRUCache
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
@@ -392,8 +392,8 @@ class Repository:
         self.exclusive = exclusive
         self._pack_writer = None
         self._chunks = None  # ChunkIndex; loaded lazily on first access to .chunks
-        # pack_id -> PackReader, per repository so close() can free the cached packs
-        self._cached_pack_reader = functools.lru_cache(maxsize=self.PACK_READER_CACHE_SIZE)(self._load_pack_reader)
+        # pack_id -> PackReader holding the whole pack; get_many loads into it, get() reuses it
+        self._pack_cache = LRUCache(capacity=self.PACK_READER_CACHE_SIZE)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self._location}>"
@@ -601,7 +601,7 @@ class Repository:
             self.store.close()
             self.store_opened = False
         self.opened = False
-        self._cached_pack_reader.cache_clear()
+        self._pack_cache.clear()
 
     def info(self):
         """return some infos about the repo (must be opened first)"""
@@ -768,10 +768,14 @@ class Repository:
             raise self.PackLocationUnknown(id, str(self._location))
         pack_id, obj_offset, obj_size = entry.pack_id, entry.obj_offset, entry.obj_size
         id_hex = bin_to_hex(id)
-        key = "packs/" + bin_to_hex(pack_id)
+        # slice from the cached whole pack if get_many (or an earlier get) already loaded it;
+        # otherwise read ranges from the store without loading and caching the whole pack.
+        reader = self._pack_cache.get(pack_id)
+        if reader is None:
+            reader = PackReader(store=self.store, pack_id=pack_id)
         try:
             if read_data:
-                return self.store.load(key, offset=obj_offset, size=obj_size)
+                return reader.read(obj_offset, obj_size)
             else:
                 # RepoObj layout supports separately encrypted metadata and data.
                 # We return enough bytes so the client can decrypt the metadata.
@@ -783,7 +787,7 @@ class Repository:
                 # uses the header's length and ignores trailing bytes -- this is just tidy.) obj_size
                 # comes from the same index we already route with.
                 load_size = min(load_size, obj_size)
-                obj = self.store.load(key, offset=obj_offset, size=load_size)
+                obj = reader.read(obj_offset, load_size)
                 hdr = obj[0:hdr_size]
                 if len(hdr) != hdr_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {hdr_size}, got {len(hdr)} bytes")
@@ -794,7 +798,7 @@ class Repository:
                     retry_size = hdr_size + meta_size
                     # same boundary as above: normally a no-op, just keeps the retry within this object.
                     retry_size = min(retry_size, obj_size)
-                    obj = self.store.load(key, offset=obj_offset, size=retry_size)
+                    obj = reader.read(obj_offset, retry_size)
                 meta = obj[hdr_size : hdr_size + meta_size]
                 if len(meta) != meta_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {meta_size}, got {len(meta)} bytes")
@@ -805,10 +809,14 @@ class Repository:
             else:
                 return None
 
-    def _load_pack_reader(self, pack_id):
-        """Return a PackReader holding the whole pack, loaded from the store."""
-        key = "packs/" + bin_to_hex(pack_id)
-        return PackReader(pack_id=pack_id, pack_contents=self.store.load(key))
+    def _cached_pack_reader(self, pack_id):
+        """Return a PackReader holding the whole pack, loading it into the cache on a miss."""
+        reader = self._pack_cache.get(pack_id)
+        if reader is None:
+            key = "packs/" + bin_to_hex(pack_id)
+            reader = PackReader(pack_id=pack_id, pack_contents=self.store.load(key))
+            self._pack_cache[pack_id] = reader
+        return reader
 
     def get_many(self, ids, read_data=True, raise_missing=True):
         if not read_data:

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -288,6 +288,32 @@ def test_get_many_evicts_least_recently_used(repo_fixtures, request):
         assert repository.store.stats["load_calls"] - loads_before == 5  # 4 distinct packs + 1 reload
 
 
+def test_get_reuses_cached_pack(repo_fixtures, request):
+    # get() slices from a pack that get_many already cached, doing no store load; a get() whose pack
+    # is not cached reads only its object's range and does not load the whole pack into the cache.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(2)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 2  # one pack: {H0, H1}
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+
+        # cold cache: get() reads one range and leaves the cache empty, so the next get() reads again
+        loads_before = repository.store.stats["load_calls"]
+        reference = repository.get(H(0))
+        assert repository.store.stats["load_calls"] - loads_before == 1  # one ranged read
+        loads_before = repository.store.stats["load_calls"]
+        repository.get(H(1))
+        assert repository.store.stats["load_calls"] - loads_before == 1  # pack was not cached, another range
+
+        list(repository.get_many([H(0), H(1)]))  # loads the whole pack into the cache
+
+        loads_before = repository.store.stats["load_calls"]
+        assert repository.get(H(0)) == reference
+        assert repository.store.stats["load_calls"] - loads_before == 0  # sliced from the cached pack
+        assert repository.get(H(1), read_data=False)  # read_data=False also peeks the cache
+        assert repository.store.stats["load_calls"] - loads_before == 0
+
+
 def build_one_pack(repository, objects):
     with repository:
         repository._pack_writer.max_count = len(objects) + 1  # prevent per-put flush; one pack on flush()

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -204,6 +204,56 @@ def test_multi_object_pack_roundtrip(repo_fixtures, request):
         assert repository.get(H(1), read_data=False) == chunk1[: hdr_size + len(meta1)]
 
 
+def test_get_many_one_load_per_pack(repo_fixtures, request):
+    # Ids that are byte-contiguous in a pack -- each id's obj_offset equals the previous id's
+    # obj_offset + obj_size -- are read with one store.load. stats["load_calls"] counts store.load()
+    # calls.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(6)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 3  # three objects per pack -> two packs for the six objects
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+        ids = [chunk_id for chunk_id, _ in objects]
+        assert len({repository.chunks[chunk_id].pack_id for chunk_id in ids}) == 2  # six ids, two packs
+        one_by_one = [repository.get(chunk_id) for chunk_id in ids]  # reference bytes, one store.load each
+
+        loads_before = repository.store.stats["load_calls"]
+        assert list(repository.get_many(ids)) == one_by_one
+        assert repository.store.stats["load_calls"] - loads_before == 2  # one store.load per pack
+
+
+def test_get_many_keeps_request_order(repo_fixtures, request):
+    # Ids requested out of their stored order come back in the requested order with their own bytes.
+    # Ids whose objects are not consecutive in a pack each take their own store.load.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(6)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 3  # two packs: {H0,H1,H2} and {H3,H4,H5}
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+        ids = [H(0), H(3), H(1), H(4), H(2), H(5)]  # interleave the two packs
+        one_by_one = [repository.get(chunk_id) for chunk_id in ids]
+
+        loads_before = repository.store.stats["load_calls"]
+        assert list(repository.get_many(ids)) == one_by_one  # same order, same bytes
+        assert repository.store.stats["load_calls"] - loads_before == 6  # each id takes its own store.load
+
+
+def test_get_many_missing_id_yields_none(repo_fixtures, request):
+    # With raise_missing=False, an id that was never stored yields None in its position; the ids
+    # before and after it read back unchanged.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(3)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 4  # above the object count, so the pack flushes on flush() only
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+        repository.flush()
+        ids = [H(0), H(99), H(2)]  # H(99) was never put
+        result = list(repository.get_many(ids, raise_missing=False))
+        assert result[0] == repository.get(H(0))
+        assert result[1] is None  # never stored -> None
+        assert result[2] == repository.get(H(2))
+
+
 def build_one_pack(repository, objects):
     with repository:
         repository._pack_writer.max_count = len(objects) + 1  # prevent per-put flush; one pack on flush()

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -205,9 +205,8 @@ def test_multi_object_pack_roundtrip(repo_fixtures, request):
 
 
 def test_get_many_one_load_per_pack(repo_fixtures, request):
-    # Ids that are byte-contiguous in a pack -- each id's obj_offset equals the previous id's
-    # obj_offset + obj_size -- are read with one store.load. stats["load_calls"] counts store.load()
-    # calls.
+    # get_many loads each pack once as a whole and slices every object out of the cached bytes.
+    # stats["load_calls"] counts store.load() calls.
     objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(6)]
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         repository._pack_writer.max_count = 3  # three objects per pack -> two packs for the six objects
@@ -224,7 +223,7 @@ def test_get_many_one_load_per_pack(repo_fixtures, request):
 
 def test_get_many_keeps_request_order(repo_fixtures, request):
     # Ids requested out of their stored order come back in the requested order with their own bytes.
-    # Ids whose objects are not consecutive in a pack each take their own store.load.
+    # Interleaving two packs still loads each pack once: the pack cache serves the second visit.
     objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(6)]
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         repository._pack_writer.max_count = 3  # two packs: {H0,H1,H2} and {H3,H4,H5}
@@ -235,7 +234,7 @@ def test_get_many_keeps_request_order(repo_fixtures, request):
 
         loads_before = repository.store.stats["load_calls"]
         assert list(repository.get_many(ids)) == one_by_one  # same order, same bytes
-        assert repository.store.stats["load_calls"] - loads_before == 6  # each id takes its own store.load
+        assert repository.store.stats["load_calls"] - loads_before == 2  # each pack loaded once
 
 
 def test_get_many_missing_id_yields_none(repo_fixtures, request):
@@ -252,6 +251,41 @@ def test_get_many_missing_id_yields_none(repo_fixtures, request):
         assert result[0] == repository.get(H(0))
         assert result[1] is None  # never stored -> None
         assert result[2] == repository.get(H(2))
+
+
+def test_get_many_repeated_ids(repo_fixtures, request):
+    # A dedup'd item repeats chunk ids, e.g. [A, A, B, C, B]. Each repeat returns the right bytes
+    # and each pack is loaded once: the cached pack serves the later visits.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(4)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 2  # two packs: {H0,H1} and {H2,H3}
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+        assert len({repository.chunks[H(i)].pack_id for i in range(4)}) == 2
+        ids = [H(0), H(0), H(1), H(2), H(1)]  # A A B C B, A/B in one pack, C in the other
+        one_by_one = [repository.get(chunk_id) for chunk_id in ids]
+
+        loads_before = repository.store.stats["load_calls"]
+        assert list(repository.get_many(ids)) == one_by_one  # every position, including repeats
+        assert repository.store.stats["load_calls"] - loads_before == 2  # two packs, one load each
+
+
+def test_get_many_evicts_least_recently_used(repo_fixtures, request):
+    # Visiting more packs than the cache holds evicts the oldest; revisiting an evicted pack reloads it.
+    objects = [(H(i), fchunk(b"payload-%02d" % i, chunk_id=H(i))) for i in range(8)]
+    with get_repository_from_fixture(repo_fixtures, request) as repository:
+        repository._pack_writer.max_count = 2  # four packs: {H0,H1} {H2,H3} {H4,H5} {H6,H7}
+        for chunk_id, chunk in objects:
+            repository.put(chunk_id, chunk)
+        assert len({repository.chunks[H(i)].pack_id for i in range(8)}) == 4
+        assert repository.PACK_READER_CACHE_SIZE == 3  # cache holds three of the four packs
+        # touch packs 0,1,2 (fills cache), then 3 (evicts pack 0), then pack 0 again (reload).
+        ids = [H(0), H(2), H(4), H(6), H(0)]
+        one_by_one = [repository.get(chunk_id) for chunk_id in ids]
+
+        loads_before = repository.store.stats["load_calls"]
+        assert list(repository.get_many(ids)) == one_by_one
+        assert repository.store.stats["load_calls"] - loads_before == 5  # 4 distinct packs + 1 reload
 
 
 def build_one_pack(repository, objects):


### PR DESCRIPTION
## What

`Repository.get_many` called `store.load` once per object. Objects in a pack file are stored back-to-back and a pack is immutable once written, so `get_many` now fetches each pack once and slices every requested object out of the in-memory copy. Repeated ids and reads that interleave several packs are served from memory instead of re-fetching.

## How

For each requested id, `get_many` looks up the chunks index entry (`pack_id`, `obj_offset`, `obj_size`). The pack is loaded whole on a cache miss and kept in a per-repository `borg.helpers.LRUCache` of up to `PACK_READER_CACHE_SIZE` (3) packs, keyed by `pack_id`. Later ids whose pack is still cached are sliced from memory with no store request. The cache is cleared when the repository is closed.

`get()` peeks the same cache before doing a store range request, in all cases including `read_data=False`: if the object's pack is already cached it is sliced from memory, otherwise `get()` does ranged reads as before and never loads a whole pack itself. Ids with no index entry, or still buffered in the pack writer, delegate from `get_many` to `get()`.

## Why it matters

On backends with per-call latency (S3, SFTP, any network store), `Archive.fetch_many` -> `Repository.get_many` dominates extract time. Deduplication makes the same chunk id repeat: a sparse file writes many identical zero chunks in a row, and a block that recurs later reappears scattered through the list. Items also interleave objects from several packs. Caching whole packs collapses this to one `store.load` per distinct pack, regardless of request order or repeats. The earlier adjacent-run grouping only helped when the request order matched storage order with no repeats.

## Tests

Tests in `repository_test.py`:
- `test_get_many_one_load_per_pack`: `store.stats["load_calls"]` delta equals the number of packs, not the number of objects.
- `test_get_many_keeps_request_order`: ids interleaved across two packs load each pack once and come back in request order.
- `test_get_many_repeated_ids`: a deduplicated list like `[A, A, B, C, B]` returns the right bytes at every position with one load per distinct pack.
- `test_get_many_evicts_least_recently_used`: visiting more packs than the cache holds evicts the oldest, and revisiting an evicted pack reloads it.
- `test_get_many_missing_id_yields_none`: with `raise_missing=False`, a missing id yields `None` in its position without disturbing neighbors.
- `test_get_reuses_cached_pack`: a cold `get()` does one ranged read and does not populate the cache; after `get_many` caches the pack, `get()` and `get(read_data=False)` do zero store loads.
