### PR TITLE
create: log the archive name, not just the repository

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -221,7 +221,7 @@ class CreateMixIn:
         dry_run = args.dry_run
         self.start_backup = time.time_ns()
         t0 = archive_ts_now()
-        logger.info('Creating archive at "%s"' % args.location.processed)
+        logger.info('Creating archive "%s" in repository %s' % (args.name, args.location.processed))
         if not dry_run:
             with Cache(
                 repository,

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -886,6 +886,15 @@ def test_create_stats_store(archivers, request):
     assert store_stats["backend_load_volume"] >= 0
 
 
+def test_create_logs_archive_name(archivers, request):
+    """`borg create --info` announces the archive name, not just the repository."""
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "testfile", contents=b"data")
+    output = cmd(archiver, "create", "--info", "my_archive", archiver.input_path)
+    assert 'Creating archive "my_archive"' in output
+
+
 def test_create_json(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file1", size=1024 * 80)


### PR DESCRIPTION
Refs  #9865

The create command only logged the repository location at info level, so the archive name never showed up in the output. Now the log line includes both.