### PR TITLE
compact: stop cleanly at a pack boundary on Ctrl-C, keep the saved index valid

### DIFF
--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -11,7 +11,7 @@ from ..helpers import get_cache_dir
 from ..helpers.argparsing import ArgumentParser
 from ..constants import *  # NOQA
 from ..hashindex import ChunkIndex
-from ..helpers import set_ec, EXIT_ERROR, format_file_size, bin_to_hex
+from ..helpers import set_ec, EXIT_ERROR, Error, sig_int, format_file_size, bin_to_hex
 from ..helpers import ProgressIndicatorPercent
 from ..manifest import Manifest
 from ..repository import Repository
@@ -50,6 +50,8 @@ class ArchiveGarbageCollector:
         self.report_and_delete()
         if not self.dry_run:
             self.save_chunk_index()
+            if sig_int:  # raise after saving, so a Ctrl-C still leaves a valid index
+                raise Error("Got Ctrl-C / SIGINT.")
             self.cleanup_files_cache()
         logger.info("Finished compaction / garbage collection...")
 
@@ -250,17 +252,17 @@ class ArchiveGarbageCollector:
         # Pass 2: collect object ids only for the affected packs (a subset, not the whole index)
         keep = {pid: set() for pid in rewrite_packs}  # survivors to copy forward, per pack
         drop = {pid: set() for pid in rewrite_packs}  # unused objects in those same packs
-        forget = []  # ids living in fully-unused packs we delete outright
+        forget = {pid: set() for pid in drop_packs}  # ids living in fully-unused packs we delete outright
         for id, entry in self.chunks.iteritems():
             pid = entry.pack_id
             if pid in rewrite_packs:
                 (keep if entry.flags & ChunkIndex.F_USED else drop)[pid].add(id)
             elif pid in drop_packs:
-                forget.append(id)
+                forget[pid].add(id)
 
         # count what we remove: every object of a dropped pack, plus the unused objects cut from
         # rewritten packs. unused objects in below-threshold packs stay, so they don't count.
-        deleted = len(forget) + sum(len(ids) for ids in drop.values())
+        deleted = sum(len(ids) for ids in forget.values()) + sum(len(ids) for ids in drop.values())
         logger.info(f"Deleting {deleted} unused objects...")
         pi = ProgressIndicatorPercent(
             total=len(drop_packs) + len(rewrite_packs),
@@ -269,17 +271,22 @@ class ArchiveGarbageCollector:
             msgid="compact.compact_packs",
         )
         progress = 0
+        # self.chunks stays consistent with the store after each pack, so Ctrl-C can stop between packs
         for pid in drop_packs:
+            if sig_int:
+                break
             try:
                 self.repository.store_delete("packs/" + bin_to_hex(pid))
             except StoreObjectNotFound:
                 # happens when a stale chunk index references an already deleted pack (#9850)
                 logger.warning(f"Pack {bin_to_hex(pid)} to delete was already gone.")
+            for id in forget[pid]:  # drop the deleted pack's index entries
+                del self.chunks[id]
             progress += 1
             pi.show(progress)  # report after the work, so the final pack lands on 100%
-        for id in forget:
-            del self.chunks[id]  # their pack file is gone, so drop their index entries too
         for pid in rewrite_packs:
+            if sig_int:
+                break
             # chunks=self.chunks: the index updates (repoint kept objects, remove dropped ones)
             # must land in the index that save_chunk_index() persists (#9850).
             self.repository.compact_pack(pid, keep_ids=keep[pid], drop_ids=drop[pid], chunks=self.chunks)

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -250,9 +250,9 @@ class ArchiveGarbageCollector:
         delete_chunkindex_from_repo(self.repository)
 
         # Pass 2: collect object ids only for the affected packs (a subset, not the whole index)
