### PR TITLE
fix #9872: refresh repository lock of an idle mount

### DIFF
--- a/src/borg/archiver/lock_cmds.py
+++ b/src/borg/archiver/lock_cmds.py
@@ -3,8 +3,9 @@ import subprocess
 from ._common import with_repository
 from ..cache import Cache
 from ..constants import *  # NOQA
-from ..helpers import prepare_subprocess_env, set_ec, CommandError, ThreadRunner
+from ..helpers import prepare_subprocess_env, set_ec, CommandError
 from ..helpers.argparsing import ArgumentParser, REMAINDER
+from ..storelocking import LockRefresher
 
 from ..logger import create_logger
 
@@ -17,7 +18,7 @@ class LocksMixIn:
         """Runs a user-specified command with the repository lock held."""
         # the repository lock needs to get refreshed regularly, or it will be killed as stale.
         # refreshing the lock is not part of the repository API, so we do it indirectly via repository.info.
-        lock_refreshing_thread = ThreadRunner(sleep_interval=60, target=repository.info)
+        lock_refreshing_thread = LockRefresher(repository.info, sleep_interval=60)
         lock_refreshing_thread.start()
         env = prepare_subprocess_env(system=True)
         try:

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -12,6 +12,11 @@ This code is only safe for single-threaded and synchronous (non-async) usage.
   asynchronous manner. However, as long as we do not use any asynchronous
   operations (like using "await") in this code, it is still de facto
   synchronous, and we are safe.
