### PR TITLE
compact: handle pack objects no chunk index entry covers, #9868

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 src/borg/compress.c
 src/borg/hashindex.c
 src/borg/crypto/low_level.c
+src/borg/legacy/crypto/low_level.c
 src/borg/item.c
 src/borg/chunkers/buzhash.c
 src/borg/chunkers/buzhash64.c
@@ -24,6 +25,7 @@ src/borg/_version.py
 *.pyc
 *.pyd
 *.so
+.claude/
 .idea/
 .junie/
 .vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE", "AUTHORS"]
 dependencies = [
   "borghash ~= 0.1.0",
-  "borgstore[rest] ~= 0.5.1",
+  "borgstore[rest] ~= 0.5.5",
   "msgpack >=1.0.3, <=1.2.1",
   "packaging",
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
@@ -51,9 +51,9 @@ mfusepy = ["mfusepy >= 3.1.0, <4.0.0"]  # fuse 2+3, high-level
 # a pypi release of borgbackup can't contain a dependency on github!
 # mfusepym = ["mfusepy @ git+https://github.com/mxmlnkn/mfusepy.git@master"]
 nofuse = []
-s3 = ["borgstore[rest,s3] ~= 0.5.1"]
-sftp = ["borgstore[rest,sftp] ~= 0.5.1"]
-rclone = ["borgstore[rest,rclone] ~= 0.5.1"]
+s3 = ["borgstore[rest,s3] ~= 0.5.5"]
+sftp = ["borgstore[rest,sftp] ~= 0.5.5"]
+rclone = ["borgstore[rest,rclone] ~= 0.5.5"]
 cockpit = ["textual>=6.8.0"]  # might also work with older versions, untested
 
 [project.urls]

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -108,16 +108,32 @@ class ArchiveGarbageCollector:
                 logger.warning(f"Could not access cache file: {e}")
         logger.info(f"Removed {len(unused_files_cache_names)} unused files cache files.")
 
+    def _mark_object_used(self, id, size=0) -> bool:
+        """Mark object <id> used in the chunks index, updating its stored size. Return False if <id>
+        is not in the index."""
+        entry = self.chunks.get(id)
+        if entry is None:
+            return False
+        new_size = size if entry.size == 0 and size != 0 else entry.size
+        self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED, size=new_size)
+        return True
+
+    def _archive_object_ids(self, archive):
+        """Yield every object id an archive references: its metadata object, item metadata, and the
+        content chunks of its items."""
+        yield archive.id
+        yield from archive.metadata.item_ptrs
+        yield from archive.metadata.items
+        for item in archive.iter_items():
+            if "chunks" in item:
+                for id, _ in item.chunks:
+                    yield id
+
     def analyze_archives(self) -> tuple[set, int, int, int]:
         """Iterate over all items in all archives, create the dicts id -> size of all used chunks."""
 
         def use_it(id, size=0):
-            entry = self.chunks.get(id)
-            if entry is not None:
-                # the chunk is in the repo, mark it used.
-                new_size = size if entry.size == 0 and size != 0 else entry.size
-                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED, size=new_size)
-            else:
+            if not self._mark_object_used(id, size):
                 # with --stats: we do NOT have this chunk in the repository!
                 # without --stats: we do not have this chunk or the chunks index is incomplete.
                 missing_chunks.add(id)
@@ -204,24 +220,11 @@ class ArchiveGarbageCollector:
         "borg undelete" can still recover it. An archive whose metadata object is itself already
         gone is skipped with a warning.
         """
-
-        def mark(id):
-            entry = self.chunks.get(id)
-            if entry is not None:
-                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED)
-
         for archive_info in self.manifest.archives.list(sort_by=["ts"], deleted=True):
             try:
                 archive = Archive(self.manifest, archive_info.id, iec=self.iec, deleted=True)
-                mark(archive.id)
-                for id in archive.metadata.item_ptrs:
-                    mark(id)
-                for id in archive.metadata.items:
-                    mark(id)
-                for item in archive.iter_items():
-                    if "chunks" in item:
-                        for id, _ in item.chunks:
-                            mark(id)
+                for id in self._archive_object_ids(archive):
+                    self._mark_object_used(id)
             except (Repository.ObjectNotFound, IntegrityError) as e:
                 name, hex_id = archive_info.name, bin_to_hex(archive_info.id)
                 logger.warning(f"Soft-deleted archive {name} {hex_id} cannot be fully preserved: {e}")
@@ -247,8 +250,9 @@ class ArchiveGarbageCollector:
         such packs be rewritten or dropped rather than kept forever. See issue #9868.
 
         When the repo is damaged (archives reference chunks the index cannot find), packs holding
-        unindexed bytes are left untouched: those bytes may be live data "borg check --repair" can
-        recover. Packs without unindexed bytes are still compacted, so delete/prune waste is reclaimed.
+        unindexed objects are left untouched: those objects may be live data "borg check --repair"
+        can recover. Packs without unindexed objects are still compacted, so delete/prune waste is
+        reclaimed.
 
         Returns (repo_size_before, repo_size_after), the on-disk pack size before and after this run.
         """
@@ -289,7 +293,7 @@ class ArchiveGarbageCollector:
         pack_unused = {}  # pack_id -> wasted bytes, for the packs we act on (drop or rewrite)
         skipped_unindexed = 0  # packs left alone because they hold unindexed bytes on a damaged repo
         for pid, total in pack_total.items():
-            used = pack_used.get(pid, 0)
+            used = pack_used[pid]
             unused = total - used
             if unused < 0:
                 # the index says more is used than the file holds.
@@ -331,9 +335,9 @@ class ArchiveGarbageCollector:
         delete_chunkindex_from_repo(self.repository)
 
         # Pass 2: collect object ids only for the affected packs (a subset, not the whole index)
-        keep = defaultdict(set)  # survivors to copy forward, per rewritten pack
-        drop = defaultdict(set)  # unused objects in those same packs
-        forget = defaultdict(set)  # ids in fully-unused packs we delete outright
+        keep = defaultdict(set)  # rewrite pack_id -> survivors to copy forward
+        drop = defaultdict(set)  # rewrite pack_id -> unused objects in that pack
+        forget = defaultdict(set)  # drop pack_id -> objects to remove from the index
         for id, entry in self.chunks.iteritems():
             pid = entry.pack_id
             if pid in rewrite_packs:

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -221,12 +221,16 @@ class ArchiveGarbageCollector:
         gone is skipped with a warning.
         """
         for archive_info in self.manifest.archives.list(sort_by=["ts"], deleted=True):
+            name, hex_id = archive_info.name, bin_to_hex(archive_info.id)
             try:
                 archive = Archive(self.manifest, archive_info.id, iec=self.iec, deleted=True)
-                for id in self._archive_object_ids(archive):
-                    self._mark_object_used(id)
+                missing = sum(not self._mark_object_used(id) for id in self._archive_object_ids(archive))
+                if missing:
+                    logger.warning(
+                        f"Soft-deleted archive {name} {hex_id}: {missing} objects missing from the index; "
+                        f'"borg undelete" may not fully recover it.'
+                    )
             except (Repository.ObjectNotFound, IntegrityError) as e:
-                name, hex_id = archive_info.name, bin_to_hex(archive_info.id)
                 logger.warning(f"Soft-deleted archive {name} {hex_id} cannot be fully preserved: {e}")
 
     def compact_packs(self):
@@ -286,8 +290,17 @@ class ArchiveGarbageCollector:
                 logger.error(f"{stale_used} of them are still in use: repository data is missing!")
                 set_ec(EXIT_ERROR)
 
-        # decide each pack's fate. compact reclaims only indexed-but-unused bytes; bytes no index entry
-        # covers (total - indexed) are preserved by compact_pack, so they never count as reclaimable.
+        # bytes no index entry covers. compact_pack reclaims the redundant duplicates among them while
+        # rewriting a pack; the rest is left for "borg check --repair".
+        unindexed = sum(total - pack_indexed[pid] for pid, total in pack_total.items() if total > pack_indexed[pid])
+        if unindexed:
+            logger.info(
+                f"{format_file_size(unindexed, iec=self.iec)} in pack files is not covered by the index; "
+                'redundant copies are reclaimed on pack rewrite, the rest by "borg check --repair".'
+            )
+
+        # decide each pack's fate. a pack's reclaimable bytes are its indexed-but-unused bytes; the
+        # redundant duplicates compact_pack finds in the gaps are reclaimed on top when it rewrites.
         drop_packs, rewrite_packs = set(), set()
         pack_reclaim = {}  # pack_id -> reclaimable bytes, for the packs we act on (drop or rewrite)
         for pid, total in pack_total.items():
@@ -345,6 +358,7 @@ class ArchiveGarbageCollector:
             msgid="compact.compact_packs",
         )
         progress = 0
+        freed = 0  # bytes removed from disk this run, for --stats
         # self.chunks stays consistent with the store after each pack, so Ctrl-C can stop between packs
         for pid in drop_packs:
             if sig_int:
@@ -354,6 +368,8 @@ class ArchiveGarbageCollector:
             except StoreObjectNotFound:
                 # happens when a stale chunk index references an already deleted pack (#9850)
                 logger.warning(f"Pack {bin_to_hex(pid)} to delete was already gone.")
+            else:
+                freed += pack_total[pid]  # whole pack removed
             for id in forget[pid]:  # drop the deleted pack's index entries
                 del self.chunks[id]
             progress += 1
@@ -363,13 +379,13 @@ class ArchiveGarbageCollector:
                 break
             # chunks=self.chunks: the index updates (repoint kept objects, remove dropped ones)
             # must land in the index that save_chunk_index() persists (#9850).
-            self.repository.compact_pack(pid, keep_ids=keep[pid], drop_ids=drop[pid], chunks=self.chunks)
+            _, dropped = self.repository.compact_pack(pid, keep_ids=keep[pid], drop_ids=drop[pid], chunks=self.chunks)
+            freed += dropped  # unused indexed objects plus superseded duplicates
             progress += 1
             pi.show(progress)
         pi.finish()
 
-        # a rewritten pack shrinks by exactly its dropped bytes, so reclaimed is the exact on-disk delta.
-        return repo_size_before, repo_size_before - reclaimed
+        return repo_size_before, repo_size_before - freed
 
 
 class CompactMixIn:
@@ -398,9 +414,11 @@ class CompactMixIn:
             - backups of source files that encountered an I/O error mid-transfer and were skipped
             - corruption of the repository (e.g., the archives directory lost entries; see notes below)
 
-            ``borg compact`` only reclaims objects the chunk index knows about. Bytes no index entry
-            covers (redundant copies written by concurrent backups, or packs left behind by a backup
-            that crashed before recording its objects) are kept and reclaimed by ``borg check --repair``.
+            ``borg compact`` reclaims objects the chunk index knows about, plus redundant copies of
+            indexed chunks (e.g. written by concurrent backups) that it finds while rewriting a pack.
+            Other bytes no index entry covers, such as packs left behind by a backup that crashed
+            before recording its objects, are re-indexed by ``borg check --repair`` and reclaimed by
+            the next ``borg compact``.
 
             You usually do not want to run ``borg compact`` after every write operation, but
             either regularly (e.g., once a month, possibly together with ``borg check``) or

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 from pathlib import Path
 
-from borgstore.store import ObjectNotFound as StoreObjectNotFound
-from borgstore.store import ItemInfo
+from borgstore.store import ItemInfo, ObjectNotFound as StoreObjectNotFound
 
 from ._common import with_repository
 from ..archive import Archive
@@ -28,6 +27,7 @@ class ArchiveGarbageCollector:
         assert isinstance(repository, Repository)
         self.manifest = manifest
         self.chunks = None  # a ChunkIndex, here used for: id -> (is_used, stored_size)
+        self.missing_chunks = set()  # chunk ids referenced by archives but missing from the index
         self.total_files = None  # overall number of source files written to all archives in this repo
         self.total_size = None  # overall size of source file content data written to all archives
         self.archives_count = None  # number of archives
@@ -38,7 +38,7 @@ class ArchiveGarbageCollector:
 
     @property
     def repository_size(self):
-        if self.chunks is None or not self.stats:
+        if not self.stats:
             return None
         # on-disk size: sum of the actual pack file sizes, including bytes no index entry covers.
         return sum(ItemInfo(*info).size for info in self.repository.store_list("packs"))
@@ -164,7 +164,9 @@ class ArchiveGarbageCollector:
             for id in sorted(self.missing_chunks):
                 logger.debug(f"Missing object {bin_to_hex(id)}")
             set_ec(EXIT_ERROR)
-        if not self.dry_run:  # nuking removes the soft-deleted archives from the archives directory; skip on a dry run
+        # a missing chunk means the repo is damaged: keep the soft-deleted archives so "borg undelete"
+        # stays possible until "borg check --repair" has run.
+        if not self.dry_run and not self.missing_chunks:  # skip nuking on a dry run or a damaged repo
             logger.info("Cleaning archives directory from soft-deleted archives...")
             archive_infos = self.manifest.archives.list(sort_by=["ts"], deleted=True)
             for archive_info in archive_infos:
@@ -175,18 +177,7 @@ class ArchiveGarbageCollector:
                     logger.warning(f"Soft-deleted archive {name} {hex_id} not found.")
 
         repo_size_before = self.repository_size if self.stats else 0
-        if self.missing_chunks:
-            # compacting drops pack bytes no index entry covers. a backup that crashed before writing
-            # its index leaves live chunks unindexed, and those are the missing chunks reported here.
-            # "borg check --repair" can still recover them from the pack headers, so do not compact
-            # while chunks are missing.
-            logger.error(
-                "Skipping pack compaction: archives reference missing objects. "
-                'Run "borg check --repair" first; compacting now could delete unindexed data '
-                "that repair might still recover."
-            )
-        else:
-            self.compact_packs()
+        self.compact_packs()
         repo_size_after = self.repository_size if self.stats else 0
 
         if self.stats:
@@ -233,6 +224,10 @@ class ArchiveGarbageCollector:
         A pack can hold bytes no index entry covers (a chunk copy stored again elsewhere, or objects
         from a backup that crashed before writing its index); counting those against the file size lets
         such packs be rewritten or dropped rather than kept forever. See issue #9868.
+
+        When the repo is damaged (archives reference chunks the index cannot find), packs holding
+        unindexed bytes are left untouched: those bytes may be live data "borg check --repair" can
+        recover. Packs without unindexed bytes are still compacted, so delete/prune waste is reclaimed.
         """
         # Pass 1: list the pack files and their sizes; these are the packs we consider.
         pack_total = {}  # pack_id -> file size in the store