-        keep = {pid: set() for pid in rewrite_packs}  # survivors to copy forward, per pack
-        drop = {pid: set() for pid in rewrite_packs}  # unused objects in those same packs
-        forget = {pid: set() for pid in drop_packs}  # ids living in fully-unused packs we delete outright
+        keep = defaultdict(set)  # survivors to copy forward, per rewritten pack
+        drop = defaultdict(set)  # unused objects in those same packs
+        forget = defaultdict(set)  # ids in fully-unused packs we delete outright
         for id, entry in self.chunks.iteritems():
             pid = entry.pack_id
             if pid in rewrite_packs:

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -177,9 +177,10 @@ def test_compact_soft_interrupt_persists_valid_index(archivers, request, monkeyp
 
         def store_delete_then_interrupt(name, **kwargs):
             original_store_delete(name, **kwargs)
-            calls.append(name)
-            if len(calls) == 1:
-                sig_int._sig_int_triggered = True  # one Ctrl-C after the first pack is deleted
+            if name.startswith("packs/"):  # only real pack deletes, not the earlier archive/index deletes
+                calls.append(name)
+                if len(calls) == 1:
+                    sig_int._sig_int_triggered = True  # one Ctrl-C after the first pack is deleted
 
         monkeypatch.setattr(repository, "store_delete", store_delete_then_interrupt)
         try:
@@ -188,13 +189,12 @@ def test_compact_soft_interrupt_persists_valid_index(archivers, request, monkeyp
         finally:
             sig_int._sig_int_triggered = False  # reset the global flag for the following tests
 
-    assert 0 < len(calls) < len(pack_names_before)  # stopped before deleting all packs
-
     # every persisted index entry points at a pack that still exists
     repository = open_repository(archiver)
     with repository:
         assert list_chunkindex_hashes(repository) != []
         pack_names_after = {info.name for info in repository.store_list("packs")}
+        assert 0 < len(pack_names_after) < len(pack_names_before)  # some packs deleted, some left
         for id, entry in repository.chunks.iteritems():
             assert bin_to_hex(entry.pack_id) in pack_names_after
 

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from ...constants import *  # NOQA
-from ...helpers import get_cache_dir, bin_to_hex
+from ...helpers import get_cache_dir, bin_to_hex, sig_int, Error
 from ...hashindex import ChunkIndex
 from ...repository import Repository
 from ...cache import files_cache_name, discover_files_cache_names, list_chunkindex_hashes
@@ -148,6 +148,58 @@ def test_compact_interrupted_does_not_poison_chunk_index(archivers, request, mon
         assert "missing" not in output
         with open(os.path.join("input", "file1"), "rb") as fd:
             assert fd.read() == content
+
+
+def test_compact_soft_interrupt_persists_valid_index(archivers, request, monkeypatch):
+    """One Ctrl-C during pack deletion stops at the next pack boundary, saves a chunk index that
+    still matches the repository, and exits with an error (#9830). A later compact finishes the rest."""
+    from ...archiver.compact_cmd import ArchiveGarbageCollector
+
+    archiver = request.getfixturevalue(archivers)
+    monkeypatch.setenv("BORG_PACK_MAX_COUNT", "1")  # one object per pack -> several packs to stop between
+
+    for i in range(3):
+        create_regular_file(archiver.input_path, f"file{i}", contents=os.urandom(1024))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "archive", "input")
+    cmd(archiver, "delete", "-a", "archive")
+
+    repository = open_repository(archiver)
+    with repository:
+        pack_names_before = {info.name for info in repository.store_list("packs")}
+        assert len(pack_names_before) >= 2  # need several packs to observe an early stop
+
+        manifest = Manifest.load(repository, (Manifest.Operation.DELETE,))
+        gc = ArchiveGarbageCollector(repository, manifest, stats=False, iec=False, threshold=10)
+
+        original_store_delete = repository.store_delete
+        calls = []
+
+        def store_delete_then_interrupt(name, **kwargs):
+            original_store_delete(name, **kwargs)
+            calls.append(name)
+            if len(calls) == 1:
+                sig_int._sig_int_triggered = True  # one Ctrl-C after the first pack is deleted
+
+        monkeypatch.setattr(repository, "store_delete", store_delete_then_interrupt)
+        try:
+            with pytest.raises(Error, match="Got Ctrl-C"):
+                gc.garbage_collect()
+        finally:
+            sig_int._sig_int_triggered = False  # reset the global flag for the following tests
+
+    assert 0 < len(calls) < len(pack_names_before)  # stopped before deleting all packs
+
+    # every persisted index entry points at a pack that still exists
+    repository = open_repository(archiver)
+    with repository:
+        assert list_chunkindex_hashes(repository) != []
+        pack_names_after = {info.name for info in repository.store_list("packs")}
+        for id, entry in repository.chunks.iteritems():
+            assert bin_to_hex(entry.pack_id) in pack_names_after
+
+    output = cmd(archiver, "compact", "-v", exit_code=0)
+    assert "Finished compaction" in output
 
 
 def test_compact_packs_respects_threshold(tmp_path):


### PR DESCRIPTION
## Summary

`borg compact` invalidates the chunk index before deleting any packs, then rewrites it once at the end. If Ctrl-C hits mid-deletion, that rewrite never happens, so the next command finds no valid index and rebuilds it from scratch, scanning every pack. On a remote repository that can mean pulling the whole thing over the network.

Now a single Ctrl-C stops the pack-deletion and pack-rewrite loops at the next pack boundary. The index for whatever was already processed gets saved before the command exits with an error, so nothing downstream needs a rebuild. A second Ctrl-C still aborts immediately, same as before.

## Test plan

- Added a test that interrupts compact right after the first pack delete and checks the saved index still matches the repository.
- Ran the compact test suite locally, all green.

Closes #9830
