### PR TITLE
fuse: expose POSIX ACLs on Linux mounts, fixes #1042

### DIFF
--- a/docs/usage/mount.rst.inc
+++ b/docs/usage/mount.rst.inc
@@ -113,7 +113,12 @@ This command mounts a repository or an archive as a FUSE filesystem.
 This can be useful for browsing or restoring individual files.
 
 When restoring, take into account that the current FUSE implementation does
-not support special fs flags and ACLs.
+not support special fs flags. On Linux, POSIX ACLs of the archived fs objects
+are exposed (read-only) via the ``system.posix_acl_access`` and
+``system.posix_acl_default`` extended attributes, so tools like ``getfacl`` or
+``rsync -A`` can read them from the mounted archive. Note that the mount does
+not enforce the ACLs for permission checks. On other platforms, ACLs are not
+supported.
 
 When mounting a repository, the top directories will be named like the
 archives and the directory structure below these will be loaded on-demand from

--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -71,7 +71,12 @@ class MountMixIn:
         This can be useful for browsing or restoring individual files.
 
         When restoring, take into account that the current FUSE implementation does
-        not support special fs flags and ACLs.
+        not support special fs flags. On Linux, POSIX ACLs of the archived fs objects
+        are exposed (read-only) via the ``system.posix_acl_access`` and
+        ``system.posix_acl_default`` extended attributes, so tools like ``getfacl`` or
+        ``rsync -A`` can read them from the mounted archive. Note that the mount does
+        not enforce the ACLs for permission checks. On other platforms, ACLs are not
+        supported.
 
         When mounting a repository, the top directories will be named like the
         archives and the directory structure below these will be loaded on-demand from

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -74,8 +74,8 @@ from .helpers import msgpack
 from .storelocking import LockRefresher
 from .helpers.lrucache import LRUCache
 from .item import Item
-from .platform import uid2user, gid2group
-from .platformflags import is_darwin
+from .platform import uid2user, gid2group, acl_text_to_xattr
+from .platformflags import is_darwin, is_linux
 from .repository import Repository
 
 
@@ -92,6 +92,10 @@ def fuse_main():
     else:
         return llfuse.main(workers=1)
 
+
+# on Linux, the kernel exposes POSIX ACLs via these special, binary encoded xattrs.
+# maps the xattr name to the borg item attribute holding the ACL text.
+ACL_XATTRS = {b"system.posix_acl_access": "acl_access", b"system.posix_acl_default": "acl_default"}
 
 # size of some LRUCaches (1 element per simultaneously open file)
 # note: _inode_cache might have rather large elements - Item.chunks can be large!
@@ -676,11 +680,24 @@ class FuseOperations(llfuse.Operations, FuseBackend):
     @async_wrapper
     def listxattr(self, inode, ctx=None):
         item = self.get_item(inode)
-        return item.get("xattrs", {}).keys()
+        names = list(item.get("xattrs", {}).keys())
+        if is_linux:
+            # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
+            names.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
+        return names
 
     @async_wrapper
     def getxattr(self, inode, name, ctx=None):
         item = self.get_item(inode)
+        if is_linux and name in ACL_XATTRS:
+            acl = item.get(ACL_XATTRS[name])
+            if acl is None:
+                raise llfuse.FUSEError(ENOATTR)
+            try:
+                return acl_text_to_xattr(acl, numeric_ids=self.numeric_ids)
+            except ValueError:
+                logger.warning("mount: could not convert ACL of inode %d to the xattr representation", inode)
+                raise llfuse.FUSEError(errno.EIO) from None
         try:
             return item.get("xattrs", {})[name] or b""
         except KeyError:

--- a/src/borg/fuse.py
+++ b/src/borg/fuse.py
@@ -95,7 +95,8 @@ def fuse_main():
 
 # on Linux, the kernel exposes POSIX ACLs via these special, binary encoded xattrs.
 # maps the xattr name to the borg item attribute holding the ACL text.
