### PR TITLE
tests: date: filter runs local,binary (drop remote)

### DIFF
--- a/src/borg/testsuite/archiver/match_archives_date_test.py
+++ b/src/borg/testsuite/archiver/match_archives_date_test.py
@@ -10,7 +10,7 @@ from ...helpers.errors import CommandError
 from ...platform import is_win32
 from . import cmd, create_src_archive, generate_archiver_tests, RK_ENCRYPTION
 
-pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote,binary")  # NOQA
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
 
 @pytest.fixture


### PR DESCRIPTION
Follow-up to #8776.

The `date:` archive match selector (added in #8776) is client-side manifest filtering — it has no transport-specific behavior. Its test file was running with `kinds="local,remote,binary"`, but the `remote` kind adds no coverage here.

Per the kind-picking policy documented in `src/borg/testsuite/archiver/__init__.py` (introduced by the #9324 testsuite speedup), `remote` should only be used where a backend genuinely branches its implementation per transport; pure command/formatting logic belongs in the `local,binary` bucket.

This file expands to ~33 test instances, each creating a repo and archives, so the `remote` leg was spawning ~33 REST-server round-trip sessions for zero extra coverage. This drops `remote`:

```
kinds="local,remote,binary"  ->  kinds="local,binary"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)