### PR TITLE
json: support BORG_JSON_COMPACT env var for single-line output

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -1418,11 +1418,24 @@ def basic_json_data(manifest, *, cache=None, extra=None):
     return data
 
 
+def _json_indent_from_env():
+    """Parse BORG_JSON_INDENT env var for json.dumps indent parameter."""
+    value = os.environ.get("BORG_JSON_INDENT")
+    if value is None:
+        return 4
+    if value.lower() == "none":
+        return None
+    if value == "":
+        return ""
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
 def json_dump(obj):
     """Dump using BorgJSONEncoder."""
-    indent = 4
-    if os.environ.get("BORG_JSON_COMPACT"):
-        indent = None
+    indent = _json_indent_from_env()
     return json.dumps(obj, sort_keys=True, indent=indent, cls=BorgJsonEncoder)
 
 

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -1420,7 +1420,10 @@ def basic_json_data(manifest, *, cache=None, extra=None):
 
 def json_dump(obj):
     """Dump using BorgJSONEncoder."""
-    return json.dumps(obj, sort_keys=True, indent=4, cls=BorgJsonEncoder)
+    indent = 4
+    if os.environ.get("BORG_JSON_COMPACT"):
+        indent = None
+    return json.dumps(obj, sort_keys=True, indent=indent, cls=BorgJsonEncoder)
 
 
 def json_print(obj):

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -724,10 +724,10 @@ def test_invalid_chunkerparams(invalid_chunker_params):
 @pytest.mark.parametrize(
     "env_value, expect_newlines",
     [
-        (None, True),       # default indent=4
-        ("none", False),    # compact single-line
-        ("0", True),        # newlines only, no spaces
-        ("4", True),        # explicit pretty-print
+        (None, True),  # default indent=4
+        ("none", False),  # compact single-line
+        ("0", True),  # newlines only, no spaces
+        ("4", True),  # explicit pretty-print
     ],
 )
 def test_json_dump_indent(monkeypatch, env_value, expect_newlines):

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -728,6 +728,8 @@ def test_invalid_chunkerparams(invalid_chunker_params):
         ("none", False),  # compact single-line
         ("0", True),  # newlines only, no spaces
         ("4", True),  # explicit pretty-print
+        ("", True),  # empty string, newlines only
+        ("\t", True),  # tab indent string
     ],
 )
 def test_json_dump_indent(monkeypatch, env_value, expect_newlines):
@@ -736,6 +738,8 @@ def test_json_dump_indent(monkeypatch, env_value, expect_newlines):
     obj = {"key": "value", "number": 42}
     if env_value is not None:
         monkeypatch.setenv("BORG_JSON_INDENT", env_value)
+    else:
+        monkeypatch.delenv("BORG_JSON_INDENT", raising=False)
 
     result = json_dump(obj)
     if expect_newlines:

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -721,17 +721,25 @@ def test_invalid_chunkerparams(invalid_chunker_params):
         ChunkerParams(invalid_chunker_params)
 
 
-def test_json_dump_compact(monkeypatch):
+@pytest.mark.parametrize(
+    "env_value, expect_newlines",
+    [
+        (None, True),       # default indent=4
+        ("none", False),    # compact single-line
+        ("0", True),        # newlines only, no spaces
+        ("4", True),        # explicit pretty-print
+    ],
+)
+def test_json_dump_indent(monkeypatch, env_value, expect_newlines):
     from ...helpers.parseformat import json_dump
 
     obj = {"key": "value", "number": 42}
+    if env_value is not None:
+        monkeypatch.setenv("BORG_JSON_INDENT", env_value)
 
-    # Default: pretty-printed (multi-line)
     result = json_dump(obj)
-    assert "\n" in result
-
-    # With BORG_JSON_COMPACT set: single-line
-    monkeypatch.setenv("BORG_JSON_COMPACT", "1")
-    result = json_dump(obj)
-    assert "\n" not in result
+    if expect_newlines:
+        assert "\n" in result
+    else:
+        assert "\n" not in result
     assert json.loads(result) == obj

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 
 import re
@@ -718,3 +719,19 @@ def test_valid_chunkerparams(chunker_params, expected_return):
 def test_invalid_chunkerparams(invalid_chunker_params):
     with pytest.raises(ArgumentTypeError):
         ChunkerParams(invalid_chunker_params)
+
+
+def test_json_dump_compact(monkeypatch):
+    from ...helpers.parseformat import json_dump
+
+    obj = {"key": "value", "number": 42}
+
+    # Default: pretty-printed (multi-line)
+    result = json_dump(obj)
+    assert "\n" in result
+
+    # With BORG_JSON_COMPACT set: single-line
+    monkeypatch.setenv("BORG_JSON_COMPACT", "1")
+    result = json_dump(obj)
+    assert "\n" not in result
+    assert json.loads(result) == obj


### PR DESCRIPTION
<!--
Thank you for contributing to BorgBackup!

Please make sure your PR complies with our contribution guidelines:
https://borgbackup.readthedocs.io/en/latest/development.html#contributions
-->

## Description

When BORG_JSON_COMPACT is set, json_dump() produces single-line JSON instead of the default indented output. This makes it easier for log collectors to parse borg's JSON stdout as one event per line. Implementation uses an env var and not CLI flag.

Fixes #3605 

## Checklist

- [x] PR is against `master`
- [x] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues