### PR TITLE
legacy: support date: archive patterns for --from-borg1

### DIFF
--- a/src/borg/legacy/archives.py
+++ b/src/borg/legacy/archives.py
@@ -15,7 +15,7 @@ from ..constants import *  # NOQA
 from ..helpers.datastruct import StableDict
 from ..helpers.errors import CommandError, Error
 from ..helpers.parseformat import bin_to_hex
-from ..helpers.time import parse_timestamp
+from ..helpers.time import parse_timestamp, compile_date_pattern, DatePatternError
 from ..item import ArchiveItem
 from ..patterns import get_regex_from_pattern
 
@@ -123,6 +123,13 @@ class LegacyArchives:
                 elif match.startswith("host:"):
                     wanted_host = match.removeprefix("host:")
                     archive_infos = [x for x in archive_infos if x.host == wanted_host]
+                elif match.startswith("date:"):
+                    wanted_date = match.removeprefix("date:")
+                    try:
+                        date_matches = compile_date_pattern(wanted_date)
+                    except DatePatternError as exc:
+                        raise CommandError(f"Invalid date pattern: {match} ({exc})")
+                    archive_infos = [x for x in archive_infos if date_matches(x.ts)]
                 else:
                     match = match.removeprefix("name:")
                     regex = get_regex_from_pattern(match)

--- a/src/borg/testsuite/legacy_archives_test.py
+++ b/src/borg/testsuite/legacy_archives_test.py
@@ -371,6 +371,20 @@ def test_list_match_host():
     assert la.list(match=["host:laptop"]) == [i1]
 
 
+def test_list_match_date():
+    i1 = _archiveinfo("a", _id(1), ts=TS)  # 2020-06-01
+    i2 = _archiveinfo("b", _id(2), ts=TS2)  # 2021-06-01
+    la = _make_list_target([i1, i2])
+    assert la.list(match=["date:2020-06"]) == [i1]
+
+
+def test_list_match_date_invalid_raises():
+    i1 = _archiveinfo("a", _id(1))
+    la = _make_list_target([i1])
+    with pytest.raises(CommandError, match="Invalid date pattern"):
+        la.list(match=["date:not-a-date"])
+
+
 def test_list_match_tags():
     i1 = _archiveinfo("a", _id(1), tags=("prod", "db"))
     i2 = _archiveinfo("b", _id(2), tags=("dev",))


### PR DESCRIPTION
## Problem

The `date:` archive-matching pattern (#8776) works for borg2 repos but not when filtering legacy (borg 1.x) repos via `--from-borg1` — e.g. `borg2 repo-list --from-borg1 -a 'date:2026-03'` returns no matching archives even when matches exist. Reported in #9949.

The pattern is implemented in `Archives._matching_info_tuples` (manifest.py) but the corresponding `LegacyArchives._matching_info_tuples` (legacy/archives.py) handles `aid:`, `tags:`, `user:`, `host:` and name matching only — it silently falls through to name matching for `date:`, matching nothing.

## Fix

Add the same `date:` branch to `LegacyArchives._matching_info_tuples`, mirroring the borg2 implementation (`compile_date_pattern` / `DatePatternError` → `CommandError`). This is especially useful for `borg2 transfer --from-borg1`.

## Tests

Added `test_list_match_date` and `test_list_match_date_invalid_raises` to `legacy_archives_test.py`, alongside the existing `user:`/`host:`/`tags:` match tests.

- `legacy_archives_test.py`: 52 passed
- `match_archives_date_test.py` (existing date suite): 34 passed, no regression

Fixes #9949

🤖 Generated with [Claude Code](https://claude.com/claude-code)