### PR TITLE
repository: env-gated writethrough cache for the packs/ namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,14 +144,14 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "mypy"},
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "docs"},
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse"},
-              {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3"},
+              {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3", "store_cache": "1"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"}
             ]
           }' || '{
             "include": [
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3"},
-              {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-mfusepy"},
+              {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-mfusepy", "store_cache": "1"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-x86_64-gh"},
               {"os": "ubuntu-24.04-arm", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-arm64-gh"},
               {"os": "macos-15", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-arm64-gh"},
@@ -277,6 +277,10 @@ jobs:
         mc mb --ignore-existing local/borg
         # Export S3 test URL for tox via GITHUB_ENV
         echo "BORG_TEST_S3_REPO=s3:minioadmin:minioadmin@http://127.0.0.1:9000/borg/s3-repo" >> $GITHUB_ENV
+
+    - name: Enable store cache (test only)
+      if: ${{ matrix.store_cache == '1' }}
+      run: echo "BORG_STORE_CACHE=1" >> $GITHUB_ENV
 
     - name: Install Python requirements
       run: |

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -16,6 +16,7 @@ from .hashindex import ChunkIndex
 from .helpers import Error, ErrorWithTraceback, IntegrityError
 from .helpers import Location
 from .helpers import bin_to_hex, hex_to_bin
+from .helpers import get_cache_dir
 from .helpers import ProgressIndicatorPercent
 from .storelocking import Lock
 from .logger import create_logger
@@ -336,6 +337,21 @@ class Repository:
         permissions = permissions if permissions is not None else os.environ.get("BORG_REPO_PERMISSIONS", "all")
         permissions = borg_permissions(permissions)
 
+        # writethrough cache on the packs/ namespace: a load that misses the cache fetches the whole
+        # pack and caches it, so later loads of that pack's objects come from the local cache.
+        # BORG_PACK_CACHE sets the cache directory ("1" means <cache_dir>/packcache). BORG_PACK_CACHE_SIZE
+        # bounds it in bytes, evicting least recently accessed packs at store open and close.
+        cache_url = None
+        pack_cache = os.environ.get("BORG_PACK_CACHE")
+        if pack_cache:
+            cache_dir = Path(get_cache_dir()) / "packcache" if pack_cache == "1" else Path(pack_cache)
+            os.makedirs(cache_dir, exist_ok=True)
+            ns_config["packs/"]["cache"] = "writethrough"
+            cache_size = os.environ.get("BORG_PACK_CACHE_SIZE")
+            if cache_size:
+                ns_config["packs/"]["size"] = int(cache_size)
+            cache_url = cache_dir.as_uri()
+
         try:
             if location.proto == "rest":
                 # rest:// is served by "borg serve --rest" (reachable via ssh if a host is given),
@@ -343,9 +359,9 @@ class Repository:
                 # permissions are not given to the (remote) backend here; they are enforced on the
                 # server side by "borg serve --rest --permissions ...".
                 backend = build_rest_backend(location)
-                self.store = Store(backend=backend, config=ns_config)
+                self.store = Store(backend=backend, config=ns_config, cache_url=cache_url)
             else:
-                self.store = Store(url, config=ns_config, permissions=permissions)
+                self.store = Store(url, config=ns_config, permissions=permissions, cache_url=cache_url)
         except StoreBackendError as e:
             raise Error(str(e))
         self.store_opened = False
@@ -495,7 +511,14 @@ class Repository:
         if lock:
             self.lock = Lock(self.store, exclusive, timeout=lock_wait).acquire()
         self._chunks = None
-        self._pack_writer = PackWriter(self.store, repository=self)
+        # pack-sizing overrides: BORG_PACK_MAX_COUNT sets the max object count per pack,
+        # BORG_PACK_MAX_SIZE the max pack size in bytes.
+        pw_kwargs = {}
+        if (v := os.environ.get("BORG_PACK_MAX_COUNT")) is not None:
+            pw_kwargs["max_count"] = int(v)
+        if (v := os.environ.get("BORG_PACK_MAX_SIZE")) is not None:
+            pw_kwargs["max_size"] = int(v)
+        self._pack_writer = PackWriter(self.store, repository=self, **pw_kwargs)
         self.opened = True
 
     @property

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -337,14 +337,17 @@ class Repository:
         permissions = permissions if permissions is not None else os.environ.get("BORG_REPO_PERMISSIONS", "all")
         permissions = borg_permissions(permissions)
 
-        # writethrough cache on the packs/ namespace: a load that misses the cache fetches the whole
-        # pack and caches it, so later loads of that pack's objects come from the local cache.
-        # BORG_PACK_CACHE sets the cache directory ("1" means <cache_dir>/packcache). BORG_PACK_CACHE_SIZE
-        # bounds it in bytes, evicting least recently accessed packs at store open and close.
+        # writethrough cache for the packs/ namespace: on a cache miss borgstore loads the whole
+        # pack, caches it, and serves later reads of that pack's objects from the cache.
+        # packs are named by content hash, so one cache directory can hold packs from several
+        # repositories; a colliding name has identical content, so sharing is safe.
+        # BORG_STORE_CACHE sets the cache directory ("1" means <cache_dir>/storecache); the
+        # directory holds the whole store's cache, currently just the packs/ namespace.
+        # BORG_PACK_CACHE_SIZE limits the pack cache size in bytes.
         cache_url = None
-        pack_cache = os.environ.get("BORG_PACK_CACHE")
-        if pack_cache:
-            cache_dir = Path(get_cache_dir()) / "packcache" if pack_cache == "1" else Path(pack_cache)
+        store_cache = os.environ.get("BORG_STORE_CACHE")
+        if store_cache:
+            cache_dir = Path(get_cache_dir()) / "storecache" if store_cache == "1" else Path(store_cache)
             os.makedirs(cache_dir, exist_ok=True)
             ns_config["packs/"]["cache"] = "writethrough"
             cache_size = os.environ.get("BORG_PACK_CACHE_SIZE")


### PR DESCRIPTION
## Description

Adds a writethrough cache for the `packs/` namespace. It is off by default and turned on with `BORG_STORE_CACHE`.

With pack files, reading an object is a ranged read of its pack, so extracting a file that spans many objects costs one backend request per object. On a high-latency backend that gets slow. With the cache on, the first read of an object in a pack fetches the whole pack and caches it locally, and the other objects in that pack are then served from the cache with no backend request.

Packs are named by content hash, so one cache directory can hold packs from several repositories. A colliding name has identical content, so sharing the directory is safe.

Environment variables, all off unless set:
- `BORG_STORE_CACHE`: cache directory for the store. `"1"` uses a `storecache` dir under the borg cache dir. The directory holds the whole store's cache, currently just the `packs/` namespace.
- `BORG_PACK_CACHE_SIZE`: size bound of the pack cache in bytes. borgstore evicts the least recently accessed packs down to this size at store open and close.
- `BORG_PACK_MAX_COUNT` and `BORG_PACK_MAX_SIZE`: override the per-pack object count and byte size, for checking cache behavior against different pack sizes.

Reading 60 objects that live in 3 packs, one at a time: with the cache off that is 62 backend read requests; with the cache on it is 5 (one whole-pack read per pack, the rest repository metadata) plus 57 cache hits.

Refs #8572.

Known limitation: the size bound is checked at store open and close, not during a run, so a long run can grow the cache past the bound until it ends. Bounding it mid-run is a separate follow-up.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