-ACL_XATTRS = {b"system.posix_acl_access": "acl_access", b"system.posix_acl_default": "acl_default"}
+# empty on platforms we can not do this for, so the mount just does not offer these xattrs there.
+ACL_XATTRS = {b"system.posix_acl_access": "acl_access", b"system.posix_acl_default": "acl_default"} if is_linux else {}
 
 # size of some LRUCaches (1 element per simultaneously open file)
 # note: _inode_cache might have rather large elements - Item.chunks can be large!
@@ -681,15 +682,14 @@ class FuseOperations(llfuse.Operations, FuseBackend):
     def listxattr(self, inode, ctx=None):
         item = self.get_item(inode)
         names = list(item.get("xattrs", {}).keys())
-        if is_linux:
-            # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
-            names.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
+        # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
+        names.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
         return names
 
     @async_wrapper
     def getxattr(self, inode, name, ctx=None):
         item = self.get_item(inode)
-        if is_linux and name in ACL_XATTRS:
+        if name in ACL_XATTRS:
             acl = item.get(ACL_XATTRS[name])
             if acl is None:
                 raise llfuse.FUSEError(ENOATTR)

--- a/src/borg/hlfuse.py
+++ b/src/borg/hlfuse.py
@@ -39,7 +39,8 @@ BLOCK_SIZE = 512  # Standard filesystem block size for st_blocks and statfs
 
 # on Linux, the kernel exposes POSIX ACLs via these special, binary encoded xattrs.
 # maps the xattr name to the borg item attribute holding the ACL text.
-ACL_XATTRS = {"system.posix_acl_access": "acl_access", "system.posix_acl_default": "acl_default"}
+# empty on platforms we can not do this for, so the mount just does not offer these xattrs there.
+ACL_XATTRS = {"system.posix_acl_access": "acl_access", "system.posix_acl_default": "acl_default"} if is_linux else {}
 
 DEBUG_LOG: str | None = None  # os.path.join(os.getcwd(), "fuse_debug.log")
 
@@ -591,9 +592,8 @@ class borgfs(hlfuse.Operations, FuseBackend):
             raise hlfuse.FuseOSError(errno.ENOENT)
         item = self.get_inode(node.ino)
         result = [k.decode("utf-8", "surrogateescape") for k in item.get("xattrs", {}).keys()]
-        if is_linux:
-            # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
-            result.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
+        # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
+        result.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
         debug_log(f"listxattr -> {result}")
         return result
 
@@ -604,7 +604,7 @@ class borgfs(hlfuse.Operations, FuseBackend):
             raise hlfuse.FuseOSError(errno.ENOENT)
         item = self.get_inode(node.ino)
         name_str = name if isinstance(name, str) else name.decode("utf-8", "surrogateescape")
-        if is_linux and name_str in ACL_XATTRS:
+        if name_str in ACL_XATTRS:
             acl = item.get(ACL_XATTRS[name_str])
             if acl is None:
                 debug_log("getxattr -> ENOATTR")

--- a/src/borg/hlfuse.py
+++ b/src/borg/hlfuse.py
@@ -31,11 +31,16 @@ from .helpers import msgpack
 from .storelocking import LockRefresher
 from .helpers.lrucache import LRUCache
 from .item import Item
-from .platform import uid2user, gid2group
-from .platformflags import is_darwin
+from .platform import uid2user, gid2group, acl_text_to_xattr
+from .platformflags import is_darwin, is_linux
 from .repository import Repository
 
 BLOCK_SIZE = 512  # Standard filesystem block size for st_blocks and statfs
+
+# on Linux, the kernel exposes POSIX ACLs via these special, binary encoded xattrs.
+# maps the xattr name to the borg item attribute holding the ACL text.
+ACL_XATTRS = {"system.posix_acl_access": "acl_access", "system.posix_acl_default": "acl_default"}
+
 DEBUG_LOG: str | None = None  # os.path.join(os.getcwd(), "fuse_debug.log")
 
 
@@ -586,6 +591,9 @@ class borgfs(hlfuse.Operations, FuseBackend):
             raise hlfuse.FuseOSError(errno.ENOENT)
         item = self.get_inode(node.ino)
         result = [k.decode("utf-8", "surrogateescape") for k in item.get("xattrs", {}).keys()]