@@ -240,8 +235,10 @@ class ArchiveGarbageCollector:
             info = ItemInfo(*info)
             pack_total[hex_to_bin(info.name)] = info.size
 
-        # sum the used bytes per pack from the index; collect index entries whose pack is not in the store.
+        # sum the used bytes per pack from the index; also sum every entry's bytes (used or not) to
+        # detect which packs hold unindexed bytes. collect index entries whose pack is not in the store.
         pack_used = defaultdict(int)
+        pack_indexed = defaultdict(int)  # pack_id -> bytes of all its index entries, used or not
         stale_ids = []  # index entries referencing a pack file that is not in the store
         stale_used = 0  # how many of those were still flagged used (lost data)
         for id, entry in self.chunks.iteritems():
@@ -250,11 +247,14 @@ class ArchiveGarbageCollector:
                 stale_ids.append(id)
                 if entry.flags & ChunkIndex.F_USED:
                     stale_used += 1
-            elif entry.flags & ChunkIndex.F_USED:
-                pack_used[pid] += entry.obj_size
+            else:
+                pack_indexed[pid] += entry.obj_size
+                if entry.flags & ChunkIndex.F_USED:
+                    pack_used[pid] += entry.obj_size
 
         if stale_ids:
-            logger.warning(f"Dropping {len(stale_ids)} index entries that reference missing pack files.")
+            drop_verb = "Would drop" if self.dry_run else "Dropping"
+            logger.warning(f"{drop_verb} {len(stale_ids)} index entries that reference missing pack files.")
             if stale_used:
                 logger.error(f"{stale_used} of them were still in use: repository data is missing!")
                 set_ec(EXIT_ERROR)
@@ -262,6 +262,7 @@ class ArchiveGarbageCollector:
         # decide each pack's fate: unused = its file size minus the bytes the index says are used.
         drop_packs, rewrite_packs = set(), set()
         pack_unused = {}  # pack_id -> wasted bytes, for the packs we act on (drop or rewrite)
+        skipped_unindexed = 0  # packs left alone because they hold unindexed bytes on a damaged repo
         for pid, total in pack_total.items():
             used = pack_used.get(pid, 0)
             unused = total - used
@@ -270,6 +271,11 @@ class ArchiveGarbageCollector:
                 logger.error(f'Pack {bin_to_hex(pid)}: index claims more data than the file holds, run "borg check".')
                 set_ec(EXIT_ERROR)
                 continue  # leave this pack untouched
+            if self.missing_chunks and total > pack_indexed[pid]:
+                # the repo is damaged and this pack holds bytes no index entry covers. those bytes may be
+                # live data "borg check --repair" can recover from the pack headers, so leave the pack alone.
+                skipped_unindexed += 1
+                continue
             if unused == 0:
                 continue  # fully used -> leave alone
             if used == 0:
@@ -279,6 +285,12 @@ class ArchiveGarbageCollector:
                 rewrite_packs.add(pid)  # mixed and wasteful enough -> copy survivors forward
                 pack_unused[pid] = unused
             # else: mixed but below threshold -> leave alone
+        if skipped_unindexed:
+            logger.error(
+                f"Skipped {skipped_unindexed} packs holding unindexed data that "
+                '"borg check --repair" might still recover; run it, then compact again.'
+            )
+            set_ec(EXIT_ERROR)
         if self.dry_run:
             freed = sum(pack_unused[pid] for pid in drop_packs) + sum(pack_unused[pid] for pid in rewrite_packs)
             logger.info(
@@ -385,8 +397,8 @@ class CompactMixIn:
             seeing fatal errors when creating backups or when archives are missing in
             ``borg repo-list``).
 
-            With ``--stats``, borg additionally reports the sum of stored object sizes
-            before and after compaction.
+            With ``--stats``, borg additionally reports the on-disk size of the pack files
+            before and after compaction (the reported compression factor is based on that size).
             """
         )
         subparser = ArgumentParser(parents=[common_parser], description=self.do_compact.__doc__, epilog=compact_epilog)

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -232,32 +232,29 @@ class ArchiveGarbageCollector:
     def compact_packs(self):
         """Free space one pack at a time (the store can only delete whole packs).
 
-        analyze_archives() has flagged the used objects F_USED. Per pack:
+        analyze_archives() has flagged the used objects F_USED. Only indexed-but-unused bytes are
+        reclaimed; bytes no index entry covers are preserved (see below). Per pack:
 
-        - all objects unused -> delete the pack.
-        - all objects used   -> keep it.
-        - mixed              -> rewrite only if the unused bytes reach --threshold percent: copy the
-                                used objects into a new pack via compact_pack and drop the old one.
-                                Below the threshold keep the pack, so we don't rewrite a large pack
-                                to reclaim little.
+        - all indexed objects unused, whole file indexed -> delete the pack.
+        - some indexed objects unused                    -> rewrite if the unused bytes reach
+                                --threshold percent: copy the used objects (and any unindexed bytes)
+                                into a new pack via compact_pack and drop the old one. Below the
+                                threshold keep the pack, so we don't rewrite a large pack to reclaim
+                                little.
+        - no indexed objects unused                      -> keep the pack.
+
+        A pack can hold bytes no index entry covers (a chunk copy stored again elsewhere, or objects
+        from a backup that crashed before writing its index). compact_pack keeps those; recovering or
+        dropping them is "borg check --repair"'s job. See issue #9868.
 
         Two passes bound the memory use: the first keeps only per-pack byte counts to pick the packs
         to change, the second collects object ids for just those packs, not the whole index.
 
-        A pack's size is taken from the store (the actual file size), not from summing index entries.
-        A pack can hold bytes no index entry covers (a chunk copy stored again elsewhere, or objects
-        from a backup that crashed before writing its index); counting those against the file size lets
-        such packs be rewritten or dropped rather than kept forever. See issue #9868.
-
-        When the repo is damaged (archives reference chunks the index cannot find), packs holding
-        unindexed objects are left untouched: those objects may be live data "borg check --repair"
-        can recover. Packs without unindexed objects are still compacted, so delete/prune waste is
-        reclaimed.
+        A pack's size is the file size the store reports, so it also counts bytes no index entry covers.
 
         Returns (repo_size_before, repo_size_after), the on-disk pack size before and after this run.
         """
-        # Pass 1: list the pack files and their sizes; these are the packs we consider. This is the
-        # only pack listing per run.
+        # Pass 1: list the pack files and their sizes; these are the packs we consider.
         pack_total = {}  # pack_id -> file size in the store
         for info in self.repository.store_list("packs"):
             info = ItemInfo(*info)
@@ -282,52 +279,43 @@ class ArchiveGarbageCollector:
                     pack_used[pid] += entry.obj_size
 
         if stale_ids:
-            drop_verb = "Would drop" if self.dry_run else "Dropping"
-            logger.warning(f"{drop_verb} {len(stale_ids)} index entries that reference missing pack files.")
+            # keep these entries: they may be an archive's only pointer to a chunk. dropping them is
+            # "borg check --repair"'s call.
+            logger.warning(f'{len(stale_ids)} index entries reference missing pack files; run "borg check --repair".')
             if stale_used:
-                logger.error(f"{stale_used} of them were still in use: repository data is missing!")
+                logger.error(f"{stale_used} of them are still in use: repository data is missing!")
                 set_ec(EXIT_ERROR)
 
-        # decide each pack's fate: unused = its file size minus the bytes the index says are used.
+        # decide each pack's fate. compact reclaims only indexed-but-unused bytes; bytes no index entry
+        # covers (total - indexed) are preserved by compact_pack, so they never count as reclaimable.
         drop_packs, rewrite_packs = set(), set()
-        pack_unused = {}  # pack_id -> wasted bytes, for the packs we act on (drop or rewrite)
-        skipped_unindexed = 0  # packs left alone because they hold unindexed bytes on a damaged repo
+        pack_reclaim = {}  # pack_id -> reclaimable bytes, for the packs we act on (drop or rewrite)
         for pid, total in pack_total.items():
+            indexed = pack_indexed[pid]
             used = pack_used[pid]
-            unused = total - used
-            if unused < 0:
-                # the index says more is used than the file holds.
+            if indexed > total:
+                # the index lists more bytes than the file holds.
                 logger.error(f'Pack {bin_to_hex(pid)}: index claims more data than the file holds, run "borg check".')
                 set_ec(EXIT_ERROR)
                 continue  # leave this pack untouched
-            if self.missing_chunks and total > pack_indexed[pid]:
-                # the repo is damaged and this pack holds bytes no index entry covers. those bytes may be
-                # live data "borg check --repair" can recover from the pack headers, so leave the pack alone.
-                skipped_unindexed += 1
-                continue
-            if unused == 0:
-                continue  # fully used -> leave alone
-            if used == 0:
-                drop_packs.add(pid)  # no used bytes -> drop the whole file
-                pack_unused[pid] = unused
-            elif 100 * unused / total >= self.threshold:
-                rewrite_packs.add(pid)  # mixed and wasteful enough -> copy survivors forward
-                pack_unused[pid] = unused
-            # else: mixed but below threshold -> leave alone
-        if skipped_unindexed:
-            logger.error(
-                f"Skipped {skipped_unindexed} packs holding unindexed data that "
-                '"borg check --repair" might still recover; run it, then compact again.'
-            )
-            set_ec(EXIT_ERROR)
+            reclaimable = indexed - used  # unused indexed bytes; the only bytes compact removes
+            if reclaimable == 0:
+                continue  # nothing to reclaim -> leave alone
+            if used == 0 and indexed == total:
+                drop_packs.add(pid)  # whole file is unused indexed bytes -> drop it
+                pack_reclaim[pid] = reclaimable
+            elif 100 * reclaimable / total >= self.threshold:
+                rewrite_packs.add(pid)  # wasteful enough -> copy used objects (and unindexed bytes) forward
+                pack_reclaim[pid] = reclaimable
+            # else: below threshold -> leave alone
         if self.dry_run:
-            freed = sum(pack_unused[pid] for pid in drop_packs) + sum(pack_unused[pid] for pid in rewrite_packs)
+            freed = sum(pack_reclaim.values())
             logger.info(
                 f"Would free {format_file_size(freed, iec=self.iec)} "
                 f"by dropping {len(drop_packs)} packs and rewriting {len(rewrite_packs)} packs."
             )
             return repo_size_before, repo_size_before  # dry run: report only, change nothing
-        if not drop_packs and not rewrite_packs and not stale_ids:
+        if not drop_packs and not rewrite_packs:
             logger.info("Deleting 0 unused objects...")
             return repo_size_before, repo_size_before  # nothing to reclaim; chunk indexes stay valid
 
@@ -335,7 +323,7 @@ class ArchiveGarbageCollector:
         delete_chunkindex_from_repo(self.repository)
 
         # Pass 2: collect object ids only for the affected packs (a subset, not the whole index)
-        keep = defaultdict(set)  # rewrite pack_id -> survivors to copy forward
+        keep = defaultdict(set)  # rewrite pack_id -> its used objects, kept in the new pack
         drop = defaultdict(set)  # rewrite pack_id -> unused objects in that pack
         forget = defaultdict(set)  # drop pack_id -> objects to remove from the index
         for id, entry in self.chunks.iteritems():
@@ -346,10 +334,9 @@ class ArchiveGarbageCollector:
                 forget[pid].add(id)
 
         # deleted counts index objects removed: every object of a dropped pack, plus the unused
-        # objects cut from rewritten packs. reclaimed counts the bytes freed, which also includes
-        # unindexed spans that are not index objects.
+        # objects cut from rewritten packs. reclaimed counts the bytes freed.
         deleted = sum(len(ids) for ids in forget.values()) + sum(len(ids) for ids in drop.values())
-        reclaimed = sum(pack_unused[pid] for pid in drop_packs) + sum(pack_unused[pid] for pid in rewrite_packs)
+        reclaimed = sum(pack_reclaim.values())
         logger.info(f"Deleting {deleted} unused objects, freeing {format_file_size(reclaimed, iec=self.iec)}...")
         pi = ProgressIndicatorPercent(
             total=len(drop_packs) + len(rewrite_packs),
@@ -381,7 +368,7 @@ class ArchiveGarbageCollector:
             pi.show(progress)
         pi.finish()
 
-        # a rewritten pack's new size equals its kept bytes, so reclaimed is the exact on-disk delta.
+        # a rewritten pack shrinks by exactly its dropped bytes, so reclaimed is the exact on-disk delta.
         return repo_size_before, repo_size_before - reclaimed
 
 
@@ -409,9 +396,11 @@ class CompactMixIn:
             - use of ``borg delete`` or ``borg prune``
             - interrupted backups (consider retrying the backup before running compact)
             - backups of source files that encountered an I/O error mid-transfer and were skipped
-            - duplicate chunks written by concurrent backups (the redundant copies are unused)
-            - packs left behind by a backup that crashed before recording its objects
             - corruption of the repository (e.g., the archives directory lost entries; see notes below)
+
+            ``borg compact`` only reclaims objects the chunk index knows about. Bytes no index entry
+            covers (redundant copies written by concurrent backups, or packs left behind by a backup
+            that crashed before recording its objects) are kept and reclaimed by ``borg check --repair``.
 
             You usually do not want to run ``borg compact`` after every write operation, but
             either regularly (e.g., once a month, possibly together with ``borg check``) or

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from borgstore.store import ObjectNotFound as StoreObjectNotFound
+from borgstore.store import ItemInfo
 
 from ._common import with_repository
 from ..archive import Archive
@@ -11,7 +12,7 @@ from ..helpers import get_cache_dir
 from ..helpers.argparsing import ArgumentParser
 from ..constants import *  # NOQA
 from ..hashindex import ChunkIndex
-from ..helpers import set_ec, EXIT_ERROR, Error, sig_int, format_file_size, bin_to_hex
+from ..helpers import set_ec, EXIT_ERROR, Error, sig_int, format_file_size, bin_to_hex, hex_to_bin
 from ..helpers import ProgressIndicatorPercent
 from ..manifest import Manifest
 from ..repository import Repository
@@ -39,7 +40,8 @@ class ArchiveGarbageCollector:
     def repository_size(self):
         if self.chunks is None or not self.stats:
             return None
-        return sum(entry.obj_size for id, entry in self.chunks.iteritems())  # sum of stored sizes
+        # on-disk size: sum of the actual pack file sizes, including bytes no index entry covers.
+        return sum(ItemInfo(*info).size for info in self.repository.store_list("packs"))
 
     def garbage_collect(self):
         """Removes unused chunks from a repository."""
@@ -173,7 +175,18 @@ class ArchiveGarbageCollector:
                     logger.warning(f"Soft-deleted archive {name} {hex_id} not found.")
 
         repo_size_before = self.repository_size if self.stats else 0
-        self.compact_packs()
+        if self.missing_chunks:
+            # compacting drops pack bytes no index entry covers. a backup that crashed before writing
+            # its index leaves live chunks unindexed, and those are the missing chunks reported here.
+            # "borg check --repair" can still recover them from the pack headers, so do not compact
+            # while chunks are missing.
+            logger.error(
+                "Skipping pack compaction: archives reference missing objects. "
+                'Run "borg check --repair" first; compacting now could delete unindexed data '
+                "that repair might still recover."
+            )
+        else:
+            self.compact_packs()
         repo_size_after = self.repository_size if self.stats else 0
 
         if self.stats:
@@ -215,25 +228,56 @@ class ArchiveGarbageCollector:
 
         Two passes bound the memory use: the first keeps only per-pack byte counts to pick the packs
         to change, the second collects object ids for just those packs, not the whole index.
+
+        A pack's size is taken from the store (the actual file size), not from summing index entries.
+        A pack can hold bytes no index entry covers (a chunk copy stored again elsewhere, or objects
+        from a backup that crashed before writing its index); counting those against the file size lets
+        such packs be rewritten or dropped rather than kept forever. See issue #9868.
         """
