### PR TITLE
CI: fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - uses: astral-sh/ruff-action@v3
+    - uses: astral-sh/ruff-action@v4.1.0
 
   security:
 
@@ -424,169 +424,172 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Test on ${{ matrix.display_name }}
+      - name: Start VM for ${{ matrix.display_name }}
         id: cross_os
         uses: cross-platform-actions/action@v1.3.0
-        env:
-          DO_BINARIES: ${{ matrix.do_binaries }}
         with:
           operating_system: ${{ matrix.os }}
           version: ${{ matrix.version }}
           shell: bash
-          run: |
-            set -euxo pipefail
 
-            case "${{ matrix.os }}" in
-              freebsd)
-                export IGNORE_OSVERSION=yes
-                sudo -E pkg update -f
-                sudo -E pkg install -y liblz4 pkgconf
-                sudo -E pkg install -y fusefs-libs
-                sudo -E kldload fusefs
-                sudo -E sysctl vfs.usermount=1
-                sudo -E chmod 666 /dev/fuse
-                sudo -E pkg install -y rust
-                sudo -E pkg install -y gmake
-                sudo -E pkg install -y git
-                sudo -E pkg install -y python314 py314-sqlite3
-                sudo ln -sf /usr/local/bin/python3.14 /usr/local/bin/python3
-                sudo ln -sf /usr/local/bin/python3.14 /usr/local/bin/python
-                sudo ln -sf /usr/local/bin/pip3.14 /usr/local/bin/pip3
-                sudo ln -sf /usr/local/bin/pip3.14 /usr/local/bin/pip
+      - name: Test on ${{ matrix.display_name }}
+        shell: cpa.sh {0}
+        env:
+          DO_BINARIES: ${{ matrix.do_binaries }}
+        run: |
+          set -euxo pipefail
 
-                # required for libsodium/pynacl build
-                export MAKE=gmake
+          case "${{ matrix.os }}" in
+            freebsd)
+              export IGNORE_OSVERSION=yes
+              sudo -E pkg update -f
+              sudo -E pkg install -y liblz4 pkgconf
+              sudo -E pkg install -y fusefs-libs
+              sudo -E kldload fusefs
+              sudo -E sysctl vfs.usermount=1
+              sudo -E chmod 666 /dev/fuse
+              sudo -E pkg install -y rust
+              sudo -E pkg install -y gmake
+              sudo -E pkg install -y git
+              sudo -E pkg install -y python314 py314-sqlite3
+              sudo ln -sf /usr/local/bin/python3.14 /usr/local/bin/python3
+              sudo ln -sf /usr/local/bin/python3.14 /usr/local/bin/python
+              sudo ln -sf /usr/local/bin/pip3.14 /usr/local/bin/pip3
+              sudo ln -sf /usr/local/bin/pip3.14 /usr/local/bin/pip
 
