### PR TITLE
Drop borgfs runtime warning about symlinks and improve corresponding docs

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -3283,10 +3283,26 @@ class Archiver:
         archives and the directory structure below these will be loaded on-demand from
         the repository when entering these directories, so expect some delay.
 
-        Care should be taken, as Borg backs up symlinks as-is. When an archive
-        or repository is mounted, it is possible to “jump” outside the mount point
-        by following a symlink. If this happens, files or directories (or versions of them)
-        that are not part of the archive or repository may appear to be within the mount point.
+        .. note::
+
+            Borg stores symbolic links as-is. Consequently, when an archive or
+            repository is mounted, symbolic links may resolve to locations outside of
+            the mountpoint, either because they are absolute or because relative links
+            traverse outside of the mounted tree.
+
+            Normal UNIX pathname resolution applies: most tools follow symbolic links
+            by default and may therefore access files or directories that are not part
+            of the mounted archive. Consequently, operations intended to inspect
+            archived data may instead access "live" data from the host filesystem.
+
+            On Linux, this can be prevented by remounting the mountpoint with the
+            ``nosymfollow`` VFS mount option, for example:
+
+                borg mount <repo path> <mountpoint>
+                mount -o remount,nosymfollow <repo path> <mountpoint>
+
+            Alternatively, access the mounted archive from an appropriately isolated
+            environment (for example, a container or ``chroot``).
 
         Unless the ``--foreground`` option is given the command will run in the
         background until the filesystem is ``unmounted``.

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -569,7 +569,6 @@ class FuseOperations(llfuse.Operations, FuseBackend):
                                 user=dir_user, group=dir_group, uid=dir_uid, gid=dir_gid)
         self._create_filesystem()
         llfuse.init(self, mountpoint, options)
-        logger.warning('Warning: The mounted archive is capable of containing symlinks that point outside the archive tree. When following such symlinks you may see files and directories within the mountpoint that do not reflect the archive content.')
         if not foreground:
             if isinstance(self.repository_uncached, RemoteRepository):
                 daemonize()


### PR DESCRIPTION
1. 46ed8bd6d9ccd43fafc65d0036fdc153380c20eb: Drop non-actionable borgfs runtime warning about symlinks
2. e3f7eb7757f06c06bfa603f118160d174c928169: Improve and highlight docs note about borgfs symlink behaviour

Reasoning see https://github.com/borgbackup/borg/issues/9254#issuecomment-4882407124