-        # Pass 1: one index scan, keep only per-pack byte tallies (two ints per pack, no id lists).
-        pack_total, pack_unused = defaultdict(int), defaultdict(int)
+        # Pass 1: list the pack files and their sizes; these are the packs we consider.
+        pack_total = {}  # pack_id -> file size in the store
+        for info in self.repository.store_list("packs"):
+            info = ItemInfo(*info)
+            pack_total[hex_to_bin(info.name)] = info.size
+
+        # sum the used bytes per pack from the index; collect index entries whose pack is not in the store.
+        pack_used = defaultdict(int)
+        stale_ids = []  # index entries referencing a pack file that is not in the store
+        stale_used = 0  # how many of those were still flagged used (lost data)
         for id, entry in self.chunks.iteritems():
             pid = entry.pack_id
-            pack_total[pid] += entry.obj_size
-            if not (entry.flags & ChunkIndex.F_USED):
-                pack_unused[pid] += entry.obj_size
+            if pid not in pack_total:
+                stale_ids.append(id)
+                if entry.flags & ChunkIndex.F_USED:
+                    stale_used += 1
+            elif entry.flags & ChunkIndex.F_USED:
+                pack_used[pid] += entry.obj_size
 
-        # decide each pack's fate from the tallies
+        if stale_ids:
+            logger.warning(f"Dropping {len(stale_ids)} index entries that reference missing pack files.")
+            if stale_used:
+                logger.error(f"{stale_used} of them were still in use: repository data is missing!")
+                set_ec(EXIT_ERROR)
+
+        # decide each pack's fate: unused = its file size minus the bytes the index says are used.
         drop_packs, rewrite_packs = set(), set()
+        pack_unused = {}  # pack_id -> wasted bytes, for the packs we act on (drop or rewrite)
         for pid, total in pack_total.items():
-            unused = pack_unused.get(pid, 0)  # .get, not [pid]: don't insert all-used packs into the dict
+            used = pack_used.get(pid, 0)
+            unused = total - used
+            if unused < 0:
+                # the index says more is used than the file holds.
+                logger.error(f'Pack {bin_to_hex(pid)}: index claims more data than the file holds, run "borg check".')
+                set_ec(EXIT_ERROR)
+                continue  # leave this pack untouched
             if unused == 0:
-                continue  # all used -> leave alone
-            if unused == total:
-                drop_packs.add(pid)  # all unused -> drop the whole file
+                continue  # fully used -> leave alone
+            if used == 0:
+                drop_packs.add(pid)  # no used bytes -> drop the whole file
+                pack_unused[pid] = unused
             elif 100 * unused / total >= self.threshold:
                 rewrite_packs.add(pid)  # mixed and wasteful enough -> copy survivors forward
+                pack_unused[pid] = unused
             # else: mixed but below threshold -> leave alone
         if self.dry_run:
             freed = sum(pack_unused[pid] for pid in drop_packs) + sum(pack_unused[pid] for pid in rewrite_packs)
@@ -242,7 +286,7 @@ class ArchiveGarbageCollector:
                 f"by dropping {len(drop_packs)} packs and rewriting {len(rewrite_packs)} packs."
             )
             return  # dry run: report only, change nothing
-        if not drop_packs and not rewrite_packs:
+        if not drop_packs and not rewrite_packs and not stale_ids:
             logger.info("Deleting 0 unused objects...")
             return  # nothing to reclaim; do not touch the chunk indexes
 
@@ -260,10 +304,12 @@ class ArchiveGarbageCollector:
             elif pid in drop_packs:
                 forget[pid].add(id)
 
-        # count what we remove: every object of a dropped pack, plus the unused objects cut from
-        # rewritten packs. unused objects in below-threshold packs stay, so they don't count.
+        # deleted counts index objects removed: every object of a dropped pack, plus the unused
+        # objects cut from rewritten packs. reclaimed counts the bytes freed, which also includes
+        # unindexed spans that are not index objects.
         deleted = sum(len(ids) for ids in forget.values()) + sum(len(ids) for ids in drop.values())
-        logger.info(f"Deleting {deleted} unused objects...")
+        reclaimed = sum(pack_unused[pid] for pid in drop_packs) + sum(pack_unused[pid] for pid in rewrite_packs)
+        logger.info(f"Deleting {deleted} unused objects, freeing {format_file_size(reclaimed, iec=self.iec)}...")
         pi = ProgressIndicatorPercent(
             total=len(drop_packs) + len(rewrite_packs),
             msg="Compacting packs %3.1f%%",
@@ -319,6 +365,8 @@ class CompactMixIn:
             - use of ``borg delete`` or ``borg prune``
             - interrupted backups (consider retrying the backup before running compact)
             - backups of source files that encountered an I/O error mid-transfer and were skipped
+            - duplicate chunks written by concurrent backups (the redundant copies are unused)
+            - packs left behind by a backup that crashed before recording its objects
             - corruption of the repository (e.g., the archives directory lost entries; see notes below)
 
             You usually do not want to run ``borg compact`` after every write operation, but

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -11,7 +11,7 @@ from ..helpers import get_cache_dir
 from ..helpers.argparsing import ArgumentParser
 from ..constants import *  # NOQA
 from ..hashindex import ChunkIndex
-from ..helpers import set_ec, EXIT_ERROR, Error, sig_int, format_file_size, bin_to_hex, hex_to_bin
+from ..helpers import set_ec, EXIT_ERROR, Error, sig_int, format_file_size, bin_to_hex, hex_to_bin, IntegrityError
 from ..helpers import ProgressIndicatorPercent
 from ..manifest import Manifest
 from ..repository import Repository
@@ -35,13 +35,6 @@ class ArchiveGarbageCollector:
         self.threshold = threshold  # rewrite a mixed pack only when its wasted-bytes fraction reaches this percent
         self.iec = iec  # formats statistics using IEC units (1KiB = 1024B)
         self.dry_run = dry_run
-
-    @property
-    def repository_size(self):
-        if not self.stats:
-            return None
-        # on-disk size: sum of the actual pack file sizes, including bytes no index entry covers.
-        return sum(ItemInfo(*info).size for info in self.repository.store_list("packs"))
 
     def garbage_collect(self):
         """Removes unused chunks from a repository."""
@@ -164,9 +157,10 @@ class ArchiveGarbageCollector:
             for id in sorted(self.missing_chunks):
                 logger.debug(f"Missing object {bin_to_hex(id)}")
             set_ec(EXIT_ERROR)
-        # a missing chunk means the repo is damaged: keep the soft-deleted archives so "borg undelete"
-        # stays possible until "borg check --repair" has run.
-        if not self.dry_run and not self.missing_chunks:  # skip nuking on a dry run or a damaged repo
+            # the repo is damaged: keep the soft-deleted archives so "borg undelete" stays possible
+            # until "borg check --repair" has run.
+            self.mark_soft_deleted_used()
+        elif not self.dry_run:
             logger.info("Cleaning archives directory from soft-deleted archives...")
             archive_infos = self.manifest.archives.list(sort_by=["ts"], deleted=True)
             for archive_info in archive_infos:
@@ -176,9 +170,7 @@ class ArchiveGarbageCollector:
                 except self.repository.ObjectNotFound:
                     logger.warning(f"Soft-deleted archive {name} {hex_id} not found.")
 
-        repo_size_before = self.repository_size if self.stats else 0
-        self.compact_packs()
-        repo_size_after = self.repository_size if self.stats else 0
+        repo_size_before, repo_size_after = self.compact_packs()
 
         if self.stats:
             deduplicated_size = sum(
@@ -205,6 +197,35 @@ class ArchiveGarbageCollector:
                     f"{format_file_size(repo_size_before - repo_size_after, precision=0, iec=self.iec)}."
                 )
 
+    def mark_soft_deleted_used(self):
+        """Flag every chunk of the soft-deleted archives F_USED, so compaction keeps them.
+
+        Keeps each soft-deleted archive's metadata object, item metadata and file content, so
+        "borg undelete" can still recover it. An archive whose metadata object is itself already
+        gone is skipped with a warning.
+        """
+
+        def mark(id):
+            entry = self.chunks.get(id)
+            if entry is not None:
+                self.chunks[id] = entry._replace(flags=entry.flags | ChunkIndex.F_USED)
+
+        for archive_info in self.manifest.archives.list(sort_by=["ts"], deleted=True):
+            try:
+                archive = Archive(self.manifest, archive_info.id, iec=self.iec, deleted=True)
+                mark(archive.id)
+                for id in archive.metadata.item_ptrs:
+                    mark(id)
+                for id in archive.metadata.items:
+                    mark(id)
+                for item in archive.iter_items():
+                    if "chunks" in item:
+                        for id, _ in item.chunks:
+                            mark(id)
+            except (Repository.ObjectNotFound, IntegrityError) as e:
+                name, hex_id = archive_info.name, bin_to_hex(archive_info.id)
+                logger.warning(f"Soft-deleted archive {name} {hex_id} cannot be fully preserved: {e}")
+
     def compact_packs(self):
         """Free space one pack at a time (the store can only delete whole packs).
 
@@ -228,12 +249,16 @@ class ArchiveGarbageCollector:
         When the repo is damaged (archives reference chunks the index cannot find), packs holding
         unindexed bytes are left untouched: those bytes may be live data "borg check --repair" can
         recover. Packs without unindexed bytes are still compacted, so delete/prune waste is reclaimed.
+
+        Returns (repo_size_before, repo_size_after), the on-disk pack size before and after this run.
         """
-        # Pass 1: list the pack files and their sizes; these are the packs we consider.
+        # Pass 1: list the pack files and their sizes; these are the packs we consider. This is the
+        # only pack listing per run.
         pack_total = {}  # pack_id -> file size in the store
         for info in self.repository.store_list("packs"):
             info = ItemInfo(*info)
             pack_total[hex_to_bin(info.name)] = info.size
+        repo_size_before = sum(pack_total.values())  # on-disk pack size before compaction (for --stats)
 
         # sum the used bytes per pack from the index; also sum every entry's bytes (used or not) to
         # detect which packs hold unindexed bytes. collect index entries whose pack is not in the store.
@@ -297,10 +322,10 @@ class ArchiveGarbageCollector:
                 f"Would free {format_file_size(freed, iec=self.iec)} "
                 f"by dropping {len(drop_packs)} packs and rewriting {len(rewrite_packs)} packs."
             )
