### PR TITLE
check: track a set of checked packs for partial checks

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -37,7 +37,7 @@ config/
 cache/
   checked-packs
     repository check progress (partial checks, full checks' checkpointing),
-    the set of packs checked so far this cycle (pack key -> timestamp, result),
+    the set of packs checked so far this cycle (pack id -> timestamp, result),
     as a hashtable with an appended integrity hash
 
 There is a list of pointers to archive objects in this directory:

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -31,11 +31,14 @@ config/
     the repository version encoded as decimal number text
   manifest
     some data about the repository, binary
-  last-pack-checked
-    repository check progress (partial checks, full checks' checkpointing),
-    key of last pack checked as text
   space-reserve.N
     purely random binary data to reserve space, e.g. for disk-full emergencies
+
+cache/
+  checked-packs
+    repository check progress (partial checks, full checks' checkpointing),
+    the set of packs checked so far this cycle (pack key -> timestamp, result),
+    as a hashtable with an appended integrity hash
 
 There is a list of pointers to archive objects in this directory:
 

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -33,8 +33,8 @@ from .crypto.key import is_keyfile
 logger = create_logger(__name__)
 
 # check() records the packs verified in the current check cycle in CHECKED_PACKS, a HashTableNT mapping
-# pack_id (32 bytes) -> (timestamp, result). Partial checks (--max-duration) skip packs already in this
-# set. Pack names are content sha256s with no meaningful order, so skipping is a set lookup.
+# pack_id (32 bytes) -> (timestamp, result). A partial check (--max-duration) skips packs recorded intact
+# and re-verifies packs recorded corrupt.
 CHECKED_PACKS = "cache/checked-packs"
 CheckedPackEntry = namedtuple("CheckedPackEntry", "timestamp result")
 CheckedPackEntryFormatT = namedtuple("CheckedPackEntryFormatT", "timestamp result")
@@ -737,7 +737,8 @@ class Repository:
                 self._lock_refresh()
                 pack_pi.show(increase=1)  # advance for every pack, including ones a partial resume skips below
                 pack_id = hex_to_bin(info.name)
-                if pack_id in checked_packs:  # already verified this cycle
+                entry = checked_packs.get(pack_id)
+                if entry is not None and entry.result:  # verified intact earlier in this cycle
                     continue
                 pack_files += 1
                 ok = verify("packs", info.name)

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -32,18 +32,6 @@ from .crypto.key import is_keyfile
 
 logger = create_logger(__name__)
 
-# check() records the packs verified in the current check cycle in CHECKED_PACKS, a HashTableNT mapping
-# pack_id (32 bytes) -> (timestamp, result). A partial check (--max-duration) skips packs recorded intact
-# and re-verifies packs recorded corrupt.
-CHECKED_PACKS = "cache/checked-packs"
-CheckedPackEntry = namedtuple("CheckedPackEntry", "timestamp result")
-CheckedPackEntryFormatT = namedtuple("CheckedPackEntryFormatT", "timestamp result")
-CheckedPackEntryFormat = CheckedPackEntryFormatT(timestamp="Q", result="B")  # unix ts (uint64), result 1=ok 0=corrupt
-
-
-def new_checked_packs_table():
-    return HashTableNT(key_size=32, value_type=CheckedPackEntry, value_format=CheckedPackEntryFormat)
-
 
 def repo_lister(repository, *, limit=None):
     marker = None
@@ -246,6 +234,60 @@ class PackReader:
             obj_size = hdr_size + hdr.meta_size + hdr.data_size
             yield hdr.chunk_id, offset, obj_size
             offset += obj_size
+
+
+class PackTracker:
+    """Packs check() has verified in the current cycle, mapping pack_id (32 bytes) -> (timestamp, result).
+
+    is_intact() drives the skip in a partial check: intact packs are skipped, packs recorded corrupt are
+    re-verified. save() appends a sha256 over the serialized table; load() drops a blob whose sha256 does
+    not match, so a rotted set re-checks everything instead of skipping an unverified pack.
+    """
+
+    NAME = "cache/checked-packs"
+    Entry = namedtuple("Entry", "timestamp result")
+    EntryFormatT = namedtuple("EntryFormatT", "timestamp result")
+    _EntryFormat = EntryFormatT(timestamp="Q", result="B")  # unix ts, 1=ok 0=corrupt
+
+    def __init__(self, store):
+        self.store = store
+        self.table = HashTableNT(key_size=32, value_type=self.Entry, value_format=self._EntryFormat)
+
+    def __len__(self):
+        return len(self.table)
+
+    def is_intact(self, pack_id):
+        entry = self.table.get(pack_id)
+        return entry is not None and bool(entry.result)
+
+    def record(self, pack_id, ok):
+        self.table[pack_id] = self.Entry(timestamp=int(time.time()), result=int(ok))
+
+    def load(self):
+        try:
+            data = self.store.load(self.NAME)
+        except StoreObjectNotFound:
+            return
+        if len(data) < 32 or sha256(data[:-32]).digest() != data[-32:]:
+            logger.warning("Ignoring corrupted checked-packs set.")
+            return
+        try:
+            with io.BytesIO(data[:-32]) as f:
+                self.table = HashTableNT.read(f)
+        except ValueError:
+            logger.warning("Ignoring unreadable checked-packs set.")
+
+    def save(self):
+        with io.BytesIO() as f:
+            self.table.write(f)
+            data = f.getvalue()
+        self.store.store(self.NAME, data + sha256(data).digest())
+
+    def clear(self):
+        try:
+            self.store.delete(self.NAME)
+        except StoreObjectNotFound:
+            pass
 
 
 class Repository:
@@ -694,18 +736,13 @@ class Repository:
         assert not (repair and partial)
         mode = "partial" if partial else "full"
         logger.info(f"Starting {mode} repository check")
+        tracker = PackTracker(self.store)
         if partial:
-            # resume the cycle: packs already in the set are skipped below.
-            checked_packs = self._load_checked_packs()
+            tracker.load()  # resume the cycle: packs already recorded intact are skipped below.
         else:
-            # a full check verifies every pack; start a new cycle.
-            checked_packs = new_checked_packs_table()
-            try:
-                self.store.delete(CHECKED_PACKS)
-            except StoreObjectNotFound:
-                pass
-        if len(checked_packs):
-            logger.info(f"Continuing check cycle, {len(checked_packs)} packs already checked.")
+            tracker.clear()  # a full check verifies every pack; start a new cycle.
+        if len(tracker):
+            logger.info(f"Continuing check cycle, {len(tracker)} packs already checked.")
         else:
             logger.info("Starting from beginning.")
         t_start = time.monotonic()
@@ -737,32 +774,28 @@ class Repository:
                 self._lock_refresh()
                 pack_pi.show(increase=1)  # advance for every pack, including ones a partial resume skips below
                 pack_id = hex_to_bin(info.name)
-                entry = checked_packs.get(pack_id)
-                if entry is not None and entry.result:  # verified intact earlier in this cycle
+                if tracker.is_intact(pack_id):  # verified intact earlier in this cycle
                     continue
                 pack_files += 1
                 ok = verify("packs", info.name)
                 if not ok:
                     pack_errors += 1  # repair (salvage into a new pack, fix index) is not implemented yet
-                checked_packs[pack_id] = CheckedPackEntry(timestamp=int(time.time()), result=int(ok))
+                tracker.record(pack_id, ok)
                 now = time.monotonic()
-                if now > t_last_checkpoint + 300:  # checkpoint every 5 mins
+                if now > t_last_checkpoint + 60:  # checkpoint every minute
                     t_last_checkpoint = now
                     logger.info(f"Checkpointing at pack {info.name}.")
-                    self._store_checked_packs(checked_packs)
+                    tracker.save()
                 if partial and now > t_start + max_duration:
-                    logger.info(f"Finished partial repository check, {len(checked_packs)} packs checked so far.")
-                    self._store_checked_packs(checked_packs)
+                    logger.info(f"Finished partial repository check, {len(tracker)} packs checked so far.")
+                    tracker.save()
                     break
             else:
                 # scanned all packs without hitting the time limit: the cycle is done, drop the set.
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-                try:
-                    self.store.delete(CHECKED_PACKS)
-                except StoreObjectNotFound:
-                    pass
+                tracker.clear()
             pack_pi.finish()
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
@@ -778,30 +811,6 @@ class Repository:
         else:
             logger.error(f"Finished {mode} repository check, errors found.")
         return objs_errors == 0 or repair
-
-    def _load_checked_packs(self):
-        """Load the CHECKED_PACKS set. Return an empty table if it is missing, corrupted or unreadable."""
-        try:
-            data = self.store.load(CHECKED_PACKS)
-        except StoreObjectNotFound:
-            return new_checked_packs_table()
-        # the trailing 32 bytes are a sha256 over the rest; a mismatch means the blob rotted.
-        if len(data) < 32 or sha256(data[:-32]).digest() != data[-32:]:
-            logger.warning("Ignoring corrupted checked-packs set.")
-            return new_checked_packs_table()
-        try:
-            with io.BytesIO(data[:-32]) as f:
-                return HashTableNT.read(f)
-        except ValueError:
-            logger.warning("Ignoring unreadable checked-packs set.")
-            return new_checked_packs_table()
-
-    def _store_checked_packs(self, checked_packs):
-        """Store the CHECKED_PACKS set with a sha256 appended over its content."""
-        with io.BytesIO() as f:
-            checked_packs.write(f)
-            data = f.getvalue()
-        self.store.store(CHECKED_PACKS, data + sha256(data).digest())
 
     def list(self, limit=None, marker=None):
         """

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -237,58 +237,69 @@ class PackReader:
 
 
 class PackTracker:
-    """Packs check() verified in the current cycle, mapping pack_id (32 bytes) -> (timestamp, result).
+    """Packs verified in the current check cycle, mapping pack_id -> (timestamp, result).
 
-    A cycle is one full pass over packs/, which --max-duration may spread over several partial checks.
-    The set is stored at cache/checked-packs with a sha256 over the serialized table appended. load()
-    accepts the table only if that hash matches and its entries have the layout this class writes.
+    A cycle is one full pass over packs/; --max-duration may spread it over several partial checks.
+    Stored at cache/checked-packs as the serialized table with a sha256 over it appended.
+    new() starts a cycle, load() resumes the stored one.
     """
 
     NAME = "cache/checked-packs"
+    KEY_SIZE = 32  # pack id
+    DIGEST_SIZE = 32  # sha256
     Entry = namedtuple("Entry", "timestamp result")
     EntryFormatT = namedtuple("EntryFormatT", "timestamp result")
     _EntryFormat = EntryFormatT(timestamp="Q", result="B")  # unix ts, 1=ok 0=corrupt
 
-    def __init__(self, store):
+    def __init__(self, store, table):
         self.store = store
-        self.table = self._new_table()
+        self.table = table
 
     @classmethod
-    def _new_table(cls):
-        return HashTableNT(key_size=32, value_type=cls.Entry, value_format=cls._EntryFormat)
+    def new(cls, store):
+        """Return a tracker with an empty table."""
+        table = HashTableNT(key_size=cls.KEY_SIZE, value_type=cls.Entry, value_format=cls._EntryFormat)
+        return cls(store, table)
+
+    @classmethod
+    def load(cls, store):
+        """Return a tracker holding the stored table.
+
+        Return an empty one if cache/checked-packs is missing, its appended sha256 does not match,
+        it does not deserialize, or its entries do not have this class's key size and Entry layout.
+        """
+        try:
+            data = store.load(cls.NAME)
+        except StoreObjectNotFound:
+            return cls.new(store)
+        if len(data) < cls.DIGEST_SIZE or sha256(data[: -cls.DIGEST_SIZE]).digest() != data[-cls.DIGEST_SIZE :]:
+            logger.warning("Ignoring corrupted checked-packs set.")
+            return cls.new(store)
+        try:
+            with io.BytesIO(data[: -cls.DIGEST_SIZE]) as f:
+                table = HashTableNT.read(f)
+        except ValueError:
+            logger.warning("Ignoring unreadable checked-packs set.")
+            return cls.new(store)
+        # read() takes key size and value type from the blob itself, so the table needs a layout check
+        # against Entry here. All entries in a table share one layout, so checking one entry suffices.
+        sample = next(iter(table.items()), None)
+        if sample is not None:
+            key, value = sample
+            if len(key) != cls.KEY_SIZE or value._fields != cls.Entry._fields:
+                logger.warning("Ignoring checked-packs set with an unexpected layout.")
+                return cls.new(store)
+        return cls(store, table)
 
     def __len__(self):
         return len(self.table)
 
-    def is_intact(self, pack_id):
-        entry = self.table.get(pack_id)
-        return entry is not None and bool(entry.result)
+    def get(self, pack_id):
+        """Return the Entry for pack_id, or None if it is not recorded."""
+        return self.table.get(pack_id)
 
     def record(self, pack_id, ok):
         self.table[pack_id] = self.Entry(timestamp=int(time.time()), result=int(ok))
-
-    def load(self):
-        try:
-            data = self.store.load(self.NAME)
-        except StoreObjectNotFound:
-            return
-        if len(data) < 32 or sha256(data[:-32]).digest() != data[-32:]:
-            logger.warning("Ignoring corrupted checked-packs set.")
-            return
-        try:
-            with io.BytesIO(data[:-32]) as f:
-                table = HashTableNT.read(f)
-        except ValueError:
-            logger.warning("Ignoring unreadable checked-packs set.")
-            return
-        # read() rebuilds key size and value type from the blob, so a table written with a different
-        # Entry layout reads without error. All entries share one layout, so sampling one is enough.
-        for key, value in table.items():
-            if len(key) != 32 or value._fields != self.Entry._fields:
-                logger.warning("Ignoring checked-packs set with an unexpected layout.")
-                return
-            break
-        self.table = table
 
     def save(self):
         with io.BytesIO() as f:
@@ -750,11 +761,11 @@ class Repository:
         assert not (repair and partial)
         mode = "partial" if partial else "full"
         logger.info(f"Starting {mode} repository check")
-        tracker = PackTracker(self.store)
         if partial:
-            tracker.load()  # resume the cycle
+            tracker = PackTracker.load(self.store)
         else:
-            tracker.clear()  # a full check verifies every pack, so start a new cycle
+            tracker = PackTracker.new(self.store)
+            tracker.clear()  # a full check verifies every pack, so discard the stored cycle
         if len(tracker):
             logger.info(f"Continuing check cycle, {len(tracker)} packs already checked.")
         else:
@@ -785,7 +796,8 @@ class Repository:
                 self._lock_refresh()
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
-                if tracker.is_intact(pack_id):  # verified intact earlier in this cycle
+                entry = tracker.get(pack_id)
+                if entry is not None and entry.result:  # intact in this cycle; a corrupt one is verified again
                     continue
                 pack_files += 1
                 ok = verify("packs", info.name)

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -237,11 +237,11 @@ class PackReader:
 
 
 class PackTracker:
-    """Packs check() has verified in the current cycle, mapping pack_id (32 bytes) -> (timestamp, result).
+    """Packs check() verified in the current cycle, mapping pack_id (32 bytes) -> (timestamp, result).
 
-    is_intact() drives the skip in a partial check: intact packs are skipped, packs recorded corrupt are
-    re-verified. save() appends a sha256 over the serialized table; load() drops a blob whose sha256 does
-    not match, so a rotted set re-checks everything instead of skipping an unverified pack.
+    A cycle is one full pass over packs/, which --max-duration may spread over several partial checks.
+    The set is stored at cache/checked-packs with a sha256 over the serialized table appended. load()
+    accepts the table only if that hash matches and its entries have the layout this class writes.
     """
 
     NAME = "cache/checked-packs"
@@ -251,7 +251,11 @@ class PackTracker:
 
     def __init__(self, store):
         self.store = store
-        self.table = HashTableNT(key_size=32, value_type=self.Entry, value_format=self._EntryFormat)
+        self.table = self._new_table()
+
+    @classmethod
+    def _new_table(cls):
+        return HashTableNT(key_size=32, value_type=cls.Entry, value_format=cls._EntryFormat)
 
     def __len__(self):
         return len(self.table)
@@ -273,9 +277,18 @@ class PackTracker:
             return
         try:
             with io.BytesIO(data[:-32]) as f:
-                self.table = HashTableNT.read(f)
+                table = HashTableNT.read(f)
         except ValueError:
             logger.warning("Ignoring unreadable checked-packs set.")
+            return
+        # read() rebuilds key size and value type from the blob, so a table written with a different
+        # Entry layout reads without error. All entries share one layout, so sampling one is enough.
+        for key, value in table.items():
+            if len(key) != 32 or value._fields != self.Entry._fields:
+                logger.warning("Ignoring checked-packs set with an unexpected layout.")
+                return
+            break
+        self.table = table
 
     def save(self):
         with io.BytesIO() as f:
@@ -284,6 +297,7 @@ class PackTracker:
         self.store.store(self.NAME, data + sha256(data).digest())
 
     def clear(self):
+        self.table.clear()
         try:
             self.store.delete(self.NAME)
         except StoreObjectNotFound:
@@ -738,9 +752,9 @@ class Repository:
         logger.info(f"Starting {mode} repository check")
         tracker = PackTracker(self.store)
         if partial:
-            tracker.load()  # resume the cycle: packs already recorded intact are skipped below.
+            tracker.load()  # resume the cycle
         else:
-            tracker.clear()  # a full check verifies every pack; start a new cycle.
+            tracker.clear()  # a full check verifies every pack, so start a new cycle
         if len(tracker):
             logger.info(f"Continuing check cycle, {len(tracker)} packs already checked.")
         else:
@@ -749,11 +763,9 @@ class Repository:
         t_last_checkpoint = t_start
         index_files = index_errors = 0
         pack_files = pack_errors = 0
-        # check index and packs with separate progress indicators, each running from 0% to 100%.
-        # hash the index first, on full and partial checks alike: it is small, and a corrupt index
-        # already means the user must repair it (rebuilding the index re-reads all packs anyway), so we
-        # stop and report that rather than continue. matters for partial checks too, whose runs can be
-        # days apart (e.g. a weekend cron job).
+        # index and packs get separate progress indicators, each running from 0% to 100%.
+        # the index is checked first and in full, on partial checks too: it is small, and index errors
+        # stop the pack check below.
         index_infos = store_list("index")
         index_pi = ProgressIndicatorPercent(total=len(index_infos), msg="Checking index %3.0f%%", msgid="check.index")
         for info in index_infos:
@@ -766,23 +778,23 @@ class Repository:
             index_pi.show(current=len(index_infos))  # finish at 100%
         index_pi.finish()
         if index_errors == 0:
-            # list the packs only now: a corrupt index skips this entirely. packs are the bulk of the
-            # work and the part --max-duration splits.
+            # packs are the bulk of the work and the part --max-duration spreads over several checks.
             pack_infos = store_list("packs")
             pack_pi = ProgressIndicatorPercent(total=len(pack_infos), msg="Checking packs %3.0f%%", msgid="check.packs")
             for info in pack_infos:
                 self._lock_refresh()
-                pack_pi.show(increase=1)  # advance for every pack, including ones a partial resume skips below
+                pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 if tracker.is_intact(pack_id):  # verified intact earlier in this cycle
                     continue
                 pack_files += 1
                 ok = verify("packs", info.name)
                 if not ok:
-                    pack_errors += 1  # repair (salvage into a new pack, fix index) is not implemented yet
+                    pack_errors += 1
                 tracker.record(pack_id, ok)
                 now = time.monotonic()
-                if now > t_last_checkpoint + 30 * 60:  # checkpoint every 30 minutes
+                # a checkpoint rewrites the whole table (41 bytes per pack), so keep the interval long.
+                if now > t_last_checkpoint + 30 * 60:
                     t_last_checkpoint = now
                     logger.info(f"Checkpointing at pack {info.name}.")
                     tracker.save()

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1,9 +1,12 @@
+import io
 import os
 import sys
 import time
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from pathlib import Path
 from hashlib import sha256
+
+from borghash import HashTableNT
 
 from borgstore.store import Store
 from borgstore.backends.rest import REST, ssh_cmd
@@ -29,6 +32,18 @@ from .crypto.key import is_keyfile
 
 logger = create_logger(__name__)
 
+# check() records the packs verified in the current check cycle in CHECKED_PACKS, a HashTableNT mapping
+# pack_id (32 bytes) -> (timestamp, result). Partial checks (--max-duration) skip packs already in this
+# set. Pack names are content sha256s with no meaningful order, so skipping is a set lookup.
+CHECKED_PACKS = "cache/checked-packs"
+CheckedPackEntry = namedtuple("CheckedPackEntry", "timestamp result")
+CheckedPackEntryFormatT = namedtuple("CheckedPackEntryFormatT", "timestamp result")
+CheckedPackEntryFormat = CheckedPackEntryFormatT(timestamp="Q", result="B")  # unix ts (uint64), result 1=ok 0=corrupt
+
+
+def new_checked_packs_table():
+    return HashTableNT(key_size=32, value_type=CheckedPackEntry, value_format=CheckedPackEntryFormat)
+
 
 def repo_lister(repository, *, limit=None):
     marker = None
@@ -53,7 +68,7 @@ def borg_permissions(permissions):
             return {
                 "": "lr",
                 "archives": "lrw",
-                "cache": "lrwWD",  # WD for last-pack-checked, ...
+                "cache": "lrwWD",  # WD for checked-packs, ...
                 "config": "lrW",  # W for manifest
                 "index": "lrwWD",  # WD for index/<HASH> (merge/compaction of incremental indexes)
                 "keys": "lr",
@@ -678,23 +693,19 @@ class Repository:
         partial = bool(max_duration)
         assert not (repair and partial)
         mode = "partial" if partial else "full"
-        LAST_PACK_CHECKED = "cache/last-pack-checked"
         logger.info(f"Starting {mode} repository check")
         if partial:
-            # continue a past partial check (if any) or from a checkpoint or start one from beginning
-            try:
-                last_pack_checked = self.store.load(LAST_PACK_CHECKED).decode()
-            except StoreObjectNotFound:
-                last_pack_checked = ""
+            # resume the cycle: packs already in the set are skipped below.
+            checked_packs = self._load_checked_packs()
         else:
-            # start from the beginning and also forget about any potential past partial checks
-            last_pack_checked = ""
+            # a full check verifies every pack; start a new cycle.
+            checked_packs = new_checked_packs_table()
             try:
-                self.store.delete(LAST_PACK_CHECKED)
+                self.store.delete(CHECKED_PACKS)
             except StoreObjectNotFound:
                 pass
-        if last_pack_checked:
-            logger.info(f"Skipping to packs after {last_pack_checked}.")
+        if len(checked_packs):
+            logger.info(f"Continuing check cycle, {len(checked_packs)} packs already checked.")
         else:
             logger.info("Starting from beginning.")
         t_start = time.monotonic()
@@ -725,28 +736,30 @@ class Repository:
             for info in pack_infos:
                 self._lock_refresh()
                 pack_pi.show(increase=1)  # advance for every pack, including ones a partial resume skips below
-                key = "packs/%s" % info.name
-                if key <= last_pack_checked:  # needs sorted keys
+                pack_id = hex_to_bin(info.name)
+                if pack_id in checked_packs:  # already verified this cycle
                     continue
                 pack_files += 1
-                if not verify("packs", info.name):
+                ok = verify("packs", info.name)
+                if not ok:
                     pack_errors += 1  # repair (salvage into a new pack, fix index) is not implemented yet
+                checked_packs[pack_id] = CheckedPackEntry(timestamp=int(time.time()), result=int(ok))
                 now = time.monotonic()
                 if now > t_last_checkpoint + 300:  # checkpoint every 5 mins
                     t_last_checkpoint = now
-                    logger.info(f"Checkpointing at pack {key}.")
-                    self.store.store(LAST_PACK_CHECKED, key.encode())
+                    logger.info(f"Checkpointing at pack {info.name}.")
+                    self._store_checked_packs(checked_packs)
                 if partial and now > t_start + max_duration:
-                    logger.info(f"Finished partial repository check, last pack checked is {key}.")
-                    self.store.store(LAST_PACK_CHECKED, key.encode())
+                    logger.info(f"Finished partial repository check, {len(checked_packs)} packs checked so far.")
+                    self._store_checked_packs(checked_packs)
                     break
             else:
-                # the pack scan reached the end (no partial timeout): the check is complete, drop the checkpoint.
+                # scanned all packs without hitting the time limit: the cycle is done, drop the set.
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
                 try:
-                    self.store.delete(LAST_PACK_CHECKED)
+                    self.store.delete(CHECKED_PACKS)
                 except StoreObjectNotFound:
                     pass
             pack_pi.finish()
@@ -764,6 +777,30 @@ class Repository:
         else:
             logger.error(f"Finished {mode} repository check, errors found.")
         return objs_errors == 0 or repair
+
+    def _load_checked_packs(self):
+        """Load the CHECKED_PACKS set. Return an empty table if it is missing, corrupted or unreadable."""
+        try:
+            data = self.store.load(CHECKED_PACKS)
+        except StoreObjectNotFound:
+            return new_checked_packs_table()
+        # the trailing 32 bytes are a sha256 over the rest; a mismatch means the blob rotted.
+        if len(data) < 32 or sha256(data[:-32]).digest() != data[-32:]:
+            logger.warning("Ignoring corrupted checked-packs set.")
+            return new_checked_packs_table()
+        try:
+            with io.BytesIO(data[:-32]) as f:
+                return HashTableNT.read(f)
+        except ValueError:
+            logger.warning("Ignoring unreadable checked-packs set.")
+            return new_checked_packs_table()
+
+    def _store_checked_packs(self, checked_packs):
+        """Store the CHECKED_PACKS set with a sha256 appended over its content."""
+        with io.BytesIO() as f:
+            checked_packs.write(f)
+            data = f.getvalue()
+        self.store.store(CHECKED_PACKS, data + sha256(data).digest())
 
     def list(self, limit=None, marker=None):
         """

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -782,7 +782,7 @@ class Repository:
                     pack_errors += 1  # repair (salvage into a new pack, fix index) is not implemented yet
                 tracker.record(pack_id, ok)
                 now = time.monotonic()
-                if now > t_last_checkpoint + 60:  # checkpoint every minute
+                if now > t_last_checkpoint + 30 * 60:  # checkpoint every 30 minutes
                     t_last_checkpoint = now
                     logger.info(f"Checkpointing at pack {info.name}.")
                     tracker.save()

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -5,16 +5,8 @@ from hashlib import sha256
 import pytest
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
-from ..repository import (
-    Repository,
-    MAX_DATA_SIZE,
-    rest_serve_command,
-    PackWriter,
-    PackReader,
-    CHECKED_PACKS,
-    CheckedPackEntry,
-    new_checked_packs_table,
-)
+from ..repository import Repository, MAX_DATA_SIZE, rest_serve_command, PackWriter, PackReader
+from ..repository import CHECKED_PACKS, CheckedPackEntry, new_checked_packs_table
 from ..repoobj import RepoObj, OBJ_MAGIC, OBJ_VERSION
 from .hashindex_test import H
 
@@ -1025,6 +1017,45 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
         repository.store_store("packs/" + bin_to_hex(early_id), b"CORRUPT-does-not-match-name")
 
         assert repository.check(repair=False, max_duration=3600) is False
+
+
+def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
+    # a pack recorded corrupt earlier in the cycle is re-verified, so the corruption keeps being reported.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        corrupt_id = H(1)  # stored content does not hash to this name
+        repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
+
+        table = new_checked_packs_table()
+        table[corrupt_id] = CheckedPackEntry(timestamp=1, result=0)
+        repository._store_checked_packs(table)
+
+        assert repository.check(repair=False, max_duration=3600) is False
+
+
+def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypatch):
+    # a pack recorded corrupt is re-verified, not skipped: assert True alone would also hold if the
+    # pack were skipped outright, so this spies on store.hash to confirm verify() actually ran on it.
+    intact = fchunk(b"INTACT", chunk_id=H(1))
+    intact_id = sha256(intact).digest()
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        pack_key = "packs/" + bin_to_hex(intact_id)
+        repository.store_store(pack_key, intact)
+
+        table = new_checked_packs_table()
+        table[intact_id] = CheckedPackEntry(timestamp=1, result=0)  # stale corrupt record
+        repository._store_checked_packs(table)
+
+        hashed_keys = []
+        orig_hash = repository.store.hash
+
+        def spy_hash(key):
+            hashed_keys.append(key)
+            return orig_hash(key)
+
+        monkeypatch.setattr(repository.store, "hash", spy_hash)
+
+        assert repository.check(repair=False, max_duration=3600) is True
+        assert pack_key in hashed_keys  # verify() ran on the pack; it was not skipped
 
 
 def test_check_progress_covers_packs_and_index(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1,8 +1,12 @@
+import io
 import os
 import sys
+from collections import namedtuple
 from hashlib import sha256
 
 import pytest
+from borghash import HashTableNT
+
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
 from ..repository import Repository, MAX_DATA_SIZE, rest_serve_command, PackWriter, PackReader
@@ -1035,30 +1039,93 @@ def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
         assert repository.check(repair=False, max_duration=3600) is False
 
 
-def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypatch):
-    # a pack recorded corrupt is re-verified, not skipped: assert True alone would also hold if the
-    # pack were skipped outright, so this spies on store.hash to confirm verify() actually ran on it.
+def _spy_hash(repository, monkeypatch):
+    # collect the keys passed to store.hash. check() hashes a pack exactly when it verifies it.
+    hashed_keys = []
+    orig_hash = repository.store.hash
+
+    def spy_hash(key):
+        hashed_keys.append(key)
+        return orig_hash(key)
+
+    monkeypatch.setattr(repository.store, "hash", spy_hash)
+    return hashed_keys
+
+
+def _store_intact_pack(repository):
     intact = fchunk(b"INTACT", chunk_id=H(1))
     intact_id = sha256(intact).digest()
+    pack_key = "packs/" + bin_to_hex(intact_id)
+    repository.store_store(pack_key, intact)
+    return intact_id, pack_key
+
+
+def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypatch):
+    # a pack recorded corrupt is re-verified, and an intact result replaces the stale record.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        pack_key = "packs/" + bin_to_hex(intact_id)
-        repository.store_store(pack_key, intact)
+        intact_id, pack_key = _store_intact_pack(repository)
 
         tracker = PackTracker(repository.store)
         tracker.record(intact_id, ok=False)  # stale corrupt record
         tracker.save()
 
-        hashed_keys = []
-        orig_hash = repository.store.hash
-
-        def spy_hash(key):
-            hashed_keys.append(key)
-            return orig_hash(key)
-
-        monkeypatch.setattr(repository.store, "hash", spy_hash)
+        hashed_keys = _spy_hash(repository, monkeypatch)
 
         assert repository.check(repair=False, max_duration=3600) is True
-        assert pack_key in hashed_keys  # verify() ran on the pack; it was not skipped
+        assert pack_key in hashed_keys  # re-verified
+
+
+def test_check_partial_skips_pack_recorded_intact(tmp_path, monkeypatch):
+    # a pack recorded intact in this cycle is skipped when a partial check resumes.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker(repository.store)
+        tracker.record(intact_id, ok=True)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_duration=3600) is True
+        assert pack_key not in hashed_keys  # skipped, not re-verified
+
+
+def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
+    # a full check verifies every pack regardless of the recorded set, then drops the set.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker(repository.store)
+        tracker.record(intact_id, ok=True)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False) is True
+        assert pack_key in hashed_keys  # verified
+
+        after = PackTracker(repository.store)
+        after.load()
+        assert len(after) == 0  # cycle complete, set dropped
+
+
+def test_check_checked_packs_ignores_foreign_entry_layout(tmp_path):
+    # load() drops a set whose entries have a different layout than Entry, even though its sha256 matches.
+    OtherEntry = namedtuple("OtherEntry", "timestamp result extra")
+    OtherFormat = namedtuple("OtherFormat", "timestamp result extra")
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        table = HashTableNT(
+            key_size=32, value_type=OtherEntry, value_format=OtherFormat(timestamp="Q", result="B", extra="B")
+        )
+        table[H(1)] = OtherEntry(timestamp=123, result=1, extra=9)
+        with io.BytesIO() as f:
+            table.write(f)
+            data = f.getvalue()
+        repository.store_store(PackTracker.NAME, data + sha256(data).digest())
+
+        tracker = PackTracker(repository.store)
+        tracker.load()
+        assert len(tracker) == 0
 
 
 def test_check_progress_covers_packs_and_index(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -5,7 +5,16 @@ from hashlib import sha256
 import pytest
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
-from ..repository import Repository, MAX_DATA_SIZE, rest_serve_command, PackWriter, PackReader
+from ..repository import (
+    Repository,
+    MAX_DATA_SIZE,
+    rest_serve_command,
+    PackWriter,
+    PackReader,
+    CHECKED_PACKS,
+    CheckedPackEntry,
+    new_checked_packs_table,
+)
 from ..repoobj import RepoObj, OBJ_MAGIC, OBJ_VERSION
 from .hashindex_test import H
 
@@ -977,6 +986,45 @@ def test_check_intact_multi_object_pack_passes(tmp_path):
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         repository.store_store(pack_name, pack)
         assert repository.check(repair=False) is True
+
+
+def test_check_checked_packs_roundtrip(tmp_path):
+    # the set survives a store/load round-trip; a rotted blob loads as empty.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        table = new_checked_packs_table()
+        table[H(1)] = CheckedPackEntry(timestamp=123, result=1)
+        table[H(2)] = CheckedPackEntry(timestamp=456, result=0)
+        repository._store_checked_packs(table)
+
+        loaded = repository._load_checked_packs()
+        assert len(loaded) == 2
+        assert H(1) in loaded and H(2) in loaded
+        assert tuple(loaded[H(2)]) == (456, 0)
+
+        corrupted = bytearray(repository.store.load(CHECKED_PACKS))
+        corrupted[0] ^= 0xFF  # break the appended sha256
+        repository.store.store(CHECKED_PACKS, bytes(corrupted))
+        assert len(repository._load_checked_packs()) == 0
+
+
+def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
+    # a partial check verifies a new pack even when its id sorts before an already-checked pack.
+    intact = fchunk(b"INTACT", chunk_id=H(1))
+    intact_id = sha256(intact).digest()
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        repository.store_store("packs/" + bin_to_hex(intact_id), intact)
+
+        # mark the intact pack as already checked in this cycle.
+        table = new_checked_packs_table()
+        table[intact_id] = CheckedPackEntry(timestamp=1, result=1)
+        repository._store_checked_packs(table)
+
+        # add a corrupt pack (content does not hash to its name) whose id sorts before intact_id.
+        early_id = b"\x00" * 32
+        assert bin_to_hex(early_id) < bin_to_hex(intact_id)
+        repository.store_store("packs/" + bin_to_hex(early_id), b"CORRUPT-does-not-match-name")
+
+        assert repository.check(repair=False, max_duration=3600) is False
 
 
 def test_check_progress_covers_packs_and_index(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -987,13 +987,12 @@ def test_check_intact_multi_object_pack_passes(tmp_path):
 def test_check_checked_packs_roundtrip(tmp_path):
     # the set survives a store/load round-trip; a rotted blob loads as empty.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.table[H(1)] = PackTracker.Entry(timestamp=123, result=1)
         tracker.table[H(2)] = PackTracker.Entry(timestamp=456, result=0)
         tracker.save()
 
-        loaded = PackTracker(repository.store)
-        loaded.load()
+        loaded = PackTracker.load(repository.store)
         assert len(loaded) == 2
         assert H(1) in loaded.table and H(2) in loaded.table
         assert tuple(loaded.table[H(2)]) == (456, 0)
@@ -1001,8 +1000,7 @@ def test_check_checked_packs_roundtrip(tmp_path):
         corrupted = bytearray(repository.store.load(PackTracker.NAME))
         corrupted[0] ^= 0xFF  # break the appended sha256
         repository.store.store(PackTracker.NAME, bytes(corrupted))
-        rotted = PackTracker(repository.store)
-        rotted.load()
+        rotted = PackTracker.load(repository.store)
         assert len(rotted) == 0
 
 
@@ -1014,7 +1012,7 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
         repository.store_store("packs/" + bin_to_hex(intact_id), intact)
 
         # mark the intact pack as already checked in this cycle.
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.record(intact_id, ok=True)
         tracker.save()
 
@@ -1032,7 +1030,7 @@ def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
         corrupt_id = H(1)  # stored content does not hash to this name
         repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
 
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.record(corrupt_id, ok=False)
         tracker.save()
 
@@ -1065,7 +1063,7 @@ def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypa
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.record(intact_id, ok=False)  # stale corrupt record
         tracker.save()
 
@@ -1080,7 +1078,7 @@ def test_check_partial_skips_pack_recorded_intact(tmp_path, monkeypatch):
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.record(intact_id, ok=True)
         tracker.save()
 
@@ -1095,7 +1093,7 @@ def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
-        tracker = PackTracker(repository.store)
+        tracker = PackTracker.new(repository.store)
         tracker.record(intact_id, ok=True)
         tracker.save()
 
@@ -1104,8 +1102,7 @@ def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
         assert repository.check(repair=False) is True
         assert pack_key in hashed_keys  # verified
 
-        after = PackTracker(repository.store)
-        after.load()
+        after = PackTracker.load(repository.store)
         assert len(after) == 0  # cycle complete, set dropped
 
 
@@ -1123,8 +1120,7 @@ def test_check_checked_packs_ignores_foreign_entry_layout(tmp_path):
             data = f.getvalue()
         repository.store_store(PackTracker.NAME, data + sha256(data).digest())
 
-        tracker = PackTracker(repository.store)
-        tracker.load()
+        tracker = PackTracker.load(repository.store)
         assert len(tracker) == 0
 
 

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -6,7 +6,7 @@ import pytest
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
 from ..repository import Repository, MAX_DATA_SIZE, rest_serve_command, PackWriter, PackReader
-from ..repository import CHECKED_PACKS, CheckedPackEntry, new_checked_packs_table
+from ..repository import PackTracker
 from ..repoobj import RepoObj, OBJ_MAGIC, OBJ_VERSION
 from .hashindex_test import H
 
@@ -983,20 +983,23 @@ def test_check_intact_multi_object_pack_passes(tmp_path):
 def test_check_checked_packs_roundtrip(tmp_path):
     # the set survives a store/load round-trip; a rotted blob loads as empty.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        table = new_checked_packs_table()
-        table[H(1)] = CheckedPackEntry(timestamp=123, result=1)
-        table[H(2)] = CheckedPackEntry(timestamp=456, result=0)
-        repository._store_checked_packs(table)
+        tracker = PackTracker(repository.store)
+        tracker.table[H(1)] = PackTracker.Entry(timestamp=123, result=1)
+        tracker.table[H(2)] = PackTracker.Entry(timestamp=456, result=0)
+        tracker.save()
 
-        loaded = repository._load_checked_packs()
+        loaded = PackTracker(repository.store)
+        loaded.load()
         assert len(loaded) == 2
-        assert H(1) in loaded and H(2) in loaded
-        assert tuple(loaded[H(2)]) == (456, 0)
+        assert H(1) in loaded.table and H(2) in loaded.table
+        assert tuple(loaded.table[H(2)]) == (456, 0)
 
-        corrupted = bytearray(repository.store.load(CHECKED_PACKS))
+        corrupted = bytearray(repository.store.load(PackTracker.NAME))
         corrupted[0] ^= 0xFF  # break the appended sha256
-        repository.store.store(CHECKED_PACKS, bytes(corrupted))
-        assert len(repository._load_checked_packs()) == 0
+        repository.store.store(PackTracker.NAME, bytes(corrupted))
+        rotted = PackTracker(repository.store)
+        rotted.load()
+        assert len(rotted) == 0
 
 
 def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
@@ -1007,9 +1010,9 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
         repository.store_store("packs/" + bin_to_hex(intact_id), intact)
 
         # mark the intact pack as already checked in this cycle.
-        table = new_checked_packs_table()
-        table[intact_id] = CheckedPackEntry(timestamp=1, result=1)
-        repository._store_checked_packs(table)
+        tracker = PackTracker(repository.store)
+        tracker.record(intact_id, ok=True)
+        tracker.save()
 
         # add a corrupt pack (content does not hash to its name) whose id sorts before intact_id.
         early_id = b"\x00" * 32
@@ -1025,9 +1028,9 @@ def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
         corrupt_id = H(1)  # stored content does not hash to this name
         repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
 
-        table = new_checked_packs_table()
-        table[corrupt_id] = CheckedPackEntry(timestamp=1, result=0)
-        repository._store_checked_packs(table)
+        tracker = PackTracker(repository.store)
+        tracker.record(corrupt_id, ok=False)
+        tracker.save()
 
         assert repository.check(repair=False, max_duration=3600) is False
 
@@ -1041,9 +1044,9 @@ def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypa
         pack_key = "packs/" + bin_to_hex(intact_id)
         repository.store_store(pack_key, intact)
 
-        table = new_checked_packs_table()
-        table[intact_id] = CheckedPackEntry(timestamp=1, result=0)  # stale corrupt record
-        repository._store_checked_packs(table)
+        tracker = PackTracker(repository.store)
+        tracker.record(intact_id, ok=False)  # stale corrupt record
+        tracker.save()
 
         hashed_keys = []
         orig_hash = repository.store.hash


### PR DESCRIPTION
The repository check writes a marker holding the last pack id it verified, so a partial check (`--max-duration`) resumes by skipping every pack up to that marker. This assumes the pack listing is sorted.

Pack files are named by the sha256 of their content, so a pack added between two partial runs can sort anywhere. If its id sorts before the marker, the resumed check skips it and never verifies it.

This replaces the marker with a persisted set of checked pack ids, a `HashTableNT` mapping pack id to `(timestamp, result)`. A pack is skipped only when it appears in the set recorded as intact; a pack recorded as corrupt is re-verified rather than skipped. So a newly added pack gets checked whatever its name sorts to, and a pack that was corrupt in an earlier run is looked at again. The set is dropped once a cycle has checked every pack.

The set is managed by a `PackTracker` class. It persists via `store.store()` (atomic write) with a sha256 appended over the serialized table. On load the table is accepted only if that sha256 matches and its entries have the layout `PackTracker` writes; `HashTableNT.read()` rebuilds key size and value type from the blob, so a set written by a borg with a different `Entry` layout would otherwise read without error. A rejected set re-checks everything instead of skipping an unverified pack. Ctrl-C is therefore safe: the on-disk set is never partially written and never records a pack that was not verified.

The cycle is checkpointed every 30 minutes rather than every minute: the checkpoint now rewrites the whole table (~41 bytes/pack) instead of a fixed ~70-byte marker, so on large repos each save is no longer O(1). At 30-minute intervals that cost stays negligible while an interrupt still redoes at most 30 minutes of verification work.

The set is stored at `cache/checked-packs`; `docs/internals/data-structures.rst` is updated to document it in place of the old marker.

Closes #9897