-                python -m venv .venv
-                . .venv/bin/activate
-                python -V
-                pip -V
-                python -m pip install --upgrade pip wheel
-                pip install -r requirements.d/development.lock.txt
-                pip install -e ".[mfusepy,cockpit,s3,sftp,rclone]"
-                if [[ "${{ matrix.do_binaries }}" == "true" && "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-                  python -m pip install -r requirements.d/pyinstaller.txt
-                  ./scripts/build-borg-using-pyinstaller.sh
-                  pushd dist/binary
-                  echo "single-file binary"
-                  chmod +x borg.exe
-                  ./borg.exe -V
-                  echo "single-directory binary"
-                  chmod +x borg-dir/borg.exe
-                  ./borg-dir/borg.exe -V
-                  tar czf borg.tgz borg-dir
-                  popd
-                  mkdir -p artifacts
-                  if [ -f dist/binary/borg.exe ]; then
-                    cp -v dist/binary/borg.exe artifacts/${{ matrix.artifact_prefix }}
-                  fi
-                  if [ -f dist/binary/borg.tgz ]; then
-                    cp -v dist/binary/borg.tgz artifacts/${{ matrix.artifact_prefix }}.tgz
-                  fi
+              # required for libsodium/pynacl build
+              export MAKE=gmake
+
+              python -m venv .venv
+              . .venv/bin/activate
+              python -V
+              pip -V
+              python -m pip install --upgrade pip wheel
+              pip install -r requirements.d/development.lock.txt
+              pip install -e ".[mfusepy,cockpit,s3,sftp,rclone]"
+              if [[ "${{ matrix.do_binaries }}" == "true" && "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+                python -m pip install -r requirements.d/pyinstaller.txt
+                ./scripts/build-borg-using-pyinstaller.sh
+                pushd dist/binary
+                echo "single-file binary"
+                chmod +x borg.exe
+                ./borg.exe -V
+                echo "single-directory binary"
+                chmod +x borg-dir/borg.exe
+                ./borg-dir/borg.exe -V
+                tar czf borg.tgz borg-dir
+                popd
+                mkdir -p artifacts
+                if [ -f dist/binary/borg.exe ]; then
+                  cp -v dist/binary/borg.exe artifacts/${{ matrix.artifact_prefix }}
                 fi
-                export PATH="$(pwd)/dist/binary:$PATH"
-                tox -e py314-mfusepy
-                ;;
+                if [ -f dist/binary/borg.tgz ]; then
+                  cp -v dist/binary/borg.tgz artifacts/${{ matrix.artifact_prefix }}.tgz
+                fi
+              fi
+              export PATH="$(pwd)/dist/binary:$PATH"
+              tox -e py314-mfusepy
+              ;;
 
-              netbsd)
-                arch="$(uname -m)"
-                sudo -E mkdir -p /usr/pkg/etc/pkgin
-                echo "https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/10.1/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
-                sudo -E pkgin update
-                sudo -E pkgin -y upgrade
-                sudo -E pkgin -y install lz4 git
-                sudo -E pkgin -y install rust
-                sudo -E pkgin -y install pkg-config
-                sudo -E pkgin -y install py311-pip py311-virtualenv py311-tox
-                sudo -E ln -sf /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
-                sudo -E ln -sf /usr/pkg/bin/pip3.11 /usr/pkg/bin/pip3
-                sudo -E ln -sf /usr/pkg/bin/virtualenv-3.11 /usr/pkg/bin/virtualenv3
-                sudo -E ln -sf /usr/pkg/bin/tox-3.11 /usr/pkg/bin/tox3
+            netbsd)
+              arch="$(uname -m)"
+              sudo -E mkdir -p /usr/pkg/etc/pkgin
+              echo "https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/10.1/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
+              sudo -E pkgin update
+              sudo -E pkgin -y upgrade
+              sudo -E pkgin -y install lz4 git
+              sudo -E pkgin -y install rust
+              sudo -E pkgin -y install pkg-config
+              sudo -E pkgin -y install py311-pip py311-virtualenv py311-tox
+              sudo -E ln -sf /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
+              sudo -E ln -sf /usr/pkg/bin/pip3.11 /usr/pkg/bin/pip3
+              sudo -E ln -sf /usr/pkg/bin/virtualenv-3.11 /usr/pkg/bin/virtualenv3
+              sudo -E ln -sf /usr/pkg/bin/tox-3.11 /usr/pkg/bin/tox3
 
-                # Ensure base system admin tools are on PATH for the non-root shell
-                export PATH="/sbin:/usr/sbin:$PATH"
+              # Ensure base system admin tools are on PATH for the non-root shell
+              export PATH="/sbin:/usr/sbin:$PATH"
 
-                echo "--- Preparing an extattr-enabled filesystem ---"
-                # On many NetBSD setups /tmp is tmpfs without extended attributes.
-                # Create a FFS image with extended attributes enabled and use it for TMPDIR.
-                VNDDEV="vnd0"
-                IMGFILE="/tmp/fs.img"
-                sudo -E dd if=/dev/zero of=${IMGFILE} bs=1m count=1024
-                sudo -E vndconfig -c "${VNDDEV}" "${IMGFILE}"
-                sudo -E newfs -O 2ea /dev/r${VNDDEV}a
-                MNT="/mnt/eafs"
-                sudo -E mkdir -p ${MNT}
-                sudo -E mount -t ffs -o extattr /dev/${VNDDEV}a $MNT
-                export TMPDIR="${MNT}/tmp"
-                sudo -E mkdir -p ${TMPDIR}
-                sudo -E chmod 1777 ${TMPDIR}
+              echo "--- Preparing an extattr-enabled filesystem ---"
+              # On many NetBSD setups /tmp is tmpfs without extended attributes.
+              # Create a FFS image with extended attributes enabled and use it for TMPDIR.
+              VNDDEV="vnd0"
+              IMGFILE="/tmp/fs.img"
+              sudo -E dd if=/dev/zero of=${IMGFILE} bs=1m count=1024
+              sudo -E vndconfig -c "${VNDDEV}" "${IMGFILE}"
+              sudo -E newfs -O 2ea /dev/r${VNDDEV}a
+              MNT="/mnt/eafs"
+              sudo -E mkdir -p ${MNT}
+              sudo -E mount -t ffs -o extattr /dev/${VNDDEV}a $MNT
+              export TMPDIR="${MNT}/tmp"
+              sudo -E mkdir -p ${TMPDIR}
+              sudo -E chmod 1777 ${TMPDIR}
 
-                touch ${TMPDIR}/testfile
-                lsextattr user ${TMPDIR}/testfile && echo "[xattr] *** xattrs SUPPORTED on ${TMPDIR}! ***"
+              touch ${TMPDIR}/testfile
+              lsextattr user ${TMPDIR}/testfile && echo "[xattr] *** xattrs SUPPORTED on ${TMPDIR}! ***"
 
-                tox3 -e py311-none
-                ;;
+              tox3 -e py311-none
+              ;;
 
-              openbsd)
-                sudo -E pkg_add lz4 git
-                sudo -E pkg_add rust
-                sudo -E pkg_add openssl%3.5
-                sudo -E pkg_add py3-pip py3-virtualenv py3-tox
+            openbsd)
+              sudo -E pkg_add lz4 git
+              sudo -E pkg_add rust
+              sudo -E pkg_add openssl%3.5
+              sudo -E pkg_add py3-pip py3-virtualenv py3-tox
 
