### PR TITLE
create file retries: do not sleep before giving up on the last try

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -405,16 +405,13 @@ class CreateMixIn:
                     if err.errno in (errno.EPERM, errno.EACCES):
                         # Do not try again, such errors can not be fixed by retrying.
                         raise
+                if last_try:
+                    # giving up with retries, error will be dealt with (logged) by upper error handler
+                    raise
                 # sleep a bit, so temporary problems might go away...
                 sleep_s = 1000.0 / 1e6 * 10 ** (retry / 2)  # retry 0: 1ms, retry 6: 1s, ...
                 time.sleep(sleep_s)
-                if retry < MAX_RETRIES - 1:
-                    logger.warning(
-                        f"{path}: {err}, slept {sleep_s:.3f}s, next: retry: {retry + 1} of {MAX_RETRIES - 1}..."
-                    )
-                else:
-                    # giving up with retries, error will be dealt with (logged) by upper error handler
-                    raise
+                logger.warning(f"{path}: {err}, slept {sleep_s:.3f}s, next: retry: {retry + 1} of {MAX_RETRIES - 1}...")
                 # we better do a fresh stat on the file, just to make sure to get the current file
                 # mode right (which could have changed due to a race condition and is important for
                 # dispatching) and also to get current inode number of that file.


### PR DESCRIPTION
In `_process_any`'s retry handler (from #7351), the sleep happens before checking whether this was the last try. When all retries are used up, the error is re-raised anyway, so that final sleep is pointless — and it is the *longest* one of the backoff sequence: retry 9 sleeps `10^4.5` ms ≈ 31.6 s. On a source with many permanently failing files (e.g. a disk returning I/O errors), that adds ~31.6 s per failing file on top of the earlier backoff sleeps.

Check `last_try` first and re-raise immediately; only sleep (and log the retry warning) when another attempt will actually follow. The `if retry < MAX_RETRIES - 1` / `else` split around the warning becomes unnecessary, since the handler now only reaches that point when a retry follows.

No behavior change for retried files: same backoff sleeps, same warning messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)