+        if is_linux:
+            # expose the archived POSIX ACLs, so e.g. getfacl or tools copying from the mount can read them.
+            result.extend(xattr_name for xattr_name, attr in ACL_XATTRS.items() if attr in item)
         debug_log(f"listxattr -> {result}")
         return result
 
@@ -595,6 +603,19 @@ class borgfs(hlfuse.Operations, FuseBackend):
         if node is None:
             raise hlfuse.FuseOSError(errno.ENOENT)
         item = self.get_inode(node.ino)
+        name_str = name if isinstance(name, str) else name.decode("utf-8", "surrogateescape")
+        if is_linux and name_str in ACL_XATTRS:
+            acl = item.get(ACL_XATTRS[name_str])
+            if acl is None:
+                debug_log("getxattr -> ENOATTR")
+                raise hlfuse.FuseOSError(ENOATTR)
+            try:
+                result = acl_text_to_xattr(acl, numeric_ids=self.numeric_ids)
+            except ValueError:
+                logger.warning(f"mount: could not convert ACL of {path!r} to the xattr representation")
+                raise hlfuse.FuseOSError(errno.EIO) from None
+            debug_log(f"getxattr -> {len(result)} bytes")
+            return result
         try:
             if isinstance(name, str):
                 name = name.encode("utf-8", "surrogateescape")

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -11,6 +11,7 @@ from ..platformflags import is_win32, is_linux, is_freebsd, is_netbsd, is_darwin
 from .base import ENOATTR
 from .base import SaveFile, sync_dir, fdatasync, safe_fadvise
 from .base import get_process_id, fqdn, hostname, hostid, swidth
+from .base import acl_text_to_xattr  # overridden below for platforms supporting it
 
 # work around pyinstaller "forgetting" to include the xattr module
 from . import xattr  # noqa: F401
@@ -20,6 +21,7 @@ platform_ug: ModuleType | None = None  # make mypy happy
 if is_linux:  # pragma: linux only
     from .linux import listxattr, getxattr, setxattr
     from .linux import acl_get, acl_set
