### PR TITLE
testsuite: don't run transport-agnostic archiver tests over rest:// (#9324)

### DIFF
--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -128,13 +128,22 @@ def generate_archiver_tests(metafunc, kinds: str):
     # - "local" should always be included.
     # - "remote" exercises the rest:// transport (it spawns a borgstore-server-rest subprocess and does
     #   synchronous HTTP-over-stdio round trips per object), so a remote run costs several times its local
-    #   twin. Only add "remote" where the *store I/O pattern itself* is what's under test and is not already
-    #   covered elsewhere: writing/reading archive data over the wire (create, extract, tar), repository
-    #   lifecycle (repo create/delete), integrity (check, compact), locking, repo space and transfer.
-    #   Pure command logic that operates on metadata or only formats output (prune scheduling, diff/list/info
-    #   rendering, rename, delete/undelete, recreate, key handling, debug, return codes, fuse mount) behaves
-    #   identically regardless of transport, so it runs "local,binary" only - the data path over rest is
-    #   already covered by the create/extract tests.
+    #   twin. Only add "remote" where a backend genuinely branches its implementation per transport, and
+    #   that branch is not already exercised by another remote-tested file:
+    #   - create/extract exercise Repository.get()/PackWriter's store.load(offset=, size=) partial reads
+    #     and store.store()'s content-hash header - the REST backend implements both very differently
+    #     (HTTP Range requests, upload hash verification) than e.g. posixfs (seek/read, plain write).
+    #   - check exercises store.hash(), which the REST backend computes server-side (nothing downloaded)
+    #     instead of the default download-then-hash - see check_cmd_remote_test.py.
+    #   - transfer opens two Repository/store connections at once (source and destination); no other
+    #     command does that, so it isn't covered by anything else.
+    #   - compact has its own store-level defrag/pack-rewrite path.
+    #   Everything else - even commands that move real archive data, like tar (routes through the same
+    #   Repository.get()/put() as extract/create) or repo space (never calls store.quota(), just generic
+    #   store_list/store/delete) - only calls the generic list/load/store/delete forwarding that every
+    #   backend implements the same way, so it runs "local,binary" only: repo lifecycle (repo create/
+    #   delete), locking, repo space, tar, recreate, and pure command/formatting logic (prune scheduling,
+    #   diff/list/info rendering, rename, delete/undelete, key handling, debug, return codes, fuse mount).
     # - "binary" runs the frozen borg.exe; it is only built for tag releases, so it does not affect normal
     #   PR/push CI run time.
     archivers = []

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -123,6 +123,20 @@ def cmd_fixture(request):
 
 def generate_archiver_tests(metafunc, kinds: str):
     # Generate tests for different scenarios: local repository, remote repository, and using the borg binary.
+    #
+    # Picking "kinds" (see #9324, testsuite speedup):
+    # - "local" should always be included.
+    # - "remote" exercises the rest:// transport (it spawns a borgstore-server-rest subprocess and does
+    #   synchronous HTTP-over-stdio round trips per object), so a remote run costs several times its local
+    #   twin. Only add "remote" where the *store I/O pattern itself* is what's under test and is not already
+    #   covered elsewhere: writing/reading archive data over the wire (create, extract, tar), repository
+    #   lifecycle (repo create/delete), integrity (check, compact), locking, repo space and transfer.
+    #   Pure command logic that operates on metadata or only formats output (prune scheduling, diff/list/info
+    #   rendering, rename, delete/undelete, recreate, key handling, debug, return codes, fuse mount) behaves
+    #   identically regardless of transport, so it runs "local,binary" only - the data path over rest is
+    #   already covered by the create/extract tests.
+    # - "binary" runs the frozen borg.exe; it is only built for tag releases, so it does not affect normal
+    #   PR/push CI run time.
     archivers = []
     for kind in kinds.split(","):
         if kind == "local":

