### PR TITLE
check: keep pack check results, add --max-age to reuse them

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -37,12 +37,12 @@ config/
 cache/
   checked-packs
     repository check results (pack id -> timestamp, result), as a hashtable with an
-    appended integrity hash. Records of intact packs hold the check progress (partial
-    checks, full checks' checkpointing) and are dropped when a check cycle completes.
-    With ``check --max-age`` they are kept across cycles instead and reused while
-    younger than the given age. Records of corrupt packs are kept for repair until
-    the pack verifies intact or is no longer listed in packs/. Records of packs no
-    longer listed in packs/ are pruned when a cycle completes.
+    appended integrity hash. Records are kept across checks: ``check --max-age``
+    skips packs whose intact record is younger than the given age, which also lets
+    partial checks (``--max-duration``) continue where a previous one stopped.
+    Records of corrupt packs are kept for repair and always re-verified. Records of
+    packs no longer listed in packs/ are pruned when a check finishes scanning
+    packs/.
 
 There is a list of pointers to archive objects in this directory:
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -36,9 +36,11 @@ config/
 
 cache/
   checked-packs
-    repository check progress (partial checks, full checks' checkpointing),
-    the set of packs checked so far this cycle (pack id -> timestamp, result),
-    as a hashtable with an appended integrity hash
+    repository check results (pack id -> timestamp, result), as a hashtable with an
+    appended integrity hash. Records of intact packs hold the check progress (partial
+    checks, full checks' checkpointing) and are dropped when a check cycle completes.
+    Records of corrupt packs are kept for repair until the pack verifies intact or is
+    no longer listed in packs/.
 
 There is a list of pointers to archive objects in this directory:
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -39,8 +39,10 @@ cache/
     repository check results (pack id -> timestamp, result), as a hashtable with an
     appended integrity hash. Records of intact packs hold the check progress (partial
     checks, full checks' checkpointing) and are dropped when a check cycle completes.
-    Records of corrupt packs are kept for repair until the pack verifies intact or is
-    no longer listed in packs/.
+    With ``check --max-age`` they are kept across cycles instead and reused while
+    younger than the given age. Records of corrupt packs are kept for repair until
+    the pack verifies intact or is no longer listed in packs/. Records of packs no
+    longer listed in packs/ are pruned when a cycle completes.
 
 There is a list of pointers to archive objects in this directory:
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -38,10 +38,11 @@ cache/
   checked-packs
     repository check results (pack id -> timestamp, result), as a hashtable with an
     appended integrity hash. Records are kept across checks: ``check --max-age``
-    skips packs whose intact record is younger than the given age, which also lets
-    partial checks (``--max-duration``) continue where a previous one stopped.
-    Records of corrupt packs are kept for repair and always re-verified. Records of
-    packs no longer listed in packs/ are pruned when a check finishes.
+    skips packs whose intact record is younger than the given age, and partial checks
+    (``--max-duration``) verify the least-recently-checked packs first so repeated
+    runs cover the whole repository. Records of corrupt packs are kept for repair and
+    always re-verified. Records of packs no longer listed in packs/ are pruned when a
+    check finishes.
 
 There is a list of pointers to archive objects in this directory:
 

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -41,8 +41,7 @@ cache/
     skips packs whose intact record is younger than the given age, which also lets
     partial checks (``--max-duration``) continue where a previous one stopped.
     Records of corrupt packs are kept for repair and always re-verified. Records of
-    packs no longer listed in packs/ are pruned when a check finishes scanning
-    packs/.
+    packs no longer listed in packs/ are pruned when a check finishes.
 
 There is a list of pointers to archive objects in this directory:
 

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -132,7 +132,8 @@ class CheckMixIn:
         interval (e.g. ``--max-age=4w``) are skipped, spreading the verification
         cost over repeated checks. Check results are recorded in any case;
         ``--max-age`` only controls their reuse. Packs recorded corrupt are always
-        re-verified. ``--max-age`` cannot be combined with ``--repair``.
+        re-verified. ``--max-age`` affects only the repository check and cannot be
+        combined with ``--archives-only`` or ``--repair``.
 
         The ``--max-duration`` option can be used to split a long-running repository
         check into multiple partial checks. After the given number of seconds, the

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -148,7 +148,8 @@ class CheckMixIn:
         interrupted. A partial check verifies the least-recently-checked packs first,
         so repeated runs cover the whole repository. Add ``--max-age`` to also skip
         packs whose result is still younger than the given age: once every pack has a
-        recent result, further runs re-check each pack about once per ``--max-age``.
+        recent result, further runs re-check each pack at most once per ``--max-age``,
+        and no faster than the per-run budget allows.
         Assuming a complete check would take 7 hours, running a daily check with
         ``--max-duration=3600 --max-age=1w`` (1 hour) results in one full repository
         verification per week. Partial repository checks run neither archive checks

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -140,10 +140,13 @@ class CheckMixIn:
         The ``--max-age`` option makes the check reuse the results of previous
         repository checks: packs whose intact result is younger than the given
         timespan (e.g. ``--max-age=4w`` or ``--max-age=12m``) are skipped, spreading
-        the verification cost over repeated checks. Check results are recorded in any case;
-        ``--max-age`` only controls their reuse. Packs recorded corrupt are always
-        re-verified. ``--max-age`` affects only the repository check and cannot be
-        combined with ``--archives-only`` or ``--repair``.
+        the verification cost over repeated checks. The timespan uses the same markers
+        as ``--older``/``--newer``: ``d``, ``w``, ``H``, ``M``, ``S`` are exact spans,
+        while ``m`` and ``y`` are calendar units counted from now (so ``12m`` equals
+        ``1y``). Check results are recorded in any case; ``--max-age`` only controls
+        their reuse. Packs recorded corrupt are always re-verified. ``--max-age``
+        affects only the repository check and cannot be combined with
+        ``--archives-only`` or ``--repair``.
 
         The ``--max-duration`` option can be used to split a long-running repository
         check into multiple partial checks. After the given number of seconds, the

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -44,8 +44,7 @@ class CheckMixIn:
         if args.repo_only and args.find_lost_archives:
             raise CommandError("--repository-only contradicts the --find-lost-archives option.")
         # resolve the marker (e.g. 4w, 12m) to seconds; calendar units (m, y) count from now, as for
-        # --older/--newer. the validator returns a string (truthy even for a zero span like 0d), so
-        # the --max-duration guard below tests max_age, the resolved value, not args.max_age.
+        # --older/--newer. max_age stays 0 when --max-age is not given, which disables reuse.
         if args.max_age is not None:
             now = archive_ts_now()
             max_age = int((now - calculate_relative_offset(args.max_age, now, earlier=True)).total_seconds())
@@ -60,10 +59,6 @@ class CheckMixIn:
         if args.archives_only and args.max_age is not None:
             # --max-age only affects the repository check; --archives-only skips it.
             raise CommandError("--archives-only does not allow the --max-age option.")
-        if args.max_duration and not max_age:
-            # a partial check advances by skipping packs younger than max_age, so it needs a nonzero
-            # window (--max-age=0d resolves to 0).
-            raise CommandError("--max-duration requires the --max-age option, e.g. --max-age=4w.")
         if args.max_duration and not args.repo_only:
             # --max-duration limits only the repository check; the archives check has no max_duration
             # support.
@@ -148,18 +143,17 @@ class CheckMixIn:
         affects only the repository check and cannot be combined with
         ``--archives-only`` or ``--repair``.
 
-        The ``--max-duration`` option can be used to split a long-running repository
-        check into multiple partial checks. After the given number of seconds, the
-        check is interrupted. Because a verified pack's result is recorded and
-        reused, ``--max-duration`` requires ``--max-age``: the next partial check
-        skips the recently verified packs and continues with the rest, until every
-        pack has a result younger than ``--max-age``. Assuming a complete check
-        would take 7 hours, then running a daily check with ``--max-duration=3600
-        --max-age=1w`` (1 hour) would result in one full repository verification
-        per week. With partial repository checks you can run neither archive
-        checks, nor enable repair mode. Consequently, if you want to use
-        ``--max-duration`` you must also pass ``--repository-only``, and must not
-        pass ``--archives-only``, nor ``--repair``.
+        The ``--max-duration`` option splits a long-running repository check into
+        several partial checks. After the given number of seconds, the check is
+        interrupted. A partial check verifies the least-recently-checked packs first,
+        so repeated runs cover the whole repository. Add ``--max-age`` to also skip
+        packs whose result is still younger than the given age: once every pack has a
+        recent result, further runs re-check each pack about once per ``--max-age``.
+        Assuming a complete check would take 7 hours, running a daily check with
+        ``--max-duration=3600 --max-age=1w`` (1 hour) results in one full repository
+        verification per week. Partial repository checks run neither archive checks
+        nor repair mode, so ``--max-duration`` requires ``--repository-only`` and
+        cannot be combined with ``--archives-only`` or ``--repair``.
 
         **Warning:** Please note that partial repository checks (i.e., running with
         ``--max-duration``) can only perform non-cryptographic checksum checks on the

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -4,8 +4,9 @@ from ._common import with_repository, Highlander
 from ..archive import ArchiveChecker
 from ..constants import *  # NOQA
 from ..helpers import set_ec, EXIT_WARNING, CancelledByUser, CommandError, IntegrityError
-from ..helpers import interval, yes, ArchiveFormatter
+from ..helpers import relative_time_marker_validator, yes, ArchiveFormatter
 from ..helpers.argparsing import ArgumentParser
+from ..helpers.time import archive_ts_now, calculate_relative_offset
 
 from ..logger import create_logger
 
@@ -45,6 +46,8 @@ class CheckMixIn:
         if args.repair and args.max_duration:
             raise CommandError("--repair does not allow --max-duration argument.")
         if args.repair and args.max_age:
+            # reusing recorded results during repair depends on repository repair (refs #8572), which
+            # does not exist yet, so repair verifies every pack.
             raise CommandError("--repair does not allow the --max-age option.")
         if args.archives_only and args.max_age:
             # --max-age only affects the repository check, which --archives-only skips.
@@ -53,9 +56,8 @@ class CheckMixIn:
             # partial checks progress by skipping packs whose record is younger than max_age.
             raise CommandError("--max-duration requires the --max-age option, e.g. --max-age=4w.")
         if args.max_duration and not args.repo_only:
-            # when doing a partial repo check, we can only do a low-level check of the repository files.
-            # archives check requires that a full repo check was done before and has built/cached a ChunkIndex.
-            # also, there is no max_duration support in the archives check code anyway.
+            # --max-duration time-boxes the repository pack check only; the archives check has no
+            # max_duration support and builds its own chunk index, so it cannot be split this way.
             raise CommandError("--repository-only is required for --max-duration support.")
         if not args.repo_only:
             # if we need the key later for the archives check, ask NOW for the passphrase! #1931
@@ -72,7 +74,13 @@ class CheckMixIn:
             # the repository check has finished, which can take hours.
             ArchiveFormatter.validate_format(format)
         if not args.archives_only:
-            max_age = int(args.max_age.total_seconds()) if args.max_age else 0
+            if args.max_age:
+                # resolve the relative marker (e.g. 4w, 12m) to a concrete age in seconds; calendar
+                # units (m, y) are measured against now, like --older / --newer.
+                now = archive_ts_now()
+                max_age = int((now - calculate_relative_offset(args.max_age, now, earlier=True)).total_seconds())
+            else:
+                max_age = 0
             if not repository.check(repair=args.repair, max_duration=args.max_duration, max_age=max_age):
                 set_ec(EXIT_WARNING)
         if not args.repo_only and not archive_checker.check(
@@ -129,8 +137,8 @@ class CheckMixIn:
 
         The ``--max-age`` option makes the check reuse the results of previous
         repository checks: packs whose intact result is younger than the given
-        interval (e.g. ``--max-age=4w``) are skipped, spreading the verification
-        cost over repeated checks. Check results are recorded in any case;
+        timespan (e.g. ``--max-age=4w`` or ``--max-age=12m``) are skipped, spreading
+        the verification cost over repeated checks. Check results are recorded in any case;
         ``--max-age`` only controls their reuse. Packs recorded corrupt are always
         re-verified. ``--max-age`` affects only the repository check and cannot be
         combined with ``--archives-only`` or ``--repair``.
@@ -242,12 +250,12 @@ class CheckMixIn:
         )
         subparser.add_argument(
             "--max-age",
-            metavar="INTERVAL",
+            metavar="TIMESPAN",
             dest="max_age",
-            type=interval,
+            type=relative_time_marker_validator,
             default=None,
             action=Highlander,
-            help="reuse intact-pack check results younger than INTERVAL (e.g. 4w)",
+            help="reuse intact-pack check results younger than TIMESPAN, e.g. 4w or 12m",
         )
         subparser.add_argument(
             "--max-duration",

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -43,21 +43,30 @@ class CheckMixIn:
             )
         if args.repo_only and args.find_lost_archives:
             raise CommandError("--repository-only contradicts the --find-lost-archives option.")
+        # resolve the marker (e.g. 4w, 12m) to seconds; calendar units (m, y) count from now, as for
+        # --older/--newer. the validator returns a string (truthy even for a zero span like 0d), so
+        # the --max-duration guard below tests max_age, the resolved value, not args.max_age.
+        if args.max_age is not None:
+            now = archive_ts_now()
+            max_age = int((now - calculate_relative_offset(args.max_age, now, earlier=True)).total_seconds())
+        else:
+            max_age = 0
         if args.repair and args.max_duration:
             raise CommandError("--repair does not allow --max-duration argument.")
-        if args.repair and args.max_age:
-            # reusing recorded results during repair depends on repository repair (refs #8572), which
-            # does not exist yet, so repair verifies every pack.
+        if args.repair and args.max_age is not None:
+            # repair verifies every pack; reusing recorded results during repair needs repository
+            # repair (refs #8572).
             raise CommandError("--repair does not allow the --max-age option.")
-        if args.archives_only and args.max_age:
-            # --max-age only affects the repository check, which --archives-only skips.
+        if args.archives_only and args.max_age is not None:
+            # --max-age only affects the repository check; --archives-only skips it.
             raise CommandError("--archives-only does not allow the --max-age option.")
-        if args.max_duration and not args.max_age:
-            # partial checks progress by skipping packs whose record is younger than max_age.
+        if args.max_duration and not max_age:
+            # a partial check advances by skipping packs younger than max_age, so it needs a nonzero
+            # window (--max-age=0d resolves to 0).
             raise CommandError("--max-duration requires the --max-age option, e.g. --max-age=4w.")
         if args.max_duration and not args.repo_only:
-            # --max-duration time-boxes the repository pack check only; the archives check has no
-            # max_duration support and builds its own chunk index, so it cannot be split this way.
+            # --max-duration limits only the repository check; the archives check has no max_duration
+            # support.
             raise CommandError("--repository-only is required for --max-duration support.")
         if not args.repo_only:
             # if we need the key later for the archives check, ask NOW for the passphrase! #1931
@@ -74,13 +83,6 @@ class CheckMixIn:
             # the repository check has finished, which can take hours.
             ArchiveFormatter.validate_format(format)
         if not args.archives_only:
-            if args.max_age:
-                # resolve the relative marker (e.g. 4w, 12m) to a concrete age in seconds; calendar
-                # units (m, y) are measured against now, like --older / --newer.
-                now = archive_ts_now()
-                max_age = int((now - calculate_relative_offset(args.max_age, now, earlier=True)).total_seconds())
-            else:
-                max_age = 0
             if not repository.check(repair=args.repair, max_duration=args.max_duration, max_age=max_age):
                 set_ec(EXIT_WARNING)
         if not args.repo_only and not archive_checker.check(

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -46,9 +46,12 @@ class CheckMixIn:
             raise CommandError("--repair does not allow --max-duration argument.")
         if args.repair and args.max_age:
             raise CommandError("--repair does not allow the --max-age option.")
+        if args.archives_only and args.max_age:
+            # --max-age only affects the repository check, which --archives-only skips.
+            raise CommandError("--archives-only does not allow the --max-age option.")
         if args.max_duration and not args.max_age:
             # partial checks progress by skipping packs whose record is younger than max_age.
-            raise CommandError("--max-duration requires the --max-age option.")
+            raise CommandError("--max-duration requires the --max-age option, e.g. --max-age=4w.")
         if args.max_duration and not args.repo_only:
             # when doing a partial repo check, we can only do a low-level check of the repository files.
             # archives check requires that a full repo check was done before and has built/cached a ChunkIndex.

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -46,6 +46,9 @@ class CheckMixIn:
             raise CommandError("--repair does not allow --max-duration argument.")
         if args.repair and args.max_age:
             raise CommandError("--repair does not allow the --max-age option.")
+        if args.max_duration and not args.max_age:
+            # partial checks progress by skipping packs whose record is younger than max_age.
+            raise CommandError("--max-duration requires the --max-age option.")
         if args.max_duration and not args.repo_only:
             # when doing a partial repo check, we can only do a low-level check of the repository files.
             # archives check requires that a full repo check was done before and has built/cached a ChunkIndex.
@@ -121,23 +124,25 @@ class CheckMixIn:
         repository checks only, or pass ``--archives-only`` to run the archive checks
         only.
 
-        The ``--max-duration`` option can be used to split a long-running repository
-        check into multiple partial checks. After the given number of seconds, the check
-        is interrupted. The next partial check will continue where the previous one
-        stopped, until the full repository has been checked. Assuming a complete check
-        would take 7 hours, then running a daily check with ``--max-duration=3600``
-        (1 hour) would result in one full repository check per week. Doing a full
-        repository check aborts any previous partial check; the next partial check will
-        restart from the beginning. With partial repository checks you can run neither
-        archive checks, nor enable repair mode. Consequently, if you want to use
-        ``--max-duration`` you must also pass ``--repository-only``, and must not pass
-        ``--archives-only``, nor ``--repair``.
+        The ``--max-age`` option makes the check reuse the results of previous
+        repository checks: packs whose intact result is younger than the given
+        interval (e.g. ``--max-age=4w``) are skipped, spreading the verification
+        cost over repeated checks. Check results are recorded in any case;
+        ``--max-age`` only controls their reuse. Packs recorded corrupt are always
+        re-verified. ``--max-age`` cannot be combined with ``--repair``.
 
-        The ``--max-age`` option keeps the results of previous repository checks and
-        skips packs whose intact result is younger than the given interval (e.g.
-        ``--max-age=4w``), spreading the verification cost over repeated checks.
-        Packs recorded corrupt are always re-verified. ``--max-age`` cannot be
-        combined with ``--repair``.
+        The ``--max-duration`` option can be used to split a long-running repository
+        check into multiple partial checks. After the given number of seconds, the
+        check is interrupted. Because a verified pack's result is recorded and
+        reused, ``--max-duration`` requires ``--max-age``: the next partial check
+        skips the recently verified packs and continues with the rest, until every
+        pack has a result younger than ``--max-age``. Assuming a complete check
+        would take 7 hours, then running a daily check with ``--max-duration=3600
+        --max-age=1w`` (1 hour) would result in one full repository verification
+        per week. With partial repository checks you can run neither archive
+        checks, nor enable repair mode. Consequently, if you want to use
+        ``--max-duration`` you must also pass ``--repository-only``, and must not
+        pass ``--archives-only``, nor ``--repair``.
 
         **Warning:** Please note that partial repository checks (i.e., running with
         ``--max-duration``) can only perform non-cryptographic checksum checks on the

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -4,7 +4,7 @@ from ._common import with_repository, Highlander
 from ..archive import ArchiveChecker
 from ..constants import *  # NOQA
 from ..helpers import set_ec, EXIT_WARNING, CancelledByUser, CommandError, IntegrityError
-from ..helpers import yes, ArchiveFormatter
+from ..helpers import interval, yes, ArchiveFormatter
 from ..helpers.argparsing import ArgumentParser
 
 from ..logger import create_logger
@@ -44,6 +44,8 @@ class CheckMixIn:
             raise CommandError("--repository-only contradicts the --find-lost-archives option.")
         if args.repair and args.max_duration:
             raise CommandError("--repair does not allow --max-duration argument.")
+        if args.repair and args.max_age:
+            raise CommandError("--repair does not allow the --max-age option.")
         if args.max_duration and not args.repo_only:
             # when doing a partial repo check, we can only do a low-level check of the repository files.
             # archives check requires that a full repo check was done before and has built/cached a ChunkIndex.
@@ -64,7 +66,8 @@ class CheckMixIn:
             # the repository check has finished, which can take hours.
             ArchiveFormatter.validate_format(format)
         if not args.archives_only:
-            if not repository.check(repair=args.repair, max_duration=args.max_duration):
+            max_age = int(args.max_age.total_seconds()) if args.max_age else 0
+            if not repository.check(repair=args.repair, max_duration=args.max_duration, max_age=max_age):
                 set_ec(EXIT_WARNING)
         if not args.repo_only and not archive_checker.check(
             repository,
@@ -129,6 +132,12 @@ class CheckMixIn:
         archive checks, nor enable repair mode. Consequently, if you want to use
         ``--max-duration`` you must also pass ``--repository-only``, and must not pass
         ``--archives-only``, nor ``--repair``.
+
+        The ``--max-age`` option keeps the results of previous repository checks and
+        skips packs whose intact result is younger than the given interval (e.g.
+        ``--max-age=4w``), spreading the verification cost over repeated checks.
+        Packs recorded corrupt are always re-verified. ``--max-age`` cannot be
+        combined with ``--repair``.
 
         **Warning:** Please note that partial repository checks (i.e., running with
         ``--max-duration``) can only perform non-cryptographic checksum checks on the
@@ -221,6 +230,15 @@ class CheckMixIn:
         )
         subparser.add_argument(
             "--find-lost-archives", dest="find_lost_archives", action="store_true", help="attempt to find lost archives"
+        )
+        subparser.add_argument(
+            "--max-age",
+            metavar="INTERVAL",
+            dest="max_age",
+            type=interval,
+            default=None,
+            action=Highlander,
+            help="reuse intact-pack check results younger than INTERVAL (e.g. 4w)",
         )
         subparser.add_argument(
             "--max-duration",

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -71,6 +71,11 @@ MIN_PACK_SIZE = DEFAULT_PACK_MAX_SIZE // 50  # 1 MB
 # MAX_OBJECT_SIZE = MAX_DATA_SIZE + len(PUT header)
 MAX_OBJECT_SIZE = MAX_DATA_SIZE + 41  # see assertion at end of repository module
 
+# Clock skew is the difference between the clocks of the machines writing to a repository (seconds).
+# A check result timestamp up to this far in the future still counts as recent; further ahead than
+# this, the pack is re-verified.
+MAX_CLOCK_SKEW = 7200  # [s]
+
 # How many segment files Borg puts into a single directory by default.
 DEFAULT_SEGMENTS_PER_DIR = 1000
 

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -900,6 +900,15 @@ class Repository:
         if index_errors == 0:
             # packs are the bulk of the work and the part --max-duration spreads over several checks.
             pack_infos = store_list("packs")
+            if partial:
+                # a partial check stops after max_duration; verify the least-recently-checked packs
+                # first so repeated runs cover every pack. sort by recorded check time, unrecorded
+                # (time 0) first.
+                def recorded_ts(info):
+                    entry = tracker.get(hex_to_bin(info.name))
+                    return entry.timestamp if entry is not None else 0
+
+                pack_infos.sort(key=recorded_ts)
             pack_pi = ProgressIndicatorPercent(total=len(pack_infos), msg="Checking packs %3.0f%%", msgid="check.packs")
             for info in pack_infos:
                 self._lock_refresh()

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -836,13 +836,13 @@ class Repository:
         corrupt packs and dropping those packs is left to repair, refs #8572. The ids of the packs
         found corrupt are kept in cache/checked-packs for repair, refs #9696.
 
-        Any pack on record as corrupt fails the check, including on a partial run that stops before
-        re-reaching it. The record clears when the pack verifies intact again, when compact removes
-        the pack, or when repair salvages and drops it (refs #8572).
+        A pack recorded corrupt fails the check, also on a partial run that stops before re-reaching
+        it. The record clears at the check that finds the pack intact again or gone (removed by
+        compact, or salvaged and dropped by repair; refs #8572); prune() does this from packs/.
 
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
-        max_age, tolerating up to MAX_CLOCK_SKEW of clock skew at both ends of the window. Check
-        results are always recorded and kept.
+        max_age, accepting a future timestamp up to MAX_CLOCK_SKEW (clock skew). Results are recorded
+        regardless of max_age.
         """
 
         def verify(namespace, name):
@@ -906,14 +906,12 @@ class Repository:
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
-                # skip the pack if its recorded intact result is younger than max_age. the timestamp
-                # is written by whichever client ran the earlier check, so it may be off by up to
-                # MAX_CLOCK_SKEW against our clock in either direction; tolerate that much skew at both
-                # ends of the window, but never more than the window itself.
+                # skip a pack recorded intact within the last max_age seconds. the timestamp is set
+                # by the client that ran the earlier check; accept a future one (negative age) up to
+                # MAX_CLOCK_SKEW, and re-verify anything at or past max_age.
                 if entry is not None and entry.result and max_age:
                     age = time.time() - entry.timestamp
-                    skew = min(MAX_CLOCK_SKEW, max_age)
-                    if -skew <= age <= max_age + skew:
+                    if -min(MAX_CLOCK_SKEW, max_age) <= age < max_age:
                         pack_skipped += 1
                         continue
                 pack_files += 1
@@ -947,8 +945,8 @@ class Repository:
         if pack_skipped:
             summary += f" Reused {pack_skipped} recent pack check result(s)."
         logger.info(summary)
-        # every pack recorded corrupt, not only those verified this run; empty if the index is
-        # corrupt, since then no packs were scanned.
+        # corrupt_ids() is every pack recorded corrupt, including from earlier runs. with a corrupt
+        # index the packs were not scanned, so report nothing.
         corrupt_ids = tracker.corrupt_ids() if index_errors == 0 else []
         if corrupt_ids:
             # one id per line (the list can be long).

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -313,11 +313,14 @@ def superseded_gap_ranges(reader, chunks, pack_id, obj_ranges, pack_size):
 
 
 class PackTracker:
-    """Packs verified in the current check cycle, mapping pack_id -> (timestamp, result).
+    """Pack verification results, mapping pack_id -> (timestamp, result).
 
     A cycle is one full pass over packs/; --max-duration may spread it over several partial checks.
+    Intact records (result=1) hold the cycle progress and are dropped when the cycle completes.
+    Corrupt records (result=0) are kept across cycles until the pack verifies intact or is no longer
+    listed in packs/.
     Stored at cache/checked-packs as the serialized table with a sha256 over it appended.
-    new() starts a cycle, load() resumes the stored one.
+    new() starts an empty tracker, load() reads the stored one.
     """
 
     NAME = "cache/checked-packs"
@@ -376,6 +379,31 @@ class PackTracker:
 
     def record(self, pack_id, ok):
         self.table[pack_id] = self.Entry(timestamp=int(time.time()), result=int(ok))
+
+    def corrupt_ids(self):
+        """Return the ids of the packs recorded corrupt, sorted."""
+        return sorted(pack_id for pack_id, entry in self.table.items() if not entry.result)
+
+    def drop_ok(self):
+        """Remove the intact-pack records, keeping the corrupt ones."""
+        # the keys are collected first because the table must not be mutated while iterating it.
+        for pack_id in [pack_id for pack_id, entry in self.table.items() if entry.result]:
+            del self.table[pack_id]
+
+    def finish_cycle(self, pack_ids):
+        """End a completed cycle: drop the intact records and the corrupt records of packs that are
+        gone, then store the remaining records (or delete the stored object if none remain).
+
+        pack_ids is the set of pack ids listed in packs/ during this cycle; a record for an id not in
+        it refers to a pack that was deleted or compacted away.
+        """
+        self.drop_ok()
+        for pack_id in [pack_id for pack_id, _ in self.table.items() if pack_id not in pack_ids]:
+            del self.table[pack_id]
+        if len(self.table):
+            self.save()
+        else:
+            self.clear()
 
     def save(self):
         with io.BytesIO() as f:
@@ -815,7 +843,8 @@ class Repository:
         rebuild re-reads every pack anyway - so a read-only check just stops and reports it instead of
         continuing. The index is never rebuilt here in any case: reading every pack to do so would be
         far too slow and expensive for a routine (e.g. cron) check. Salvaging good objects out of
-        corrupt packs and dropping those packs is left to repair, refs #8572.
+        corrupt packs and dropping those packs is left to repair, refs #8572. The ids of the packs
+        found corrupt are kept in cache/checked-packs for repair, refs #9696.
         """
 
         def verify(namespace, name):
@@ -839,15 +868,15 @@ class Repository:
         assert not (repair and partial)
         mode = "partial" if partial else "full"
         logger.info(f"Starting {mode} repository check")
-        if partial:
-            tracker = PackTracker.load(self.store)
-        else:
-            tracker = PackTracker.new(self.store)
-            tracker.clear()  # a full check verifies every pack, so discard the stored cycle
-        if len(tracker):
+        tracker = PackTracker.load(self.store)
+        if not partial:
+            tracker.drop_ok()  # a full check verifies every pack, so it starts a new cycle
+        if not len(tracker):
+            logger.info("Starting from beginning.")
+        elif partial:
             logger.info(f"Continuing check cycle, {len(tracker)} packs already checked.")
         else:
-            logger.info("Starting from beginning.")
+            logger.info(f"Starting from beginning, re-verifying {len(tracker)} packs recorded corrupt.")
         t_start = time.monotonic()
         t_last_checkpoint = t_start
         index_files = index_errors = 0
@@ -899,11 +928,11 @@ class Repository:
                     tracker.save()
                     break
             else:
-                # scanned all packs without hitting the time limit: the cycle is done, drop the set.
+                # scanned all packs without hitting the time limit: the cycle is done, drop its progress.
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-                tracker.clear()
+                tracker.finish_cycle({hex_to_bin(info.name) for info in pack_infos})
             pack_pi.finish()
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
@@ -912,6 +941,10 @@ class Repository:
         logger.info(
             f"Checked {index_files} index files ({index_errors} errors) and {pack_files} packs ({pack_errors} errors)."
         )
+        if index_errors == 0:  # the packs were checked, so the corrupt records are from this check
+            corrupt_ids = tracker.corrupt_ids()
+            if corrupt_ids:
+                logger.error("Corrupt packs: " + ", ".join(bin_to_hex(pack_id) for pack_id in corrupt_ids))
         if objs_errors == 0:
             logger.info(f"Finished {mode} repository check, no problems found.")
         elif repair:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -836,6 +836,10 @@ class Repository:
         corrupt packs and dropping those packs is left to repair, refs #8572. The ids of the packs
         found corrupt are kept in cache/checked-packs for repair, refs #9696.
 
+        Any pack on record as corrupt fails the check, including on a partial run that stops before
+        re-reaching it. The record clears when the pack verifies intact again, when compact removes
+        the pack, or when repair salvages and drops it (refs #8572).
+
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
         max_age. Check results are always recorded and kept.
         """
@@ -901,11 +905,12 @@ class Repository:
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
-                # skip the pack if its recorded intact result is younger than max_age; a timestamp up
-                # to MAX_CLOCK_SKEW in the future still counts as recent, further ahead it is re-verified.
+                # skip the pack if its recorded intact result is younger than max_age. a future
+                # timestamp (writer clock ahead of ours) also counts as recent, tolerated up to
+                # MAX_CLOCK_SKEW or max_age ahead, whichever is smaller.
                 if entry is not None and entry.result and max_age:
                     age = time.time() - entry.timestamp
-                    if -MAX_CLOCK_SKEW <= age < max_age:
+                    if -min(MAX_CLOCK_SKEW, max_age) <= age < max_age:
                         pack_skipped += 1
                         continue
                 pack_files += 1

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -871,6 +871,10 @@ class Repository:
             logger.info("Starting from beginning.")
         elif max_age:
             logger.info(f"{len(tracker)} pack check results on record, reusing those younger than --max-age.")
+        elif partial:
+            logger.info(
+                f"{len(tracker)} pack check results on record, verifying the least-recently-checked packs first."
+            )
         else:
             logger.info(f"{len(tracker)} pack check results on record, verifying every pack.")
         t_start = time.monotonic()

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -841,7 +841,8 @@ class Repository:
         the pack, or when repair salvages and drops it (refs #8572).
 
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
-        max_age. Check results are always recorded and kept.
+        max_age, tolerating up to MAX_CLOCK_SKEW of clock skew at both ends of the window. Check
+        results are always recorded and kept.
         """
 
         def verify(namespace, name):
@@ -869,7 +870,7 @@ class Repository:
         if not len(tracker):
             logger.info("Starting from beginning.")
         elif max_age:
-            logger.info(f"{len(tracker)} pack check results on record, reusing those younger than max_age.")
+            logger.info(f"{len(tracker)} pack check results on record, reusing those younger than --max-age.")
         else:
             logger.info(f"{len(tracker)} pack check results on record, verifying every pack.")
         t_start = time.monotonic()
@@ -905,12 +906,14 @@ class Repository:
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
-                # skip the pack if its recorded intact result is younger than max_age. a future
-                # timestamp (writer clock ahead of ours) also counts as recent, tolerated up to
-                # MAX_CLOCK_SKEW or max_age ahead, whichever is smaller.
+                # skip the pack if its recorded intact result is younger than max_age. the timestamp
+                # is written by whichever client ran the earlier check, so it may be off by up to
+                # MAX_CLOCK_SKEW against our clock in either direction; tolerate that much skew at both
+                # ends of the window, but never more than the window itself.
                 if entry is not None and entry.result and max_age:
                     age = time.time() - entry.timestamp
-                    if -min(MAX_CLOCK_SKEW, max_age) <= age < max_age:
+                    skew = min(MAX_CLOCK_SKEW, max_age)
+                    if -skew <= age <= max_age + skew:
                         pack_skipped += 1
                         continue
                 pack_files += 1

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -316,9 +316,9 @@ class PackTracker:
     """Pack verification results, mapping pack_id -> (timestamp, result).
 
     A cycle is one full pass over packs/; --max-duration may spread it over several partial checks.
-    Intact records (result=1) hold the cycle progress and are dropped when the cycle completes.
-    Corrupt records (result=0) are kept across cycles until the pack verifies intact or is no longer
-    listed in packs/.
+    Intact records (result=1) hold the cycle progress and are dropped when the cycle completes,
+    or kept across cycles when the cycle is finished with keep_ok. Corrupt records (result=0)
+    are kept across cycles until the pack verifies intact or is no longer listed in packs/.
     Stored at cache/checked-packs as the serialized table with a sha256 over it appended.
     new() starts an empty tracker, load() reads the stored one.
     """
@@ -390,14 +390,15 @@ class PackTracker:
         for pack_id in [pack_id for pack_id, entry in self.table.items() if entry.result]:
             del self.table[pack_id]
 
-    def finish_cycle(self, pack_ids):
-        """End a completed cycle: drop the intact records and the corrupt records of packs that are
-        gone, then store the remaining records (or delete the stored object if none remain).
+    def finish_cycle(self, pack_ids, keep_ok=False):
+        """End a completed cycle: drop the intact records (unless keep_ok) and the records of packs
+        that are gone, then store the remaining records (or delete the stored object if none remain).
 
         pack_ids is the set of pack ids listed in packs/ during this cycle; a record for an id not in
         it refers to a pack that was deleted or compacted away.
         """
-        self.drop_ok()
+        if not keep_ok:
+            self.drop_ok()
         for pack_id in [pack_id for pack_id, _ in self.table.items() if pack_id not in pack_ids]:
             del self.table[pack_id]
         if len(self.table):
@@ -831,7 +832,7 @@ class Repository:
         info = dict(id=self.id, version=self.version)
         return info
 
-    def check(self, repair=False, max_duration=0):
+    def check(self, repair=False, max_duration=0, max_age=0):
         """Check repository consistency.
 
         packs/ and index/ objects are named by the sha256 of their content, so a pack or index file
@@ -845,6 +846,9 @@ class Repository:
         far too slow and expensive for a routine (e.g. cron) check. Salvaging good objects out of
         corrupt packs and dropping those packs is left to repair, refs #8572. The ids of the packs
         found corrupt are kept in cache/checked-packs for repair, refs #9696.
+
+        max_age (seconds, 0 = off): keep the intact-pack records across cycles and skip packs whose
+        intact record is younger than max_age.
         """
 
         def verify(namespace, name):
@@ -869,12 +873,14 @@ class Repository:
         mode = "partial" if partial else "full"
         logger.info(f"Starting {mode} repository check")
         tracker = PackTracker.load(self.store)
-        if not partial:
-            tracker.drop_ok()  # a full check verifies every pack, so it starts a new cycle
+        if not partial and not max_age:
+            tracker.drop_ok()  # without max_age, a full check verifies every pack: start a new cycle
         if not len(tracker):
             logger.info("Starting from beginning.")
         elif partial:
-            logger.info(f"Continuing check cycle, {len(tracker)} packs already checked.")
+            logger.info(f"Continuing check cycle, {len(tracker)} pack check results on record.")
+        elif max_age:
+            logger.info(f"{len(tracker)} pack check results on record, reusing those younger than max_age.")
         else:
             logger.info(f"Starting from beginning, re-verifying {len(tracker)} packs recorded corrupt.")
         t_start = time.monotonic()
@@ -910,8 +916,9 @@ class Repository:
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
-                if entry is not None and entry.result:  # intact in this cycle; a corrupt one is verified again
-                    continue
+                if entry is not None and entry.result:  # recorded intact; a corrupt one is verified again
+                    if not max_age or time.time() - entry.timestamp < max_age:
+                        continue
                 pack_files += 1
                 ok = verify("packs", info.name)
                 if not ok:
@@ -932,7 +939,7 @@ class Repository:
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-                tracker.finish_cycle({hex_to_bin(info.name) for info in pack_infos})
+                tracker.finish_cycle({hex_to_bin(info.name) for info in pack_infos}, keep_ok=bool(max_age))
             pack_pi.finish()
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -901,8 +901,11 @@ class Repository:
                 pack_pi.show(increase=1)  # advance for skipped packs too, so the bar tracks packs/, not work done
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
-                if entry is not None and entry.result:  # recorded intact; a corrupt one is verified again
-                    if max_age and time.time() - entry.timestamp < max_age:
+                # skip the pack if its recorded intact result is younger than max_age; a timestamp up
+                # to MAX_CLOCK_SKEW in the future still counts as recent, further ahead it is re-verified.
+                if entry is not None and entry.result and max_age:
+                    age = time.time() - entry.timestamp
+                    if -MAX_CLOCK_SKEW <= age < max_age:
                         continue
                 pack_files += 1
                 ok = verify("packs", info.name)
@@ -934,7 +937,10 @@ class Repository:
         if index_errors == 0:  # the packs were checked, so the corrupt records are from this check
             corrupt_ids = tracker.corrupt_ids()
             if corrupt_ids:
-                logger.error("Corrupt packs: " + ", ".join(bin_to_hex(pack_id) for pack_id in corrupt_ids))
+                # one id per line (the list can be long).
+                logger.error(f"Found {len(corrupt_ids)} corrupt pack(s):")
+                for pack_id in corrupt_ids:
+                    logger.error(f"Corrupt pack: {bin_to_hex(pack_id)}")
         if objs_errors == 0:
             logger.info(f"Finished {mode} repository check, no problems found.")
         elif repair:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -315,10 +315,9 @@ def superseded_gap_ranges(reader, chunks, pack_id, obj_ranges, pack_size):
 class PackTracker:
     """Pack verification results, mapping pack_id -> (timestamp, result).
 
-    A cycle is one full pass over packs/; --max-duration may spread it over several partial checks.
-    Intact records (result=1) hold the cycle progress and are dropped when the cycle completes,
-    or kept across cycles when the cycle is finished with keep_ok. Corrupt records (result=0)
-    are kept across cycles until the pack verifies intact or is no longer listed in packs/.
+    Records are kept across checks: intact records (result=1) are reused by checks run with
+    max_age, corrupt records (result=0) are kept for repair and always re-verified. Records of
+    packs no longer listed in packs/ are pruned when a check finishes scanning packs/.
     Stored at cache/checked-packs as the serialized table with a sha256 over it appended.
     new() starts an empty tracker, load() reads the stored one.
     """
@@ -384,21 +383,11 @@ class PackTracker:
         """Return the ids of the packs recorded corrupt, sorted."""
         return sorted(pack_id for pack_id, entry in self.table.items() if not entry.result)
 
-    def drop_ok(self):
-        """Remove the intact-pack records, keeping the corrupt ones."""
-        # the keys are collected first because the table must not be mutated while iterating it.
-        for pack_id in [pack_id for pack_id, entry in self.table.items() if entry.result]:
-            del self.table[pack_id]
-
-    def finish_cycle(self, pack_ids, keep_ok=False):
-        """End a completed cycle: drop the intact records (unless keep_ok) and the records of packs
-        that are gone, then store the remaining records (or delete the stored object if none remain).
-
-        pack_ids is the set of pack ids listed in packs/ during this cycle; a record for an id not in
-        it refers to a pack that was deleted or compacted away.
+    def prune(self, pack_ids):
+        """Drop the records whose pack id is not in pack_ids (the set of pack ids listed in packs/),
+        then store the remaining records (or delete the stored object if none remain).
         """
-        if not keep_ok:
-            self.drop_ok()
+        # the keys are collected first because the table must not be mutated while iterating it.
         for pack_id in [pack_id for pack_id, _ in self.table.items() if pack_id not in pack_ids]:
             del self.table[pack_id]
         if len(self.table):
@@ -847,8 +836,8 @@ class Repository:
         corrupt packs and dropping those packs is left to repair, refs #8572. The ids of the packs
         found corrupt are kept in cache/checked-packs for repair, refs #9696.
 
-        max_age (seconds, 0 = off): keep the intact-pack records across cycles and skip packs whose
-        intact record is younger than max_age.
+        max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
+        max_age. Check results are always recorded and kept.
         """
 
         def verify(namespace, name):
@@ -873,16 +862,12 @@ class Repository:
         mode = "partial" if partial else "full"
         logger.info(f"Starting {mode} repository check")
         tracker = PackTracker.load(self.store)
-        if not partial and not max_age:
-            tracker.drop_ok()  # without max_age, a full check verifies every pack: start a new cycle
         if not len(tracker):
             logger.info("Starting from beginning.")
-        elif partial:
-            logger.info(f"Continuing check cycle, {len(tracker)} pack check results on record.")
         elif max_age:
             logger.info(f"{len(tracker)} pack check results on record, reusing those younger than max_age.")
         else:
-            logger.info(f"Starting from beginning, re-verifying {len(tracker)} packs recorded corrupt.")
+            logger.info(f"{len(tracker)} pack check results on record, verifying every pack.")
         t_start = time.monotonic()
         t_last_checkpoint = t_start
         index_files = index_errors = 0
@@ -917,7 +902,7 @@ class Repository:
                 pack_id = hex_to_bin(info.name)
                 entry = tracker.get(pack_id)
                 if entry is not None and entry.result:  # recorded intact; a corrupt one is verified again
-                    if not max_age or time.time() - entry.timestamp < max_age:
+                    if max_age and time.time() - entry.timestamp < max_age:
                         continue
                 pack_files += 1
                 ok = verify("packs", info.name)
@@ -931,15 +916,13 @@ class Repository:
                     logger.info(f"Checkpointing at pack {info.name}.")
                     tracker.save()
                 if partial and now > t_start + max_duration:
-                    logger.info(f"Finished partial repository check, {len(tracker)} packs checked so far.")
-                    tracker.save()
+                    logger.info(f"Finished partial repository check, {len(tracker)} pack check results on record.")
                     break
             else:
-                # scanned all packs without hitting the time limit: the cycle is done, drop its progress.
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-                tracker.finish_cycle({hex_to_bin(info.name) for info in pack_infos}, keep_ok=bool(max_age))
+            tracker.prune({hex_to_bin(info.name) for info in pack_infos})
             pack_pi.finish()
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -871,7 +871,7 @@ class Repository:
         t_start = time.monotonic()
         t_last_checkpoint = t_start
         index_files = index_errors = 0
-        pack_files = pack_errors = 0
+        pack_files = pack_errors = pack_skipped = 0
         # index and packs get separate progress indicators, each running from 0% to 100%.
         # the index is checked first and in full, on partial checks too: it is small, and index errors
         # stop the pack check below.
@@ -906,6 +906,7 @@ class Repository:
                 if entry is not None and entry.result and max_age:
                     age = time.time() - entry.timestamp
                     if -MAX_CLOCK_SKEW <= age < max_age:
+                        pack_skipped += 1
                         continue
                 pack_files += 1
                 ok = verify("packs", info.name)
@@ -931,23 +932,30 @@ class Repository:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
             logger.error("Repository index is corrupted and must be repaired; skipping the pack check.")
         objs_errors = index_errors + pack_errors
-        logger.info(
-            f"Checked {index_files} index files ({index_errors} errors) and {pack_files} packs ({pack_errors} errors)."
+        summary = (
+            f"Checked {index_files} index files ({index_errors} errors) "
+            f"and {pack_files} packs ({pack_errors} errors)."
         )
-        if index_errors == 0:  # the packs were checked, so the corrupt records are from this check
-            corrupt_ids = tracker.corrupt_ids()
-            if corrupt_ids:
-                # one id per line (the list can be long).
-                logger.error(f"Found {len(corrupt_ids)} corrupt pack(s):")
-                for pack_id in corrupt_ids:
-                    logger.error(f"Corrupt pack: {bin_to_hex(pack_id)}")
-        if objs_errors == 0:
+        if pack_skipped:
+            summary += f" Reused {pack_skipped} recent pack check result(s)."
+        logger.info(summary)
+        # every pack recorded corrupt, not only those verified this run; empty if the index is
+        # corrupt, since then no packs were scanned.
+        corrupt_ids = tracker.corrupt_ids() if index_errors == 0 else []
+        if corrupt_ids:
+            # one id per line (the list can be long).
+            logger.error(f"Found {len(corrupt_ids)} corrupt pack(s):")
+            for pack_id in corrupt_ids:
+                logger.error(f"Corrupt pack: {bin_to_hex(pack_id)}")
+        # fail if this run found errors, or any pack is recorded corrupt.
+        problems = objs_errors != 0 or bool(corrupt_ids)
+        if not problems:
             logger.info(f"Finished {mode} repository check, no problems found.")
         elif repair:
             logger.error(f"Finished {mode} repository check, errors found (repository repair not implemented).")
         else:
             logger.error(f"Finished {mode} repository check, errors found.")
-        return objs_errors == 0 or repair
+        return not problems or repair
 
     def list(self, limit=None, marker=None):
         """

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -79,17 +79,25 @@ def test_check_max_age(archivers, request):
     check_cmd_setup(archiver)
 
     # --repair and --archives-only do not allow --max-age, and --max-duration requires --max-age.
+    # a zero span like 0d resolves to max_age=0 (no reuse), so it must not satisfy the guards either.
     if archiver.FORK_DEFAULT:
         cmd(archiver, "check", "--repair", "--max-age=1d", exit_code=CommandError().exit_code)
+        cmd(archiver, "check", "--repair", "--max-age=0d", exit_code=CommandError().exit_code)
         cmd(archiver, "check", "--archives-only", "--max-age=1d", exit_code=CommandError().exit_code)
         cmd(archiver, "check", "--repository-only", "--max-duration=3600", exit_code=CommandError().exit_code)
+        ec = CommandError().exit_code
+        cmd(archiver, "check", "--repository-only", "--max-duration=3600", "--max-age=0d", exit_code=ec)
     else:
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repair", "--max-age=1d")
         with pytest.raises(CommandError):
+            cmd(archiver, "check", "--repair", "--max-age=0d")
+        with pytest.raises(CommandError):
             cmd(archiver, "check", "--archives-only", "--max-age=1d")
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repository-only", "--max-duration=3600")
+        with pytest.raises(CommandError):
+            cmd(archiver, "check", "--repository-only", "--max-duration=3600", "--max-age=0d")
 
     # a check records its results, a later one with --max-age reuses them.
     output = cmd(archiver, "check", "-v", "--repository-only", exit_code=0)

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -78,13 +78,16 @@ def test_check_max_age(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)
 
-    # --repair does not allow --max-age, and --max-duration requires --max-age.
+    # --repair and --archives-only do not allow --max-age, and --max-duration requires --max-age.
     if archiver.FORK_DEFAULT:
         cmd(archiver, "check", "--repair", "--max-age=1d", exit_code=CommandError().exit_code)
+        cmd(archiver, "check", "--archives-only", "--max-age=1d", exit_code=CommandError().exit_code)
         cmd(archiver, "check", "--repository-only", "--max-duration=3600", exit_code=CommandError().exit_code)
     else:
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repair", "--max-age=1d")
+        with pytest.raises(CommandError):
+            cmd(archiver, "check", "--archives-only", "--max-age=1d")
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repository-only", "--max-duration=3600")
 

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -78,15 +78,13 @@ def test_check_max_age(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)
 
-    # --repair and --archives-only do not allow --max-age, and --max-duration requires --max-age.
-    # a zero span like 0d resolves to max_age=0 (no reuse), so it must not satisfy the guards either.
+    # --repair and --archives-only do not allow --max-age; 0d is a valid value (resolves to no reuse).
+    # --max-duration needs --repository-only, but not --max-age: a partial check advances on its own.
     if archiver.FORK_DEFAULT:
         cmd(archiver, "check", "--repair", "--max-age=1d", exit_code=CommandError().exit_code)
         cmd(archiver, "check", "--repair", "--max-age=0d", exit_code=CommandError().exit_code)
         cmd(archiver, "check", "--archives-only", "--max-age=1d", exit_code=CommandError().exit_code)
-        cmd(archiver, "check", "--repository-only", "--max-duration=3600", exit_code=CommandError().exit_code)
-        ec = CommandError().exit_code
-        cmd(archiver, "check", "--repository-only", "--max-duration=3600", "--max-age=0d", exit_code=ec)
+        cmd(archiver, "check", "--max-duration=3600", exit_code=CommandError().exit_code)
     else:
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repair", "--max-age=1d")
@@ -95,9 +93,10 @@ def test_check_max_age(archivers, request):
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--archives-only", "--max-age=1d")
         with pytest.raises(CommandError):
-            cmd(archiver, "check", "--repository-only", "--max-duration=3600")
-        with pytest.raises(CommandError):
-            cmd(archiver, "check", "--repository-only", "--max-duration=3600", "--max-age=0d")
+            cmd(archiver, "check", "--max-duration=3600")
+
+    # a partial check runs without --max-age.
+    cmd(archiver, "check", "--repository-only", "--max-duration=3600", exit_code=0)
 
     # a check records its results, a later one with --max-age reuses them.
     output = cmd(archiver, "check", "-v", "--repository-only", exit_code=0)

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -95,7 +95,7 @@ def test_check_max_age(archivers, request):
     output = cmd(archiver, "check", "-v", "--repository-only", exit_code=0)
     assert "Starting full repository check" in output
     output = cmd(archiver, "check", "-v", "--repository-only", "--max-age=4w", exit_code=0)
-    assert "reusing those younger than max_age" in output
+    assert "reusing those younger than --max-age" in output
     assert "no problems found" in output
 
 

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -74,6 +74,25 @@ def test_check_usage(archivers, request):
     assert "archive2" in output
 
 
+def test_check_max_age(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    check_cmd_setup(archiver)
+
+    # --repair does not allow --max-age.
+    if archiver.FORK_DEFAULT:
+        cmd(archiver, "check", "--repair", "--max-age=1d", exit_code=CommandError().exit_code)
+    else:
+        with pytest.raises(CommandError):
+            cmd(archiver, "check", "--repair", "--max-age=1d")
+
+    # a first check with --max-age records the results, a second one reuses them.
+    output = cmd(archiver, "check", "-v", "--repository-only", "--max-age=4w", exit_code=0)
+    assert "Starting full repository check" in output
+    output = cmd(archiver, "check", "-v", "--repository-only", "--max-age=4w", exit_code=0)
+    assert "reusing those younger than max_age" in output
+    assert "no problems found" in output
+
+
 def test_date_matching(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -78,15 +78,18 @@ def test_check_max_age(archivers, request):
     archiver = request.getfixturevalue(archivers)
     check_cmd_setup(archiver)
 
-    # --repair does not allow --max-age.
+    # --repair does not allow --max-age, and --max-duration requires --max-age.
     if archiver.FORK_DEFAULT:
         cmd(archiver, "check", "--repair", "--max-age=1d", exit_code=CommandError().exit_code)
+        cmd(archiver, "check", "--repository-only", "--max-duration=3600", exit_code=CommandError().exit_code)
     else:
         with pytest.raises(CommandError):
             cmd(archiver, "check", "--repair", "--max-age=1d")
+        with pytest.raises(CommandError):
+            cmd(archiver, "check", "--repository-only", "--max-duration=3600")
 
-    # a first check with --max-age records the results, a second one reuses them.
-    output = cmd(archiver, "check", "-v", "--repository-only", "--max-age=4w", exit_code=0)
+    # a check records its results, a later one with --max-age reuses them.
+    output = cmd(archiver, "check", "-v", "--repository-only", exit_code=0)
     assert "Starting full repository check" in output
     output = cmd(archiver, "check", "-v", "--repository-only", "--max-age=4w", exit_code=0)
     assert "reusing those younger than max_age" in output

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1291,8 +1291,8 @@ def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
 
 
 def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):
-    # a record timestamped slightly in the future (clock skew between machines) still counts as
-    # recent, up to MAX_CLOCK_SKEW ahead, and is not re-verified.
+    # with a window wider than MAX_CLOCK_SKEW, a record timestamped up to MAX_CLOCK_SKEW into the
+    # future (writer clock ahead of ours) still counts as recent and is not re-verified.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1303,13 +1303,13 @@ def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
-        assert repository.check(repair=False, max_age=3600) is True
-        assert pack_key not in hashed_keys  # near-future timestamp still counts as recent
+        assert repository.check(repair=False, max_age=MAX_CLOCK_SKEW * 2) is True
+        assert pack_key not in hashed_keys  # within MAX_CLOCK_SKEW ahead, still counts as recent
 
 
 def test_check_max_age_reverifies_far_future_ok(tmp_path, monkeypatch):
-    # a record dated more than MAX_CLOCK_SKEW into the future is not plausible clock skew and is
-    # re-verified.
+    # with a window wider than MAX_CLOCK_SKEW, a record more than MAX_CLOCK_SKEW into the future is
+    # not plausible clock skew and is re-verified.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1320,8 +1320,26 @@ def test_check_max_age_reverifies_far_future_ok(tmp_path, monkeypatch):
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
-        assert repository.check(repair=False, max_age=3600) is True
+        assert repository.check(repair=False, max_age=MAX_CLOCK_SKEW * 2) is True
         assert pack_key in hashed_keys  # too far ahead to be clock skew, re-verified
+
+
+def test_check_max_age_reverifies_future_beyond_small_window(tmp_path, monkeypatch):
+    # the future tolerance is capped at max_age: with a window smaller than MAX_CLOCK_SKEW, a record
+    # further ahead than max_age is re-verified even though it is within MAX_CLOCK_SKEW.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        small_window = MAX_CLOCK_SKEW // 4
+        tracker = PackTracker.new(repository.store)
+        future_ts = int(time.time()) + MAX_CLOCK_SKEW // 2  # ahead of us, but < MAX_CLOCK_SKEW
+        tracker.table[intact_id] = PackTracker.Entry(timestamp=future_ts, result=1)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=small_window) is True
+        assert pack_key in hashed_keys  # further ahead than max_age, re-verified
 
 
 def test_check_max_age_reverifies_corrupt_even_when_fresh(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1215,6 +1215,38 @@ def test_check_partial_keeps_corrupt_record_across_runs(tmp_path):
         assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
 
 
+def test_check_partial_break_reports_unreached_corrupt_record(tmp_path, monkeypatch, caplog):
+    # a partial check that stops before re-reaching a carried-over corrupt record still fails and
+    # reports it, so the timeout does not hide known corruption.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, _ = _store_intact_pack(repository)
+        # a corrupt pack whose id sorts after the intact one, so the scan reaches the intact pack first.
+        corrupt_id = b"\xff" * 32
+        assert bin_to_hex(intact_id) < bin_to_hex(corrupt_id)
+        repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(corrupt_id, ok=False)  # recorded corrupt by an earlier check
+        tracker.save()
+
+        # jump the clock past max_duration once the first pack has been hashed, so the scan breaks
+        # before it reaches the corrupt pack.
+        clock = {"t": 0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        orig_hash = repository.store.hash
+
+        def hash_then_advance(key):
+            result = orig_hash(key)
+            clock["t"] = 10**9
+            return result
+
+        monkeypatch.setattr(repository.store, "hash", hash_then_advance)
+
+        with caplog.at_level(logging.ERROR, logger="borg.repository"):
+            assert repository.check(repair=False, max_duration=1, max_age=3600) is False
+        assert f"Corrupt pack: {bin_to_hex(corrupt_id)}" in caplog.text
+
+
 def test_check_max_age_skips_fresh_ok(tmp_path, monkeypatch):
     # with max_age, a pack recorded intact recently is not re-verified, and its record is kept.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import sys
+import time
 from collections import namedtuple
 from hashlib import sha256
 
@@ -1211,6 +1212,99 @@ def test_check_partial_keeps_corrupt_record_across_runs(tmp_path):
         # a second run re-verifies it and keeps reporting it.
         assert repository.check(repair=False, max_duration=3600) is False
         assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
+
+
+def test_check_max_age_skips_fresh_ok(tmp_path, monkeypatch):
+    # with max_age, a pack recorded intact recently is not re-verified, and its record is kept.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(intact_id, ok=True)  # fresh timestamp
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=3600) is True
+        assert pack_key not in hashed_keys  # skipped, its record is fresh
+
+        after = PackTracker.load(repository.store)
+        assert after.table[intact_id].result == 1  # kept across the cycle
+
+
+def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
+    # with max_age, a pack whose intact record is older than max_age is re-verified.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        old_ts = int(time.time()) - 100
+        tracker.table[intact_id] = PackTracker.Entry(timestamp=old_ts, result=1)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=50) is True
+        assert pack_key in hashed_keys  # stale, re-verified
+
+        after = PackTracker.load(repository.store)
+        assert after.table[intact_id].timestamp > old_ts  # record refreshed
+
+
+def test_check_max_age_reverifies_corrupt_even_when_fresh(tmp_path, monkeypatch):
+    # the age window only applies to intact records: a fresh corrupt record is still re-verified.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(intact_id, ok=False)  # fresh, but corrupt
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=3600) is True
+        assert pack_key in hashed_keys  # re-verified despite the fresh record
+
+
+def test_check_max_age_prunes_vanished_ok_record(tmp_path):
+    # with max_age, an intact record for a pack no longer listed is pruned at cycle end.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, _ = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(intact_id, ok=True)
+        tracker.record(H(9), ok=True)  # no such pack in packs/
+        tracker.save()
+
+        assert repository.check(repair=False, max_age=3600) is True
+
+        after = PackTracker.load(repository.store)
+        assert intact_id in after.table
+        assert H(9) not in after.table
+
+
+def test_check_max_age_partial_progress(tmp_path, monkeypatch):
+    # a partial check with max_age skips packs with a fresh intact record and verifies the rest.
+    pack_a = fchunk(b"A", chunk_id=H(1))
+    pack_a_id = sha256(pack_a).digest()
+    pack_b = fchunk(b"BB", chunk_id=H(2))
+    pack_b_id = sha256(pack_b).digest()
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        repository.store_store("packs/" + bin_to_hex(pack_a_id), pack_a)
+        repository.store_store("packs/" + bin_to_hex(pack_b_id), pack_b)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(pack_a_id, ok=True)  # fresh
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is True
+        assert "packs/" + bin_to_hex(pack_a_id) not in hashed_keys
+        assert "packs/" + bin_to_hex(pack_b_id) in hashed_keys
+
+        after = PackTracker.load(repository.store)
+        assert pack_a_id in after.table and pack_b_id in after.table
 
 
 def test_check_checked_packs_ignores_foreign_entry_layout(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 import pytest
 from borghash import HashTableNT
 
+from ..constants import MAX_CLOCK_SKEW
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
 from ..repository import Repository, MAX_DATA_SIZE, propagate_rsh, rest_serve_command, PackWriter, PackReader
@@ -1216,34 +1217,39 @@ def test_check_partial_keeps_corrupt_record_across_runs(tmp_path):
 
 
 def test_check_partial_break_reports_unreached_corrupt_record(tmp_path, monkeypatch, caplog):
-    # a partial check that stops before re-reaching a carried-over corrupt record still fails and
-    # reports it, so the timeout does not hide known corruption.
+    # a partial check that breaks before re-reaching a corrupt record from an earlier check still
+    # fails and reports that pack.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        intact_id, _ = _store_intact_pack(repository)
+        intact_id, intact_key = _store_intact_pack(repository)
         # a corrupt pack whose id sorts after the intact one, so the scan reaches the intact pack first.
         corrupt_id = b"\xff" * 32
         assert bin_to_hex(intact_id) < bin_to_hex(corrupt_id)
-        repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
+        corrupt_key = "packs/" + bin_to_hex(corrupt_id)
+        repository.store_store(corrupt_key, b"CORRUPT-does-not-match-name")
 
         tracker = PackTracker.new(repository.store)
         tracker.record(corrupt_id, ok=False)  # recorded corrupt by an earlier check
         tracker.save()
 
-        # jump the clock past max_duration once the first pack has been hashed, so the scan breaks
-        # before it reaches the corrupt pack.
-        clock = {"t": 0}
+        # freeze the clock, then jump it past max_duration right after the intact pack is hashed, so the
+        # pack loop breaks before it reaches the corrupt pack.
+        clock = {"t": 0.0}
         monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        hashed_keys = []
         orig_hash = repository.store.hash
 
-        def hash_then_advance(key):
+        def hash_and_advance(key):
+            hashed_keys.append(key)
             result = orig_hash(key)
-            clock["t"] = 10**9
+            if key == intact_key:
+                clock["t"] = 10**9
             return result
 
-        monkeypatch.setattr(repository.store, "hash", hash_then_advance)
+        monkeypatch.setattr(repository.store, "hash", hash_and_advance)
 
         with caplog.at_level(logging.ERROR, logger="borg.repository"):
             assert repository.check(repair=False, max_duration=1, max_age=3600) is False
+        assert corrupt_key not in hashed_keys  # the scan broke before reaching the corrupt pack
         assert f"Corrupt pack: {bin_to_hex(corrupt_id)}" in caplog.text
 
 
@@ -1282,6 +1288,40 @@ def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
 
         after = PackTracker.load(repository.store)
         assert after.table[intact_id].timestamp > old_ts  # record refreshed
+
+
+def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):
+    # a record timestamped slightly in the future (clock skew between machines) still counts as
+    # recent, up to MAX_CLOCK_SKEW ahead, and is not re-verified.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        future_ts = int(time.time()) + MAX_CLOCK_SKEW // 2
+        tracker.table[intact_id] = PackTracker.Entry(timestamp=future_ts, result=1)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=3600) is True
+        assert pack_key not in hashed_keys  # near-future timestamp still counts as recent
+
+
+def test_check_max_age_reverifies_far_future_ok(tmp_path, monkeypatch):
+    # a record dated more than MAX_CLOCK_SKEW into the future is not plausible clock skew and is
+    # re-verified.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        far_future_ts = int(time.time()) + MAX_CLOCK_SKEW + 3600
+        tracker.table[intact_id] = PackTracker.Entry(timestamp=far_future_ts, result=1)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=3600) is True
+        assert pack_key in hashed_keys  # too far ahead to be clock skew, re-verified
 
 
 def test_check_max_age_reverifies_corrupt_even_when_fresh(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1414,6 +1414,45 @@ def test_check_max_age_partial_progress(tmp_path, monkeypatch):
         assert pack_a_id in after.table and pack_b_id in after.table
 
 
+def test_check_partial_verifies_least_recently_checked_first(tmp_path, monkeypatch):
+    # a partial check verifies the least-recently-checked packs first. with a budget for one pack, the
+    # pack with the oldest recorded result is verified, though its id sorts last.
+    max_age = 3600
+    recent_id = b"\x00" * 32  # sorts first by id
+    older_id = b"\xff" * 32  # sorts last by id
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        for pid in (recent_id, older_id):
+            repository.store_store("packs/" + bin_to_hex(pid), b"content-" + pid[:4])
+
+        now = int(time.time())
+        tracker = PackTracker.new(repository.store)
+        # both records are past max_age, so both need re-verification; the more recently recorded pack
+        # has the id that sorts first.
+        tracker.table[recent_id] = PackTracker.Entry(timestamp=now - (max_age + 100), result=1)
+        tracker.table[older_id] = PackTracker.Entry(timestamp=now - (max_age + 100000), result=1)
+        tracker.save()
+
+        # freeze the clock and jump it past max_duration after the first hash, so exactly one pack is
+        # verified this run.
+        clock = {"t": 0.0}
+        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
+        hashed_keys = []
+        orig_hash = repository.store.hash
+
+        def hash_and_advance(key):
+            hashed_keys.append(key)
+            result = orig_hash(key)
+            clock["t"] = 10**9
+            return result
+
+        monkeypatch.setattr(repository.store, "hash", hash_and_advance)
+
+        repository.check(repair=False, max_duration=1, max_age=max_age)
+
+        pack_hashes = [key for key in hashed_keys if key.startswith("packs/")]
+        assert pack_hashes == ["packs/" + bin_to_hex(older_id)]  # the oldest recorded pack
+
+
 def test_check_max_age_reuses_records_of_plain_check(tmp_path, monkeypatch):
     # a check without max_age records its results, a later check with max_age reuses them.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import sys
 from collections import namedtuple
@@ -1133,7 +1134,83 @@ def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
         assert pack_key in hashed_keys  # verified
 
         after = PackTracker.load(repository.store)
-        assert len(after) == 0  # cycle complete, set dropped
+        assert len(after) == 0  # cycle complete, intact records dropped
+
+
+def _store_corrupt_pack(repository, pack_id):
+    # the stored content does not hash to pack_id, so verifying it fails.
+    repository.store_store("packs/" + bin_to_hex(pack_id), b"CORRUPT-does-not-match-name")
+    return pack_id
+
+
+def test_check_full_keeps_corrupt_record_after_cycle(tmp_path):
+    # a completed cycle keeps the records of corrupt packs and drops the records of intact ones.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, _ = _store_intact_pack(repository)
+        corrupt_id = _store_corrupt_pack(repository, H(2))
+
+        assert repository.check(repair=False) is False
+
+        after = PackTracker.load(repository.store)
+        assert after.corrupt_ids() == [corrupt_id]
+        assert intact_id not in after.table
+
+
+def test_check_full_reports_corrupt_pack_ids(tmp_path, caplog):
+    # the summary names the corrupt packs.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        corrupt_id = _store_corrupt_pack(repository, H(1))
+
+        with caplog.at_level(logging.ERROR, logger="borg.repository"):
+            assert repository.check(repair=False) is False
+
+        assert f"Corrupt packs: {bin_to_hex(corrupt_id)}" in caplog.text
+
+
+def test_check_full_reverifies_carried_over_corrupt_record(tmp_path, monkeypatch):
+    # a corrupt record from an earlier cycle is re-verified and dropped once the pack is intact again.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(intact_id, ok=False)  # recorded corrupt in an earlier cycle
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False) is True
+        assert pack_key in hashed_keys  # re-verified
+
+        after = PackTracker.load(repository.store)
+        assert len(after) == 0  # verified intact, so the corrupt record is dropped
+
+
+def test_check_full_prunes_corrupt_record_of_vanished_pack(tmp_path):
+    # a corrupt record for a pack that is no longer listed is dropped at cycle end.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        _store_intact_pack(repository)
+
+        tracker = PackTracker.new(repository.store)
+        tracker.record(H(9), ok=False)  # no such pack in packs/
+        tracker.save()
+
+        assert repository.check(repair=False) is True
+
+        after = PackTracker.load(repository.store)
+        assert len(after) == 0
+
+
+def test_check_partial_keeps_corrupt_record_across_runs(tmp_path):
+    # corrupt records survive a partial check that completes its cycle, too.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        corrupt_id = _store_corrupt_pack(repository, H(1))
+
+        assert repository.check(repair=False, max_duration=3600) is False
+        assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
+
+        # a second run re-verifies it and keeps reporting it.
+        assert repository.check(repair=False, max_duration=3600) is False
+        assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
 
 
 def test_check_checked_packs_ignores_foreign_entry_layout(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1272,22 +1272,41 @@ def test_check_max_age_skips_fresh_ok(tmp_path, monkeypatch):
 
 
 def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
-    # with max_age, a pack whose intact record is older than max_age is re-verified.
+    # with max_age, a pack whose intact record is older than max_age plus the skew tolerance is re-verified.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
+        max_age = 50
         tracker = PackTracker.new(repository.store)
-        old_ts = int(time.time()) - 100
+        old_ts = int(time.time()) - (max_age + MAX_CLOCK_SKEW + 100)  # clearly beyond max_age + skew
         tracker.table[intact_id] = PackTracker.Entry(timestamp=old_ts, result=1)
         tracker.save()
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
-        assert repository.check(repair=False, max_age=50) is True
+        assert repository.check(repair=False, max_age=max_age) is True
         assert pack_key in hashed_keys  # stale, re-verified
 
         after = PackTracker.load(repository.store)
         assert after.table[intact_id].timestamp > old_ts  # record refreshed
+
+
+def test_check_max_age_skips_stale_within_skew(tmp_path, monkeypatch):
+    # a record older than max_age but within MAX_CLOCK_SKEW of it still counts as recent (writer clock
+    # behind ours), so it is not re-verified.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        max_age = MAX_CLOCK_SKEW * 2  # wide window, so the skew tolerance is MAX_CLOCK_SKEW
+        tracker = PackTracker.new(repository.store)
+        past_ts = int(time.time()) - (max_age + MAX_CLOCK_SKEW // 2)  # past the window, within skew
+        tracker.table[intact_id] = PackTracker.Entry(timestamp=past_ts, result=1)
+        tracker.save()
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=max_age) is True
+        assert pack_key not in hashed_keys  # within MAX_CLOCK_SKEW past the window, still recent
 
 
 def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1120,7 +1120,7 @@ def test_check_partial_skips_pack_recorded_intact(tmp_path, monkeypatch):
         assert pack_key not in hashed_keys  # skipped, not re-verified
 
 
-def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
+def test_check_without_max_age_verifies_all_but_keeps_records(tmp_path, monkeypatch):
     # without max_age, a check verifies every pack regardless of the recorded set, but keeps the records.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
@@ -1165,7 +1165,7 @@ def test_check_full_reports_corrupt_pack_ids(tmp_path, caplog):
         with caplog.at_level(logging.ERROR, logger="borg.repository"):
             assert repository.check(repair=False) is False
 
-        assert f"Corrupt packs: {bin_to_hex(corrupt_id)}" in caplog.text
+        assert f"Corrupt pack: {bin_to_hex(corrupt_id)}" in caplog.text
 
 
 def test_check_full_reverifies_carried_over_corrupt_record(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1043,7 +1043,7 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         repository.store_store("packs/" + bin_to_hex(intact_id), intact)
 
-        # mark the intact pack as already checked in this cycle.
+        # mark the intact pack as recently checked.
         tracker = PackTracker.new(repository.store)
         tracker.record(intact_id, ok=True)
         tracker.save()
@@ -1053,11 +1053,11 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
         assert bin_to_hex(early_id) < bin_to_hex(intact_id)
         repository.store_store("packs/" + bin_to_hex(early_id), b"CORRUPT-does-not-match-name")
 
-        assert repository.check(repair=False, max_duration=3600) is False
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is False
 
 
 def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
-    # a pack recorded corrupt earlier in the cycle is re-verified, so the corruption keeps being reported.
+    # a pack recorded corrupt earlier is re-verified, so the corruption keeps being reported.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         corrupt_id = H(1)  # stored content does not hash to this name
         repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
@@ -1066,7 +1066,7 @@ def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
         tracker.record(corrupt_id, ok=False)
         tracker.save()
 
-        assert repository.check(repair=False, max_duration=3600) is False
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is False
 
 
 def _spy_hash(repository, monkeypatch):
@@ -1101,12 +1101,12 @@ def test_check_partial_clears_recorded_corruption_when_intact(tmp_path, monkeypa
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
-        assert repository.check(repair=False, max_duration=3600) is True
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is True
         assert pack_key in hashed_keys  # re-verified
 
 
 def test_check_partial_skips_pack_recorded_intact(tmp_path, monkeypatch):
-    # a pack recorded intact in this cycle is skipped when a partial check resumes.
+    # a pack recorded intact recently is skipped when a partial check resumes.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1116,12 +1116,12 @@ def test_check_partial_skips_pack_recorded_intact(tmp_path, monkeypatch):
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
-        assert repository.check(repair=False, max_duration=3600) is True
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is True
         assert pack_key not in hashed_keys  # skipped, not re-verified
 
 
 def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
-    # a full check verifies every pack regardless of the recorded set, then drops the set.
+    # without max_age, a check verifies every pack regardless of the recorded set, but keeps the records.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1132,10 +1132,10 @@ def test_check_full_ignores_recorded_set(tmp_path, monkeypatch):
         hashed_keys = _spy_hash(repository, monkeypatch)
 
         assert repository.check(repair=False) is True
-        assert pack_key in hashed_keys  # verified
+        assert pack_key in hashed_keys  # verified despite the fresh intact record
 
         after = PackTracker.load(repository.store)
-        assert len(after) == 0  # cycle complete, intact records dropped
+        assert after.table[intact_id].result == 1  # record kept
 
 
 def _store_corrupt_pack(repository, pack_id):
@@ -1144,8 +1144,8 @@ def _store_corrupt_pack(repository, pack_id):
     return pack_id
 
 
-def test_check_full_keeps_corrupt_record_after_cycle(tmp_path):
-    # a completed cycle keeps the records of corrupt packs and drops the records of intact ones.
+def test_check_full_keeps_records_after_check(tmp_path):
+    # a completed check keeps the records of both corrupt and intact packs.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, _ = _store_intact_pack(repository)
         corrupt_id = _store_corrupt_pack(repository, H(2))
@@ -1154,7 +1154,7 @@ def test_check_full_keeps_corrupt_record_after_cycle(tmp_path):
 
         after = PackTracker.load(repository.store)
         assert after.corrupt_ids() == [corrupt_id]
-        assert intact_id not in after.table
+        assert after.table[intact_id].result == 1
 
 
 def test_check_full_reports_corrupt_pack_ids(tmp_path, caplog):
@@ -1169,12 +1169,12 @@ def test_check_full_reports_corrupt_pack_ids(tmp_path, caplog):
 
 
 def test_check_full_reverifies_carried_over_corrupt_record(tmp_path, monkeypatch):
-    # a corrupt record from an earlier cycle is re-verified and dropped once the pack is intact again.
+    # a corrupt record from an earlier check is re-verified; an intact result replaces it.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
         tracker = PackTracker.new(repository.store)
-        tracker.record(intact_id, ok=False)  # recorded corrupt in an earlier cycle
+        tracker.record(intact_id, ok=False)  # recorded corrupt in an earlier check
         tracker.save()
 
         hashed_keys = _spy_hash(repository, monkeypatch)
@@ -1183,13 +1183,13 @@ def test_check_full_reverifies_carried_over_corrupt_record(tmp_path, monkeypatch
         assert pack_key in hashed_keys  # re-verified
 
         after = PackTracker.load(repository.store)
-        assert len(after) == 0  # verified intact, so the corrupt record is dropped
+        assert after.table[intact_id].result == 1  # verified intact, corrupt record replaced
 
 
 def test_check_full_prunes_corrupt_record_of_vanished_pack(tmp_path):
-    # a corrupt record for a pack that is no longer listed is dropped at cycle end.
+    # a corrupt record for a pack that is no longer listed is dropped when the check finishes.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        _store_intact_pack(repository)
+        intact_id, _ = _store_intact_pack(repository)
 
         tracker = PackTracker.new(repository.store)
         tracker.record(H(9), ok=False)  # no such pack in packs/
@@ -1198,19 +1198,20 @@ def test_check_full_prunes_corrupt_record_of_vanished_pack(tmp_path):
         assert repository.check(repair=False) is True
 
         after = PackTracker.load(repository.store)
-        assert len(after) == 0
+        assert H(9) not in after.table
+        assert intact_id in after.table
 
 
 def test_check_partial_keeps_corrupt_record_across_runs(tmp_path):
-    # corrupt records survive a partial check that completes its cycle, too.
+    # corrupt records survive completed partial checks, too.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         corrupt_id = _store_corrupt_pack(repository, H(1))
 
-        assert repository.check(repair=False, max_duration=3600) is False
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is False
         assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
 
         # a second run re-verifies it and keeps reporting it.
-        assert repository.check(repair=False, max_duration=3600) is False
+        assert repository.check(repair=False, max_duration=3600, max_age=3600) is False
         assert PackTracker.load(repository.store).corrupt_ids() == [corrupt_id]
 
 
@@ -1229,7 +1230,7 @@ def test_check_max_age_skips_fresh_ok(tmp_path, monkeypatch):
         assert pack_key not in hashed_keys  # skipped, its record is fresh
 
         after = PackTracker.load(repository.store)
-        assert after.table[intact_id].result == 1  # kept across the cycle
+        assert after.table[intact_id].result == 1  # record kept
 
 
 def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
@@ -1267,7 +1268,7 @@ def test_check_max_age_reverifies_corrupt_even_when_fresh(tmp_path, monkeypatch)
 
 
 def test_check_max_age_prunes_vanished_ok_record(tmp_path):
-    # with max_age, an intact record for a pack no longer listed is pruned at cycle end.
+    # an intact record for a pack no longer listed is pruned when the check finishes.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, _ = _store_intact_pack(repository)
 
@@ -1305,6 +1306,19 @@ def test_check_max_age_partial_progress(tmp_path, monkeypatch):
 
         after = PackTracker.load(repository.store)
         assert pack_a_id in after.table and pack_b_id in after.table
+
+
+def test_check_max_age_reuses_records_of_plain_check(tmp_path, monkeypatch):
+    # a check without max_age records its results, a later check with max_age reuses them.
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        intact_id, pack_key = _store_intact_pack(repository)
+
+        assert repository.check(repair=False) is True
+
+        hashed_keys = _spy_hash(repository, monkeypatch)
+
+        assert repository.check(repair=False, max_age=3600) is True
+        assert pack_key not in hashed_keys  # skipped, reusing the plain check's record
 
 
 def test_check_checked_packs_ignores_foreign_entry_layout(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1058,7 +1058,7 @@ def test_check_partial_rechecks_pack_sorting_before_checked_one(tmp_path):
 
 
 def test_check_partial_rechecks_pack_recorded_corrupt(tmp_path):
-    # a pack recorded corrupt earlier is re-verified, so the corruption keeps being reported.
+    # a pack recorded corrupt earlier is re-verified and reported again.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         corrupt_id = H(1)  # stored content does not hash to this name
         repository.store_store("packs/" + bin_to_hex(corrupt_id), b"CORRUPT-does-not-match-name")
@@ -1272,13 +1272,13 @@ def test_check_max_age_skips_fresh_ok(tmp_path, monkeypatch):
 
 
 def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
-    # with max_age, a pack whose intact record is older than max_age plus the skew tolerance is re-verified.
+    # with max_age, a pack whose intact record is older than max_age is re-verified.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
         max_age = 50
         tracker = PackTracker.new(repository.store)
-        old_ts = int(time.time()) - (max_age + MAX_CLOCK_SKEW + 100)  # clearly beyond max_age + skew
+        old_ts = int(time.time()) - (max_age + 100)  # clearly beyond max_age
         tracker.table[intact_id] = PackTracker.Entry(timestamp=old_ts, result=1)
         tracker.save()
 
@@ -1291,27 +1291,25 @@ def test_check_max_age_reverifies_stale_ok(tmp_path, monkeypatch):
         assert after.table[intact_id].timestamp > old_ts  # record refreshed
 
 
-def test_check_max_age_skips_stale_within_skew(tmp_path, monkeypatch):
-    # a record older than max_age but within MAX_CLOCK_SKEW of it still counts as recent (writer clock
-    # behind ours), so it is not re-verified.
+def test_check_max_age_reverifies_stale_within_skew(tmp_path, monkeypatch):
+    # a record past max_age gets no skew tolerance: it is re-verified even within MAX_CLOCK_SKEW of it.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
-        max_age = MAX_CLOCK_SKEW * 2  # wide window, so the skew tolerance is MAX_CLOCK_SKEW
+        max_age = MAX_CLOCK_SKEW * 2  # window wider than MAX_CLOCK_SKEW
         tracker = PackTracker.new(repository.store)
-        past_ts = int(time.time()) - (max_age + MAX_CLOCK_SKEW // 2)  # past the window, within skew
+        past_ts = int(time.time()) - (max_age + MAX_CLOCK_SKEW // 2)  # just past the window
         tracker.table[intact_id] = PackTracker.Entry(timestamp=past_ts, result=1)
         tracker.save()
 
         hashed_keys = _spy_hash(repository, monkeypatch)
 
         assert repository.check(repair=False, max_age=max_age) is True
-        assert pack_key not in hashed_keys  # within MAX_CLOCK_SKEW past the window, still recent
+        assert pack_key in hashed_keys  # past max_age, re-verified
 
 
 def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):
-    # with a window wider than MAX_CLOCK_SKEW, a record timestamped up to MAX_CLOCK_SKEW into the
-    # future (writer clock ahead of ours) still counts as recent and is not re-verified.
+    # a future timestamp (writer clock ahead of ours) up to MAX_CLOCK_SKEW is tolerated and skipped.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1323,12 +1321,11 @@ def test_check_max_age_skips_near_future_ok(tmp_path, monkeypatch):
         hashed_keys = _spy_hash(repository, monkeypatch)
 
         assert repository.check(repair=False, max_age=MAX_CLOCK_SKEW * 2) is True
-        assert pack_key not in hashed_keys  # within MAX_CLOCK_SKEW ahead, still counts as recent
+        assert pack_key not in hashed_keys  # within MAX_CLOCK_SKEW ahead, skipped
 
 
 def test_check_max_age_reverifies_far_future_ok(tmp_path, monkeypatch):
-    # with a window wider than MAX_CLOCK_SKEW, a record more than MAX_CLOCK_SKEW into the future is
-    # not plausible clock skew and is re-verified.
+    # a future timestamp more than MAX_CLOCK_SKEW ahead exceeds the skew tolerance and is re-verified.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         intact_id, pack_key = _store_intact_pack(repository)
 
@@ -1340,7 +1337,7 @@ def test_check_max_age_reverifies_far_future_ok(tmp_path, monkeypatch):
         hashed_keys = _spy_hash(repository, monkeypatch)
 
         assert repository.check(repair=False, max_age=MAX_CLOCK_SKEW * 2) is True
-        assert pack_key in hashed_keys  # too far ahead to be clock skew, re-verified
+        assert pack_key in hashed_keys  # more than MAX_CLOCK_SKEW ahead, re-verified
 
 
 def test_check_max_age_reverifies_future_beyond_small_window(tmp_path, monkeypatch):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1083,8 +1083,9 @@ def _spy_hash(repository, monkeypatch):
     return hashed_keys
 
 
-def _store_intact_pack(repository):
-    intact = fchunk(b"INTACT", chunk_id=H(1))
+def _store_intact_pack(repository, chunk_id=H(1)):
+    # a distinct chunk_id yields distinct bytes and thus a distinct sha256 pack id.
+    intact = fchunk(b"INTACT", chunk_id=chunk_id)
     intact_id = sha256(intact).digest()
     pack_key = "packs/" + bin_to_hex(intact_id)
     repository.store_store(pack_key, intact)
@@ -1414,43 +1415,34 @@ def test_check_max_age_partial_progress(tmp_path, monkeypatch):
         assert pack_a_id in after.table and pack_b_id in after.table
 
 
-def test_check_partial_verifies_least_recently_checked_first(tmp_path, monkeypatch):
-    # a partial check verifies the least-recently-checked packs first. with a budget for one pack, the
-    # pack with the oldest recorded result is verified, though its id sorts last.
+def test_check_partial_orders_stale_oldest_first_and_skips_fresh(tmp_path, monkeypatch):
+    # a partial check skips packs whose intact record is younger than max_age and verifies the rest
+    # least-recently-checked first. the sort orders by recorded time, not pack id: the older record is
+    # on the pack whose id sorts later, so an id-ordered scan would verify the two stale packs in the
+    # other order.
     max_age = 3600
-    recent_id = b"\x00" * 32  # sorts first by id
-    older_id = b"\xff" * 32  # sorts last by id
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
-        for pid in (recent_id, older_id):
-            repository.store_store("packs/" + bin_to_hex(pid), b"content-" + pid[:4])
+        fresh_id, fresh_key = _store_intact_pack(repository, chunk_id=H(1))
+        id2, _ = _store_intact_pack(repository, chunk_id=H(2))
+        id3, _ = _store_intact_pack(repository, chunk_id=H(3))
+        older_id, newer_id = (id2, id3) if id2 > id3 else (id3, id2)
+        older_key = "packs/" + bin_to_hex(older_id)
+        newer_key = "packs/" + bin_to_hex(newer_id)
 
         now = int(time.time())
         tracker = PackTracker.new(repository.store)
-        # both records are past max_age, so both need re-verification; the more recently recorded pack
-        # has the id that sorts first.
-        tracker.table[recent_id] = PackTracker.Entry(timestamp=now - (max_age + 100), result=1)
-        tracker.table[older_id] = PackTracker.Entry(timestamp=now - (max_age + 100000), result=1)
+        tracker.table[fresh_id] = PackTracker.Entry(timestamp=now - 10, result=1)  # within max_age
+        tracker.table[older_id] = PackTracker.Entry(timestamp=now - (max_age + 1000), result=1)
+        tracker.table[newer_id] = PackTracker.Entry(timestamp=now - (max_age + 100), result=1)
         tracker.save()
 
-        # freeze the clock and jump it past max_duration after the first hash, so exactly one pack is
-        # verified this run.
-        clock = {"t": 0.0}
-        monkeypatch.setattr(time, "monotonic", lambda: clock["t"])
-        hashed_keys = []
-        orig_hash = repository.store.hash
+        hashed_keys = _spy_hash(repository, monkeypatch)
 
-        def hash_and_advance(key):
-            hashed_keys.append(key)
-            result = orig_hash(key)
-            clock["t"] = 10**9
-            return result
-
-        monkeypatch.setattr(repository.store, "hash", hash_and_advance)
-
-        repository.check(repair=False, max_duration=1, max_age=max_age)
+        assert repository.check(repair=False, max_duration=3600, max_age=max_age) is True
 
         pack_hashes = [key for key in hashed_keys if key.startswith("packs/")]
-        assert pack_hashes == ["packs/" + bin_to_hex(older_id)]  # the oldest recorded pack
+        assert fresh_key not in pack_hashes  # skipped, record younger than max_age
+        assert pack_hashes == [older_key, newer_key]  # oldest record first, ignoring id order
 
 
 def test_check_max_age_reuses_records_of_plain_check(tmp_path, monkeypatch):


### PR DESCRIPTION
Refs #9696.

`cache/checked-packs` maps pack id -> (timestamp, result) and holds the results of the repository pack check. Before this branch its contents were throwaway: a completed check called `tracker.clear()`, which empties the table and deletes the store object, and the next check cleared it again before starting. The records existed only to let a `--max-duration` check resume where the previous one stopped.

That made two things impossible. A cheap cron check could not hand its findings to a later repair, so corrupt pack ids only ever appeared as log lines in whichever run happened to find them. And a check could not reuse a result that was still perfectly good, which matters on remote or cloud storage where hashing every pack takes hours.

This branch keeps the records instead and lets the user decide, at check time, how old a result may be.

**Retention.** Records are kept in all cases. `tracker.clear()` at the end of a check becomes `tracker.prune(pack_ids)`: drop the records whose pack id is no longer listed in `packs/`, then store the rest. Pruning runs after the pack listing has been scanned, on both the completed and the interrupted path.

**Reuse.** The new `borg check --max-age INTERVAL` skips a pack when its recorded result is intact and younger than INTERVAL. Without `--max-age` (the default) every pack is verified, and the results are still recorded. Records of corrupt packs are always re-verified regardless of age, so a repair never acts on a stale failure. `--max-age` cannot be combined with `--repair` or `--archives-only`.

**Partial checks.** Progress comes from the record timestamps: a partial check verifies the least-recently-checked packs first, so repeated `--max-duration` runs cover the whole repository whether or not `--max-age` is set. Bare `--max-duration` keeps working as documented today, so there is no breaking change and no sign-off to make. `--max-age` is a pure optimization on top: with `--max-duration=3600 --max-age=1w`, a daily one hour check skips packs whose result is younger than a week, so it covers the whole repository at most once a week, and no faster than the per-run budget allows.

The summary names the corrupt packs, guarded on `index_errors == 0` so the ids only appear when the pack check actually ran.

No format change and no version bump. Old blobs load unchanged, and an older borg reading a newer blob sees `result=0` entries it re-verifies anyway. A single store object was preferred over a separate `cache/corrupt-packs`, because `result` already encodes the distinction and two files can drift out of sync where one cannot.

`docs/internals/data-structures.rst` describes the retention rule and how `--max-age` and `--max-duration` interact.

Tests in `repository_test.py` and `check_cmd_test.py` cover: intact and corrupt records surviving a completed check; a plain check recording results that a later `--max-age` check reuses; a check without `--max-age` verifying every pack while keeping the records; a carried-over corrupt record being re-verified and replaced once the pack is intact; selective pruning of records whose pack is no longer listed; corrupt records surviving across consecutive partial checks; a partial check verifying the least-recently-checked packs first while skipping packs younger than `--max-age`; the summary naming the corrupt ids; and the argument rules for `--max-age` (rejected with `--repair` and `--archives-only`) and `--max-duration` (requires `--repository-only`). black and ruff are clean.

Not in here: machine-readable output, `--repair` consuming the recorded list, clearing records after a successful repair. Those depend on how `borg check --repair` and a separate repair command end up being split, which is still open.
