### PR TITLE
create --stats: populate bytes read/sent from store stats

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -105,8 +105,8 @@ Unchanged files: {unchanged_files}
 Modified files: {modified_files}
 Error files: {error_files}
 Files changed while reading: {files_changed_while_reading}
-Bytes read from remote: {stats.rx_bytes}
-Bytes sent to remote: {stats.tx_bytes}
+Bytes read from repository: {stats.rx_bytes}
+Bytes sent to repository: {stats.tx_bytes}
 """.format(
             stats=self,
             hashing_time=hashing_time,
@@ -130,6 +130,8 @@ Bytes sent to remote: {stats.tx_bytes}
             "hashing_time": self.hashing_time,
             "chunking_time": self.chunking_time,
             "files_stats": self.files_stats,
+            "rx_bytes": self.rx_bytes,
+            "tx_bytes": self.tx_bytes,
         }
 
     def as_raw_dict(self):

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -60,6 +60,49 @@ SF_DATALESS = getattr(stat, "SF_DATALESS", 0x40000000)
 has_link = hasattr(os, "link")
 
 
+# order for rendering store stats, grouped by method, then backend, then cache
+_STORE_STATS_ORDER = []
+for _method in ("info", "list", "load", "store", "delete", "move"):
+    _STORE_STATS_ORDER += [f"{_method}_calls", f"{_method}_time", f"{_method}_volume", f"{_method}_throughput"]
+_STORE_STATS_ORDER += [
+    "backend_load_calls",
+    "backend_load_volume",
+    "backend_store_calls",
+    "backend_store_volume",
+    "backend_delete_calls",
+    "cache_disabled",
+    "cache_hits",
+    "cache_misses",
+    "cache_hit_ratio",
+    "cache_errors",
+    "cache_load_calls",
+    "cache_load_volume",
+    "cache_store_calls",
+    "cache_store_volume",
+    "cache_delete_calls",
+]
+del _method
+
+
+def format_store_stats(stats, iec=False):
+    """Render a borgstore stats dict as one "Store <name>: <value>" line per entry."""
+
+    def format_value(key, value):
+        if key.endswith("_throughput"):
+            return f"{format_file_size(value, iec=iec)}/s"
+        if key.endswith("_volume"):
+            return format_file_size(value, iec=iec)
+        if key.endswith("_time"):
+            return f"{value:.3f} seconds"
+        if key.endswith("_ratio"):
+            return f"{value * 100:.1f}%"
+        return str(value)
+
+    ordered = [key for key in _STORE_STATS_ORDER if key in stats]
+    ordered += [key for key in stats if key not in _STORE_STATS_ORDER]
+    return "\n".join(f"Store {key.replace('_', ' ')}: {format_value(key, stats[key])}" for key in ordered)
+
+
 class Statistics:
     def __init__(self, output_json=False, iec=False):
         self.output_json = output_json
@@ -69,8 +112,7 @@ class Statistics:
         self.files_stats = defaultdict(int)
         self.chunking_time = 0.0
         self.hashing_time = 0.0
-        self.rx_bytes = 0
-        self.tx_bytes = 0
+        self.store_stats = {}
 
     def update(self, size, unique):
         self.osize += size
@@ -94,7 +136,7 @@ class Statistics:
     def __str__(self):
         hashing_time = format_timedelta(timedelta(seconds=self.hashing_time))
         chunking_time = format_timedelta(timedelta(seconds=self.chunking_time))
-        return """\
+        result = """\
 Number of files: {stats.nfiles}
 Original size: {stats.osize_fmt}
 Deduplicated size: {stats.usize_fmt}
@@ -105,8 +147,6 @@ Unchanged files: {unchanged_files}
 Modified files: {modified_files}
 Error files: {error_files}
 Files changed while reading: {files_changed_while_reading}
-Bytes read from repository: {stats.rx_bytes}
-Bytes sent to repository: {stats.tx_bytes}
 """.format(
             stats=self,
             hashing_time=hashing_time,
@@ -117,6 +157,9 @@ Bytes sent to repository: {stats.tx_bytes}
             error_files=self.files_stats["E"],
             files_changed_while_reading=self.files_stats["C"],
         )
+        if self.store_stats:
+            result += format_store_stats(self.store_stats, iec=self.iec) + "\n"
+        return result
 
     def __repr__(self):
         return "<{cls} object at {hash:#x} ({self.osize}, {self.usize})>".format(
@@ -130,8 +173,7 @@ Bytes sent to repository: {stats.tx_bytes}
             "hashing_time": self.hashing_time,
             "chunking_time": self.chunking_time,
             "files_stats": self.files_stats,
-            "rx_bytes": self.rx_bytes,
-            "tx_bytes": self.tx_bytes,
+            "store_stats": self.store_stats,
         }
 
     def as_raw_dict(self):

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -279,10 +279,8 @@ class CreateMixIn:
                 create_inner(archive, cache, fso)
             args.stats |= args.json
             if args.stats:
-                # store.stats is complete only after the cache is closed (last pack flushed).
-                store_stats = repository.store.stats
-                archive.stats.rx_bytes = store_stats["backend_load_volume"]
-                archive.stats.tx_bytes = store_stats["backend_store_volume"]
+                # Cache.close() writes the chunks index to the repo; sample after it so that traffic is counted.
+                archive.stats.store_stats = repository.store.stats
                 if args.json:
                     json_print(basic_json_data(manifest, cache=cache, extra={"archive": archive}))
                 else:
@@ -674,21 +672,22 @@ class CreateMixIn:
         the state after creation. Also, the ``--stats`` and ``--dry-run`` options are mutually
         exclusive because the data is not actually compressed and deduplicated during a dry run.
 
-        The ``--stats`` output also reports "Bytes read from repository" and "Bytes sent
-        to repository": the data volume transferred from/to the backend for this run. This
-        includes chunk data and Borg's own index and metadata writes; for reads it counts
-        what actually reached the backend (cache hits are served locally). The values are
-        approximate due to write buffering and caching. On a repeated backup, a near-zero
-        "sent" value means almost no new data had to be stored because the chunks already
-        exist in the repository (deduplication); a much larger value than usual means a lot
-        of new or changed data was stored this run.
+        The ``--stats`` output also reports the store statistics (lines prefixed with
+        "Store"), taken from the storage layer after this run. These cover the backend and
+        the local store cache: call counts and timings per operation, the load/store data
+        volumes and throughput, and cache hits/misses. "Store backend load volume" and
+        "Store backend store volume" are the bytes actually read from and sent to the
+        backend; a load counts only what missed the cache, and a store counts chunk data
+        together with Borg's own index and metadata writes. The values are approximate
+        because of write buffering and caching. On a repeated backup a near-zero store
+        volume means almost no new data had to be written, because the chunks already exist
+        in the repository (deduplication).
 
         The "Added", "Modified" and "Unchanged" file counters come from the files-cache
         comparison described above: "Unchanged" files matched the cached metadata and were
         not read again (their existing chunks are reused); "Added" and "Modified" files did
         not match and were read and chunked (new chunks are stored, already-known chunks are
-        deduplicated). The comparison uses the files cache, keyed by the file's absolute
-        path, not a parent archive selected by name.
+        deduplicated). The comparison uses the files cache, keyed by the file's absolute path.
 
         For more help on include/exclude patterns, see the :ref:`borg_patterns` command output.
 

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -205,20 +205,12 @@ class CreateMixIn:
                 if args.progress:
                     archive.stats.show_progress(final=True)
                 archive.stats += fso.stats
-                archive.stats.rx_bytes = getattr(repository, "rx_bytes", 0)
-                archive.stats.tx_bytes = getattr(repository, "tx_bytes", 0)
                 if sig_int:
                     # do not save the archive if the user ctrl-c-ed.
                     raise Error("Got Ctrl-C / SIGINT.")
                 else:
                     archive.tags = set(args.tags or [])
                     archive.save(comment=args.comment, timestamp=args.timestamp)
-                    args.stats |= args.json
-                    if args.stats:
-                        if args.json:
-                            json_print(basic_json_data(manifest, cache=cache, extra={"archive": archive}))
-                        else:
-                            log_multi(str(archive), str(archive.stats), logger=logging.getLogger("borg.output.stats"))
 
         self.output_filter = args.output_filter
         self.output_list = args.output_list
@@ -285,6 +277,16 @@ class CreateMixIn:
                     files_changed=args.files_changed,
                 )
                 create_inner(archive, cache, fso)
+            args.stats |= args.json
+            if args.stats:
+                # store.stats is complete only after the cache is closed (last pack flushed).
+                store_stats = repository.store.stats
+                archive.stats.rx_bytes = store_stats["backend_load_volume"]
+                archive.stats.tx_bytes = store_stats["backend_store_volume"]
+                if args.json:
+                    json_print(basic_json_data(manifest, cache=cache, extra={"archive": archive}))
+                else:
+                    log_multi(str(archive), str(archive.stats), logger=logging.getLogger("borg.output.stats"))
         else:
             create_inner(None, None, None)
 
@@ -671,6 +673,22 @@ class CreateMixIn:
         how much your repository will grow. Please note that the "All archives" stats refer to
         the state after creation. Also, the ``--stats`` and ``--dry-run`` options are mutually
         exclusive because the data is not actually compressed and deduplicated during a dry run.
+
+        The ``--stats`` output also reports "Bytes read from repository" and "Bytes sent
+        to repository": the data volume transferred from/to the backend for this run. This
+        includes chunk data and Borg's own index and metadata writes; for reads it counts
+        what actually reached the backend (cache hits are served locally). The values are
+        approximate due to write buffering and caching. On a repeated backup, a near-zero
+        "sent" value means almost no new data had to be stored because the chunks already
+        exist in the repository (deduplication); a much larger value than usual means a lot
+        of new or changed data was stored this run.
+
+        The "Added", "Modified" and "Unchanged" file counters come from the files-cache
+        comparison described above: "Unchanged" files matched the cached metadata and were
+        not read again (their existing chunks are reused); "Added" and "Modified" files did
+        not match and were read and chunked (new chunks are stored, already-known chunks are
+        deduplicated). The comparison uses the files cache, keyed by the file's absolute
+        path, not a parent archive selected by name.
 
         For more help on include/exclude patterns, see the :ref:`borg_patterns` command output.
 

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -93,8 +93,6 @@ Unchanged files: 0
 Modified files: 0
 Error files: 0
 Files changed while reading: 0
-Bytes read from repository: 0
-Bytes sent to repository: 0
 """
     )
     s = f"{stats.osize_fmt}"

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -93,8 +93,8 @@ Unchanged files: 0
 Modified files: 0
 Error files: 0
 Files changed while reading: 0
-Bytes read from remote: 0
-Bytes sent to remote: 0
+Bytes read from repository: 0
+Bytes sent to repository: 0
 """
     )
     s = f"{stats.osize_fmt}"

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -868,6 +868,30 @@ def test_file_status_counters(archivers, request):
     assert result["Modified files"] == 1
 
 
+def test_create_stats_bytes(archivers, request):
+    """Bytes read/sent in `borg create --stats` are populated from the store stats."""
+    archiver = request.getfixturevalue(archivers)
+
+    def to_dict(borg_create_output):
+        lines = [line.split(":", 1) for line in borg_create_output.strip().splitlines()]
+        return {
+            key.strip(): int(value)
+            for key, value in lines
+            if key.strip() in ("Bytes read from repository", "Bytes sent to repository")
+        }
+
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "testfile", contents=b"some data to back up")
+    result = to_dict(cmd(archiver, "create", "--stats", "test_archive", archiver.input_path))
+    assert result["Bytes sent to repository"] > 0
+    assert result["Bytes read from repository"] >= 0
+    # the json output carries the same numbers
+    create_info = json.loads(cmd(archiver, "create", "--json", "--stats", "test_archive2", archiver.input_path))
+    stats = create_info["archive"]["stats"]
+    assert "rx_bytes" in stats
+    assert "tx_bytes" in stats
+
+
 def test_create_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file1", size=1024 * 80)

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -868,28 +868,22 @@ def test_file_status_counters(archivers, request):
     assert result["Modified files"] == 1
 
 
-def test_create_stats_bytes(archivers, request):
-    """Bytes read/sent in `borg create --stats` are populated from the store stats."""
+def test_create_stats_store(archivers, request):
+    """`borg create --stats` shows the full store stats, populated from the store."""
     archiver = request.getfixturevalue(archivers)
-
-    def to_dict(borg_create_output):
-        lines = [line.split(":", 1) for line in borg_create_output.strip().splitlines()]
-        return {
-            key.strip(): int(value)
-            for key, value in lines
-            if key.strip() in ("Bytes read from repository", "Bytes sent to repository")
-        }
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     create_regular_file(archiver.input_path, "testfile", contents=b"some data to back up")
-    result = to_dict(cmd(archiver, "create", "--stats", "test_archive", archiver.input_path))
-    assert result["Bytes sent to repository"] > 0
-    assert result["Bytes read from repository"] >= 0
-    # the json output carries the same numbers
+    output = cmd(archiver, "create", "--stats", "test_archive", archiver.input_path)
+    # the store stats block is present, formatted like the other stats lines
+    assert "Store backend store volume:" in output
+    assert "Store backend load volume:" in output
+    assert "Store cache hit ratio:" in output
+    # the json output carries the same numbers as a structured dict
     create_info = json.loads(cmd(archiver, "create", "--json", "--stats", "test_archive2", archiver.input_path))
-    stats = create_info["archive"]["stats"]
-    assert "rx_bytes" in stats
-    assert "tx_bytes" in stats
+    store_stats = create_info["archive"]["stats"]["store_stats"]
+    assert store_stats["backend_store_volume"] > 0
+    assert store_stats["backend_load_volume"] >= 0
 
 
 def test_create_json(archivers, request):


### PR DESCRIPTION
## Description

On borgstore-backed repositories, `borg create --stats` always printed "Bytes read/sent from remote: 0".

`rx_bytes` and `tx_bytes` only exist on the legacy `RemoteRepository`. A modern repository doesn't have them, so `getattr(repository, "rx_bytes", 0)` returned 0 every time.

Rather than pulling two numbers out of `repository.store.stats`, this now reports the full store stats dict: call counts and timings per operation, load/store volume and throughput, and cache hit/miss numbers. Each entry gets its own "Store <name>: <value>" line in `--stats` output, and the full dict is included under `store_stats` in `--json`.

The stats are sampled after the cache is closed, since `Cache.close()` writes the chunks index to the repo and that traffic should be counted too. The create epilog documents what the store stats mean.

fixes #9405

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [x] Tests pass (run `tox` or the relevant test subset)
- [x] Commit messages are clean and reference related issues