--- a/src/borg/testsuite/archiver/check_cmd_remote_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_remote_test.py
@@ -1,0 +1,29 @@
+import pytest
+
+from ...constants import *  # NOQA
+from ..repository_test import corrupt_chunk_on_disk
+from . import cmd, src_file, open_archive, generate_archiver_tests
+from .check_cmd_test import check_cmd_setup
+
+# Repository.check() verifies packs via store.hash(name) == name. The REST backend overrides
+# hash() to compute it server-side (nothing downloaded), unlike every other check_cmd scenario,
+# which just exercises the generic store list/load/delete calls already covered by other
+# archiver tests under "remote" (create, extract, compact, ...). So this is the one check_cmd
+# path worth its own "remote" coverage; see generate_archiver_tests() for the full policy.
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote")  # NOQA
+
+
+def test_repository_check_detects_corrupted_pack(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    check_cmd_setup(archiver)
+    archive, repository = open_archive(archiver.repository_path, "archive1")
+    with repository:
+        for item in archive.iter_items():
+            if item.path.endswith(src_file):
+                corrupt_chunk_on_disk(repository, item.chunks[-1].id)
+                break
+        else:
+            pytest.fail("should not happen")
+
+    output = cmd(archiver, "check", "--repository-only", exit_code=1)
+    assert "is corrupted" in output

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -13,7 +13,7 @@ from ...repository import Repository
 from ..repository_test import fchunk, corrupt_chunk_on_disk
 from . import cmd, src_file, create_src_archive, open_archive, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def corrupt(data, position):

--- a/src/borg/testsuite/archiver/debug_cmds_test.py
+++ b/src/borg/testsuite/archiver/debug_cmds_test.py
@@ -7,7 +7,7 @@ from .. import changedir
 from ..compress_test import Compressor
 from . import cmd, create_test_files, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_debug_profile(archivers, request):

--- a/src/borg/testsuite/archiver/delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/delete_cmd_test.py
@@ -1,7 +1,7 @@
 from ...constants import *  # NOQA
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_delete_options(archivers, request):

--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -17,7 +17,7 @@ from . import (
     assert_line_not_exists,
 )
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_basic_functionality(archivers, request):

--- a/src/borg/testsuite/archiver/info_cmd_test.py
+++ b/src/borg/testsuite/archiver/info_cmd_test.py
@@ -5,7 +5,7 @@ from ...constants import *  # NOQA
 from .. import changedir
 from . import cmd, checkts, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_info(archivers, request):

--- a/src/borg/testsuite/archiver/key_cmds_test.py
+++ b/src/borg/testsuite/archiver/key_cmds_test.py
@@ -23,7 +23,7 @@ from . import (
     generate_archiver_tests,
 )
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_change_passphrase(archivers, request):

--- a/src/borg/testsuite/archiver/list_cmd_test.py
+++ b/src/borg/testsuite/archiver/list_cmd_test.py
@@ -5,7 +5,7 @@ import pytest
 from ...constants import *  # NOQA
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION, requires_hardlinks
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_list_format(archivers, request, backup_files):

--- a/src/borg/testsuite/archiver/lock_cmds_test.py
+++ b/src/borg/testsuite/archiver/lock_cmds_test.py
@@ -10,7 +10,7 @@ from . import cmd, generate_archiver_tests, RK_ENCRYPTION
 from ...helpers import CommandError
 from ...platformflags import is_haiku, is_win32
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_break_lock(archivers, request):

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -22,7 +22,7 @@ from ..platform.platform_test import fakeroot_detected
 from . import RK_ENCRYPTION, cmd, assert_dirs_equal, create_regular_file, create_src_archive, open_archive, src_file
 from . import requires_hardlinks, _extract_hardlinks_setup, fuse_mount, create_test_files, generate_archiver_tests
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 @requires_hardlinks

--- a/src/borg/testsuite/archiver/prune_cmd_test.py
+++ b/src/borg/testsuite/archiver/prune_cmd_test.py
@@ -20,7 +20,7 @@ from ...helpers import CommandError
 from ...manifest import ArchiveInfo
 from . import cmd, RK_ENCRYPTION, generate_archiver_tests
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def _create_archive_dt(archiver, backup_files, name, dt, tzinfo=timezone.utc):

--- a/src/borg/testsuite/archiver/recreate_cmd_test.py
+++ b/src/borg/testsuite/archiver/recreate_cmd_test.py
@@ -22,7 +22,7 @@ from . import (
     RK_ENCRYPTION,
 )
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_recreate_exclude_caches(archivers, request):

--- a/src/borg/testsuite/archiver/rename_cmd_test.py
+++ b/src/borg/testsuite/archiver/rename_cmd_test.py
@@ -3,7 +3,7 @@ from ...manifest import Manifest
 from ...repository import Repository
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_rename(archivers, request):

--- a/src/borg/testsuite/archiver/repo_create_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_create_cmd_test.py
@@ -8,7 +8,7 @@ from ...constants import *  # NOQA
 from ...crypto.key import FlexiKey
 from . import cmd, generate_archiver_tests, RK_ENCRYPTION, KF_ENCRYPTION, KF_LOCATION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_repo_create_interrupt(archivers, request):

--- a/src/borg/testsuite/archiver/repo_delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_delete_cmd_test.py
@@ -6,7 +6,7 @@ from ...constants import *  # NOQA
 from ...helpers import CancelledByUser
 from . import create_regular_file, cmd, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_delete_repo(archivers, request):

--- a/src/borg/testsuite/archiver/repo_info_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_info_cmd_test.py
@@ -3,7 +3,7 @@ import json
 from ...constants import *  # NOQA
 from . import checkts, cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION, KF_ENCRYPTION, KF_LOCATION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_info(archivers, request):

--- a/src/borg/testsuite/archiver/repo_list_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_list_cmd_test.py
@@ -7,7 +7,7 @@ from ...constants import *  # NOQA
 from . import cmd, checkts, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 from .prune_cmd_test import _create_archive_ts
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_repo_list_glob(archivers, request, backup_files):

--- a/src/borg/testsuite/archiver/repo_space_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_space_cmd_test.py
@@ -2,7 +2,7 @@ from ...constants import *  # NOQA
 
 from . import cmd, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local")  # NOQA
 
 
 def test_repo_space_basics(archivers, request):

--- a/src/borg/testsuite/archiver/return_codes_test.py
+++ b/src/borg/testsuite/archiver/return_codes_test.py
@@ -5,7 +5,7 @@ from ...helpers import IncludePatternNeverMatchedWarning
 from ...repository import Repository
 from . import cmd, changedir, generate_archiver_tests  # NOQA
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_return_codes(archivers, request):

--- a/src/borg/testsuite/archiver/tar_cmds_test.py
+++ b/src/borg/testsuite/archiver/tar_cmds_test.py
@@ -13,7 +13,7 @@ from . import generate_archiver_tests
 from ...platform import acl_get, acl_set
 from ..platform.platform_test import skipif_not_linux, skipif_acls_not_working
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def have_gnutar():

--- a/src/borg/testsuite/archiver/undelete_cmd_test.py
+++ b/src/borg/testsuite/archiver/undelete_cmd_test.py
@@ -1,7 +1,7 @@
 from ...constants import *  # NOQA
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 def test_undelete_single(archivers, request):


### PR DESCRIPTION
## What

Stop running the `remote` (`rest://`) archiver variant for tests whose behavior does not depend on the repository transport.

## Why

Profiling the testsuite (`-n auto`, no coverage) showed **every one of the 40 slowest tests was a `remote_archiver` variant**. The remote variant spawns a `borgstore-server-rest` subprocess and does synchronous HTTP-over-stdio round trips per object, so a remote run costs several times its local twin — e.g. `test_prune_repository_example`: **~2.8s local vs ~12.2s remote (4.4x)**.

Most of those tests exercise pure command logic that operates on metadata or only formats output (prune scheduling, diff/list/info rendering, rename, delete/undelete, recreate, key handling, debug, return codes, fuse mount, lock_cmds, repo-create/repo-delete, repo-space, tar). That logic is identical regardless of transport — none of it calls a store method whose implementation actually differs per backend — and the wire-transport-specific behavior is already covered by the create/extract/check/compact/transfer tests.

## What changed

- 20 archiver test files switched from `kinds="local,remote,binary"` (or `"local,remote"`) to `kinds="local,binary"` (or `"local"`).
- `generate_archiver_tests()`'s docstring now states the rule directly: only keep `remote` where a backend genuinely branches its *implementation* per transport (not just "moves real archive data"), and that branch isn't already exercised by another remote-tested file.
- Added `check_cmd_remote_test.py`: `check_cmd_test.py` itself dropped `remote` (its tests only exercise generic store list/load/delete, same as prune/list/etc.), but `Repository.check()`'s repository-only mode relies on `store.hash()`, which the REST backend computes **server-side** (nothing downloaded) instead of the default download-then-hash. No existing test actually exercised a plain `--repository-only` check catching pack corruption via that hash comparison (the existing corruption tests all go through `--verify-data`, which decrypts client-side instead), so this closes a real coverage gap rather than just moving it.

`remote` is now **kept** only where the store I/O pattern itself genuinely differs by backend:
- **create / extract**: `Repository.get()`'s `store.load(offset=, size=)` (partial reads — HTTP Range requests for REST vs. seek/read elsewhere) and `store.store()`'s content-hash upload header.
- **check** (new `check_cmd_remote_test.py`): `store.hash()` computed server-side.
- **compact**: its own store-level defrag/pack-rewrite path.
- **transfer**: the only command that opens two live repository/store connections at once (source + destination).
- Plus the already-`local,remote` `checks_test.py` (shared setup/teardown for the check suite).

Commands whose remote testing turned out to be redundant on closer look (all confirmed by reading the actual command implementation, not just assumption):
- **tar cmds** (`export-tar`/`import-tar`): route through the exact same `Archive`/`Repository.get()`/`put()` machinery as extract/create, so their own remote run is redundant — same category as `recreate`.
- **repo-create / repo-delete**: `store.create()`/`store.destroy()` are trivial 1:1 RPC forwards in the REST backend (no content-dependent divergence); still incidentally exercised over the wire by every remaining remote test file's own `repo-create` setup step, and by `checks_test.py`'s `repo-delete`.
- **repo-space**: grepped borg's own code for `.quota(` — **it's never called**. `repo_space_cmd.py` only does generic `store_list`/`store_store`/`store_delete` on `config/space-reserve.*`, despite `quota()` being a genuinely backend-specific method in borgstore that borg simply doesn't use.
- **lock_cmds**: `Lock` only does generic `list`/`store`/`delete` on `locks/*`; its one host-specific check (`process_alive()` across hosts) isn't exercised differently by this test infra regardless of "kind" anyway (client hostid is the same host either way).

## Effect

Two independent measurements, both `-n auto`, no coverage, `-k "not binary"`:

The 374 → 178 → 128 invocation counts and the original 242.7s → 154.2s wall-clock come from the PR author's machine (see the numbers earlier in this description). On top of that, this update was verified with a same-machine, apples-to-apples before/after (12-core machine, checked out the pre-PR commit into the working tree, ran the full archiver suite, then restored the branch and re-ran):

| | before this PR (pre-#9837, same machine) | after this update |
|---|---|---|
| archiver suite wall-clock (`-n auto`) | 219.7s (1 failed, 913 passed, 55 skipped) | 96.0s (683 passed, 39 skipped) |
| `remote_archiver` invocations (archiver suite) | 374 | 128 (−66%) |

The one failure in the "before" run (`test_fuse_allow_damaged_files`, a FUSE-daemonization timeout) is an unrelated, known-flaky test (stale/slow FUSE mount teardown), not caused by this change — it did not reproduce in the "after" run. Test counts differ between the two runs because kind-pruning also removes the parametrized `[remote_archiver]` variants themselves (not just their execution time), so "after" collects fewer test IDs overall.

## Notes for review

The categorization is per-file (the existing granularity). Previously-open borderline calls, now resolved:
- **recreate / tar** — both rewrite/stream chunk data; recreate was already dropped from `remote` (covered by create+extract); **tar is now dropped too**, for the same reason (redundant with create+extract's coverage of the actual wire-specific `Repository.get()`/`put()` behavior).
- **check_cmd** was the single biggest time sink and was originally kept whole on `remote` "since it is borg's integrity command." On closer inspection, only its `store.hash()`-based repository-only corruption check is actually backend-specific; the rest of `check_cmd_test.py`'s 17 tests are transport-agnostic (metadata presence/absence, `--verify-data` decryption-based corruption which never touches `store.hash()`). Dropped `remote` from `check_cmd_test.py` and added one small dedicated `check_cmd_remote_test.py` test for the hash-comparison path instead — which also fixed a real gap, since no prior test exercised plain `--repository-only` corruption detection under any transport.
- The two remaining `get_kind() == "remote"` branches in the touched files (`test_repo_list_from_borg1`, `test_migrate_lock_alive`) were already `pytest.skip("only works locally")`, so nothing was left dead.

Refs #9324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

