### PR TITLE
locking: do not leave a lock behind when exclusive acquire times out

### DIFF
--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -189,6 +189,9 @@ class Lock:
                                 return self
                             time.sleep(self.other_locks_go_away_delay)
                         logger.debug("LOCK-ACQUIRE: timeout while waiting for non-exclusive locks to go away.")
+                        # we won't get the exclusive lock, so do not leave our lock behind:
+                        # it would needlessly block other clients until it expired as stale.
+                        self._delete_lock(key, ignore_not_found=True, update_last_refresh=True)
                         break  # timeout
                     else:
                         logger.debug("LOCK-ACQUIRE: someone else also created an exclusive lock, deleting ours.")

--- a/src/borg/testsuite/storelocking_test.py
+++ b/src/borg/testsuite/storelocking_test.py
@@ -45,6 +45,17 @@ class TestLock:
             with pytest.raises(LockTimeout):
                 Lock(lockstore, exclusive=True, id=ID2).acquire()
 
+    def test_exclusive_lock_timeout_leaves_no_lock(self, lockstore):
+        # When acquiring an exclusive lock times out because a non-exclusive lock does not go away,
+        # the not-acquired exclusive lock must not stay behind in the store: it would block all
+        # other clients (even on other hosts) until it expired as stale.
+        with Lock(lockstore, exclusive=False, id=ID1) as shared_lock:
+            with pytest.raises(LockTimeout):
+                Lock(lockstore, exclusive=True, id=ID2).acquire()
+            locks = shared_lock._get_locks()
+            assert len(locks) == 1  # only the non-exclusive lock of ID1 is left
+            assert not any(lock["exclusive"] for lock in locks.values())
+
     def test_double_nonexclusive_lock_succeeds(self, lockstore):
         with Lock(lockstore, exclusive=False, id=ID1):
             with Lock(lockstore, exclusive=False, id=ID2):


### PR DESCRIPTION
### Problem

When `Lock.acquire()` for an exclusive lock succeeded in creating its lock object but then timed out waiting for existing non-exclusive locks to go away, it exited the retry loop via `break` and raised `LockTimeout` **without deleting the exclusive lock it had just created**.

That zombie exclusive lock then blocked every other client:

- clients on **other hosts** were locked out until the lock expired as stale (up to 30 minutes by default),
- clients on the same host recovered earlier only because `process_alive()` detects the dead owner process.

Easy to hit in practice: e.g. `borg compact` (exclusive) timing out against a long-running `borg create` (shared) leaves the repo unusable for other clients for the staleness period.

### Fix

Delete our lock before giving up on the timeout path, same as the other back-off paths in `acquire()` already do.

### Testing

Added `test_exclusive_lock_timeout_leaves_no_lock`: a shared lock is held, an exclusive acquire times out, and the store must contain only the shared lock afterwards. The test fails against the unfixed code (the zombie exclusive lock is found) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)