### PR TITLE
fix #9884: chunks index terminology update

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -23,7 +23,7 @@ Buzhash_ algorithm ("buzhash" and "buzhash64" chunker) or a simpler
 fixed block size algorithm ("fixed" chunker).
 
 To perform the repository-wide deduplication, a hash of each
-chunk is checked against the :ref:`chunks cache <cache>`, which is a
+chunk is checked against the :ref:`chunks index <index>`, which is a
 hash table of all chunks that already exist.
 
 .. figure:: internals/structure.png

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -275,7 +275,7 @@ Borg releases unaware of feature flags.
 .. _Cache feature flags:
 .. rubric:: Cache feature flags
 
-`The cache`_ does not have its separate set of feature flags. Instead, Borg stores
+`The cache <cache>`_ does not have its separate set of feature flags. Instead, Borg stores
 which flags were used to create or modify a cache.
 
 All mandatory manifest features from all operations are gathered in one set.
@@ -503,8 +503,8 @@ chunking level (0 disables it); 2 is a good default. E.g.: ``fastcdc,19,23,21,2`
 
 .. _cache:
 
-The cache
----------
+The files cache
+---------------
 
 The **files cache** is stored in ``cache/files.<SUFFIX>`` and is used at backup
 time to quickly determine whether a given file is unchanged and we have all its
@@ -561,11 +561,15 @@ The on-disk format of the files cache is a stream of msgpacked tuples (key, valu
 Loading the files cache involves reading the file, one msgpack object at a time,
 unpacking it, and msgpacking the value (in an effort to save memory).
 
-The **chunks cache** is not persisted to disk, but dynamically built in memory
-by querying the existing object IDs from the repository.
+.. _index:
+
+The chunks index
+----------------
+
+The **chunks index** is persisted in the repository as index fragments and loaded in memory.
 It is used to determine whether we already have a specific chunk.
 
-The chunks cache is a key -> value mapping and contains:
+The chunks index is a key -> value mapping and contains:
 
 * key:
 
@@ -575,7 +579,7 @@ The chunks cache is a key -> value mapping and contains:
   - reference count (always MAX_VALUE as we do not refcount anymore)
   - size (0 for prev. existing objects, we can't query their plaintext size)
 
-The chunks cache is a HashIndex_.
+The chunks index is a HashIndex_.
 
 .. _cache-memory-usage:
 
@@ -587,11 +591,11 @@ Here is the estimated memory usage of Borg - it's complicated::
   chunk_size ~= 2 ^ HASH_MASK_BITS  (for buzhash chunker, BLOCK_SIZE for fixed chunker)
   chunk_count ~= total_file_size / chunk_size
 
-  chunks_cache_usage = chunk_count * 40
+  chunks_index_usage = chunk_count * 40
 
   files_cache_usage = total_file_count * 240 + chunk_count * 165
 
-  mem_usage ~= chunks_cache_usage + files_cache_usage
+  mem_usage ~= chunks_index_usage + files_cache_usage
              = chunk_count * 205 + total_file_count * 240
 
 Due to the hashtables, the best/usual/worst cases for memory allocation can
@@ -610,7 +614,7 @@ It is also assuming that typical chunk size is 2^HASH_MASK_BITS (if you have
 a lot of files smaller than this statistical medium chunk size, you will have
 more chunks than estimated above, because 1 file is at least 1 chunk).
 
-The chunks cache and files cache are all implemented as hash tables.
+The chunks index and files cache are all implemented as hash tables.
 A hash table must have a significant amount of unused entries to be fast -
 the so-called load factor gives the used/unused elements ratio.
 
@@ -640,7 +644,7 @@ b) with ``create --chunker-params buzhash,19,23,21,4095`` (default):
 HashIndex
 ---------
 
-The chunks cache is implemented as a hash table, with
+The chunks index is implemented as a hash table, with
 only one slot per bucket, spreading hash collisions to the following
 buckets. As a consequence the hash is just a start position for a linear
 search. If a key is looked up that is not in the table, then the hash table

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -197,7 +197,7 @@ Internal transaction progress::
 
     {"message": "Saving files cache", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false}
     {"message": "Saving cache config", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false}
-    {"message": "Saving chunks cache", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false}
+    {"message": "Saving index", "operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": false}
     {"operation": 2, "msgid": "cache.commit", "type": "progress_message", "finished": true}
 
 A debug log message::

--- a/docs/usage/debug.rst
+++ b/docs/usage/debug.rst
@@ -9,7 +9,7 @@ what their name suggests: put objects into the repository / delete objects from 
 
 Please note:
 
-- they will not update the chunks cache (chunks index) about the object
+- they will not update the chunks index about the object
 - they will not update the manifest (so no automatic chunks index resync is triggered)
 - they will not check whether the object is in use (e.g. before delete-obj)
 - they will not update any metadata which may point to the object

--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -16,8 +16,8 @@ Examples
     Remember your passphrase. Your data will be inaccessible without it.
     Key in "/root/.config/borg/keys/mnt_backup" created.
     Keep this key safe. Your data will be inaccessible without it.
-    Synchronizing chunks cache...
-    Archives: 0, w/ cached Idx: 0, w/ outdated Idx: 0, w/o cached Idx: 0.
+    Synchronizing index...
+    Archives: 0, w/ index: 0, w/ outdated index: 0, w/o index: 0.
     Done.
 
     # Change key file passphrase

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1780,9 +1780,9 @@ class ArchiveChecker:
         # A normal (non-repair) archives check trusts the in-repo index: the repository check verified
         # each index object's sha256, and the index is the authoritative record of which chunks exist,
         # so we do not rebuild it from the packs (reading every pack is far too slow for a routine check).
-        # --repair does rebuild from the packs (disable_caches=repair), working from the real packs so it
+        # --repair does rebuild from the packs (slow_rebuild=repair), working from the real packs so it
         # can detect and fix archives that reference chunks whose pack has gone missing.
-        self.chunks = build_chunkindex_from_repo(self.repository, disable_caches=repair, cache_immediately=False)
+        self.chunks = build_chunkindex_from_repo(self.repository, slow_rebuild=repair, write_immediately=False)
         if self.key is None:
             self.key = self.make_key(repository)
         self.repo_objs = RepoObj(self.key)

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -56,17 +56,17 @@ class ArchiveGarbageCollector:
     def get_repository_chunks(self) -> ChunkIndex:
         """return a chunks index"""
         # Entries must start as unused (F_NONE); analyze_archives() marks the used ones afterwards.
-        # The cached index loads entries with F_NONE flags and each object's obj_size (used by --stats).
-        # init_flags applies when there is no cached index and the entries are read from the pack headers.
-        logger.info("Getting object IDs from the cached chunks index...")
+        # The index loads entries with F_NONE flags and each object's obj_size (used by --stats).
+        # init_flags applies when there is no index and the entries are read from the pack headers.
+        logger.info("Getting object IDs from the index...")
         chunks = build_chunkindex_from_repo(
-            self.repository, cache_immediately=not self.dry_run, init_flags=ChunkIndex.F_NONE
+            self.repository, write_immediately=not self.dry_run, init_flags=ChunkIndex.F_NONE
         )
         return chunks
 
     def save_chunk_index(self):
         # as we may have deleted some chunks, we must write a full updated chunkindex to the repo
-        # and also remove all older cached chunk indexes.
+        # and also remove all older chunk indexes.
         # write_chunkindex_to_repo now removes all flags and size infos.
         # we need this, as we put the wrong size in there to support --stats computations.
         write_chunkindex_to_repo(
@@ -242,9 +242,9 @@ class ArchiveGarbageCollector:
             return  # dry run: report only, change nothing
         if not drop_packs and not rewrite_packs:
             logger.info("Deleting 0 unused objects...")
-            return  # nothing to reclaim; do not touch the cached chunk indexes
+            return  # nothing to reclaim; do not touch the chunk indexes
 
-        # crash-safety (#9748): invalidate cached chunk indexes before the first store change
+        # crash-safety (#9748): invalidate chunk indexes before the first store change
         delete_chunkindex_from_repo(self.repository)
 
         # Pass 2: collect object ids only for the affected packs (a subset, not the whole index)

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -762,10 +762,10 @@ def repack_chunkindex(repository):
 
 
 def build_chunkindex_from_repo(
-    repository, *, disable_caches=False, cache_immediately=False, init_flags=ChunkIndex.F_USED
+    repository, *, slow_rebuild=False, write_immediately=False, init_flags=ChunkIndex.F_USED
 ):
-    # first, try to build a fresh, mostly complete chunk index from centrally cached chunk indexes:
-    if not disable_caches:
+    # first, try to build a fresh, mostly complete chunk index from centrally stored index fragments:
+    if not slow_rebuild:
         # a concurrent repack_chunkindex (another client, shared lock) deletes the small fragments it
         # merged - only after storing the merged replacement, so no entries are ever lost, but a
         # fragment we just listed can vanish before we load it. the index must be built from ALL
@@ -775,22 +775,22 @@ def build_chunkindex_from_repo(
         # set (e.g. a persistently unreadable fragment), fall through to the slow rebuild instead.
         for _ in range(CHUNKINDEX_MERGE_ATTEMPTS):
             hashes = list_chunkindex_hashes(repository)
-            if not hashes:  # no cached chunk index available
+            if not hashes:  # no chunk index fragments available
                 break
             chunks = ChunkIndex()  # we'll merge all fragments into this
             complete = True
             for hash in hashes:
                 chunks_to_merge = read_chunkindex_from_repo(repository, hash)
                 if chunks_to_merge is None:
-                    logger.debug(f"cached chunk index {hash} vanished or is invalid, restarting the merge...")
+                    logger.debug(f"chunk index fragment {hash} vanished or is invalid, restarting the merge...")
                     complete = False
                     break
-                logger.debug(f"cached chunk index {hash} gets merged...")
+                logger.debug(f"chunk index fragment {hash} gets merged...")
                 for k, v in chunks_to_merge.items():
                     chunks[k] = v
                 chunks_to_merge.clear()
             if complete:
-                if len(hashes) > 1 and cache_immediately:
+                if len(hashes) > 1 and write_immediately:
                     # consolidate small fragments on the repo so they don't pile up. this is a
                     # bounded repack: it does not collapse large, already-sealed fragments, so those
                     # stay immutable (and cache-stable for other clients) rather than being re-uploaded.
@@ -801,8 +801,8 @@ def build_chunkindex_from_repo(
                 return chunks
             chunks.clear()  # free the partial merge before retrying
         else:
-            logger.warning("could not read a complete set of cached chunk index fragments, rebuilding the index.")
-    # if we didn't get anything from the cache, compute the ChunkIndex the slow way:
+            logger.warning("could not read a complete set of chunk index fragments, rebuilding the index.")
+    # if we didn't get anything from the index fragments, compute the ChunkIndex the slow way:
     logger.debug("rebuilding the chunk index from the repo the slow way...")
     chunks = ChunkIndex()
     t0 = perf_counter()
@@ -830,7 +830,7 @@ def build_chunkindex_from_repo(
     # Protocol overhead is neglected in this calculation.
     speed = format_file_size(num_chunks * 34 / duration)
     logger.debug(f"queried {num_chunks} chunk IDs in {duration} s, ~{speed}/s")
-    if cache_immediately:
+    if write_immediately:
         # immediately update the index, so we only rarely have to do it the slow way:
         write_chunkindex_to_repo(
             repository, chunks, incremental=False, clear=False, force_write=True, delete_other=True
@@ -847,8 +847,8 @@ class ChunksMixin:
         self._chunks = None
         self.last_refresh_dt = datetime.now(UTC)
         self.refresh_td = timedelta(seconds=60)
-        self.chunks_cache_last_write = datetime.now(UTC)
-        self.chunks_cache_write_td = timedelta(seconds=600)
+        self.chunks_index_last_write = datetime.now(UTC)
+        self.chunks_index_write_td = timedelta(seconds=600)
 
     @property
     def chunks(self):
@@ -856,7 +856,7 @@ class ChunksMixin:
             # the repository owns the one and only chunk index; use it rather than
             # building a second one and pushing it back into the repository.
             self._chunks = self.repository.chunks
-            # note: we deliberately do NOT consolidate the cached chunk index fragments here.
+            # note: we deliberately do NOT consolidate the chunk index fragments here.
             # each backup writes a small incremental index/* fragment (only its new chunks),
             # which is cheap. collapsing them all into one big fragment on every run would re-upload
             # the whole index and, with delete_other, invalidate every other client's fragments --
@@ -893,7 +893,7 @@ class ChunksMixin:
             else:
                 raise ValueError("when giving compressed data for a chunk, the uncompressed size must be given also")
         now = datetime.now(UTC)
-        self._maybe_write_chunks_cache(now)
+        self._maybe_write_chunks_index(now)
         exists = self.seen_chunk(id, size)
         if exists:
             # if borg create is processing lots of unchanged files (no content and not metadata changes),
@@ -910,11 +910,11 @@ class ChunksMixin:
         stats.update(size, not exists)
         return ChunkListEntry(id, size)
 
-    def _maybe_write_chunks_cache(self, now, force=False, clear=False):
-        if force or now > self.chunks_cache_last_write + self.chunks_cache_write_td:
+    def _maybe_write_chunks_index(self, now, force=False, clear=False):
+        if force or now > self.chunks_index_last_write + self.chunks_index_write_td:
             if self._chunks is not None:
                 write_chunkindex_to_repo(self.repository, self._chunks, clear=clear)
-            self.chunks_cache_last_write = now
+            self.chunks_index_last_write = now
 
     def refresh_lock(self, now):
         if now > self.last_refresh_dt + self.refresh_td:
@@ -1014,10 +1014,10 @@ class AdHocWithFilesCache(FilesCacheMixin, ChunksMixin):
         if self._chunks is not None:
             for key, value in sorted(self._chunks.stats.items()):
                 logger.debug(f"Chunks index stats: {key}: {value}")
-            pi.output("Saving chunks cache")
+            pi.output("Saving index")
             # note: index/* in repo has a different integrity mechanism
             now = datetime.now(UTC)
-            self._maybe_write_chunks_cache(now, force=True, clear=True)
+            self._maybe_write_chunks_index(now, force=True, clear=True)
             self._chunks = None  # nothing there (cleared!)
             # this run just appended a (small) incremental fragment; consolidate accumulated small
             # fragments so their count/size stays in a healthy range (bounded repack, see the function).

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -575,7 +575,7 @@ class Repository:
     def invalidate_chunk_index(self):
         """Drop the in-memory chunk index so close() will not persist a stale copy.
 
-        Called when the on-disk chunk index cache is deleted; the next access to
+        Called when the on-disk chunk index is deleted; the next access to
         .chunks rebuilds the index from actual repository contents.  PackWriter
         reads the index through this Repository, so it follows automatically.
         """

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -105,7 +105,7 @@ def test_compact_interrupted_does_not_poison_chunk_index(archivers, request, mon
     not re-upload the affected chunks and silently produces an archive with dangling object
     references (which extracts to zero bytes).
 
-    The fix invalidates all cached chunk indexes before the first delete, so an interruption
+    The fix invalidates all chunk indexes before the first delete, so an interruption
     is conservative: the next client rebuilds the index from actual repository contents and
     re-uploads any deleted data. This is tested for both compact paths (default and --stats).
     """
@@ -135,7 +135,7 @@ def test_compact_interrupted_does_not_poison_chunk_index(archivers, request, mon
         with pytest.raises(KeyboardInterrupt):
             gc.garbage_collect()
 
-    # The objects were deleted, so no readable cached chunk index may still list them.
+    # The objects were deleted, so no readable chunk index may still list them.
     repository = open_repository(archiver)
     with repository:
         assert list_chunkindex_hashes(repository) == []
@@ -193,7 +193,7 @@ def test_compact_packs_respects_threshold(tmp_path):
 
 
 def test_compact_gc_after_index_loss(archivers, request):
-    """When no cached chunk index exists (e.g. after an interrupted compact, #9748), compact
+    """When no chunk index exists (e.g. after an interrupted compact, #9748), compact
     rebuilds the index from the packs. The rebuilt entries must start unused (init_flags=F_NONE),
     otherwise every object looks used and this compact run frees nothing."""
     archiver = request.getfixturevalue(archivers)
@@ -202,7 +202,7 @@ def test_compact_gc_after_index_loss(archivers, request):
     create_src_archive(archiver, "archive")
     cmd(archiver, "delete", "-a", "archive")
 
-    # drop all cached chunk indexes, like an interrupted compact leaves the repo
+    # drop all chunk indexes, like an interrupted compact leaves the repo
     repository = open_repository(archiver)
     with repository:
         delete_chunkindex_from_repo(repository)

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -558,21 +558,21 @@ def test_pack_writer_rolls_back_index_on_failed_store():
 
 
 def test_failed_store_phantom_not_persisted(tmp_path):
-    # The phantom must not survive into the persisted repo cache either: close() can write the
+    # The phantom must not survive into the persisted repo index either: close() can write the
     # in-memory index on context exit, so the rollback has to happen before anything is serialized.
     from ..cache import write_chunkindex_to_repo, build_chunkindex_from_repo
 
     chunk_id = H(60)
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         # fail only the pack write on the repository's own store; index/* writes still work,
-        # so one store models "just the pack write broke" (PackWriter and the index cache share a
+        # so one store models "just the pack write broke" (PackWriter and the index share a
         # store in production). the failing store is thus load-bearing for every assertion below.
         repository.store = FailingPackStore(repository.store)
         pw = PackWriter(repository.store, max_count=1, repository=repository)
         with pytest.raises(OSError):
             pw.add(chunk_id, fchunk(b"DATA"))
         assert repository.chunks.get(chunk_id) is None  # rolled back from the in-memory index ...
-        # ... and persisting + reloading the cache (through that same store) does not bring it back:
+        # ... and persisting + reloading the index (through that same store) does not bring it back:
         write_chunkindex_to_repo(repository, repository.chunks, incremental=True)
         reloaded = build_chunkindex_from_repo(repository)
         assert reloaded.get(chunk_id) is None


### PR DESCRIPTION
Rename chunks cache / cached chunks index to chunks index or index, renaming parameters/variables where appropriate to avoid 'cache' terminology for index.