-                export BORG_OPENSSL_NAME=eopenssl35
-                tox -e py312-none
-                ;;
+              export BORG_OPENSSL_NAME=eopenssl35
+              tox -e py312-none
+              ;;
 
-              omnios)
-                sudo pkg install gcc14 git pkg-config python-313 gnu-make gnu-coreutils rust
-                sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
-                sudo ln -sf /usr/bin/python3.13-config /usr/bin/python3-config
-                sudo python3 -m ensurepip
-                sudo python3 -m pip install virtualenv
+            omnios)
+              sudo pkg install gcc14 git pkg-config python-313 gnu-make gnu-coreutils rust
+              sudo ln -sf /usr/bin/python3.13 /usr/bin/python3
+              sudo ln -sf /usr/bin/python3.13-config /usr/bin/python3-config
+              sudo python3 -m ensurepip
+              sudo python3 -m pip install virtualenv
 
-                # On omniOS /tmp is swap-backed tmpfs (small, RAM-bound), so the pip/cargo
-                # build temps and the pytest temp tree quickly exhaust it ("no space left on
-                # device"). /var/tmp is disk-backed (ZFS), so redirect TMPDIR there.
-                export TMPDIR=/var/tmp/borg-ci
-                mkdir -p "$TMPDIR"
+              # On omniOS /tmp is swap-backed tmpfs (small, RAM-bound), so the pip/cargo
+              # build temps and the pytest temp tree quickly exhaust it ("no space left on
+              # device"). /var/tmp is disk-backed (ZFS), so redirect TMPDIR there.
+              export TMPDIR=/var/tmp/borg-ci
+              mkdir -p "$TMPDIR"
 
-                python3 -m venv .venv
-                . .venv/bin/activate
-                python -V
-                pip -V
-                python -m pip install --upgrade pip wheel
-                pip install -r requirements.d/development.lock.txt
-                # no fuse support on omnios in our tests usually
-                pip install -e .
+              python3 -m venv .venv
+              . .venv/bin/activate
+              python -V
+              pip -V
+              python -m pip install --upgrade pip wheel
+              pip install -r requirements.d/development.lock.txt
+              # no fuse support on omnios in our tests usually
+              pip install -e .
 
-                tox -e py313-none
-                ;;
+              tox -e py313-none
+              ;;
 
