### PR TITLE
skip test_create_exclude_dataless for binary archiver (1.4-maint)

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -4386,6 +4386,10 @@ class ArchiverTestCaseBinary(ArchiverTestCase):
     def test_extract_xattrs_errors(self):
         pass
 
+    @unittest.skip('patches objects')
+    def test_create_exclude_dataless(self):
+        pass
+
     @unittest.skip('test_basic_functionality seems incompatible with fakeroot and/or the binary.')
     def test_basic_functionality(self):
         pass


### PR DESCRIPTION
`test_create_exclude_dataless` patches `borg.archiver.get_flags` via `unittest.mock.patch` in the test process. In the binary variant (`ArchiverTestCaseBinary`), the command runs in a separate `borg.exe` subprocess, so the patch has no effect there: `fake_get_flags` never applies, the file is never seen as `SF_DATALESS`, and the `'x input/cloudfile'` assertion fails.

Skip it for the binary archiver, like the other object-patching tests in that class.

master already has the equivalent skip in `test_create_exclude_dataless` (`if archiver.EXE: pytest.skip(...)`), so this is 1.4-maint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)