-            return  # dry run: report only, change nothing
+            return repo_size_before, repo_size_before  # dry run: report only, change nothing
         if not drop_packs and not rewrite_packs and not stale_ids:
             logger.info("Deleting 0 unused objects...")
-            return  # nothing to reclaim; do not touch the chunk indexes
+            return repo_size_before, repo_size_before  # nothing to reclaim; chunk indexes stay valid
 
         # crash-safety (#9748): invalidate chunk indexes before the first store change
         delete_chunkindex_from_repo(self.repository)
@@ -351,6 +376,9 @@ class ArchiveGarbageCollector:
             progress += 1
             pi.show(progress)
         pi.finish()
+
+        # a rewritten pack's new size equals its kept bytes, so reclaimed is the exact on-disk delta.
+        return repo_size_before, repo_size_before - reclaimed
 
 
 class CompactMixIn:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -904,17 +904,19 @@ class Repository:
         chunks: the ChunkIndex to look up the objects' pack locations in and to apply the index
             updates to. Must be the index keep_ids and drop_ids were derived from. Default: self.chunks.
 
-        keep_ids and drop_ids need not name every object in the pack. A pack can hold bytes that no
-        index entry covers: an older copy of a chunk that was later stored again elsewhere, or objects
-        from a backup that crashed before writing its index. Such bytes appear as gaps between the
-        listed objects and are dropped. An overlap between listed objects, or an object claiming to end
-        past the pack file, means index corruption and raises IntegrityError.
+        Together, keep_ids and drop_ids must cover every object the chunk index lists for this pack;
+        an unlisted indexed object would keep its bytes in the new pack but its index entry would go
+        stale when the old pack is deleted. Bytes that no index entry covers (an older copy of a chunk
+        that was later stored again elsewhere, or objects from a backup that crashed before writing its
+        index) appear as gaps between the listed objects; they are copied into the new pack unchanged.
+        Only drop_ids are removed. An overlap between listed objects, or an object claiming to end past
+        the pack file, means index corruption and raises IntegrityError.
 
-        Kept objects are copied into a new pack via store.defrag and repointed in the chunk index;
-        dropped objects' chunk index entries are removed.
+        The new pack is the old pack minus the dropped objects, built via store.defrag; kept objects are
+        repointed in the chunk index and dropped objects' chunk index entries are removed.
 
-        Returns the new pack_id, or None if nothing is kept, or the unchanged pack_id if nothing
-        was dropped.
+        Returns the new pack_id, or None if every byte was dropped, or the unchanged pack_id if
+        nothing was dropped.
 
         Updates the in-memory chunk index only; the caller holds the exclusive lock and writes the
         index back to the store afterwards.
@@ -935,10 +937,10 @@ class Repository:
             located.append((entry.obj_offset, obj_id, entry.obj_size, keep))
         located.sort()
 
-        # walk objects in offset order, collecting the survivors. covered is the end offset of the last
-        # object; a gap (offset > covered) is unindexed bytes we drop, an overlap (offset < covered) is
-        # index corruption.
-        kept = []  # (obj_offset, obj_id, obj_size), offset-ordered
+        # walk objects in offset order. covered is the end offset of the last object; an overlap
+        # (offset < covered) is index corruption. record the dropped objects' byte ranges; every other
+        # byte (kept objects and gaps that no index entry covers) is copied into the new pack unchanged.
+        drop_ranges = []  # (obj_offset, obj_size) of dropped objects, offset-ordered
         covered = 0
         for offset, obj_id, size, keep in located:
             if offset < covered:
@@ -947,8 +949,8 @@ class Repository:
                     f'run "borg check"'
                 )
             covered = offset + size
-            if keep:
-                kept.append((offset, obj_id, size))
+            if not keep:
+                drop_ranges.append((offset, size))
 
         # reject an object that ends past the pack file: store.defrag would short-read it into a
         # truncated object in the new pack, then the intact source pack is deleted.
@@ -959,28 +961,45 @@ class Repository:
                 f'(index corruption), run "borg check"'
             )
 
+        # the new pack is the whole file minus the dropped ranges: copy the byte spans between them.
+        sources = []  # (pack_hex, offset, size) to copy, offset-ordered
+        pack_hex = bin_to_hex(pack_id)
+        cursor = 0
+        for offset, size in drop_ranges:
+            if offset > cursor:
+                sources.append((pack_hex, cursor, offset - cursor))
+            cursor = offset + size
+        if cursor < pack_size:
+            sources.append((pack_hex, cursor, pack_size - cursor))
+
+        # write the new pack (named sha256 of its content) from those spans before touching the index
+        # or the old pack, so a failed read-back leaves everything unchanged.
+        # TODO: borgstore 0.5.5 defrag raises ReadRangeError on a short/long read (corrupt/truncated
+        # pack); catch it here and translate to IntegrityError once the dependency is bumped to 0.5.5.
+        if sources:
+            new_pack_id = hex_to_bin(self.store.defrag(sources, algorithm="sha256", namespace="packs"))
+        else:
+            new_pack_id = None  # every byte was dropped: no replacement pack
+
         for drop_id in drop_ids:  # remove dropped objects from the index
             del chunks[drop_id]
 
-        if not kept:  # nothing kept: drop the pack, no replacement
+        if new_pack_id is None:  # nothing kept: drop the pack, no replacement
             self.store_delete(pack_key)
             return None
 
-        # copy kept objects into a new pack (named sha256 of its content)
-        sources = [(bin_to_hex(pack_id), offset, size) for offset, _, size in kept]
-        new_pack_id = hex_to_bin(self.store.defrag(sources, algorithm="sha256", namespace="packs"))
-
-        # repoint kept objects at the new pack; new offset is the running sum of kept sizes
+        # repoint kept objects at the new pack; an object's new offset is its old offset minus the
+        # dropped bytes lying before it.
         new_locations = []
-        offset = 0
-        for _, keep_id, size in kept:
-            new_locations.append((keep_id, new_pack_id, offset, size))
-            offset += size
+        for offset, obj_id, size, keep in located:
+            if keep:
+                dropped_before = sum(dsize for doffset, dsize in drop_ranges if doffset < offset)
+                new_locations.append((obj_id, new_pack_id, offset - dropped_before, size))
         chunks.update_pack_info(new_locations)
 
         # delete the old pack last, after the new one is stored and indexed, so kept bytes are never the
-        # only copy. if every object was kept in order, defrag reproduced the pack (new_pack_id == pack_id)
-        # and deleting it would drop what we kept, so skip.
+        # only copy. with nothing dropped, defrag reproduced the pack (new_pack_id == pack_id) and
+        # deleting it would drop what we kept, so skip.
         if new_pack_id != pack_id:
             self.store_delete(pack_key)
         return new_pack_id

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -22,7 +22,7 @@ from .helpers.lrucache import LRUCache
 from .storelocking import Lock
 from .logger import create_logger
 from .manifest import NoManifestError
-from .repoobj import RepoObj
+from .repoobj import RepoObj, OBJ_MAGIC
 from .crypto.key import is_keyfile
 
 logger = create_logger(__name__)
@@ -906,17 +906,19 @@ class Repository:
 
         Together, keep_ids and drop_ids must cover every object the chunk index lists for this pack;
         an unlisted indexed object would keep its bytes in the new pack but its index entry would go
-        stale when the old pack is deleted. Bytes that no index entry covers (an older copy of a chunk
-        that was later stored again elsewhere, or objects from a backup that crashed before writing its
-        index) appear as gaps between the listed objects; they are copied into the new pack unchanged.
-        Only drop_ids are removed. An overlap between listed objects, or an object claiming to end past
-        the pack file, means index corruption and raises IntegrityError.
+        stale when the old pack is deleted. Bytes that no index entry covers appear as gaps between the
+        listed objects: a gap object whose chunk id is in the index is a superseded duplicate (its
+        authoritative copy is elsewhere) and is dropped; a gap object whose id is not in the index is
+        copied into the new pack unchanged, to be handled by "borg check --repair". An overlap between
+        listed objects, or an object claiming to end past the pack file, means index corruption and
+        raises IntegrityError.
 
         The new pack is the old pack minus the dropped objects, built via store.defrag; kept objects are
         repointed in the chunk index and dropped objects' chunk index entries are removed.
 
-        Returns the new pack_id, or None if every byte was dropped, or the unchanged pack_id if
-        nothing was dropped.
+        Returns (new_pack_id, dropped_bytes): new_pack_id is None if every byte was dropped, or the
+        unchanged pack_id if nothing was dropped; dropped_bytes is the on-disk bytes this rewrite freed
+        (unused indexed objects plus superseded duplicates), for --stats accounting.
 
         Updates the in-memory chunk index only; the caller holds the exclusive lock and writes the
         index back to the store afterwards.
@@ -961,6 +963,44 @@ class Repository:
                 f'(index corruption), run "borg check"'
             )
 
+        # find the gaps: byte ranges no listed object covers (a chunk copy stored again elsewhere, or
+        # objects from a backup that crashed before writing its index).
+        gaps = []  # (start, end) of each gap, offset-ordered
+        cursor = 0
+        for offset, obj_id, size, keep in located:
+            if offset > cursor:
+                gaps.append((cursor, offset))
+            cursor = offset + size
+        if cursor < pack_size:
+            gaps.append((cursor, pack_size))
+
+        # walk each gap's object headers. drop an object whose chunk id the index maps to a different
+        # location: that entry is the authoritative copy (the id is a keyed MAC of the plaintext, so
+        # equal ids mean equal content) and these bytes are redundant. keep an object whose id is not in
+        # the index (borg check --repair re-indexes it) or whose entry points back at this offset (its
+        # only copy). a header that does not parse or overruns its gap ends the walk over that gap.
+        # TODO(#9868 follow-up): classify gaps in compact_packs pass 1 too, so superseded bytes count
+        # toward the rewrite threshold and a wholly superseded orphan pack can be dropped outright.
+        reader = PackReader(store=self.store, pack_id=pack_id)
+        hdr_size = RepoObj.obj_header.size
+        for gstart, gend in gaps:
+            offset = gstart
+            while offset < gend:
+                hdr_data = reader.read(offset, hdr_size)
+                if len(hdr_data) < hdr_size:
+                    break
+                hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(hdr_data))
+                obj_size = hdr_size + hdr.meta_size + hdr.data_size
+                if hdr.magic != OBJ_MAGIC or offset + obj_size > gend:
+                    break
+                if hdr.chunk_id in chunks:
+                    entry = chunks[hdr.chunk_id]
+                    if entry.pack_id != pack_id or entry.obj_offset != offset:
+                        drop_ranges.append((offset, obj_size))
+                offset += obj_size
+        drop_ranges.sort()
+        dropped_bytes = sum(size for _, size in drop_ranges)  # on-disk bytes this rewrite frees, for --stats
+
         # the new pack is the whole file minus the dropped ranges: copy the byte spans between them.
         sources = []  # (pack_hex, offset, size) to copy, offset-ordered
         pack_hex = bin_to_hex(pack_id)
@@ -988,14 +1028,19 @@ class Repository:
 
         if new_pack_id is None:  # nothing kept: drop the pack, no replacement
             self.store_delete(pack_key)
-            return None
+            return None, dropped_bytes
 
         # repoint kept objects at the new pack; an object's new offset is its old offset minus the
-        # dropped bytes lying before it.
+        # dropped bytes lying before it. both lists are offset-ordered, so a single walk over the
+        # drop ranges keeps the running total of dropped bytes.
         new_locations = []
+        dropped_before = 0
+        di = 0
         for offset, obj_id, size, keep in located:
+            while di < len(drop_ranges) and drop_ranges[di][0] < offset:
+                dropped_before += drop_ranges[di][1]
+                di += 1
             if keep:
-                dropped_before = sum(dsize for doffset, dsize in drop_ranges if doffset < offset)
                 new_locations.append((obj_id, new_pack_id, offset - dropped_before, size))
         chunks.update_pack_info(new_locations)
 
@@ -1004,7 +1049,7 @@ class Repository:
         # deleting it would drop what we kept, so skip.
         if new_pack_id != pack_id:
             self.store_delete(pack_key)
