### PR TITLE
testsuite: relax sparse file SEEK_DATA check

### DIFF
--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -198,7 +198,9 @@ def test_sparse_file(archivers, request):
                 try:
                     if fd.seek(0, os.SEEK_HOLE) != 0:
                         sparse = False
-                    if fd.seek(0, os.SEEK_DATA) != hole_size:
+                    # FS allocation granularity may report DATA before the actual first
+                    # non-zero byte, so only check it is not after the expected content.
+                    if fd.seek(0, os.SEEK_DATA) > hole_size:
                         sparse = False
                 except OSError:
                     # OS/FS does not really support SEEK_HOLE/SEEK_DATA


### PR DESCRIPTION
On filesystems with large allocation units like tmpfs with hugepages, SEEK_DATA can report an offset before the actual first non-zero byte.

The test already verifies file contents and checks st_blocks to confirm the file is stored sparsely, so only require that the first data region is not past the expected content.

<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description

<!-- What does this PR do? Reference any related issues with "fixes #XXXX". -->

Relax the `SEEK_DATA` check in `test_sparse_file` so it tolerates filesystems with large allocation units.

On tmpfs with transparent hugepages (tested on LoongArch64 with 32 MiB hugepages), the kernel may report a `DATA` region starting before the actual first non-zero byte, because the data sits inside an already-allocated hugepage that also contains zeros. The test already verifies file contents separately and checks `st_blocks * 512 < st_size` to confirm the file is stored sparsely, so requiring an exact `SEEK_DATA` offset is too strict.

Change the assertion to only require that the first data region is not after the expected content.

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [ ] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
