### PR TITLE
Release cache resources properly in Cache.close()

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -857,6 +857,10 @@ class AdHocWithFilesCache(FilesCacheMixin, ChunksMixin):
             now = datetime.now(UTC)
             self._maybe_write_chunks_cache(now, force=True, clear=True)
             self._chunks = None  # nothing there (cleared!)
+            # the index we just cleared in-place is the same object the repository holds; drop the
+            # repository's reference too, so a later .chunks access rebuilds it from the repo instead
+            # of seeing a valid-looking but empty index (and so is_chunk_index_loaded reports False).
+            self.repository.invalidate_chunk_index()
         pi.output("Saving cache config")
         self.cache_config.save(self.manifest)
         self.cache_config.close()

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -849,6 +849,7 @@ class AdHocWithFilesCache(FilesCacheMixin, ChunksMixin):
             pi.output("Saving files cache")
             integrity_data = self._write_files_cache(self._files)
             self.cache_config.integrity[self.files_cache_name()] = integrity_data
+            self._files = None  # release the (potentially large) files cache dict, like _chunks below
         if self._chunks is not None:
             for key, value in sorted(self._chunks.stats.items()):
                 logger.debug(f"Chunks index stats: {key}: {value}")


### PR DESCRIPTION
Two small, independent resource-handling fixes in `AdHocWithFilesCache.close()`, one commit each.

## 1. Invalidate the repository chunk index after clearing it

`AdHocWithFilesCache._chunks` **is** the same `ChunkIndex` object the `Repository` holds (bound via the `.chunks` property). `close()` persists it and clears the table **in place** (`_maybe_write_chunks_cache(clear=True)`), then sets `self._chunks = None`.

That only drops the *cache's* reference — the `Repository` still points at the now-empty table, and `is_chunk_index_loaded` stays `True`. A later access to `repository.chunks` in the same process (e.g. `delete_object` doing `self.chunks.get(id)`) would then see a valid-looking but **empty** index and conclude every chunk is gone, instead of rebuilding from the repo.

`delete_chunkindex_from_repo()` already guards its analogous case with `invalidate_chunk_index()`; this does the same in `close()`.

## 2. Release the files cache dict

`close()` persists the files cache but never drops its reference to `self._files`, unlike `self._chunks` which is cleared right after being saved. For a backup of many files this dict can hold hundreds of MB and stays alive as long as the closed cache object does. Setting `self._files = None` after writing frees it earlier (accessing `.files` after `close()` was never supported anyway — `close()` also tears down `cache_config`, which `_read_files_cache` needs).

Both are latent today (in one-shot commands the process exits soon after), but they're cheap correctness/hygiene fixes that matter for long-lived / multi-operation use of a `Repository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)