-        return new_pack_id
+        return new_pack_id, dropped_bytes
 
     def break_lock(self):
         Lock(self.store).break_lock()

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -6,7 +6,7 @@ from hashlib import sha256
 
 from borgstore.store import Store
 from borgstore.backends.rest import REST, ssh_cmd
-from borgstore.store import ObjectNotFound as StoreObjectNotFound
+from borgstore.store import ObjectNotFound as StoreObjectNotFound, ReadRangeError
 from borgstore.backends.errors import BackendError as StoreBackendError
 from borgstore.backends.errors import BackendDoesNotExist as StoreBackendDoesNotExist
 from borgstore.backends.errors import BackendAlreadyExists as StoreBackendAlreadyExists
@@ -973,11 +973,13 @@ class Repository:
             sources.append((pack_hex, cursor, pack_size - cursor))
 
         # write the new pack (named sha256 of its content) from those spans before touching the index
-        # or the old pack, so a failed read-back leaves everything unchanged.
-        # TODO: borgstore 0.5.5 defrag raises ReadRangeError on a short/long read (corrupt/truncated
-        # pack); catch it here and translate to IntegrityError once the dependency is bumped to 0.5.5.
+        # or the old pack, so a failed read-back leaves everything unchanged. a span reading back short
+        # (defrag raises ReadRangeError) means the pack file is truncated or corrupt.
         if sources:
-            new_pack_id = hex_to_bin(self.store.defrag(sources, algorithm="sha256", namespace="packs"))
+            try:
+                new_pack_id = hex_to_bin(self.store.defrag(sources, algorithm="sha256", namespace="packs"))
+            except ReadRangeError as e:
+                raise IntegrityError(f'pack {pack_hex}: {e}, run "borg check"') from e
         else:
             new_pack_id = None  # every byte was dropped: no replacement pack
 

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -907,8 +907,8 @@ class Repository:
         keep_ids and drop_ids need not name every object in the pack. A pack can hold bytes that no
         index entry covers: an older copy of a chunk that was later stored again elsewhere, or objects
         from a backup that crashed before writing its index. Such bytes appear as gaps between the
-        listed objects and are dropped. An overlap between listed objects means index corruption and
-        raises IntegrityError.
+        listed objects and are dropped. An overlap between listed objects, or an object claiming to end
+        past the pack file, means index corruption and raises IntegrityError.
 
         Kept objects are copied into a new pack via store.defrag and repointed in the chunk index;
         dropped objects' chunk index entries are removed.
@@ -949,6 +949,15 @@ class Repository:
             covered = offset + size
             if keep:
                 kept.append((offset, obj_id, size))
+
+        # reject an object that ends past the pack file: store.defrag would short-read it into a
+        # truncated object in the new pack, then the intact source pack is deleted.
+        pack_size = self.store.info(pack_key).size
+        if covered > pack_size:
+            raise IntegrityError(
+                f"pack {bin_to_hex(pack_id)}: object extends past end of file at offset {covered} "
+                f'(index corruption), run "borg check"'
+            )
 
         for drop_id in drop_ids:  # remove dropped objects from the index
             del chunks[drop_id]

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -888,9 +888,7 @@ class Repository:
         # keep every object the chunk index lists for this pack, except the one being deleted.
         keep_ids = {cid for cid, e in self.chunks.iteritems() if e.pack_id == pack_id}
         keep_ids.discard(id)
-        # complete=False: a pack may also hold superseded bytes (an older copy of a chunk later re-put
-        # elsewhere, no longer in the index), so keep_ids and drop_ids need not cover the whole pack.
-        self.compact_pack(pack_id, keep_ids=keep_ids, drop_ids={id}, complete=False)
+        self.compact_pack(pack_id, keep_ids=keep_ids, drop_ids={id})
         if update_index:
             # close() only persists new entries incrementally, so write the full index here to record
             # the removal for the next borg process.
@@ -898,15 +896,19 @@ class Repository:
 
             write_chunkindex_to_repo(self, self.chunks, incremental=False, force_write=True, delete_other=True)
 