-              haiku)
-                pkgman refresh
-                pkgman install -y git pkgconfig lz4
-                pkgman install -y openssl3
-                pkgman install -y rust_bin
-                pkgman install -y python3.11
-                pkgman install -y cffi
-                pkgman install -y lz4_devel openssl3_devel libffi_devel
+            haiku)
+              pkgman refresh
+              pkgman install -y git pkgconfig lz4
+              pkgman install -y openssl3
+              pkgman install -y rust_bin
+              pkgman install -y python3.11
+              pkgman install -y cffi
+              pkgman install -y lz4_devel openssl3_devel libffi_devel
 
-                # there is no pkgman package for tox, so we install it into a venv
-                python3 -m ensurepip --upgrade
-                python3 -m pip install --upgrade pip wheel
-                python3 -m venv .venv
-                . .venv/bin/activate
+              # there is no pkgman package for tox, so we install it into a venv
+              python3 -m ensurepip --upgrade
+              python3 -m pip install --upgrade pip wheel
+              python3 -m venv .venv
+              . .venv/bin/activate
 
-                export PKG_CONFIG_PATH="/system/develop/lib/pkgconfig:/system/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-                export BORG_LIBLZ4_PREFIX=/system/develop
-                export BORG_OPENSSL_PREFIX=/system/develop
-                pip install -r requirements.d/development.lock.txt
-                pip install -e .
+              export PKG_CONFIG_PATH="/system/develop/lib/pkgconfig:/system/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+              export BORG_LIBLZ4_PREFIX=/system/develop
+              export BORG_OPENSSL_PREFIX=/system/develop
+              pip install -r requirements.d/development.lock.txt
+              pip install -e .
 
-                # troubles with either tox or pytest xdist, so we run pytest manually:
-                pytest -v -n auto -rs --cov=borg --cov-config=pyproject.toml --cov-report=xml --junitxml=test-results.xml --benchmark-skip -k "not remote and not socket"
-                ;;
-            esac
+              # troubles with either tox or pytest xdist, so we run pytest manually:
+              pytest -v -n auto -rs --cov=borg --cov-config=pyproject.toml --cov-report=xml --junitxml=test-results.xml --benchmark-skip -k "not remote and not socket"
+              ;;
+          esac
 
       - name: Upload artifacts
         if: startsWith(github.ref, 'refs/tags/') && matrix.do_binaries


### PR DESCRIPTION
Fixes the two deprecation warnings currently shown on CI runs.

### lint: Node.js 20 deprecation

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: astral-sh/ruff-action@v3.

Bumped `astral-sh/ruff-action` v3 -> v4.1.0. Checked the manifests: v3.6.1 declares `using: node20`, v4.1.0 declares `using: node24`.

The exact version has to be pinned: with v4 astral-sh switched to immutable releases and no longer publishes a floating `v4` major tag (only `v4.0.0` and `v4.1.0` exist), so `@v4` does not resolve.

Ruff version resolution itself is unchanged (pyproject-discovered, else `latest`), and we don't pin ruff, so both v3 and v4 use the latest ruff.

### vm_tests: deprecated `run` input

> Input 'run' has been deprecated with message: The "run" parameter is deprecated. Use the custom shell (`shell: cpa.sh {0}`) on subsequent steps to run commands in the virtual machine instead.

Split the single `cross-platform-actions/action` step into a "Start VM" step plus a test step using the recommended custom shell:

```yaml
- name: Start VM for ${{ matrix.display_name }}
  uses: cross-platform-actions/action@v1.3.0
  with:
    operating_system: ${{ matrix.os }}
    version: ${{ matrix.version }}
    shell: bash

- name: Test on ${{ matrix.display_name }}
  shell: cpa.sh {0}
  run: |
    ...
```

The test script itself is unchanged apart from a 2-space dedent — `git diff -w` shows only the two hunks above.

Two behaviour details that matter here:

- **File sync:** with `shell: cpa.sh {0}` the helper syncs runner->vm before the script and vm->runner after, so `artifacts/*`, `test-results.xml` and `coverage.xml` still reach the later upload steps.
- **`shutdown_vm`:** its default flips from `true` to `false` once `run` is gone, which is what we want here — the VM has to survive into the test step.