### PR TITLE
helpers/fs: let get_*_dir helpers take extra path components

### DIFF
--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -78,7 +78,7 @@ class ArchiveGarbageCollector:
         """
         logger.info("Cleaning up files cache...")
 
-        cache_dir = Path(get_cache_dir()) / self.repository.id_str
+        cache_dir = Path(get_cache_dir(self.repository.id_str, create=False))
         if not cache_dir.exists():
             logger.debug("Cache directory does not exist, skipping files cache cleanup")
             return

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -65,7 +65,7 @@ def get_keys_dir(*, create=True):
     keys_dir = os.environ.get("BORG_KEYS_DIR")
     if keys_dir is None:
         # note: do not just give this as default to the environment.get(), see issue #5979.
-        keys_dir = str(Path(get_config_dir()) / "keys")
+        return get_config_dir("keys", create=create)
     if create:
         ensure_dir(keys_dir)
     return keys_dir
@@ -76,7 +76,8 @@ def get_security_dir(repository_id=None, *, create=True):
     security_dir = os.environ.get("BORG_SECURITY_DIR")
     if security_dir is None:
         # note: do not just give this as default to the environment.get(), see issue #5979.
-        security_dir = str(Path(get_data_dir()) / "security")
+        subdirs = ("security", repository_id) if repository_id else ("security",)
+        return get_data_dir(*subdirs, create=create)
     if repository_id:
         security_dir = str(Path(security_dir) / repository_id)
     if create:
@@ -84,31 +85,46 @@ def get_security_dir(repository_id=None, *, create=True):
     return security_dir
 
 
-def get_data_dir(*, create=True):
-    """Determine where to store borg changing data on the client"""
+def get_data_dir(*subdirs, create=True):
+    """Determine where to store borg changing data on the client.
+
+    Any additional path components are appended to the data directory.
+    """
     data_dir = os.environ.get(
         "BORG_DATA_DIR", join_base_dir(".local", "share", "borg") or platformdirs.user_data_dir("borg")
     )
+    if subdirs:
+        data_dir = str(Path(data_dir).joinpath(*subdirs))
     if create:
         ensure_dir(data_dir)
     return data_dir
 
 
-def get_runtime_dir(*, create=True):
-    """Determine where to store runtime files, like sockets, PID files, ..."""
+def get_runtime_dir(*subdirs, create=True):
+    """Determine where to store runtime files, like sockets, PID files, ...
+
+    Any additional path components are appended to the runtime directory.
+    """
     runtime_dir = os.environ.get(
         "BORG_RUNTIME_DIR", join_base_dir(".cache", "borg") or platformdirs.user_runtime_dir("borg")
     )
+    if subdirs:
+        runtime_dir = str(Path(runtime_dir).joinpath(*subdirs))
     if create:
         ensure_dir(runtime_dir)
     return runtime_dir
 
 
-def get_cache_dir(*, create=True):
-    """Determine where to store Borg cache data."""
+def get_cache_dir(*subdirs, create=True):
+    """Determine where to store Borg cache data.
+
+    Any additional path components are appended to the cache directory.
+    """
     cache_dir = os.environ.get("BORG_CACHE_DIR", join_base_dir(".cache", "borg") or platformdirs.user_cache_dir("borg"))
+    full_dir = str(Path(cache_dir).joinpath(*subdirs)) if subdirs else cache_dir
     if create:
-        ensure_dir(cache_dir)
+        ensure_dir(full_dir)
+        # the CACHEDIR.TAG applies to the whole tree below it, so it goes into the cache root
         cache_tag_fn = Path(cache_dir) / CACHE_TAG_NAME
         if not cache_tag_fn.exists():
             cache_tag_contents = (
@@ -125,14 +141,19 @@ def get_cache_dir(*, create=True):
 
             with SaveFile(cache_tag_fn, binary=True) as fd:
                 fd.write(cache_tag_contents)
-    return cache_dir
+    return full_dir
 
 
-def get_config_dir(*, create=True):
-    """Determine where to store the configuration."""
+def get_config_dir(*subdirs, create=True):
+    """Determine where to store the configuration.
+
+    Any additional path components are appended to the config directory.
+    """
     config_dir = os.environ.get(
         "BORG_CONFIG_DIR", join_base_dir(".config", "borg") or platformdirs.user_config_dir("borg")
     )
+    if subdirs:
+        config_dir = str(Path(config_dir).joinpath(*subdirs))
     if create:
         ensure_dir(config_dir)
     return config_dir

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -351,7 +351,7 @@ class Repository:
                 cache_dir = Path(get_cache_dir("storecache"))
             else:
                 cache_dir = Path(store_cache)
-                os.makedirs(cache_dir, exist_ok=True)
+                cache_dir.mkdir(parents=True, exist_ok=True)
             ns_config["packs/"]["cache"] = "writethrough"
             cache_size = os.environ.get("BORG_PACK_CACHE_SIZE")
             if cache_size:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -347,8 +347,11 @@ class Repository:
         cache_url = None
         store_cache = os.environ.get("BORG_STORE_CACHE")
         if store_cache:
-            cache_dir = Path(get_cache_dir()) / "storecache" if store_cache == "1" else Path(store_cache)
-            os.makedirs(cache_dir, exist_ok=True)
+            if store_cache == "1":
+                cache_dir = Path(get_cache_dir("storecache"))
+            else:
+                cache_dir = Path(store_cache)
+                os.makedirs(cache_dir, exist_ok=True)
             ns_config["packs/"]["cache"] = "writethrough"
             cache_size = os.environ.get("BORG_PACK_CACHE_SIZE")
             if cache_size:

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -223,7 +223,7 @@ def test_compact_files_cache_cleanup(archivers, request):
         pytest.fail("Could not find repository ID in info output")
 
     # Check cache directory for files cache files
-    cache_dir = Path(get_cache_dir()) / repo_id
+    cache_dir = Path(get_cache_dir(repo_id, create=False))
     if not cache_dir.exists():
         pytest.skip("Cache directory does not exist, skipping test")
 

--- a/src/borg/testsuite/helpers/fs_test.py
+++ b/src/borg/testsuite/helpers/fs_test.py
@@ -15,6 +15,7 @@ from ...helpers.fs import (
     get_keys_dir,
     get_security_dir,
     get_config_dir,
+    get_data_dir,
     get_runtime_dir,
     dash_open,
     safe_unlink,
@@ -186,6 +187,37 @@ def test_get_runtime_dir(monkeypatch):
         assert get_runtime_dir(create=False) == os.path.join("/var/tmp/.cache", "borg")
         monkeypatch.setenv("BORG_RUNTIME_DIR", "/var/tmp")
         assert get_runtime_dir(create=False) == "/var/tmp"
+
+
+def test_get_cache_dir_subdirs(monkeypatch, tmp_path):
+    """extra path components are appended and created; the CACHEDIR.TAG stays in the cache root"""
+    monkeypatch.delenv("BORG_BASE_DIR", raising=False)
+    monkeypatch.setenv("BORG_CACHE_DIR", str(tmp_path))
+    # without subdirs the behaviour is unchanged
+    assert get_cache_dir(create=False) == str(tmp_path)
+    # extra path components are appended
+    assert get_cache_dir("storecache", create=False) == str(tmp_path / "storecache")
+    # create=True creates the nested directory ...
+    assert get_cache_dir("storecache") == str(tmp_path / "storecache")
+    assert (tmp_path / "storecache").is_dir()
+    # ... and the CACHEDIR.TAG marks the cache root, not the subdir
+    assert (tmp_path / CACHE_TAG_NAME).exists()
+    assert not (tmp_path / "storecache" / CACHE_TAG_NAME).exists()
+
+
+def test_get_dir_subdirs(monkeypatch, tmp_path):
+    """the config/data/runtime helpers append and create extra path components"""
+    monkeypatch.delenv("BORG_BASE_DIR", raising=False)
+    for env_var, get_dir in [
+        ("BORG_CONFIG_DIR", get_config_dir),
+        ("BORG_DATA_DIR", get_data_dir),
+        ("BORG_RUNTIME_DIR", get_runtime_dir),
+    ]:
+        base = tmp_path / env_var.lower()
+        monkeypatch.setenv(env_var, str(base))
+        assert get_dir("a", "b", create=False) == str(base / "a" / "b")
+        assert get_dir("a", "b") == str(base / "a" / "b")
+        assert (base / "a" / "b").is_dir()
 
 
 def test_dash_open():


### PR DESCRIPTION
## Description

`helpers.fs` has directory helpers (`get_cache_dir`, `get_config_dir`, `get_data_dir`, `get_runtime_dir`) that each return and create one fixed directory. To get a subdirectory a caller has to append the component itself and run `os.makedirs` again, even though the helper already created the parent.

This gives those four helpers a `*subdirs` argument. They append the extra components to the base and `ensure_dir` the full path. Passing no components leaves the result unchanged, so existing calls behave as before. `get_cache_dir` still writes `CACHEDIR.TAG` into the cache root, not the subdir.

`get_keys_dir` and `get_security_dir` build their paths through these helpers now (`get_config_dir("keys")`, `get_data_dir("security", repository_id)`) instead of hand-joining the component. As a side effect they now honor `create=False` for the base directory too.

The store cache in `repository.py` uses `get_cache_dir("storecache")` for the managed case and drops its own `os.makedirs`. A user-supplied `BORG_STORE_CACHE` path is still created explicitly.

## Checklist

- [x] PR is against `master`
- [x] New code has tests (`testsuite/helpers/fs_test.py`: appending components, directory creation, tag placement)
- [x] Tests pass (`fs_test.py` and `legacy_fs_test.py` subset)
- [x] Commit messages are clean
