### PR TITLE
extract: add --stats to report store statistics (fixes #9880)

### DIFF
--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -465,9 +465,9 @@ class Archiver(
         args.progress |= is_serve
         self._setup_implied_logging(vars(args))
         self._setup_topic_debugging(args)
-        if getattr(args, "stats", False) and getattr(args, "dry_run", False):
-            # the data needed for --stats is not computed when using --dry-run, so we can't do it.
-            # for ease of scripting, we just ignore --stats when given with --dry-run.
+        # extract --dry-run reads, decrypts and decompresses every object, so its store stats are accurate.
+        stats_supported_with_dry_run = func_name == "do_extract"
+        if getattr(args, "stats", False) and getattr(args, "dry_run", False) and not stats_supported_with_dry_run:
             logger.warning("Ignoring --stats. It is not supported when using --dry-run.")
             args.stats = False
         if args.show_version:

--- a/src/borg/archiver/extract_cmd.py
+++ b/src/borg/archiver/extract_cmd.py
@@ -151,8 +151,8 @@ class ExtractMixIn:
 
         When using ``--stats``, borg reports the store statistics (lines prefixed with
         "Store") for the extraction: per-operation call counts and timings, the load/store
-        data volumes and throughput, and cache hits/misses. ``--stats`` is ignored when
-        combined with ``--dry-run``.
+        data volumes and throughput, and cache hits/misses. This includes ``--dry-run``
+        extractions.
 
         .. note::
 

--- a/src/borg/archiver/extract_cmd.py
+++ b/src/borg/archiver/extract_cmd.py
@@ -4,11 +4,12 @@ import stat
 
 from ._common import with_repository, with_archive
 from ._common import build_filter, build_matcher
-from ..archive import BackupError
+from ..archive import BackupError, format_store_stats
 from ..constants import *  # NOQA
 from ..helpers import archivename_validator, PathSpec
 from ..helpers import remove_surrogates
 from ..helpers import HardLinkManager
+from ..helpers import log_multi
 from ..helpers import ProgressIndicatorPercent
 from ..helpers import BackupWarning, IncludePatternNeverMatchedWarning
 from ..helpers.argparsing import ArgumentParser
@@ -119,6 +120,11 @@ class ExtractMixIn:
             # clear progress output
             pi.finish()
 
+        if args.stats:
+            log_multi(
+                format_store_stats(repository.store.stats, iec=args.iec), logger=logging.getLogger("borg.output.stats")
+            )
+
     def build_parser_extract(self, subparsers, common_parser, mid_common_parser):
         from ._common import process_epilog
         from ._common import define_exclusion_group
@@ -143,6 +149,11 @@ class ExtractMixIn:
         ``--progress`` can be slower than no progress display, since it makes one additional
         pass over the archive metadata.
 
+        When using ``--stats``, borg reports the store statistics (lines prefixed with
+        "Store") for the extraction: per-operation call counts and timings, the load/store
+        data volumes and throughput, and cache hits/misses. ``--stats`` is ignored when
+        combined with ``--dry-run``.
+
         .. note::
 
             Currently, extract always writes into the current working directory ("."),
@@ -157,6 +168,9 @@ class ExtractMixIn:
         subparsers.add_subcommand("extract", subparser, help="extract archive contents")
         subparser.add_argument(
             "--list", dest="output_list", action="store_true", help="output a verbose list of items (files, dirs, ...)"
+        )
+        subparser.add_argument(
+            "-s", "--stats", dest="stats", action="store_true", help="print store statistics for the extraction"
         )
         subparser.add_argument(
             "-n", "--dry-run", dest="dry_run", action="store_true", help="do not actually change any files"

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -46,6 +46,18 @@ def test_symlink_extract(archivers, request):
         assert os.readlink("input/link1") == "somewhere"
 
 
+def test_extract_stats(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    with changedir("output"):
+        output = cmd(archiver, "extract", "test", "--stats")
+    assert "Store load volume:" in output
+    assert "Store backend load volume:" in output
+    assert "Store cache hit ratio:" in output
+
+
 @pytest.mark.skipif(
     not are_symlinks_supported() or not are_hardlinks_supported() or is_darwin,
     reason="symbolic links or hard links or hard-linked sym-links not supported",

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -58,6 +58,17 @@ def test_extract_stats(archivers, request):
     assert "Store cache hit ratio:" in output
 
 
+def test_extract_stats_dry_run(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    with changedir("output"):
+        output = cmd(archiver, "extract", "test", "--dry-run", "--stats")
+    assert "Ignoring --stats" not in output
+    assert "Store load volume:" in output
+
+
 @pytest.mark.skipif(
     not are_symlinks_supported() or not are_hardlinks_supported() or is_darwin,
     reason="symbolic links or hard links or hard-linked sym-links not supported",


### PR DESCRIPTION
Adds a `--stats` option to `borg extract`.

After extraction it prints the borgstore statistics (lines prefixed with "Store"): call counts and timings per operation, load/store volumes and throughput, and cache hits/misses. Useful when extracting from a remote backend and you want to see how much traffic it took.

It reads `repository.store.stats` and formats it with `format_store_stats`, so the output is the same block `create --stats` already prints. Like the other commands, `--stats` is ignored together with `--dry-run`.

Fixes #9880
