### PR TITLE
locking: misc fixes

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -594,6 +594,7 @@ class Repository:
     def flush(self):
         """Flush any buffered pack writer chunks."""
         if self._pack_writer is not None:
+            self._lock_refresh()
             self._pack_writer.flush()  # PackWriter updates _chunks internally
 
     def close(self):

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -608,7 +608,11 @@ class Repository:
 
             write_chunkindex_to_repo(self, self.chunks, incremental=True)
         if self.lock:
-            self.lock.release()
+            # ignore_not_found: close() runs during normal teardown, but also while unwinding an
+            # exception. if the lock was already gone (e.g. it went stale and another client killed
+            # it, or refresh() aborted with LockTimeout), a NotLocked raised here would mask the
+            # original error. we are closing anyway, so treat a missing lock as nothing to release.
+            self.lock.release(ignore_not_found=True)
             self.lock = None
         if self.store_opened:
             self.store.close()

--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -78,6 +78,7 @@ class Lock:
         self.stale_td = datetime.timedelta(seconds=stale)  # ignore/delete it if older
         self.refresh_td = datetime.timedelta(seconds=stale // 2)  # don't refresh it if younger
         self.last_refresh_dt = None
+        self.my_lock_key = None  # store key of the lock we currently hold, None if we hold none
         self.id = id or platform.get_process_id()
         assert len(self.id) == 3
         logger.debug(f"LOCK-INIT: initializing. store: {store}, stale: {stale}s, refresh: {stale // 2}s.")
@@ -106,6 +107,7 @@ class Lock:
         if update_last_refresh:
             # we parse the timestamp string to get *precisely* the datetime in the lock:
             self.last_refresh_dt = datetime.datetime.fromisoformat(timestamp)
+            self.my_lock_key = key
         return key
 
     def _delete_lock(self, key, *, ignore_not_found=False, update_last_refresh=False):
@@ -118,11 +120,18 @@ class Lock:
         finally:
             if update_last_refresh:
                 self.last_refresh_dt = None
+                self.my_lock_key = None
 
     def _is_our_lock(self, lock):
         return self.id == (lock["hostid"], lock["processid"], lock["threadid"])
 
     def _is_stale_lock(self, lock):
+        if lock["key"] == self.my_lock_key:
+            # the lock we are currently holding: we are obviously alive and can refresh or
+            # release it, so it must never be considered stale (and get deleted), no matter
+            # how old it is. it can get old e.g. if the machine is suspended while doing a
+            # backup or if there is a long stretch of work without repository access, see #9883.
+            return False
         now = datetime.datetime.now(datetime.UTC)
         if now > lock["dt"] + self.stale_td:
             logger.debug(f"LOCK-STALE: lock is too old, it was not refreshed. lock: {lock}.")
@@ -145,8 +154,11 @@ class Lock:
             lock["key"] = key
             lock["dt"] = datetime.datetime.fromisoformat(lock["time"])
             if self._is_stale_lock(lock):
-                # ignore it and delete it (even if it is not from us)
-                self._delete_lock(key, ignore_not_found=True, update_last_refresh=self._is_our_lock(lock))
+                # ignore it and delete it (even if it is not from us).
+                # note: this is never the lock we currently hold (see _is_stale_lock), so this
+                # must not touch last_refresh_dt / my_lock_key - a stale lock matching our id
+                # can only be a leftover of a dead process (pid reuse), not our own lock.
+                self._delete_lock(key, ignore_not_found=True)
             else:
                 locks[key] = lock
         return locks
@@ -236,6 +248,7 @@ class Lock:
         for key in locks:
             self._delete_lock(key, ignore_not_found=True)
         self.last_refresh_dt = None
+        self.my_lock_key = None
 
     def migrate_lock(self, old_id, new_id):
         """Migrates the lock ownership from old_id to new_id."""
@@ -256,8 +269,11 @@ class Lock:
             if len(old_locks) == 0:
                 # crap, my lock has been removed. :-(
                 # this can happen e.g. if my machine has been suspended while doing a backup, so that the
-                # lock will auto-expire. a borg client on another machine might then kill that lock.
+                # lock became stale and a borg client on another machine killed it.
                 # if my machine then wakes up again, the lock will have vanished and we get here.
+                # note: if our lock became stale, but is still present (no other client killed it),
+                # we do not get here - we never consider our own lock stale (see _is_stale_lock),
+                # so it is found above and simply refreshed below.
                 # in this case, we need to abort the operation, because the other borg might have removed
                 # repo objects we have written, but the referential tree was not yet full present, e.g.
                 # no archive has been added yet to the manifest, thus all objects looked unused/orphaned.

--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -285,5 +285,14 @@ class Lock:
             old_lock = old_locks[0]
             if now > old_lock["dt"] + self.refresh_td:
                 logger.debug(f"LOCK-REFRESH: lock needs a refresh. lock: {old_lock}.")
-                self._create_lock(exclusive=old_lock["exclusive"], update_last_refresh=True)
-                self._delete_lock(old_lock["key"], update_last_refresh=False)
+                new_key = self._create_lock(exclusive=old_lock["exclusive"], update_last_refresh=True)
+                try:
+                    self._delete_lock(old_lock["key"], update_last_refresh=False)
+                except ObjectNotFound:
+                    # our old lock vanished between listing and deleting it: another client considered
+                    # it stale, killed it and (not having seen our new lock in its recheck) might have
+                    # acquired its own lock already. there is no safe way to continue - clean up the
+                    # new lock (so it does not needlessly block others until it expires) and abort.
+                    logger.debug("LOCK-REFRESH: our lock was killed while refreshing it, no safe way to continue.")
+                    self._delete_lock(new_key, ignore_not_found=True, update_last_refresh=True)
+                    raise LockTimeout(str(self.store))

--- a/src/borg/testsuite/storelocking_test.py
+++ b/src/borg/testsuite/storelocking_test.py
@@ -133,6 +133,29 @@ class TestLock:
         with pytest.raises(LockTimeout):
             lock.refresh()
 
+    def test_refresh_killed_lock_race(self, lockstore, monkeypatch):
+        # if our own lock gets killed by another client *between* refresh() listing it and
+        # deleting it (the other client considered it stale and might have acquired its own
+        # lock already), refresh() must raise LockTimeout and must not leave its just-created
+        # new lock behind (it would needlessly block other clients until it expired as stale).
+        lock = Lock(lockstore, exclusive=True, id=ID1, stale=2)
+        lock.acquire()
+        old_key = lock.my_lock_key
+        time.sleep(1.1)  # older than refresh_td (stale // 2), so refresh() will renew the lock
+
+        orig_delete = lockstore.delete
+
+        def delete(name, *args, **kwargs):
+            if name == f"locks/{old_key}":
+                orig_delete(name)  # another client killed our old lock just before we delete it,
+                # so our own deletion attempt below finds it already gone and raises ObjectNotFound:
+            return orig_delete(name, *args, **kwargs)
+
+        monkeypatch.setattr(lockstore, "delete", delete)
+        with pytest.raises(LockTimeout):
+            lock.refresh()
+        assert len(list(lockstore.list("locks"))) == 0  # no new lock left behind
+
     def test_migrate_lock(self, lockstore):
         old_id, new_id = ID1, ID2
         assert old_id[1] != new_id[1]  # different PIDs (like when doing daemonize())

--- a/src/borg/testsuite/storelocking_test.py
+++ b/src/borg/testsuite/storelocking_test.py
@@ -89,13 +89,49 @@ class TestLock:
         lock.refresh()  # This should refresh the lock.
         lock_keys_b00 = set(lock._get_locks())
         time.sleep(2.1)
-        lock_keys_b21 = set(lock._get_locks())  # now the lock should be stale & gone.
+        # now the lock is stale. we never consider the lock we hold ourselves stale,
+        # but another client (== another Lock instance) does:
+        other_lock = Lock(lockstore, exclusive=True, id=ID2, stale=2)
+        lock_keys_b21 = set(other_lock._get_locks())  # now the lock should be stale & gone.
         assert lock_keys_a00 == lock_keys_a05  # was too young, no refresh done
         assert len(lock_keys_a00) == 1
         assert lock_keys_a00 != lock_keys_b00  # refresh done, new lock has different key
         assert len(lock_keys_b00) == 1
         assert len(lock_keys_b21) == 0  # stale lock was ignored
         assert len(list(lock.store.list("locks"))) == 0  # stale lock was removed from store
+
+    def test_release_stale_lock(self, lockstore):
+        # even if our own lock became stale (e.g. machine suspended while doing a backup or
+        # a long time without repository access), release() must find and remove it instead
+        # of removing it as stale and then raising NotLocked, see #9883.
+        lock = Lock(lockstore, exclusive=True, id=ID1, stale=2)
+        lock.acquire()
+        time.sleep(2.1)  # lock is now older than the stale timeout
+        lock.release()  # must not raise NotLocked
+        assert len(list(lockstore.list("locks"))) == 0
+
+    def test_refresh_stale_lock(self, lockstore):
+        # if our own lock became stale, but no other client killed it (it is still present),
+        # refresh() must renew it, so the operation can continue safely, see #9883.
+        lock = Lock(lockstore, exclusive=True, id=ID1, stale=2)
+        lock.acquire()
+        old_keys = set(lock._get_locks())
+        time.sleep(2.1)  # lock is now older than the stale timeout
+        lock.refresh()  # must not raise LockTimeout, must renew the lock
+        new_keys = set(lock._get_locks())
+        assert len(old_keys) == len(new_keys) == 1
+        assert old_keys != new_keys  # refresh done, new lock has different key
+        lock.release()
+
+    def test_refresh_killed_lock(self, lockstore):
+        # if our own lock is gone (another client considered it stale and killed it),
+        # there is no safe way to continue, refresh() must raise LockTimeout.
+        lock = Lock(lockstore, exclusive=True, id=ID1, stale=2)
+        lock.acquire()
+        time.sleep(1.1)  # older than refresh_td (stale // 2), so refresh() checks the store
+        Lock(lockstore, exclusive=True, id=ID2, stale=2).break_lock()  # kill it, like another client would
+        with pytest.raises(LockTimeout):
+            lock.refresh()
 
     def test_migrate_lock(self, lockstore):
         old_id, new_id = ID1, ID2


### PR DESCRIPTION
Fixes #9883.

### The bug

`Lock._is_stale_lock()` applied the stale-age criterion to *our own currently held lock*. If `refresh()` did not run for longer than the stale timeout (e.g. the machine was suspended while doing a backup, or there was a long stretch of work without repository access), the next `_get_locks()` call deleted our own lock as stale. `release()` at repository close then found no lock and raised `NotLocked` — borg killed its own lock and then complained it was not locked. Similarly, `refresh()` mid-operation concluded "my lock was killed" and raised `LockTimeout`, needlessly aborting a running backup although no other client had touched the lock (it was still present, just old).

Re the strange timing in #9883: the MacBook sleeping overnight explains both anomalies at once. Lock timestamps use wall clock, which kept advancing during sleep, so the lock aged beyond `stale_td`; the stats counters use `time.monotonic()`, which pauses during system sleep on macOS, so the ~5h of sleep is the unaccounted difference between the 7h wall duration and the ~2h of measured store time.

### The fix

Track the store key of the lock we currently hold (`my_lock_key`, set/cleared alongside `last_refresh_dt` in `_create_lock` / `_delete_lock`) and never consider exactly that lock stale: we are obviously alive, so we can refresh or release it, no matter how old it is. Consequences:

- `release()` finds an aged lock and removes it normally — no `NotLocked` crash at the end of a long backup.
- `refresh()` finds an aged, but still present lock and renews it, so an operation survives e.g. a suspend if no other client interfered. If the lock is actually *gone* (another client considered it stale and killed it), `refresh()` still raises `LockTimeout`, as before — the data-safety abort is preserved.
- other clients still treat our old lock as stale and may remove it (inter-client semantics unchanged).
- a stale leftover lock of a dead process that reused our pid is still cleaned up (`my_lock_key` does not match, so the id-triple match alone no longer protects it), and deleting such a leftover no longer wrongly clears our refresh state in `_get_locks()`.

### Tests

- reworked `test_lock_refresh_stale_removal`: staleness is now observed from a second `Lock` instance, as another client would see it.
- new `test_release_stale_lock`: release of an aged lock must not raise `NotLocked` (the #9883 regression test).
- new `test_refresh_stale_lock`: refresh of an aged, still present lock renews it.
- new `test_refresh_killed_lock`: refresh after another client removed our lock raises `LockTimeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)