+
+The only exception is a background thread that periodically refreshes the
+repository lock while the mount is idle (see #9872). borgstore connections are
+not thread-safe, so all repository access from the FUSE handlers and the refresh
+thread is serialized via self._repo_lock.
 """
 
 import errno
@@ -22,6 +27,7 @@ import stat
 import struct
 import sys
 import tempfile
+import threading
 import time
 from collections import defaultdict, Counter
 from signal import SIGINT
@@ -63,7 +69,7 @@ from .archiver._common import build_matcher, build_filter
 from .archive import Archive, get_item_uid_gid
 from .hashindex import FuseVersionsIndex
 from .helpers import daemonizing, signal_handler, format_file_size, bin_to_hex, Error
-from .helpers import HardLinkManager
+from .helpers import HardLinkManager, ThreadRunner
 from .helpers import msgpack
 from .helpers.lrucache import LRUCache
 from .item import Item
@@ -296,6 +302,9 @@ class FuseBackend:
         # Archives to be loaded when first accessed, mapped by their placeholder inode
         self.pending_archives = {}
         self.cache = ItemCache(repository, self.repo_objs)
+        # serializes all repository access (FUSE handlers and the background lock-refresh
+        # thread), because borgstore connections are not thread-safe. see _lock_refresh.
+        self._repo_lock = threading.Lock()
         self.allow_damaged_files = False
         self.versions = False
         self.uid_forced = None
@@ -334,15 +343,30 @@ class FuseBackend:
             return self._items[inode]
         except KeyError:
             # while self.cache does some internal caching, it has still quite some overhead, so we cache the result.
-            item = self.cache.get(inode)
+            with self._repo_lock:
+                item = self.cache.get(inode)
             self._inode_cache[inode] = item
             return item
+
+    def _lock_refresh(self):
+        # Called periodically by a background thread (see mount()) so that an idle mount keeps
+        # its repository lock alive. Without this, the lock of a long-idle mount expires as stale
+        # after <stale> seconds (currently 30 min), which would e.g. let a compact run and rewrite
+        # packs, invalidating this mount's cached pack locations (see #9872).
+        # Refreshing the lock is not part of the repository API, so we do it indirectly via
+        # repository.info() (same approach as `borg with-lock`). info() only touches the store
+        # every <stale>/2 seconds; all other calls are cheap no-ops.
+        # We serialize against the FUSE handlers via self._repo_lock, because borgstore connections
+        # are not thread-safe.
+        with self._repo_lock:
+            self.repository_uncached.info()
 
     def check_pending_archive(self, inode):
         # Check if this is an archive we need to load
         archive_info = self.pending_archives.pop(inode, None)
         if archive_info is not None:
-            self._process_archive(archive_info.id, [os.fsencode(self.archive_root_dir[archive_info.id])])
+            with self._repo_lock:
+                self._process_archive(archive_info.id, [os.fsencode(self.archive_root_dir[archive_info.id])])
 
     def _allocate_inode(self):
         self.inode_count += 1
@@ -602,12 +626,17 @@ class FuseOperations(llfuse.Operations, FuseBackend):
         # job - seeing the mountpoint empty, rsync would delete everything in the
         # mirror.
         umount = False
+        # keep the repository lock of an idle mount alive, so it is not killed as stale (see #9872).
+        # started here (after a possible daemonizing fork, as threads do not survive fork()).
+        lock_refreshing_thread = ThreadRunner(sleep_interval=60, target=self._lock_refresh)
+        lock_refreshing_thread.start()
         try:
             with signal_handler("SIGUSR1", self.sig_info_handler), signal_handler("SIGINFO", self.sig_info_handler):
                 signal = fuse_main()
             # no crash and no signal (or it's ^C and we're in the foreground) -> umount request
             umount = signal is None or (signal == SIGINT and foreground)
         finally:
+            lock_refreshing_thread.terminate()
             llfuse.close(umount)
 
     @async_wrapper
@@ -721,7 +750,8 @@ class FuseOperations(llfuse.Operations, FuseBackend):
                     del self.data_cache[id]
             else:
                 try:
-                    cdata = self.repository_uncached.get(id)
+                    with self._repo_lock:
+                        cdata = self.repository_uncached.get(id)
                 except Repository.ObjectNotFound:
                     if self.allow_damaged_files:
                         data = zeros[:s]

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -69,8 +69,9 @@ from .archiver._common import build_matcher, build_filter
 from .archive import Archive, get_item_uid_gid
 from .hashindex import FuseVersionsIndex
 from .helpers import daemonizing, signal_handler, format_file_size, bin_to_hex, Error
-from .helpers import HardLinkManager, ThreadRunner
+from .helpers import HardLinkManager
 from .helpers import msgpack
+from .storelocking import LockRefresher
 from .helpers.lrucache import LRUCache
 from .item import Item
 from .platform import uid2user, gid2group
@@ -348,19 +349,6 @@ class FuseBackend:
             self._inode_cache[inode] = item
             return item
 
-    def _lock_refresh(self):
-        # Called periodically by a background thread (see mount()) so that an idle mount keeps
-        # its repository lock alive. Without this, the lock of a long-idle mount expires as stale
-        # after <stale> seconds (currently 30 min), which would e.g. let a compact run and rewrite
-        # packs, invalidating this mount's cached pack locations (see #9872).
-        # Refreshing the lock is not part of the repository API, so we do it indirectly via
-        # repository.info() (same approach as `borg with-lock`). info() only touches the store
-        # every <stale>/2 seconds; all other calls are cheap no-ops.
-        # We serialize against the FUSE handlers via self._repo_lock, because borgstore connections
-        # are not thread-safe.
-        with self._repo_lock:
-            self.repository_uncached.info()
-
     def check_pending_archive(self, inode):
         # Check if this is an archive we need to load
         archive_info = self.pending_archives.pop(inode, None)
@@ -628,7 +616,7 @@ class FuseOperations(llfuse.Operations, FuseBackend):
         umount = False
         # keep the repository lock of an idle mount alive, so it is not killed as stale (see #9872).
         # started here (after a possible daemonizing fork, as threads do not survive fork()).
-        lock_refreshing_thread = ThreadRunner(sleep_interval=60, target=self._lock_refresh)
+        lock_refreshing_thread = LockRefresher(self.repository_uncached.info, sleep_interval=60, lock=self._repo_lock)
         lock_refreshing_thread.start()
         try:
             with signal_handler("SIGUSR1", self.sig_info_handler), signal_handler("SIGINFO", self.sig_info_handler):

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -304,7 +304,7 @@ class FuseBackend:
         self.cache = ItemCache(repository, self.repo_objs)
         # serializes all repository access (FUSE handlers and the background lock-refresh
         # thread), because borgstore connections are not thread-safe. see _lock_refresh.
-        self._repo_lock = threading.Lock()
+        self._repo_lock = threading.RLock()
         self.allow_damaged_files = False
         self.versions = False
         self.uid_forced = None

--- a/src/borg/hlfuse.py
+++ b/src/borg/hlfuse.py
@@ -3,6 +3,7 @@ import errno
 import hashlib
 import os
 import stat
+import threading
 import time
 from collections import Counter
 from typing import TYPE_CHECKING
@@ -25,7 +26,7 @@ from .archiver._common import build_matcher, build_filter
 from .archive import Archive, get_item_uid_gid
 from .hashindex import FuseVersionsIndex
 from .helpers import daemonizing, signal_handler, bin_to_hex, Error
-from .helpers import HardLinkManager
+from .helpers import HardLinkManager, ThreadRunner
 from .helpers import msgpack
 from .helpers.lrucache import LRUCache
 from .item import Item
@@ -87,6 +88,9 @@ class FuseBackend:
         self._manifest = manifest
         self.repo_objs = manifest.repo_objs
         self.repository = repository
+        # serializes all repository access (FUSE handlers and the background lock-refresh
+        # thread), because borgstore connections are not thread-safe. see _lock_refresh.
+        self._repo_lock = threading.Lock()
 
         self.default_uid = os.getuid()
         self.default_gid = os.getgid()
@@ -168,10 +172,24 @@ class FuseBackend:
                 self.root.add_child(name_bytes, archive_node)
                 self.pending_archives[archive_node] = archive
 
+    def _lock_refresh(self):
+        # Called periodically by a background thread (see mount()) so that an idle mount keeps
+        # its repository lock alive. Without this, the lock of a long-idle mount expires as stale
+        # after <stale> seconds (currently 30 min), which would e.g. let a compact run and rewrite
+        # packs, invalidating this mount's cached pack locations (see #9872).
+        # Refreshing the lock is not part of the repository API, so we do it indirectly via
+        # repository.info() (same approach as `borg with-lock`). info() only touches the store
+        # every <stale>/2 seconds; all other calls are cheap no-ops.
+        # We serialize against the FUSE handlers via self._repo_lock, because borgstore connections
+        # are not thread-safe.
+        with self._repo_lock:
+            self.repository.info()
+
     def check_pending_archive(self, node):
         archive_info = self.pending_archives.pop(node, None)
         if archive_info is not None:
-            self._process_archive(archive_info.id, node)
+            with self._repo_lock:
+                self._process_archive(archive_info.id, node)
 
     def _iter_archive_items(self, archive_item_ids, filter=None):
         unpacker = msgpack.Unpacker()
@@ -532,9 +550,16 @@ class borgfs(hlfuse.Operations, FuseBackend):
                 logger.debug("fuse: mount repo, going to background: migrating lock.")
                 self.repository.migrate_lock(old_id, new_id)
 
-        # Run the FUSE main loop in foreground (we might be daemonized already or not)
-        with signal_handler("SIGUSR1", self.sig_info_handler), signal_handler("SIGINFO", self.sig_info_handler):
-            hlfuse.FUSE(self, mountpoint, options, foreground=True, use_ino=True)
+        # keep the repository lock of an idle mount alive, so it is not killed as stale (see #9872).
+        # started here (after a possible daemonizing fork, as threads do not survive fork()).
+        lock_refreshing_thread = ThreadRunner(sleep_interval=60, target=self._lock_refresh)
+        lock_refreshing_thread.start()
+        try:
+            # Run the FUSE main loop in foreground (we might be daemonized already or not)
+            with signal_handler("SIGUSR1", self.sig_info_handler), signal_handler("SIGINFO", self.sig_info_handler):
+                hlfuse.FUSE(self, mountpoint, options, foreground=True, use_ino=True)
+        finally:
+            lock_refreshing_thread.terminate()
 
     def statfs(self, path):
         debug_log(f"statfs(path={path!r})")
@@ -645,7 +670,8 @@ class borgfs(hlfuse.Operations, FuseBackend):
             else:
                 try:
                     # Direct repository access
-                    cdata = self.repository.get(id)
+                    with self._repo_lock:
+                        cdata = self.repository.get(id)
                 except Repository.ObjectNotFound:
                     if self.allow_damaged_files:
                         data = zeros[:s]

--- a/src/borg/hlfuse.py
+++ b/src/borg/hlfuse.py
@@ -26,8 +26,9 @@ from .archiver._common import build_matcher, build_filter
 from .archive import Archive, get_item_uid_gid
 from .hashindex import FuseVersionsIndex
 from .helpers import daemonizing, signal_handler, bin_to_hex, Error
-from .helpers import HardLinkManager, ThreadRunner
+from .helpers import HardLinkManager
 from .helpers import msgpack
+from .storelocking import LockRefresher
 from .helpers.lrucache import LRUCache
 from .item import Item
 from .platform import uid2user, gid2group
@@ -171,19 +172,6 @@ class FuseBackend:
 
                 self.root.add_child(name_bytes, archive_node)
                 self.pending_archives[archive_node] = archive
-
-    def _lock_refresh(self):
-        # Called periodically by a background thread (see mount()) so that an idle mount keeps
-        # its repository lock alive. Without this, the lock of a long-idle mount expires as stale
-        # after <stale> seconds (currently 30 min), which would e.g. let a compact run and rewrite
-        # packs, invalidating this mount's cached pack locations (see #9872).
-        # Refreshing the lock is not part of the repository API, so we do it indirectly via
-        # repository.info() (same approach as `borg with-lock`). info() only touches the store
-        # every <stale>/2 seconds; all other calls are cheap no-ops.
-        # We serialize against the FUSE handlers via self._repo_lock, because borgstore connections
-        # are not thread-safe.
-        with self._repo_lock:
-            self.repository.info()
 
     def check_pending_archive(self, node):
         archive_info = self.pending_archives.pop(node, None)
@@ -552,7 +540,7 @@ class borgfs(hlfuse.Operations, FuseBackend):
 
         # keep the repository lock of an idle mount alive, so it is not killed as stale (see #9872).
         # started here (after a possible daemonizing fork, as threads do not survive fork()).
-        lock_refreshing_thread = ThreadRunner(sleep_interval=60, target=self._lock_refresh)
+        lock_refreshing_thread = LockRefresher(self.repository.info, sleep_interval=60, lock=self._repo_lock)
         lock_refreshing_thread.start()
         try:
             # Run the FUSE main loop in foreground (we might be daemonized already or not)

--- a/src/borg/hlfuse.py
+++ b/src/borg/hlfuse.py
@@ -90,7 +90,7 @@ class FuseBackend:
         self.repository = repository
         # serializes all repository access (FUSE handlers and the background lock-refresh
         # thread), because borgstore connections are not thread-safe. see _lock_refresh.
-        self._repo_lock = threading.Lock()
+        self._repo_lock = threading.RLock()
 
         self.default_uid = os.getuid()
         self.default_gid = os.getgid()

--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import json
 import random
+import threading
 import time
 
 from borgstore.store import ObjectNotFound
@@ -296,3 +297,50 @@ class Lock:
                     logger.debug("LOCK-REFRESH: our lock was killed while refreshing it, no safe way to continue.")
                     self._delete_lock(new_key, ignore_not_found=True, update_last_refresh=True)
                     raise LockTimeout(str(self.store))
+
+
+class LockRefresher:
+    def __init__(self, refresh_callable, sleep_interval=60, lock=None):
+        """
+        Periodically refreshes the repository lock in a background thread.
+
+        :param refresh_callable: Callable (e.g. repository.info) to refresh the lock.
+        :param sleep_interval: Frequency of refresh attempts (in seconds).
+        :param lock: Optional reentrant lock (RLock) to serialize repository access.
+        """
+        self.refresh_callable = refresh_callable
+        self.sleep_interval = sleep_interval
+        self.lock = lock
+        self._thread = None
+        self._keep_running = threading.Event()
+        self._keep_running.set()
+
+    def _run(self):
+        while self._keep_running.is_set():
+            try:
+                if self.lock is not None:
+                    with self.lock:
+                        self.refresh_callable()
+                else:
+                    self.refresh_callable()
+            except LockTimeout:
+                logger.error("Lock refresh thread: lock has been killed/timed out. Terminating refresh.")
+                break
+            except Exception as e:
+                logger.warning(f"Lock refresh thread: temporary error during lock refresh: {e}. Will retry.")
+
+            # sleep up to self.sleep_interval in small steps to allow quick shutdown
+            count = 1000
+            micro_sleep = float(self.sleep_interval) / count
+            while self._keep_running.is_set() and count > 0:
+                time.sleep(micro_sleep)
+                count -= 1
+
+    def start(self):
+        self._thread = threading.Thread(target=self._run, name="LockRefresher")
+        self._thread.start()
+
+    def terminate(self):
+        if self._thread is not None:
+            self._keep_running.clear()
+            self._thread.join()

--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -337,10 +337,17 @@ class LockRefresher:
                 count -= 1
 
     def start(self):
-        self._thread = threading.Thread(target=self._run, name="LockRefresher")
+        # daemon=True so a refresh that is stuck in a blocking refresh_callable() (e.g. network
+        # I/O to a remote repo that never returns) can never keep the process alive on exit.
+        self._thread = threading.Thread(target=self._run, name="LockRefresher", daemon=True)
         self._thread.start()
 
     def terminate(self):
         if self._thread is not None:
             self._keep_running.clear()
-            self._thread.join()
+            # bounded join: if refresh_callable() is wedged (e.g. a hung remote-repo request),
+            # don't let it stall shutdown - e.g. a FUSE unmount waiting for this. the thread is a
+            # daemon, so it is torn down at interpreter exit even if it is still alive here.
+            self._thread.join(timeout=5.0)
+            if self._thread.is_alive():
+                logger.warning("Lock refresh thread did not stop within 5s; continuing shutdown.")

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -380,3 +380,32 @@ def test_migrate_lock_alive(archivers, request):
     finally:
         # Undecorate
         Lock.migrate_lock = Lock.migrate_lock.__wrapped__
+
+
+@pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")
+def test_fuse_lock_refresh_calls_repository_info():
+    # regression test for #9872: an idle mount must keep its repository lock alive via a
+    # background refresh. FuseBackend._lock_refresh() does this indirectly through
+    # repository.info(), serialized against the FUSE handlers by self._repo_lock.
+    import threading
+
+    from ...fuse import FuseBackend
+
+    calls = []
+
+    class FakeRepository:
+        def info(self):
+            # record whether the caller holds the serialization lock (it must, so that repo
+            # access from the refresh thread and the FUSE handlers never runs concurrently).
+            calls.append(backend._repo_lock.locked())
+            return dict(id=b"\x00" * 32, version=3)
+
+    # build a bare backend without running the heavy __init__.
+    backend = FuseBackend.__new__(FuseBackend)
+    backend._repo_lock = threading.Lock()
+    backend.repository_uncached = FakeRepository()
+
+    backend._lock_refresh()
+
+    assert calls == [True], "repository.info() must be called exactly once, while holding _repo_lock"
+    assert not backend._repo_lock.locked(), "_repo_lock must be released again after refreshing"

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -384,26 +384,32 @@ def test_migrate_lock_alive(archivers, request):
 
 def test_fuse_lock_refresh_calls_repository_info():
     # regression test for #9872: an idle mount must keep its repository lock alive via a
-    # background refresh. LockRefresher does this indirectly through repository.info(),
-    # serialized against the FUSE handlers by self._repo_lock.
+    # background refresh. LockRefresher periodically calls repository.info() while holding
+    # the serialization lock (the FUSE handlers use the same lock), so repo access from the
+    # refresh thread and the FUSE handlers never runs concurrently.
     import threading
 
     from ...storelocking import LockRefresher
 
-    calls = []
+    # a plain Lock is enough here and, unlike RLock, has .locked() on all Python versions.
+    # in the FUSE code the lock is an RLock (it needs to be reentrant), but LockRefresher
+    # only ever acquires/releases it, so a plain Lock exercises the same code path.
+    lock = threading.Lock()
+    called = threading.Event()
+    held_while_calling = []
 
     class FakeRepository:
         def info(self):
-            # record whether the caller holds the serialization lock (it must, so that repo
-            # access from the refresh thread and the FUSE handlers never runs concurrently).
-            calls.append(lock.locked())
-            refresher._keep_running.clear()
+            held_while_calling.append(lock.locked())  # the lock must be held while we run
+            called.set()
             return dict(id=b"\x00" * 32, version=3)
 
-    lock = threading.RLock()
-    repository = FakeRepository()
-    refresher = LockRefresher(repository.info, sleep_interval=60, lock=lock)
-    refresher._run()
+    refresher = LockRefresher(FakeRepository().info, sleep_interval=60, lock=lock)
+    refresher.start()
+    try:
+        assert called.wait(timeout=10), "LockRefresher did not call repository.info()"
+    finally:
+        refresher.terminate()
 
-    assert calls == [True], "repository.info() must be called exactly once, while holding lock"
+    assert held_while_calling and all(held_while_calling), "repository.info() must run while holding the lock"
     assert not lock.locked(), "lock must be released again after refreshing"

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -382,21 +382,13 @@ def test_migrate_lock_alive(archivers, request):
         Lock.migrate_lock = Lock.migrate_lock.__wrapped__
 
 
-@pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")
 def test_fuse_lock_refresh_calls_repository_info():
     # regression test for #9872: an idle mount must keep its repository lock alive via a
-    # background refresh. FuseBackend._lock_refresh() does this indirectly through
-    # repository.info(), serialized against the FUSE handlers by self._repo_lock.
+    # background refresh. LockRefresher does this indirectly through repository.info(),
+    # serialized against the FUSE handlers by self._repo_lock.
     import threading
 
-    from ...fuse_impl import has_mfusepy
-
-    # import the FuseBackend of the active FUSE implementation (fuse.py is not even importable
-    # when the mfusepy backend is in use, and vice versa).
-    if has_mfusepy:
-        from ...hlfuse import FuseBackend
-    else:
-        from ...fuse import FuseBackend
+    from ...storelocking import LockRefresher
 
     calls = []
 
@@ -404,16 +396,14 @@ def test_fuse_lock_refresh_calls_repository_info():
         def info(self):
             # record whether the caller holds the serialization lock (it must, so that repo
             # access from the refresh thread and the FUSE handlers never runs concurrently).
-            calls.append(backend._repo_lock.locked())
+            calls.append(lock.locked())
+            refresher._keep_running.clear()
             return dict(id=b"\x00" * 32, version=3)
 
-    # build a bare backend without running the heavy __init__.
-    backend = FuseBackend.__new__(FuseBackend)
-    backend._repo_lock = threading.RLock()
-    # fuse.py refreshes via self.repository_uncached, hlfuse.py via self.repository; set both.
-    backend.repository = backend.repository_uncached = FakeRepository()
+    lock = threading.RLock()
+    repository = FakeRepository()
+    refresher = LockRefresher(repository.info, sleep_interval=60, lock=lock)
+    refresher._run()
 
-    backend._lock_refresh()
-
-    assert calls == [True], "repository.info() must be called exactly once, while holding _repo_lock"
-    assert not backend._repo_lock.locked(), "_repo_lock must be released again after refreshing"
+    assert calls == [True], "repository.info() must be called exactly once, while holding lock"
+    assert not lock.locked(), "lock must be released again after refreshing"

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -409,7 +409,7 @@ def test_fuse_lock_refresh_calls_repository_info():
 
     # build a bare backend without running the heavy __init__.
     backend = FuseBackend.__new__(FuseBackend)
-    backend._repo_lock = threading.Lock()
+    backend._repo_lock = threading.RLock()
     # fuse.py refreshes via self.repository_uncached, hlfuse.py via self.repository; set both.
     backend.repository = backend.repository_uncached = FakeRepository()
 

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -389,7 +389,14 @@ def test_fuse_lock_refresh_calls_repository_info():
     # repository.info(), serialized against the FUSE handlers by self._repo_lock.
     import threading
 
-    from ...fuse import FuseBackend
+    from ...fuse_impl import has_mfusepy
+
+    # import the FuseBackend of the active FUSE implementation (fuse.py is not even importable
+    # when the mfusepy backend is in use, and vice versa).
+    if has_mfusepy:
+        from ...hlfuse import FuseBackend
+    else:
+        from ...fuse import FuseBackend
 
     calls = []
 
@@ -403,7 +410,8 @@ def test_fuse_lock_refresh_calls_repository_info():
     # build a bare backend without running the heavy __init__.
     backend = FuseBackend.__new__(FuseBackend)
     backend._repo_lock = threading.Lock()
-    backend.repository_uncached = FakeRepository()
+    # fuse.py refreshes via self.repository_uncached, hlfuse.py via self.repository; set both.
+    backend.repository = backend.repository_uncached = FakeRepository()
 
     backend._lock_refresh()
 


### PR DESCRIPTION
## Problem

Fixes #9872.

An idle FUSE mount makes no repository calls, so its lock's refresh (which currently only happens on read activity) never runs. After `<stale>` seconds (30 min by default) the lock expires as stale. A `compact` can then run and its pack rewrites invalidate the mount's cached pack locations, so subsequent reads fail with `ObjectNotFound`/`PackNotFound` (even for chunks that still exist, just moved to a new pack) and the next lock refresh aborts the mount with `LockTimeout`.

## Fix

While mounted, run a background thread that periodically calls `repository.info()` to keep the lock alive (`info()` only touches the store every `<stale>/2` seconds; the rest are cheap no-ops). This is the same idea `borg with-lock` already used.

The thread logic is factored into a small reusable `LockRefresher` class in `storelocking.py`:

```
LockRefresher(refresh_callable, sleep_interval=60, lock=None)
```

It runs a **daemon** thread that periodically calls `refresh_callable` (optionally under a caller-supplied `lock`), stops on `LockTimeout` (the lock was killed — nothing safe left to do), and on `terminate()` joins with a **5s timeout** so a wedged refresh (e.g. a hung remote-repo request) can't stall shutdown / a FUSE unmount. `borg with-lock` now uses `LockRefresher` too, replacing its ad-hoc thread runner.

The refresh thread is started **after** the possible daemonizing `fork()` (threads do not survive `fork()`) and terminated in a `finally` around the FUSE main loop.

This is applied to **both** FUSE implementations, which are parallel and selected by `BORG_FUSE_IMPL`:

- `fuse.py` (llfuse / pyfuse3)
- `hlfuse.py` (mfusepy)

### Thread safety

The FUSE code is otherwise single-threaded, and borgstore connections are not thread-safe. To keep the refresh thread from racing with the FUSE handlers on the store connection, each mount gets a `self._repo_lock` that serializes all repository access. It is a **reentrant** `RLock`, because a FUSE handler can re-enter it on the same thread: `check_pending_archive()` holds it and calls `_process_archive()` → `_process_leaf()` (hardlink branch) → `get_item()`, which acquires it again. The `LockRefresher` is given this same lock.

Guarded repository-access points:

- `fuse.py`: `get_item()` → `ItemCache.get()`, `check_pending_archive()` → `_process_archive()`, `read()` → `repository_uncached.get()`, and the background refresh → `repository.info()`.
- `hlfuse.py`: `check_pending_archive()` → `_process_archive()` (covers the `get_many()` in `_iter_archive_items()`), `read()` → `repository.get()`, and the background refresh → `repository.info()`.

`fuse.py`'s module docstring is updated to document this single deliberate exception to the single-threaded invariant.

## Tests

- All existing `mount_cmds_test.py` FUSE tests pass on all backends (they exercise the now-serialized read / lookup / archive-loading paths, and thus the real `LockRefresher` `start()`/`terminate()` lifecycle via the mount daemon).
- Added `test_fuse_lock_refresh_calls_repository_info`: drives `LockRefresher` through its real `start()`/`terminate()` API in a background thread (bounded by an `Event` wait + join, so it can't hang) and asserts `repository.info()` is invoked while the serialization lock is held. It uses a plain `threading.Lock` (whose `.locked()` exists on all supported Python versions — `RLock.locked()` is 3.14+ only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)