### PR TITLE
fix calculate_relative_offset year offset from Feb 29

### DIFF
--- a/src/borg/helpers/time.py
+++ b/src/borg/helpers/time.py
@@ -142,7 +142,7 @@ def calculate_relative_offset(format_string, from_ts, earlier=False):
 
             match unit:
                 case "y":
-                    return from_ts.replace(year=from_ts.year + offset)
+                    return offset_n_months(from_ts, offset * 12)
                 case "m":
                     return offset_n_months(from_ts, offset)
                 case "w":
@@ -173,8 +173,15 @@ def offset_n_months(from_ts, n_months):
     following_month, year_of_following_month = get_month_and_year_from_total(total_months + 1)
     max_days_in_month = (datetime(year_of_following_month, following_month, 1) - timedelta(1)).day
 
-    return datetime(day=min(from_ts.day, max_days_in_month), month=target_month, year=target_year).replace(
-        tzinfo=from_ts.tzinfo
+    return datetime(
+        day=min(from_ts.day, max_days_in_month),
+        month=target_month,
+        year=target_year,
+        hour=from_ts.hour,
+        minute=from_ts.minute,
+        second=from_ts.second,
+        microsecond=from_ts.microsecond,
+        tzinfo=from_ts.tzinfo,
     )
 
 

--- a/src/borg/testsuite/helpers/time_test.py
+++ b/src/borg/testsuite/helpers/time_test.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime, timezone
 
-from ...helpers.time import safe_ns, safe_s, SUPPORT_32BIT_PLATFORMS
+from ...helpers.time import safe_ns, safe_s, SUPPORT_32BIT_PLATFORMS, calculate_relative_offset
 
 
 def utcfromtimestamp(timestamp):
@@ -36,3 +36,18 @@ def test_safe_timestamps():
             utcfromtimestamp(beyond_y10k)
         assert utcfromtimestamp(safe_s(beyond_y10k)) > datetime(2262, 1, 1)
         assert utcfromtimestamp(safe_ns(beyond_y10k) / 1000000000) > datetime(2262, 1, 1)
+
+
+def test_calculate_relative_offset_year_from_leap_day():
+    # regression test for #9967: year offset from Feb 29 must not crash on non-leap target year.
+    leap_day = datetime(2024, 2, 29, tzinfo=timezone.utc)
+    assert calculate_relative_offset("1y", leap_day, earlier=False) == datetime(2025, 2, 28, tzinfo=timezone.utc)
+    assert calculate_relative_offset("1y", leap_day, earlier=True) == datetime(2023, 2, 28, tzinfo=timezone.utc)
+    # target year is also a leap year -> keep Feb 29.
+    assert calculate_relative_offset("4y", leap_day, earlier=False) == datetime(2028, 2, 29, tzinfo=timezone.utc)
+
+
+def test_calculate_relative_offset_year_regular():
+    ts = datetime(2024, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
+    assert calculate_relative_offset("2y", ts, earlier=False) == datetime(2026, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
+    assert calculate_relative_offset("2y", ts, earlier=True) == datetime(2022, 6, 15, 12, 30, 45, tzinfo=timezone.utc)


### PR DESCRIPTION
Fixes #9967.

Routes the `y` case in `calculate_relative_offset` through `offset_n_months(from_ts, offset * 12)` as suggested in the issue. Result: Feb 29 + Ny no longer crashes when the target year is not a leap year — the day is clamped to the target month's last day (Feb 28 in a non-leap year, Feb 29 in a leap year).

Also extended `offset_n_months` to preserve hour/minute/second/microsecond of `from_ts` — otherwise routing the year case through it would have silently dropped time-of-day (and the month case had the same latent gap).

Regression tests added in `src/borg/testsuite/helpers/time_test.py`.