### PR TITLE
Fix false repo relocation warning on macOS due to NFC/NFD path differences (#2913)

### DIFF
--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -44,6 +44,7 @@ from .parseformat import sizeof_fmt, sizeof_fmt_iec, sizeof_fmt_decimal, Locatio
 from .parseformat import format_line, replace_placeholders, PlaceholderError, relative_time_marker_validator
 from .parseformat import format_archive, parse_stringified_list, clean_lines
 from .parseformat import location_validator, archivename_validator, comment_validator, tag_validator
+from .parseformat import normalize_local_path
 from .parseformat import BaseFormatter, ArchiveFormatter, ItemFormatter, DiffFormatter, file_status
 from .parseformat import swidth_slice, ellipsis_truncate
 from .parseformat import BorgJsonEncoder, basic_json_data, json_print, json_dump, prepare_dump_dict

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -8,6 +8,7 @@ import os.path
 import re
 import shlex
 import stat
+import unicodedata
 import uuid
 from pathlib import Path
 from typing import ClassVar, Any, TYPE_CHECKING, Literal
@@ -30,7 +31,7 @@ from .time import OutputTimestamp, format_time, safe_timestamp
 from .. import __version__ as borg_version
 from .. import __version_tuple__ as borg_version_tuple
 from ..constants import *  # NOQA
-from ..platformflags import is_win32
+from ..platformflags import is_win32, is_darwin
 
 if TYPE_CHECKING:
     from ..item import ItemDiff
@@ -595,6 +596,17 @@ def _redact_url_credentials(url):
     return url
 
 
+def normalize_local_path(path):
+    """Normalize a local filesystem path's unicode form so paths compare equal regardless of how they were entered.
+
+    On macOS the filesystem returns paths in NFD (decomposed) form, while a path typed as a command line
+    argument is usually in NFC (composed) form. These look identical but are byte-different, which otherwise
+    makes borg believe a repository was relocated (see issue #2913). We normalize to NFD to match what the
+    macOS filesystem uses. On other platforms the path is returned unchanged.
+    """
+    return unicodedata.normalize("NFD", path) if is_darwin else path
+
+
 class Location:
     """Object representing a repository location"""
 
@@ -761,7 +773,7 @@ class Location:
 
     def canonical_path(self):
         if self.proto == "file":
-            return self.path
+            return normalize_local_path(self.path)
         if self.proto in ("rest", "ssh"):
             return (
                 f"{self.proto}://"

--- a/src/borg/security.py
+++ b/src/borg/security.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from .helpers import Error
 from .helpers import get_security_dir
+from .helpers import normalize_local_path
 from .helpers import yes
 from .platform import SaveFile
 
@@ -124,7 +125,11 @@ class SecurityManager:
             previous_location = None
 
         repository_location = self.repository._location.canonical_path()
-        if previous_location and previous_location != repository_location:
+        # Normalize the unicode form of both paths before comparing them: on macOS the same path can be
+        # produced in different normalization forms (NFC when typed, NFD when derived from the filesystem),
+        # which would otherwise be mistaken for a repository relocation (see issue #2913). Normalizing is
+        # idempotent and applied symmetrically, so it never creates a spurious mismatch for remote repos.
+        if previous_location and normalize_local_path(previous_location) != normalize_local_path(repository_location):
             msg = (
                 "Warning: The repository at location {} was previously located at {}\n".format(
                     repository_location, previous_location

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import re
+import unicodedata
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -29,9 +30,10 @@ from ...helpers.parseformat import (
     eval_escapes,
     ChunkerParams,
     use_iec_units,
+    normalize_local_path,
 )
 from ...helpers.time import format_timedelta, parse_timestamp
-from ...platformflags import is_win32
+from ...platformflags import is_win32, is_darwin
 
 
 def test_bin_to_hex():
@@ -338,6 +340,33 @@ class TestLocationWithoutEnv:
         with pytest.raises(ValueError):
             # This is invalid due to the second colon. Correct: 'ssh://user@host/path'.
             Location("ssh://user@host:/path")
+
+
+def test_normalize_local_path():
+    nfc = unicodedata.normalize("NFC", "tëst")  # composed: ë is a single codepoint
+    nfd = unicodedata.normalize("NFD", "tëst")  # decomposed: e + combining diaeresis
+    assert nfc != nfd  # sanity: the two unicode forms really differ byte-wise
+    if is_darwin:
+        # on macOS both forms normalize to the same (NFD) form the filesystem uses
+        assert normalize_local_path(nfc) == normalize_local_path(nfd) == nfd
+    else:
+        # elsewhere it is a no-op
+        assert normalize_local_path(nfc) == nfc
+        assert normalize_local_path(nfd) == nfd
+
+
+def test_canonical_path_unicode_normalization(monkeypatch):
+    # regression test for #2913: a file repo path entered in NFC form (e.g. typed as an argument) and
+    # the same path in NFD form (e.g. derived from os.getcwd() on macOS) must yield the same canonical
+    # path, so borg does not mistake identical-looking paths for a repository relocation.
+    monkeypatch.delenv("BORG_REPO", raising=False)
+    nfc = unicodedata.normalize("NFC", "/absolute/tëst")
+    nfd = unicodedata.normalize("NFD", "/absolute/tëst")
+    if is_darwin:
+        assert Location(nfc).canonical_path() == Location(nfd).canonical_path()
+    else:
+        # on other platforms the filesystem does not normalize, so the forms stay distinct
+        assert Location(nfc).canonical_path() != Location(nfd).canonical_path()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2913.

## Problem

On macOS the filesystem returns paths in **NFD** (decomposed) unicode form, while a path typed as a command line argument is usually in **NFC** (composed) form. These render identically but are byte-different. So accessing a repo whose path contains non-ASCII characters via a relative path / `.` / `$(pwd)` after `cd` made borg believe the repository had been relocated:

```
cd /tmp && mkdir empty
borg init -e none tëst
borg create tëst::test1 /tmp/empty
cd tëst
borg create .::test2 /tmp/empty
>> Warning: The repository at location /private/tmp/tëst was previously located at /private/tmp/tëst
>> Do you want to continue? [yN]
```

The two locations are visually identical because one is NFC and the other NFD.

## Fix

- Add `helpers.normalize_local_path()` — normalizes to NFD on macOS (the form the filesystem itself uses, matching what `patterns.normalize_path()` already does), a no-op on other platforms.
- Run local `file` locations through it in `Location.canonical_path()`.
- Normalize both sides of the comparison in `SecurityManager.assert_location_matches()`, so existing NFC-form security `location` files still match after upgrade (no one-time spurious prompt) and remote (rest/ssh/borgstore) URLs stay consistent (normalization is idempotent and applied symmetrically).

## Scope / safety

- No-op on non-macOS platforms (`is_darwin` is fixed at import time).
- Only affects the repository **location** string used for the security/relocation check and its display — archived file paths are unaffected.

## Tests

Added `test_normalize_local_path` and `test_canonical_path_unicode_normalization` (both platform-aware). Full `parseformat` + archiver `checks` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)