### PR TITLE
docs: fix typo in serve comment (contruct -> construct)

### DIFF
--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -339,7 +339,7 @@ class Archiver(
                 # everything else comes from the forced "borg serve" command (or the defaults).
                 # stuff from denylist must never be used from the client.
                 denylist = {"restrict_to_paths", "restrict_to_repositories", "umask", "permissions"}
-                # "backend" is given by the client to the REST server to contruct a posixfs backend
+                # "backend" is given by the client to the REST server to construct a posixfs backend
                 # that shall be used as a repository (borg serve --rest --backend FILE:<path>).
                 # Like the legacy repository path (transmitted via the RPC protocol),
                 # the client chooses *which* repository it wants to use; the ssh forced command pins the


### PR DESCRIPTION
## Description

Fix a small typo in a code comment in `src/borg/archiver/__init__.py`
that describes the REST server backend handling: "contruct" -> "construct".

Comment-only change, no behavior change.

## Checklist

- [x] PR is against `master`
- [x] New code has tests and docs where appropriate (comment-only typo fix, none needed)
- [x] Commit messages are clean and reference related issues