+    from .linux import acl_text_to_xattr  # type: ignore[no-redef]
     from .linux import set_flags, get_flags
     from .linux import SyncFile
     from .posix import process_alive, local_pid_alive

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -85,6 +85,16 @@ def acl_set(path, item, numeric_ids=False, fd=None):
     """
 
 
+def acl_text_to_xattr(acl, numeric_ids=False):
+    """
+    Convert an ACL from the borg item text representation to the binary representation
+    the platform's kernel uses for the ACL extended attributes (used by the FUSE mount).
+
+    Not supported on this platform.
+    """
+    raise NotImplementedError
+
+
 try:
     from os import lchflags  # type: ignore[attr-defined]
 

--- a/src/borg/platform/linux.pyx
+++ b/src/borg/platform/linux.pyx
@@ -1,6 +1,7 @@
 import os
 import re
 import stat
+import struct
 
 from .posix import posix_acl_use_stored_uid_gid
 from . import posix_ug
@@ -358,6 +359,59 @@ def acl_set(path, item, numeric_ids=False, fd=None):
                 raise OSError(errno.errno, os.strerror(errno.errno), os.fsdecode(path))
         finally:
             acl_free(default_acl)
+
+
+# Linux kernel POSIX ACL xattr representation,
+# see linux/include/uapi/linux/posix_acl_xattr.h and linux/include/linux/posix_acl.h.
+_ACL_XATTR_VERSION = 2
+_ACL_UNDEFINED_ID = 0xFFFFFFFF
+# maps the ACL entry type to the e_tag values used for (unnamed, named) entries of that type.
+_ACL_TAGS = {
+    'user': (0x01, 0x02),   # ACL_USER_OBJ, ACL_USER
+    'group': (0x04, 0x08),  # ACL_GROUP_OBJ, ACL_GROUP
+    'mask': (0x10, None),   # ACL_MASK
+    'other': (0x20, None),  # ACL_OTHER
+}
+_ACL_PERMS = {'r': 4, 'w': 2, 'x': 1, '-': 0}
+
+
+def acl_text_to_xattr(acl, numeric_ids=False):
+    """Convert an ACL from the borg item text representation (acl_access / acl_default)
+    to the binary representation the Linux kernel uses for the system.posix_acl_access /
+    system.posix_acl_default extended attributes.
+
+    If `numeric_ids` is True, the stored numeric ids are used, otherwise the stored
+    user/group names are mapped to local uids/gids (falling back to the stored ids).
+
+    Raises ValueError for ACL text that can not be converted.
+    """
+    assert isinstance(acl, bytes)
+    converter = posix_acl_use_stored_uid_gid if numeric_ids else acl_use_local_uid_gid
+    entries = []
+    try:
+        for entry in safe_decode(converter(acl)).split('\n'):
+            if not entry:
+                continue
+            typ, qualifier, perm = entry.split(':')[:3]
+            unnamed_tag, named_tag = _ACL_TAGS[typ]
+            if qualifier:
+                if named_tag is None:
+                    raise ValueError(f"unexpected qualifier in ACL entry: {entry}")
+                tag, qid = named_tag, int(qualifier)
+            else:
+                tag, qid = unnamed_tag, _ACL_UNDEFINED_ID
+            perms = 0
+            for p in perm:
+                perms |= _ACL_PERMS[p]
+            entries.append((tag, perms, qid))
+    except (IndexError, KeyError, ValueError) as e:
+        raise ValueError(f"unsupported ACL: {acl!r}") from e
+    # the kernel expects the entries in canonical order: owner, named users, owning group,
+    # named groups, mask, other - with named entries sorted by id. the stored text should
+    # already be in this order (libacl produces it), but do not rely on that.
+    entries.sort(key=lambda e: (e[0], e[2]))
+    return b''.join([struct.pack('<I', _ACL_XATTR_VERSION)] +
+                    [struct.pack('<HHI', tag, perms, qid) for tag, perms, qid in entries])
 
 
 cdef _sync_file_range(fd, offset, length, flags):

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -18,7 +18,8 @@ from ...helpers import flags_noatime, flags_normal
 from .. import has_lchflags, has_any_fuse, ENOATTR
 from .. import changedir, filter_xattrs, same_ts_ns
 from .. import are_symlinks_supported, are_hardlinks_supported, are_fifos_supported
-from ..platform.platform_test import fakeroot_detected
+from ..platform.platform_test import fakeroot_detected, skipif_not_linux, skipif_fakeroot_detected
+from ..platform.platform_test import skipif_acls_not_working
 from . import RK_ENCRYPTION, cmd, assert_dirs_equal, create_regular_file, create_src_archive, open_archive, src_file
 from . import requires_hardlinks, _extract_hardlinks_setup, fuse_mount, create_test_files, generate_archiver_tests
 
@@ -170,6 +171,62 @@ def test_fuse(archivers, request):
                 pass
             else:
                 raise
+
+
+@pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")
+@skipif_not_linux
+@skipif_fakeroot_detected
+@skipif_acls_not_working
+def test_fuse_acls(archivers, request):
+    # on Linux, the FUSE mount exposes archived POSIX ACLs via the system.posix_acl_* xattrs.
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    file_path = os.path.join(archiver.input_path, "file1")
+    access_acl = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n"
+    default_acl = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:r--:9999\ngroup:root:r--:9999\n"
+    platform.acl_set(file_path, {"acl_access": access_acl})
+    dir_path = os.path.join(archiver.input_path, "dir1")
+    os.mkdir(dir_path)
+    platform.acl_set(dir_path, {"acl_access": access_acl, "acl_default": default_acl})
+    cmd(archiver, "create", "archive", "input")
+    mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
+    with fuse_mount(archiver, mountpoint, "-a", "archive"):
+        mounted_file = os.path.join(mountpoint, "archive", "input", "file1")
+        mounted_dir = os.path.join(mountpoint, "archive", "input", "dir1")
+        # the ACL xattrs must be listed:
+        assert "system.posix_acl_access" in os.listxattr(mounted_file)
+        assert "system.posix_acl_default" not in os.listxattr(mounted_file)
+        assert "system.posix_acl_access" in os.listxattr(mounted_dir)
+        assert "system.posix_acl_default" in os.listxattr(mounted_dir)
+        # the binary xattr values must be identical to what the kernel provides for the source fs objects:
+        try:
+            mounted_file_acl = os.getxattr(mounted_file, "system.posix_acl_access")
+        except OSError as e:
+            if e.errno == errno.ENOTSUP:
+                # the kernel refuses POSIX ACL xattr passthrough for FUSE mounts inside user
+                # namespaces (e.g. rootless containers) unless FUSE_POSIX_ACL is negotiated,
+                # which our FUSE implementations do not support.
+                pytest.skip("kernel refuses ACL xattrs on FUSE mounts inside user namespaces")
+            raise
+        assert mounted_file_acl == os.getxattr(file_path, "system.posix_acl_access")
+        for name in ("system.posix_acl_access", "system.posix_acl_default"):
+            assert os.getxattr(mounted_dir, name) == os.getxattr(dir_path, name)
+        # borg's own ACL code (going through libacl, like getfacl or tools copying
+        # from the mount would) must see the same ACLs through the mount:
+        item_src, item_mnt = {}, {}
+        platform.acl_get(file_path, item_src, os.stat(file_path))
+        platform.acl_get(mounted_file, item_mnt, os.stat(mounted_file))
+        assert item_src["acl_access"] == item_mnt["acl_access"]
+        item_src, item_mnt = {}, {}
+        platform.acl_get(dir_path, item_src, os.stat(dir_path))
+        platform.acl_get(mounted_dir, item_mnt, os.stat(mounted_dir))
+        assert item_src["acl_access"] == item_mnt["acl_access"]
+        assert item_src["acl_default"] == item_mnt["acl_default"]
+    # also check with --numeric-ids:
+    with fuse_mount(archiver, mountpoint, "-a", "archive", "--numeric-ids"):
+        mounted_file = os.path.join(mountpoint, "archive", "input", "file1")
+        assert os.getxattr(mounted_file, "system.posix_acl_access") == os.getxattr(file_path, "system.posix_acl_access")
 
 
 @pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")

--- a/src/borg/testsuite/fuse_test.py
+++ b/src/borg/testsuite/fuse_test.py
@@ -1,0 +1,154 @@
+"""Tests for the FUSE filesystem implementations that do not need an actual mount.
+
+The ACL xattrs (see ACL_XATTRS) are emulated by the FUSE implementations, so we can
+test them by directly calling the relevant methods with a fake item. Unlike the tests
+in archiver/mount_cmds_test.py, this also works in environments where the kernel does
+not offer ACL xattrs on FUSE mounts (e.g. mounts made inside a user namespace).
+"""
+
+import errno
+
+import pytest
+
+from ..helpers import StableDict
+from ..item import Item
+from ..platform import acl_text_to_xattr
+from . import has_llfuse, has_pyfuse3, has_mfusepy, ENOATTR
+from .platform.platform_test import skipif_not_linux
+
+# the ACL xattrs are only emulated on Linux:
+pytestmark = skipif_not_linux
+
+skipif_no_llfuse_api = pytest.mark.skipif(not (has_llfuse or has_pyfuse3), reason="llfuse/pyfuse3 not available")
+skipif_no_mfusepy = pytest.mark.skipif(not has_mfusepy, reason="mfusepy not available")
+
+ACCESS_ACL = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:0\ngroup:root:rw-:0\n"
+DEFAULT_ACL = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:r--:0\ngroup:root:r--:0\n"
+BROKEN_ACL = b"flubber::rw-\n"  # can not be converted to the binary xattr representation
+
+
+def make_item(*, acls=True, acl_access=ACCESS_ACL):
+    item = Item(path="file", mode=0o100666, mtime=0, xattrs=StableDict({b"user.foo": b"bar"}))
+    if acls:
+        item.acl_access = acl_access
+        item.acl_default = DEFAULT_ACL
+    return item
+
+
+def unwrap(method):
+    """Get the undecorated method: with pyfuse3, the FUSE operations are async wrapped."""
+    return getattr(method, "__wrapped__", method)
+
+
+def llfuse_ops(item, numeric_ids=False):
+    """Minimal stand-in for FuseOperations, providing what listxattr/getxattr need."""
+    from ..fuse import FuseOperations
+
+    class Operations:
+        pass
+
+    ops = Operations()
+    ops.numeric_ids = numeric_ids
+    ops.get_item = lambda inode: item
+    return ops, unwrap(FuseOperations.listxattr), unwrap(FuseOperations.getxattr)
+
+
+def mfusepy_ops(item, numeric_ids=False):
+    """Minimal stand-in for borgfs, providing what listxattr/getxattr need."""
+    from ..hlfuse import borgfs
+
+    class Node:
+        ino = 1
+
+    class Operations:
+        pass
+
+    ops = Operations()
+    ops.numeric_ids = numeric_ids
+    ops._find_node = lambda path: Node()
+    ops.get_inode = lambda ino: item
+    return ops, borgfs.listxattr, borgfs.getxattr
+
+
+@skipif_no_llfuse_api
+def test_llfuse_listxattr_acls():
+    ops, listxattr, _ = llfuse_ops(make_item())
+    assert sorted(listxattr(ops, 1)) == [b"system.posix_acl_access", b"system.posix_acl_default", b"user.foo"]
+
+
+@skipif_no_llfuse_api
+def test_llfuse_listxattr_no_acls():
+    ops, listxattr, _ = llfuse_ops(make_item(acls=False))
+    assert list(listxattr(ops, 1)) == [b"user.foo"]
+
+
+@skipif_no_llfuse_api
+@pytest.mark.parametrize("numeric_ids", [False, True])
+def test_llfuse_getxattr_acls(numeric_ids):
+    ops, _, getxattr = llfuse_ops(make_item(), numeric_ids=numeric_ids)
+    assert getxattr(ops, 1, b"system.posix_acl_access") == acl_text_to_xattr(ACCESS_ACL, numeric_ids=numeric_ids)
+    assert getxattr(ops, 1, b"system.posix_acl_default") == acl_text_to_xattr(DEFAULT_ACL, numeric_ids=numeric_ids)
+    assert getxattr(ops, 1, b"user.foo") == b"bar"  # "normal" xattrs still work
+
+
+@skipif_no_llfuse_api
+def test_llfuse_getxattr_acl_missing():
+    from ..fuse_impl import llfuse
+
+    ops, _, getxattr = llfuse_ops(make_item(acls=False))
+    with pytest.raises(llfuse.FUSEError) as excinfo:
+        getxattr(ops, 1, b"system.posix_acl_access")
+    assert excinfo.value.errno == ENOATTR
+
+
+@skipif_no_llfuse_api
+def test_llfuse_getxattr_acl_broken():
+    from ..fuse_impl import llfuse
+
+    ops, _, getxattr = llfuse_ops(make_item(acl_access=BROKEN_ACL))
+    with pytest.raises(llfuse.FUSEError) as excinfo:
+        getxattr(ops, 1, b"system.posix_acl_access")
+    assert excinfo.value.errno == errno.EIO
+
+
+@skipif_no_mfusepy
+def test_mfusepy_listxattr_acls():
+    ops, listxattr, _ = mfusepy_ops(make_item())
+    assert sorted(listxattr(ops, "/file")) == ["system.posix_acl_access", "system.posix_acl_default", "user.foo"]
+
+
+@skipif_no_mfusepy
+def test_mfusepy_listxattr_no_acls():
+    ops, listxattr, _ = mfusepy_ops(make_item(acls=False))
+    assert list(listxattr(ops, "/file")) == ["user.foo"]
+
+
+@skipif_no_mfusepy
+@pytest.mark.parametrize("numeric_ids", [False, True])
+def test_mfusepy_getxattr_acls(numeric_ids):
+    ops, _, getxattr = mfusepy_ops(make_item(), numeric_ids=numeric_ids)
+    access = getxattr(ops, "/file", "system.posix_acl_access")
+    assert access == acl_text_to_xattr(ACCESS_ACL, numeric_ids=numeric_ids)
+    default = getxattr(ops, "/file", "system.posix_acl_default")
+    assert default == acl_text_to_xattr(DEFAULT_ACL, numeric_ids=numeric_ids)
+    assert getxattr(ops, "/file", "user.foo") == b"bar"  # "normal" xattrs still work
+
+
+@skipif_no_mfusepy
+def test_mfusepy_getxattr_acl_missing():
+    from ..fuse_impl import hlfuse
+
+    ops, _, getxattr = mfusepy_ops(make_item(acls=False))
+    with pytest.raises(hlfuse.FuseOSError) as excinfo:
+        getxattr(ops, "/file", "system.posix_acl_default")
+    assert excinfo.value.errno == ENOATTR
+
+
+@skipif_no_mfusepy
+def test_mfusepy_getxattr_acl_broken():
+    from ..fuse_impl import hlfuse
+
+    ops, _, getxattr = mfusepy_ops(make_item(acl_access=BROKEN_ACL))
+    with pytest.raises(hlfuse.FuseOSError) as excinfo:
+        getxattr(ops, "/file", "system.posix_acl_access")
+    assert excinfo.value.errno == errno.EIO

--- a/src/borg/testsuite/platform/linux_test.py
+++ b/src/borg/testsuite/platform/linux_test.py
@@ -1,5 +1,8 @@
 import os
+import struct
 import tempfile
+
+import pytest
 
 from ...platform import acl_get, acl_set
 from .platform_test import skipif_not_linux, skipif_fakeroot_detected, skipif_acls_not_working, skipif_no_ubel_user
@@ -113,6 +116,48 @@ def test_non_ascii_acl():
     acl_access_numeric = get_acl(file.name, numeric_ids=True)["acl_access"]
     assert user_entry_numeric in acl_access_numeric
     assert group_entry_numeric in acl_access_numeric
+
+
+def test_acl_text_to_xattr():
+    from ...platform.linux import acl_text_to_xattr
+
+    acl = b"user::rw-\nuser:root:rw-:0\nuser:9999:r--:9999\ngroup::r--\ngroup:8888:rw-:8888\nmask::rw-\nother::r--"
+    binary = acl_text_to_xattr(acl, numeric_ids=True)
+    header, entries = binary[:4], binary[4:]
+    assert header == (2).to_bytes(4, "little")  # POSIX_ACL_XATTR_VERSION
+    parsed = [struct.unpack("<HHI", entries[i : i + 8]) for i in range(0, len(entries), 8)]
+    assert parsed == [
+        (0x01, 6, 0xFFFFFFFF),  # ACL_USER_OBJ  user::rw-
+        (0x02, 6, 0),  # ACL_USER  user:root:rw-:0
+        (0x02, 4, 9999),  # ACL_USER  user:9999:r--:9999
+        (0x04, 4, 0xFFFFFFFF),  # ACL_GROUP_OBJ  group::r--
+        (0x08, 6, 8888),  # ACL_GROUP  group:8888:rw-:8888
+        (0x10, 6, 0xFFFFFFFF),  # ACL_MASK  mask::rw-
+        (0x20, 4, 0xFFFFFFFF),  # ACL_OTHER  other::r--
+    ]
+    # unconvertible ACL text must raise ValueError:
+    with pytest.raises(ValueError):
+        acl_text_to_xattr(b"user:someuser:rw-")  # named entry without a stored numeric id
+    with pytest.raises(ValueError):
+        acl_text_to_xattr(b"flubber::rw-", numeric_ids=True)  # unknown entry type
+    with pytest.raises(ValueError):
+        acl_text_to_xattr(b"mask:0:rw-:0", numeric_ids=True)  # mask must not have a qualifier
+
+
+@skipif_acls_not_working
+def test_acl_text_to_xattr_matches_kernel():
+    from ...platform.linux import acl_text_to_xattr
+
+    file = tempfile.NamedTemporaryFile()
+    access = b"user::rw-\ngroup::r--\nmask::rw-\nother::---\nuser:root:rw-:9999\ngroup:root:rw-:9999\n"
+    set_acl(file.name, access=access)
+    kernel_binary = os.getxattr(file.name, "system.posix_acl_access")
+    # borg stores the ACL as text - converting that back to the binary xattr
+    # representation must give exactly what the kernel produced itself.
+    item = get_acl(file.name)
+    assert acl_text_to_xattr(item["acl_access"]) == kernel_binary
+    item = get_acl(file.name, numeric_ids=True)
+    assert acl_text_to_xattr(item["acl_access"], numeric_ids=True) == kernel_binary
 
 
 def test_utils():


### PR DESCRIPTION
Fixes #1042.

The FUSE mount did not expose the archived ACLs at all, so tools reading from a mounted archive (`getfacl`, `rsync -A`, `cp --preserve=all`, ...) did not see them.

### What it does

On Linux, POSIX ACLs are exposed by the kernel via the special `system.posix_acl_access` / `system.posix_acl_default` xattrs, which use a binary format (see `linux/include/uapi/linux/posix_acl_xattr.h`): a 4 byte little-endian version header, followed by 8 byte entries of `{__le16 e_tag, __le16 e_perm, __le32 e_id}`.

- `acl_text_to_xattr()` (platform/linux.pyx) converts from our stored ACL text representation (`acl_access` / `acl_default`) to that binary format. It reuses the existing `acl_use_local_uid_gid` / `posix_acl_use_stored_uid_gid` converters, so `--numeric-ids` behaves like it does for `borg extract`.
- `listxattr` / `getxattr` serve those xattrs in both FUSE implementations: `fuse.py` (llfuse/pyfuse3) and `hlfuse.py` (mfusepy).
- Stub in `platform/base.py` + dispatch in `platform/__init__.py`, so non-Linux platforms are unaffected.
- ACL text that can not be converted raises `ValueError`, which the FUSE layer turns into a warning + `EIO` instead of killing the mount.

### Why the previous attempt did not work

#8843 returned libacl's internal `acl_t` structure (sized via `acl_size()`). That is libacl's own representation, not the kernel's xattr wire format, so the kernel could not make sense of it.

To make sure this does not happen again, the conversion is tested against what the kernel itself produces: `test_acl_text_to_xattr_matches_kernel` sets an ACL on a real file, reads the raw `system.posix_acl_access` xattr the kernel returns, and requires `acl_text_to_xattr()` output to be **byte identical** to it (named and numeric mode).

### Limitations

- Read-only exposure: the mount does not enforce the ACLs for permission checks (we do not negotiate `FUSE_POSIX_ACL`).
- Linux only. Other platforms keep the previous behaviour (no ACLs on the mount).
- Since kernel 6.2 (`facd61053cff`), the kernel refuses ACL xattr passthrough for FUSE mounts whose superblock lives in a **non-initial user namespace** (e.g. a mount made inside a rootless container) unless `FUSE_POSIX_ACL` was negotiated - and none of the Python FUSE bindings expose that init flag. For init-userns mounts (normal hosts, CI) the kernel does the plain passthrough as before, so this works there. The e2e test skips with a clear reason in the userns case.

### Tests

- `test_acl_text_to_xattr` - binary format / error handling unit test.
- `test_acl_text_to_xattr_matches_kernel` - byte-identity against the kernel, see above.
- `test_fuse_acls` - e2e: file + dir with access and default ACLs, archived and mounted, compared against the source fs objects both at raw xattr level and via `platform.acl_get()`, with and without `--numeric-ids`.

Ran locally on Linux (container) with both `pyfuse3` and `mfusepy`; `mypy`, `ruff` and `black` are happy.

Docs (mount epilog) updated - they claimed ACLs were not supported.