-    def compact_pack(self, pack_id, *, keep_ids: set, drop_ids: set, complete: bool = True, chunks=None):
+    def compact_pack(self, pack_id, *, keep_ids: set, drop_ids: set, chunks=None):
         """Rewrite pack <pack_id>, keeping <keep_ids> and dropping <drop_ids>, then delete the old pack.
 
         keep_ids: chunk ids in this pack to copy into the new pack.
         drop_ids: chunk ids in this pack to discard. Must not overlap keep_ids.
-        complete: if True, keep_ids and drop_ids must together be every object in the pack (asserted).
-            If False, they may name only some of the pack's objects.
         chunks: the ChunkIndex to look up the objects' pack locations in and to apply the index
             updates to. Must be the index keep_ids and drop_ids were derived from. Default: self.chunks.
+
+        keep_ids and drop_ids need not name every object in the pack. A pack can hold bytes that no
+        index entry covers: an older copy of a chunk that was later stored again elsewhere, or objects
+        from a backup that crashed before writing its index. Such bytes appear as gaps between the
+        listed objects and are dropped. An overlap between listed objects means index corruption and
+        raises IntegrityError.
 
         Kept objects are copied into a new pack via store.defrag and repointed in the chunk index;
         dropped objects' chunk index entries are removed.
@@ -924,7 +926,7 @@ class Repository:
 
         assert keep_ids & drop_ids == set(), "an id cannot appear in both keep_ids and drop_ids"
 
-        # collect every object's range, tagged with whether it is kept, ordered by offset.
+        # collect every listed object's range, tagged with whether it is kept, ordered by offset.
         located = []  # (obj_offset, obj_id, obj_size, keep)
         for obj_id in keep_ids | drop_ids:
             keep = obj_id in keep_ids
@@ -933,21 +935,20 @@ class Repository:
             located.append((entry.obj_offset, obj_id, entry.obj_size, keep))
         located.sort()
 
-        # walk objects in offset order, collecting the survivors.
+        # walk objects in offset order, collecting the survivors. covered is the end offset of the last
+        # object; a gap (offset > covered) is unindexed bytes we drop, an overlap (offset < covered) is
+        # index corruption.
         kept = []  # (obj_offset, obj_id, obj_size), offset-ordered
         covered = 0
         for offset, obj_id, size, keep in located:
-            if complete:  # keep+drop are the whole pack: they must tile it with no gap or overlap
-                assert offset == covered, f"gap or overlap in pack {bin_to_hex(pack_id)} at offset {covered}"
-            covered += size
+            if offset < covered:
+                raise IntegrityError(
+                    f"pack {bin_to_hex(pack_id)}: overlapping objects at offset {offset} (index corruption), "
+                    f'run "borg check"'
+                )
+            covered = offset + size
             if keep:
                 kept.append((offset, obj_id, size))
-
-        if complete:  # the listed objects must reach the pack's end, no trailing object unaccounted for
-            pack_size = self.store.info(pack_key).size
-            assert (
-                covered == pack_size
-            ), f"pack {bin_to_hex(pack_id)}: {pack_size - covered} trailing bytes unaccounted for"
 
         for drop_id in drop_ids:  # remove dropped objects from the index
             del chunks[drop_id]

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -8,7 +8,7 @@ from ...helpers import get_cache_dir, bin_to_hex, sig_int, Error
 from ...hashindex import ChunkIndex
 from ...repository import Repository
 from ...cache import files_cache_name, discover_files_cache_names, list_chunkindex_hashes
-from ...cache import delete_chunkindex_from_repo
+from ...cache import delete_chunkindex_from_repo, write_chunkindex_to_repo
 from ...manifest import Manifest
 from . import cmd, create_regular_file, create_src_archive, generate_archiver_tests, open_repository, RK_ENCRYPTION
 from . import changedir
@@ -242,6 +242,133 @@ def test_compact_packs_respects_threshold(tmp_path):
         pack_names = [info.name for info in repository.store_list("packs")]
         assert bin_to_hex(wasteful_pack) not in pack_names
         assert bin_to_hex(frugal_pack) in pack_names
+
+
+def test_compact_superseded_duplicate(tmp_path):
+    # Issue #9868 repro. Concurrent backups can write the same chunk into two packs; when the index
+    # fragments merge, only one copy stays indexed and the other is left as unindexed bytes in a pack.
+    # Once such a mixed pack crosses the threshold, compact must rewrite it, dropping those bytes.
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4  # one flush() -> one pack
+        # pack A: three objects W, X, Y (X will be the one later superseded by a copy in pack B)
+        for cid, data in [(H(0), b"WWWW"), (H(1), b"XXXX"), (H(2), b"YYYY")]:
+            repository.put(cid, fchunk(data, chunk_id=cid))
+        repository.flush()
+        pack_a = repository.chunks[H(0)].pack_id
+
+        # pack B: a second copy of X only, in its own pack (as a concurrent writer would have produced).
+        repository.put(H(1), fchunk(b"XXXX", chunk_id=H(1)))
+        repository.flush()
+        pack_b = repository.chunks[H(1)].pack_id
+        assert pack_b != pack_a
+        # after the (simulated) fragment merge, the index points X at pack B; pack A's X bytes are now
+        # a superseded, unindexed span. put() already repointed the index to pack B, so nothing to do.
+
+        # mark usage: W and X used, Y unused. pack A is now mixed (W used, X superseded gap, Y unused).
+        used = {H(0), H(1)}
+        for i in range(3):
+            entry = repository.chunks[H(i)]
+            flags = ChunkIndex.F_USED if H(i) in used else ChunkIndex.F_NONE
+            repository.chunks[H(i)] = entry._replace(flags=flags)
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.compact_packs()
+
+        # W still readable; X still readable from pack B; Y dropped; pack A rewritten to only W's bytes.
+        assert pdchunk(repository.get(H(0))) == b"WWWW"
+        assert pdchunk(repository.get(H(1))) == b"XXXX"
+        assert repository.get(H(2), raise_missing=False) is None
+        assert bin_to_hex(pack_a) not in [info.name for info in repository.store_list("packs")]
+
+
+def test_compact_drops_orphan_pack(tmp_path):
+    # A pack with no index entries at all (a backup that crashed after writing the pack but before
+    # writing its index) must still be found and dropped: compact enumerates the actual pack files,
+    # not just the index (#9868).
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4
+        repository.put(H(0), fchunk(b"KEEP", chunk_id=H(0)))
+        repository.flush()
+        live_pack = repository.chunks[H(0)].pack_id
+        repository.chunks[H(0)] = repository.chunks[H(0)]._replace(flags=ChunkIndex.F_USED)
+
+        # write an extra pack directly to the store, with NO chunk-index entry for it.
+        orphan_key = "packs/" + "ab" * 32
+        repository.store_store(orphan_key, b"orphan pack bytes")
+        assert "ab" * 32 in [info.name for info in repository.store_list("packs")]
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.compact_packs()
+
+        pack_names = [info.name for info in repository.store_list("packs")]
+        assert "ab" * 32 not in pack_names  # orphan pack dropped
+        assert bin_to_hex(live_pack) in pack_names  # the used pack kept
+        assert pdchunk(repository.get(H(0))) == b"KEEP"
+
+
+def test_compact_superseded_waste_triggers_rewrite(tmp_path):
+    # A pack whose indexed objects are all used but which also holds unindexed bytes over the
+    # threshold must be rewritten (#9868). Delete one object's index entry so its bytes become
+    # unindexed waste, then compact must copy the used survivors into a fresh pack.
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4
+        for cid, data in [(H(0), b"AAAA"), (H(1), b"BBBBBBBBBB"), (H(2), b"CCCC")]:
+            repository.put(cid, fchunk(data, chunk_id=cid))
+        repository.flush()
+        pack = repository.chunks[H(0)].pack_id
+        # every remaining indexed object is used ...
+        for i in (0, 2):
+            repository.chunks[H(i)] = repository.chunks[H(i)]._replace(flags=ChunkIndex.F_USED)
+        # ... but H(1)'s big object becomes an unindexed superseded span (waste well over threshold).
+        del repository.chunks[H(1)]
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.compact_packs()
+
+        new_pack = repository.chunks[H(0)].pack_id
+        assert new_pack != pack  # the pack was rewritten despite all indexed objects being used
+        assert bin_to_hex(pack) not in [info.name for info in repository.store_list("packs")]
+        assert pdchunk(repository.get(H(0))) == b"AAAA"
+        assert pdchunk(repository.get(H(2))) == b"CCCC"
+
+
+def test_compact_refuses_when_chunks_missing(archivers, request):
+    # If an archive references a chunk the index cannot find, that chunk might be live-but-unindexed
+    # data recoverable by "check --repair". Compact must not reclaim pack bytes in that state (#9868).
+    archiver = request.getfixturevalue(archivers)
+
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_src_archive(archiver, "archive")
+
+    # remove one used chunk's index entry and persist an index without it, so analyze_archives()
+    # reports a missing object on the next compact.
+    repository = open_repository(archiver)
+    with repository:
+        some_id = next(iter(repository.chunks.iteritems()))[0]
+        del repository.chunks[some_id]
+        write_chunkindex_to_repo(repository, repository.chunks, incremental=False, force_write=True, delete_other=True)
+        packs_before = {info.name for info in repository.store_list("packs")}
+
+    output = cmd(archiver, "compact", "-v", exit_code=EXIT_ERROR)
+    assert "Skipping pack compaction" in output
+
+    # the pack files must be untouched
+    repository = open_repository(archiver)
+    with repository:
+        packs_after = {info.name for info in repository.store_list("packs")}
+    assert packs_after == packs_before
 
 
 def test_compact_gc_after_index_loss(archivers, request):

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -205,8 +205,8 @@ def test_compact_soft_interrupt_persists_valid_index(archivers, request, monkeyp
 
 def test_compact_packs_respects_threshold(tmp_path):
     # Two multi-object packs in one repo, then pack-level compaction at a 40% threshold. The pack that
-    # wastes 2/3 of its bytes is rewritten down to its single survivor (and its old file deleted); the
-    # pack that wastes only 1/3 stays untouched, since copying its survivors to reclaim that little is
+    # wastes 2/3 of its bytes is rewritten down to its single kept object (and its old file deleted); the
+    # pack that wastes only 1/3 stays untouched, since copying its kept objects to reclaim that little is
     # not worth it. This covers the rewrite, leave-alone and keep/drop split unique to multi-object packs.
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
@@ -233,7 +233,7 @@ def test_compact_packs_respects_threshold(tmp_path):
         gc.chunks = repository.chunks
         gc.compact_packs()
 
-        # wasteful pack was rewritten: the survivor reads back, the dropped objects and the old file are gone
+        # wasteful pack was rewritten: the kept object reads back, the dropped objects and the old file are gone
         assert pdchunk(repository.get(H(0))) == b"DATA0"
         assert repository.get(H(1), raise_missing=False) is None
         assert repository.get(H(2), raise_missing=False) is None
@@ -248,7 +248,8 @@ def test_compact_packs_respects_threshold(tmp_path):
 def test_compact_superseded_duplicate(tmp_path):
     # Issue #9868 repro. Concurrent backups can write the same chunk into two packs; when the index
     # fragments merge, only one copy stays indexed and the other is left as unindexed bytes in a pack.
-    # Once such a mixed pack crosses the threshold, compact must rewrite it, dropping those bytes.
+    # Rewriting such a pack (because of its ordinary unused objects) must copy those superseded bytes
+    # forward, not drop them: only "borg check --repair" decides their fate.
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
@@ -259,6 +260,8 @@ def test_compact_superseded_duplicate(tmp_path):
             repository.put(cid, fchunk(data, chunk_id=cid))
         repository.flush()
         pack_a = repository.chunks[H(0)].pack_id
+        pack_a_size = next(i.size for i in repository.store_list("packs") if i.name == bin_to_hex(pack_a))
+        y_size = repository.chunks[H(2)].obj_size
 
         # pack B: a second copy of X only, in its own pack (as a concurrent writer would have produced).
         repository.put(H(1), fchunk(b"XXXX", chunk_id=H(1)))
@@ -279,17 +282,21 @@ def test_compact_superseded_duplicate(tmp_path):
         gc.chunks = repository.chunks
         gc.compact_packs()
 
-        # W still readable; X still readable from pack B; Y dropped; pack A rewritten to only W's bytes.
+        # W still readable; X still readable from pack B; Y (the unused indexed object) dropped.
         assert pdchunk(repository.get(H(0))) == b"WWWW"
         assert pdchunk(repository.get(H(1))) == b"XXXX"
         assert repository.get(H(2), raise_missing=False) is None
+        # pack A rewritten, shrunk by exactly Y's bytes: W's and the superseded X span are kept, not dropped.
         assert bin_to_hex(pack_a) not in [info.name for info in repository.store_list("packs")]
+        new_pack = repository.chunks[H(0)].pack_id
+        new_size = next(i.size for i in repository.store_list("packs") if i.name == bin_to_hex(new_pack))
+        assert new_size == pack_a_size - y_size
 
 
-def test_compact_drops_orphan_pack(tmp_path):
+def test_compact_keeps_orphan_pack(tmp_path):
     # A pack with no index entries at all (a backup that crashed after writing the pack but before
-    # writing its index) must still be found and dropped: compact enumerates the actual pack files,
-    # not just the index (#9868).
+    # writing its index) is left alone: its objects hold no reclaimable indexed waste and may be live
+    # data, so dropping them is "borg check --repair"'s call, not compact's (#9868).
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
@@ -310,15 +317,16 @@ def test_compact_drops_orphan_pack(tmp_path):
         gc.compact_packs()
 
         pack_names = [info.name for info in repository.store_list("packs")]
-        assert "ab" * 32 not in pack_names  # orphan pack dropped
+        assert "ab" * 32 in pack_names  # orphan pack kept for check --repair
         assert bin_to_hex(live_pack) in pack_names  # the used pack kept
         assert pdchunk(repository.get(H(0))) == b"KEEP"
 
 
-def test_compact_superseded_waste_triggers_rewrite(tmp_path):
-    # A pack whose indexed objects are all used but which also holds unindexed bytes over the
-    # threshold must be rewritten (#9868). Delete one object's index entry so its bytes become
-    # unindexed waste, then compact must copy the used survivors into a fresh pack.
+def test_compact_keeps_unindexed_waste(tmp_path):
+    # A pack whose indexed objects are all used, but which also holds unindexed bytes, is left alone:
+    # compact reclaims only indexed-but-unused bytes, never bytes no index entry covers. Those may be
+    # live data for "borg check --repair" (#9868). Delete one object's index entry to make a big
+    # unindexed span; compact must not rewrite the pack over it.
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
@@ -331,56 +339,54 @@ def test_compact_superseded_waste_triggers_rewrite(tmp_path):
         # every remaining indexed object is used ...
         for i in (0, 2):
             repository.chunks[H(i)] = repository.chunks[H(i)]._replace(flags=ChunkIndex.F_USED)
-        # ... but H(1)'s big object becomes an unindexed superseded span (waste well over threshold).
+        # ... but H(1)'s big object becomes an unindexed superseded span (well over threshold if counted).
         del repository.chunks[H(1)]
 
         gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
         gc.chunks = repository.chunks
         gc.compact_packs()
 
-        new_pack = repository.chunks[H(0)].pack_id
-        assert new_pack != pack  # the pack was rewritten despite all indexed objects being used
-        assert bin_to_hex(pack) not in [info.name for info in repository.store_list("packs")]
+        assert repository.chunks[H(0)].pack_id == pack  # not rewritten: unindexed bytes are not reclaimed
+        assert bin_to_hex(pack) in [info.name for info in repository.store_list("packs")]
         assert pdchunk(repository.get(H(0))) == b"AAAA"
         assert pdchunk(repository.get(H(2))) == b"CCCC"
 
 
-def test_compact_partial_when_chunks_missing(tmp_path):
-    # On a damaged repo (archives reference missing chunks) compact still reclaims ordinary waste from
-    # packs that hold no unindexed bytes, but leaves packs that DO hold unindexed bytes alone, since
-    # those bytes may be live data "borg check --repair" can recover (#9868).
+def test_compact_reclaims_indexed_waste_only(tmp_path):
+    # compact reclaims a pack's indexed-but-unused bytes, but leaves alone a pack whose only waste is
+    # unindexed (bytes no index entry covers): those may be live data "borg check --repair" can
+    # recover (#9868).
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
     with Repository(location, exclusive=True, create=True) as repository:
         repository._pack_writer.max_count = 4
-        # clean pack: one used, one unused object -> reclaimable waste, but every byte is indexed.
+        # indexed-waste pack: one used, one unused object -> reclaimable waste, every byte still indexed.
         for cid, data in [(H(0), b"KEEP"), (H(1), b"DROPME")]:
             repository.put(cid, fchunk(data, chunk_id=cid))
         repository.flush()
-        clean_pack = repository.chunks[H(0)].pack_id
+        waste_pack = repository.chunks[H(0)].pack_id
         repository.chunks[H(0)] = repository.chunks[H(0)]._replace(flags=ChunkIndex.F_USED)
         repository.chunks[H(1)] = repository.chunks[H(1)]._replace(flags=ChunkIndex.F_NONE)  # unused waste
 
-        # damaged pack: one used object plus unindexed bytes (H(3)'s entry dropped from the index).
+        # unindexed-waste pack: one used object plus unindexed bytes (H(3)'s entry dropped from the index).
         for cid, data in [(H(2), b"LIVE"), (H(3), b"UNINDEXED")]:
             repository.put(cid, fchunk(data, chunk_id=cid))
         repository.flush()
-        damaged_pack = repository.chunks[H(2)].pack_id
+        unindexed_pack = repository.chunks[H(2)].pack_id
         repository.chunks[H(2)] = repository.chunks[H(2)]._replace(flags=ChunkIndex.F_USED)
-        del repository.chunks[H(3)]  # its bytes remain in damaged_pack as unindexed data
+        del repository.chunks[H(3)]  # its bytes remain in unindexed_pack as unindexed data
 
         gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
         gc.chunks = repository.chunks
-        gc.missing_chunks = {H(9)}  # mark the repo damaged
         gc.compact_packs()
 
         pack_names = [info.name for info in repository.store_list("packs")]
-        # clean pack: waste but no unindexed bytes -> compacted, survivor still readable
-        assert bin_to_hex(clean_pack) not in pack_names
+        # indexed waste -> compacted, kept object still readable
+        assert bin_to_hex(waste_pack) not in pack_names
         assert pdchunk(repository.get(H(0))) == b"KEEP"
-        # damaged pack: holds unindexed bytes -> left untouched for check --repair
-        assert bin_to_hex(damaged_pack) in pack_names
+        # only unindexed waste -> left untouched for check --repair
+        assert bin_to_hex(unindexed_pack) in pack_names
         assert pdchunk(repository.get(H(2))) == b"LIVE"
 
 
@@ -418,9 +424,10 @@ def test_compact_keeps_undelete_data_when_chunks_missing(archivers, request):
         assert fd.read() == b"G" * (1024 * 80)  # its data survived compaction
 
 
-def test_compact_drops_stale_index_entries(tmp_path):
-    # An index entry whose pack file is gone from the store is stale: compact drops it. If it was still
-    # flagged used, that is lost data, so compact reports it and sets an error exit code (#9850).
+def test_compact_keeps_stale_index_entries(tmp_path):
+    # An index entry whose pack file is gone from the store is stale, but it may be an archive's only
+    # pointer to a chunk: compact keeps it and only reports the problem, since dropping it is
+    # "borg check --repair"'s call. A used stale entry means data is missing (#9850).
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
@@ -436,7 +443,7 @@ def test_compact_drops_stale_index_entries(tmp_path):
         gc.chunks = repository.chunks
         gc.compact_packs()
 
-        assert H(0) not in repository.chunks  # stale entry dropped from the index
+        assert H(0) in repository.chunks  # stale entry kept for check --repair, not dropped
 
 
 def test_compact_skips_oversized_index_entry(tmp_path):

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -344,31 +344,108 @@ def test_compact_superseded_waste_triggers_rewrite(tmp_path):
         assert pdchunk(repository.get(H(2))) == b"CCCC"
 
 
-def test_compact_refuses_when_chunks_missing(archivers, request):
-    # If an archive references a chunk the index cannot find, that chunk might be live-but-unindexed
-    # data recoverable by "check --repair". Compact must not reclaim pack bytes in that state (#9868).
+def test_compact_partial_when_chunks_missing(tmp_path):
+    # On a damaged repo (archives reference missing chunks) compact still reclaims ordinary waste from
+    # packs that hold no unindexed bytes, but leaves packs that DO hold unindexed bytes alone, since
+    # those bytes may be live data "borg check --repair" can recover (#9868).
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4
+        # clean pack: one used, one unused object -> reclaimable waste, but every byte is indexed.
+        for cid, data in [(H(0), b"KEEP"), (H(1), b"DROPME")]:
+            repository.put(cid, fchunk(data, chunk_id=cid))
+        repository.flush()
+        clean_pack = repository.chunks[H(0)].pack_id
+        repository.chunks[H(0)] = repository.chunks[H(0)]._replace(flags=ChunkIndex.F_USED)
+        repository.chunks[H(1)] = repository.chunks[H(1)]._replace(flags=ChunkIndex.F_NONE)  # unused waste
+
+        # damaged pack: one used object plus unindexed bytes (H(3)'s entry dropped from the index).
+        for cid, data in [(H(2), b"LIVE"), (H(3), b"UNINDEXED")]:
+            repository.put(cid, fchunk(data, chunk_id=cid))
+        repository.flush()
+        damaged_pack = repository.chunks[H(2)].pack_id
+        repository.chunks[H(2)] = repository.chunks[H(2)]._replace(flags=ChunkIndex.F_USED)
+        del repository.chunks[H(3)]  # its bytes remain in damaged_pack as unindexed data
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.missing_chunks = {H(9)}  # mark the repo damaged
+        gc.compact_packs()
+
+        pack_names = [info.name for info in repository.store_list("packs")]
+        # clean pack: waste but no unindexed bytes -> compacted, survivor still readable
+        assert bin_to_hex(clean_pack) not in pack_names
+        assert pdchunk(repository.get(H(0))) == b"KEEP"
+        # damaged pack: holds unindexed bytes -> left untouched for check --repair
+        assert bin_to_hex(damaged_pack) in pack_names
+        assert pdchunk(repository.get(H(2))) == b"LIVE"
+
+
+def test_compact_skips_nuke_when_chunks_missing(archivers, request):
+    # On a damaged repo, compact must not finalize soft-deleted archives: it skips nuking so their
+    # directory entries survive until "borg check --repair" has run (#9868).
     archiver = request.getfixturevalue(archivers)
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
-    create_src_archive(archiver, "archive")
+    create_src_archive(archiver, "kept")
+    create_src_archive(archiver, "gone")
+    cmd(archiver, "delete", "gone")  # soft-delete: finalized only once compact nukes it
 
-    # remove one used chunk's index entry and persist an index without it, so analyze_archives()
-    # reports a missing object on the next compact.
+    # drop one used chunk's index entry and persist the index, so analyze_archives() reports a missing chunk.
     repository = open_repository(archiver)
     with repository:
         some_id = next(iter(repository.chunks.iteritems()))[0]
         del repository.chunks[some_id]
         write_chunkindex_to_repo(repository, repository.chunks, incremental=False, force_write=True, delete_other=True)
-        packs_before = {info.name for info in repository.store_list("packs")}
 
     output = cmd(archiver, "compact", "-v", exit_code=EXIT_ERROR)
-    assert "Skipping pack compaction" in output
+    assert "missing objects" in output  # the repo is seen as damaged ...
+    assert "Cleaning archives directory" not in output  # ... so soft-deleted archives are not nuked
 
-    # the pack files must be untouched
-    repository = open_repository(archiver)
-    with repository:
-        packs_after = {info.name for info in repository.store_list("packs")}
-    assert packs_after == packs_before
+
+def test_compact_drops_stale_index_entries(tmp_path):
+    # An index entry whose pack file is gone from the store is stale: compact drops it. If it was still
+    # flagged used, that is lost data, so compact reports it and sets an error exit code (#9850).
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4
+        repository.put(H(0), fchunk(b"GONE", chunk_id=H(0)))
+        repository.flush()
+        gone_pack = repository.chunks[H(0)].pack_id
+        repository.chunks[H(0)] = repository.chunks[H(0)]._replace(flags=ChunkIndex.F_USED)
+        repository.store_delete("packs/" + bin_to_hex(gone_pack))  # delete the pack file the index still references
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.compact_packs()
+
+        assert H(0) not in repository.chunks  # stale entry dropped from the index
+
+
+def test_compact_skips_oversized_index_entry(tmp_path):
+    # An index entry claiming more bytes than its pack file holds means index corruption: compact must
+    # leave the pack untouched rather than rewrite it from a bad size (#9868).
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        repository._pack_writer.max_count = 4
+        repository.put(H(0), fchunk(b"DATA", chunk_id=H(0)))
+        repository.flush()
+        pack = repository.chunks[H(0)].pack_id
+        entry = repository.chunks[H(0)]
+        repository.chunks[H(0)] = entry._replace(flags=ChunkIndex.F_USED, obj_size=entry.obj_size + 10000)
+
+        gc = ArchiveGarbageCollector(repository, manifest=None, stats=False, iec=False, threshold=10)
+        gc.chunks = repository.chunks
+        gc.compact_packs()
+
+        assert bin_to_hex(pack) in [info.name for info in repository.store_list("packs")]  # left untouched
+        assert pdchunk(repository.get(H(0))) == b"DATA"
 
 
 def test_compact_gc_after_index_loss(archivers, request):

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -10,6 +10,7 @@ from ...repository import Repository
 from ...cache import files_cache_name, discover_files_cache_names, list_chunkindex_hashes
 from ...cache import delete_chunkindex_from_repo, write_chunkindex_to_repo
 from ...manifest import Manifest
+from ...archive import Archive
 from . import cmd, create_regular_file, create_src_archive, generate_archiver_tests, open_repository, RK_ENCRYPTION
 from . import changedir
 from ..repository_test import H, fchunk, pdchunk
@@ -383,26 +384,38 @@ def test_compact_partial_when_chunks_missing(tmp_path):
         assert pdchunk(repository.get(H(2))) == b"LIVE"
 
 
-def test_compact_skips_nuke_when_chunks_missing(archivers, request):
-    # On a damaged repo, compact must not finalize soft-deleted archives: it skips nuking so their
-    # directory entries survive until "borg check --repair" has run (#9868).
+def test_compact_keeps_undelete_data_when_chunks_missing(archivers, request):
+    # On a damaged repo, compact preserves soft-deleted archives whole (metadata and data), so
+    # "borg undelete" can still recover them until "borg check --repair" has run (#9868).
     archiver = request.getfixturevalue(archivers)
 
     cmd(archiver, "repo-create", RK_ENCRYPTION)
-    create_src_archive(archiver, "kept")
-    create_src_archive(archiver, "gone")
+    # two archives with distinct content, so the soft-deleted one has its own chunks to preserve.
+    create_regular_file(archiver.input_path, "kept_dir/kept_file", contents=b"K" * (1024 * 80))
+    create_regular_file(archiver.input_path, "gone_dir/gone_file", contents=b"G" * (1024 * 80))
+    cmd(archiver, "create", "kept", "input/kept_dir")
+    cmd(archiver, "create", "gone", "input/gone_dir")
     cmd(archiver, "delete", "gone")  # soft-delete: finalized only once compact nukes it
 
-    # drop one used chunk's index entry and persist the index, so analyze_archives() reports a missing chunk.
+    # damage the repo: drop a content chunk index entry of the live "kept" archive, so compact
+    # sees a missing object and treats the repo as damaged.
     repository = open_repository(archiver)
     with repository:
-        some_id = next(iter(repository.chunks.iteritems()))[0]
-        del repository.chunks[some_id]
+        manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
+        kept = Archive(manifest, manifest.archives.get_one(["kept"]).id)
+        victim = next(id for item in kept.iter_items() if "chunks" in item for id, _ in item.chunks)
+        del repository.chunks[victim]
         write_chunkindex_to_repo(repository, repository.chunks, incremental=False, force_write=True, delete_other=True)
 
     output = cmd(archiver, "compact", "-v", exit_code=EXIT_ERROR)
     assert "missing objects" in output  # the repo is seen as damaged ...
     assert "Cleaning archives directory" not in output  # ... so soft-deleted archives are not nuked
+
+    cmd(archiver, "undelete", "gone")  # recover the soft-deleted archive
+    with changedir("output"):
+        cmd(archiver, "extract", "gone")
+    with open("output/input/gone_dir/gone_file", "rb") as fd:
+        assert fd.read() == b"G" * (1024 * 80)  # its data survived compaction
 
 
 def test_compact_drops_stale_index_entries(tmp_path):

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -248,8 +248,8 @@ def test_compact_packs_respects_threshold(tmp_path):
 def test_compact_superseded_duplicate(tmp_path):
     # Issue #9868 repro. Concurrent backups can write the same chunk into two packs; when the index
     # fragments merge, only one copy stays indexed and the other is left as unindexed bytes in a pack.
-    # Rewriting such a pack (because of its ordinary unused objects) must copy those superseded bytes
-    # forward, not drop them: only "borg check --repair" decides their fate.
+    # Rewriting such a pack (because of its ordinary unused objects) reclaims those superseded bytes:
+    # the surviving copy is authoritative, so the duplicate is dropped.
     from ...archiver.compact_cmd import ArchiveGarbageCollector
 
     location = os.fspath(tmp_path / "repo")
@@ -261,6 +261,7 @@ def test_compact_superseded_duplicate(tmp_path):
         repository.flush()
         pack_a = repository.chunks[H(0)].pack_id
         pack_a_size = next(i.size for i in repository.store_list("packs") if i.name == bin_to_hex(pack_a))
+        x_size = repository.chunks[H(1)].obj_size  # X's copy in pack A becomes a superseded gap
         y_size = repository.chunks[H(2)].obj_size
 
         # pack B: a second copy of X only, in its own pack (as a concurrent writer would have produced).
@@ -286,11 +287,11 @@ def test_compact_superseded_duplicate(tmp_path):
         assert pdchunk(repository.get(H(0))) == b"WWWW"
         assert pdchunk(repository.get(H(1))) == b"XXXX"
         assert repository.get(H(2), raise_missing=False) is None
-        # pack A rewritten, shrunk by exactly Y's bytes: W's and the superseded X span are kept, not dropped.
+        # pack A rewritten, shrunk by Y's bytes (unused indexed) plus X's superseded gap: only W remains.
         assert bin_to_hex(pack_a) not in [info.name for info in repository.store_list("packs")]
         new_pack = repository.chunks[H(0)].pack_id
         new_size = next(i.size for i in repository.store_list("packs") if i.name == bin_to_hex(new_pack))
-        assert new_size == pack_a_size - y_size
+        assert new_size == pack_a_size - y_size - x_size
 
 
 def test_compact_keeps_orphan_pack(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -399,9 +399,51 @@ def test_compact_pack_keep_all_is_noop(repo_fixtures, request):
         assert pdchunk(repository.get(H(1))) == b"DATA1"
 
 
-def test_compact_pack_complete_detects_short_coverage(repo_fixtures, request):
-    # complete=True must catch a pack whose listed objects do not reach its end: shrink the last
-    # object's recorded obj_size so the summed coverage falls short of the actual pack file size.
+def test_compact_pack_tolerates_gap(repo_fixtures, request):
+    # A pack may hold bytes no index entry covers (a superseded copy of a chunk re-put elsewhere).
+    # Drop the middle object's index entry to simulate that, then compact keeping the outer two:
+    # the gap must be skipped and its bytes reclaimed (issue #9868).
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    chunk2 = fchunk(b"DATA2", chunk_id=H(2))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1), (H(2), chunk2)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+        del repository.chunks[H(1)]  # H(1)'s bytes stay in the pack but are now unindexed (a gap)
+
+        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids=set())
+
+        assert new_pack_id is not None and new_pack_id != old_pack_id
+        assert pdchunk(repository.get(H(0))) == b"DATA0"
+        assert pdchunk(repository.get(H(2))) == b"DATA2"
+        packs = {info.name: info.size for info in repository.store_list("packs")}
+        assert bin_to_hex(old_pack_id) not in packs
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk0) + len(chunk2)  # gap bytes reclaimed
+
+
+def test_compact_pack_tolerates_trailing_bytes(repo_fixtures, request):
+    # Same as the gap case, but the unindexed bytes are at the end of the pack: dropping the last
+    # object's index entry leaves trailing bytes the listed objects do not reach. Must still succeed.
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+        del repository.chunks[H(1)]  # trailing unindexed bytes
+
+        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(0)}, drop_ids=set())
+
+        assert new_pack_id is not None and new_pack_id != old_pack_id
+        assert pdchunk(repository.get(H(0))) == b"DATA0"
+        packs = {info.name: info.size for info in repository.store_list("packs")}
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk0)  # trailing bytes reclaimed
+
+
+def test_compact_pack_detects_overlap(repo_fixtures, request):
+    # Overlapping index entries mean index corruption: compact_pack must raise IntegrityError and
+    # leave the pack in place. Point H(1) back at H(0)'s offset to overlap it.
     chunk0 = fchunk(b"DATA0", chunk_id=H(0))
     chunk1 = fchunk(b"DATA1", chunk_id=H(1))
     repository = get_repository_from_fixture(repo_fixtures, request)
@@ -409,9 +451,9 @@ def test_compact_pack_complete_detects_short_coverage(repo_fixtures, request):
     with repository:
         old_pack_id = repository.chunks[H(0)].pack_id
         entry = repository.chunks[H(1)]
-        repository.chunks[H(1)] = entry._replace(obj_size=entry.obj_size - 1)  # leave 1 trailing byte unaccounted
+        repository.chunks[H(1)] = entry._replace(obj_offset=0)  # now overlaps H(0) at offset 0
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(IntegrityError):
             repository.compact_pack(old_pack_id, keep_ids={H(0), H(1)}, drop_ids=set())
         assert bin_to_hex(old_pack_id) in [info.name for info in repository.store_list("packs")]
 

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -477,6 +477,29 @@ def test_compact_pack_detects_past_eof(repo_fixtures, request):
         assert bin_to_hex(old_pack_id) in [info.name for info in repository.store_list("packs")]
 
 
+def test_compact_pack_translates_read_range_error(repo_fixtures, request, monkeypatch):
+    # On a truncated or corrupt pack a defrag span reads back short and borgstore raises ReadRangeError.
+    # compact_pack translates it to IntegrityError, keeps the source pack and leaves the index unchanged.
+    # store.defrag is patched to raise ReadRangeError.
+    from borgstore.store import ReadRangeError
+
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+
+        def short_read(*args, **kwargs):
+            raise ReadRangeError("requested 5 bytes at offset 0, got 3")
+
+        monkeypatch.setattr(repository.store, "defrag", short_read)
+        with pytest.raises(IntegrityError):
+            repository.compact_pack(old_pack_id, keep_ids={H(0)}, drop_ids={H(1)})
+        assert bin_to_hex(old_pack_id) in [info.name for info in repository.store_list("packs")]
+        assert H(1) in repository.chunks  # still indexed: aborted before deleting the dropped id
+
+
 def test_list(repo_fixtures, request):
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         for x in range(100):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -344,7 +344,7 @@ def build_one_pack(repository, objects):
 
 
 def test_compact_pack_copy_forward(repo_fixtures, request):
-    # Keep a subset of a multi-object pack: survivors must read back, the dropped object and its bytes gone.
+    # Keep a subset of a multi-object pack: kept objects must read back, the dropped object and its bytes gone.
     chunk0 = fchunk(b"DATA0", chunk_id=H(0))
     chunk1 = fchunk(b"DATA1", chunk_id=H(1))
     chunk2 = fchunk(b"DATA2", chunk_id=H(2))
@@ -399,10 +399,11 @@ def test_compact_pack_keep_all_is_noop(repo_fixtures, request):
         assert pdchunk(repository.get(H(1))) == b"DATA1"
 
 
-def test_compact_pack_tolerates_gap(repo_fixtures, request):
+def test_compact_pack_keeps_gap(repo_fixtures, request):
     # A pack may hold bytes no index entry covers (a superseded copy of a chunk re-put elsewhere).
-    # Drop the middle object's index entry to simulate that, then compact keeping the outer two:
-    # the gap must be skipped and its bytes reclaimed (issue #9868).
+    # compact_pack must copy such gaps into the new pack rather than dropping data it was not told to
+    # drop; only "borg check --repair" decides their fate (issue #9868). Drop the middle object's index
+    # entry to make a gap, then rewrite dropping the first object and keeping the last: the gap survives.
     chunk0 = fchunk(b"DATA0", chunk_id=H(0))
     chunk1 = fchunk(b"DATA1", chunk_id=H(1))
     chunk2 = fchunk(b"DATA2", chunk_id=H(2))
@@ -412,33 +413,34 @@ def test_compact_pack_tolerates_gap(repo_fixtures, request):
         old_pack_id = repository.chunks[H(0)].pack_id
         del repository.chunks[H(1)]  # H(1)'s bytes stay in the pack but are now unindexed (a gap)
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids=set())
+        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(2)}, drop_ids={H(0)})
 
         assert new_pack_id is not None and new_pack_id != old_pack_id
-        assert pdchunk(repository.get(H(0))) == b"DATA0"
         assert pdchunk(repository.get(H(2))) == b"DATA2"
         packs = {info.name: info.size for info in repository.store_list("packs")}
         assert bin_to_hex(old_pack_id) not in packs
-        assert packs[bin_to_hex(new_pack_id)] == len(chunk0) + len(chunk2)  # gap bytes reclaimed
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk1) + len(chunk2)  # gap bytes kept, only H(0) dropped
 
 
-def test_compact_pack_tolerates_trailing_bytes(repo_fixtures, request):
+def test_compact_pack_keeps_trailing_bytes(repo_fixtures, request):
     # Same as the gap case, but the unindexed bytes are at the end of the pack: dropping the last
-    # object's index entry leaves trailing bytes the listed objects do not reach. Must still succeed.
+    # object's index entry leaves trailing bytes the listed objects do not reach. Rewrite dropping the
+    # first object; the trailing bytes must be copied forward, not lost.
     chunk0 = fchunk(b"DATA0", chunk_id=H(0))
     chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    chunk2 = fchunk(b"DATA2", chunk_id=H(2))
     repository = get_repository_from_fixture(repo_fixtures, request)
-    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1)])
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1), (H(2), chunk2)])
     with repository:
         old_pack_id = repository.chunks[H(0)].pack_id
-        del repository.chunks[H(1)]  # trailing unindexed bytes
+        del repository.chunks[H(2)]  # trailing unindexed bytes
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(0)}, drop_ids=set())
+        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(1)}, drop_ids={H(0)})
 
         assert new_pack_id is not None and new_pack_id != old_pack_id
-        assert pdchunk(repository.get(H(0))) == b"DATA0"
+        assert pdchunk(repository.get(H(1))) == b"DATA1"
         packs = {info.name: info.size for info in repository.store_list("packs")}
-        assert packs[bin_to_hex(new_pack_id)] == len(chunk0)  # trailing bytes reclaimed
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk1) + len(chunk2)  # trailing bytes kept
 
 
 def test_compact_pack_detects_overlap(repo_fixtures, request):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -458,6 +458,23 @@ def test_compact_pack_detects_overlap(repo_fixtures, request):
         assert bin_to_hex(old_pack_id) in [info.name for info in repository.store_list("packs")]
 
 
+def test_compact_pack_detects_past_eof(repo_fixtures, request):
+    # An index entry whose span ends past the pack file means index corruption: compact_pack must
+    # raise IntegrityError and leave the pack in place, so defrag never short-reads a truncated object.
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+        entry = repository.chunks[H(1)]
+        repository.chunks[H(1)] = entry._replace(obj_size=entry.obj_size + 1000)  # now claims to end past EOF
+
+        with pytest.raises(IntegrityError):
+            repository.compact_pack(old_pack_id, keep_ids={H(0), H(1)}, drop_ids=set())
+        assert bin_to_hex(old_pack_id) in [info.name for info in repository.store_list("packs")]
+
+
 def test_list(repo_fixtures, request):
     with get_repository_from_fixture(repo_fixtures, request) as repository:
         for x in range(100):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -355,9 +355,10 @@ def test_compact_pack_copy_forward(repo_fixtures, request):
         assert repository.chunks[H(1)].pack_id == old_pack_id
         assert repository.chunks[H(2)].pack_id == old_pack_id
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids={H(1)})
+        new_pack_id, dropped = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids={H(1)})
 
         assert new_pack_id is not None and new_pack_id != old_pack_id
+        assert dropped == len(chunk1)  # reported freed bytes for --stats
         assert pdchunk(repository.get(H(0))) == b"DATA0"
         assert pdchunk(repository.get(H(2))) == b"DATA2"
         assert repository.get(H(1), raise_missing=False) is None  # compact_pack removed its index entry
@@ -375,7 +376,9 @@ def test_compact_pack_drops_whole_pack(repo_fixtures, request):
     with repository:
         old_pack_id = repository.chunks[H(0)].pack_id
 
-        assert repository.compact_pack(old_pack_id, keep_ids=set(), drop_ids={H(0), H(1)}) is None
+        new_pack_id, dropped = repository.compact_pack(old_pack_id, keep_ids=set(), drop_ids={H(0), H(1)})
+        assert new_pack_id is None  # every byte dropped: no replacement pack
+        assert dropped == len(chunk0) + len(chunk1)
 
         assert repository.get(H(0), raise_missing=False) is None
         assert repository.get(H(1), raise_missing=False) is None
@@ -392,9 +395,12 @@ def test_compact_pack_keep_all_is_noop(repo_fixtures, request):
     with repository:
         old_pack_id = repository.chunks[H(0)].pack_id
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(1), H(0)}, drop_ids=set())  # out of order
+        new_pack_id, dropped = repository.compact_pack(
+            old_pack_id, keep_ids={H(1), H(0)}, drop_ids=set()
+        )  # out of order
 
         assert new_pack_id == old_pack_id
+        assert dropped == 0  # nothing dropped
         assert pdchunk(repository.get(H(0))) == b"DATA0"
         assert pdchunk(repository.get(H(1))) == b"DATA1"
 
@@ -413,7 +419,7 @@ def test_compact_pack_keeps_gap(repo_fixtures, request):
         old_pack_id = repository.chunks[H(0)].pack_id
         del repository.chunks[H(1)]  # H(1)'s bytes stay in the pack but are now unindexed (a gap)
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(2)}, drop_ids={H(0)})
+        new_pack_id, _ = repository.compact_pack(old_pack_id, keep_ids={H(2)}, drop_ids={H(0)})
 
         assert new_pack_id is not None and new_pack_id != old_pack_id
         assert pdchunk(repository.get(H(2))) == b"DATA2"
@@ -435,12 +441,58 @@ def test_compact_pack_keeps_trailing_bytes(repo_fixtures, request):
         old_pack_id = repository.chunks[H(0)].pack_id
         del repository.chunks[H(2)]  # trailing unindexed bytes
 
-        new_pack_id = repository.compact_pack(old_pack_id, keep_ids={H(1)}, drop_ids={H(0)})
+        new_pack_id, _ = repository.compact_pack(old_pack_id, keep_ids={H(1)}, drop_ids={H(0)})
 
         assert new_pack_id is not None and new_pack_id != old_pack_id
         assert pdchunk(repository.get(H(1))) == b"DATA1"
         packs = {info.name: info.size for info in repository.store_list("packs")}
         assert packs[bin_to_hex(new_pack_id)] == len(chunk1) + len(chunk2)  # trailing bytes kept
+
+
+def test_compact_pack_drops_superseded_gap(repo_fixtures, request):
+    # A gap object whose chunk id is still in the index has its authoritative copy elsewhere, so it is
+    # a superseded duplicate and compact_pack drops its bytes. Repoint H(1) to another pack: its bytes
+    # here become an indexed-elsewhere gap. Rewrite keeping H(0) and H(2); the gap is dropped and H(1)'s
+    # index entry (pointing elsewhere) stays.
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    chunk2 = fchunk(b"DATA2", chunk_id=H(2))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1), (H(2), chunk2)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+        repository.chunks[H(1)] = repository.chunks[H(1)]._replace(pack_id=H(9))  # authoritative copy elsewhere
+
+        new_pack_id, dropped = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids=set())
+
+        assert new_pack_id is not None and new_pack_id != old_pack_id
+        assert dropped == len(chunk1)  # the superseded gap's bytes are counted as freed
+        assert pdchunk(repository.get(H(0))) == b"DATA0"
+        assert pdchunk(repository.get(H(2))) == b"DATA2"
+        packs = {info.name: info.size for info in repository.store_list("packs")}
+        assert bin_to_hex(old_pack_id) not in packs
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk0) + len(chunk2)  # superseded H(1) gap dropped
+        assert repository.chunks[H(1)].pack_id == H(9)  # index entry pointing elsewhere is untouched
+
+
+def test_compact_pack_keeps_self_referencing_gap(repo_fixtures, request):
+    # A gap object whose index entry points back at this very pack and offset is the object's only copy
+    # (a caller that broke the keep+drop contract by not listing it). compact_pack must keep its bytes,
+    # not destroy them. Leave H(1) out of keep_ids and drop_ids with its entry pointing here.
+    chunk0 = fchunk(b"DATA0", chunk_id=H(0))
+    chunk1 = fchunk(b"DATA1", chunk_id=H(1))
+    chunk2 = fchunk(b"DATA2", chunk_id=H(2))
+    repository = get_repository_from_fixture(repo_fixtures, request)
+    build_one_pack(repository, [(H(0), chunk0), (H(1), chunk1), (H(2), chunk2)])
+    with repository:
+        old_pack_id = repository.chunks[H(0)].pack_id
+
+        new_pack_id, dropped = repository.compact_pack(old_pack_id, keep_ids={H(0), H(2)}, drop_ids=set())
+
+        assert new_pack_id == old_pack_id  # nothing dropped, defrag reproduced the same pack
+        assert dropped == 0  # the self-referencing gap is kept, nothing freed
+        packs = {info.name: info.size for info in repository.store_list("packs")}
+        assert packs[bin_to_hex(new_pack_id)] == len(chunk0) + len(chunk1) + len(chunk2)  # H(1) bytes kept
 
 
 def test_compact_pack_detects_overlap(repo_fixtures, request):


### PR DESCRIPTION
Fixes #9868.

## Problem

`borg compact` crashed with an `AssertionError` when a pack held bytes that no chunk index entry covered.

This happens normally under concurrent backups. Two `borg create` runs sharing the repo lock can both see the same chunk as new and write it into two different packs. When their index fragments merge, only one copy stays indexed; the other copy is left in its pack as an unindexed span. `compact_pack` assumed the objects it was told to keep and drop tiled the whole pack, so any such gap tripped the assertion. Because the crash happened after the cached chunk index was invalidated, it recurred on every subsequent run.

The index-only accounting also leaked space in two ways:
- a pack full of superseded (unindexed) bytes looked "all used" and was never rewritten;
- a fully unindexed pack (for example from a backup that crashed after writing the pack but before writing its index) was invisible and leaked forever.

## Fix

- `compact_pack` no longer asserts a fully tiled pack. It walks the listed objects in offset order, skips gaps (unindexed/superseded bytes, whose space is reclaimed by not copying them forward), and raises `IntegrityError` only on a real overlap, which can only mean index corruption. The `complete=` parameter is removed.
- `compact` now derives each pack's size from the actual pack file in the store instead of summing index entries. Superseded bytes therefore count as waste (so such packs get rewritten) and fully unindexed orphan packs become visible (so they get dropped). Index entries pointing at a pack that no longer exists are dropped, with an error and non-zero exit if any were still in use.
- `compact` refuses to reclaim pack bytes while archives reference missing objects. Those missing chunks may be live-but-unindexed data that `borg check --repair` can still recover from the pack headers, so dropping them here would destroy recoverable data.

## Tests

- `repository_test.py`: `compact_pack` tolerates a gap and trailing unindexed bytes, and raises `IntegrityError` on an overlap.
- `compact_cmd_test.py`: the #9868 repro (superseded duplicate), dropping a fully unindexed orphan pack, rewriting a pack whose waste is unindexed, and refusing to compact while chunks are missing.

All affected suites pass; `black` and `ruff` are clean.
