### PR TITLE
shtab: exclude 1.8.2 and 1.9.0 releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.
   "argon2-cffi",
-  "shtab>=1.8.0",
+  "shtab>=1.8.0,!=1.8.2,!=1.9.0",  # these generate broken zsh completions, see tqdm/shtab#224
   "backports-zstd; python_version < '3.14'", # for python < 3.14.
   "jsonargparse>=4.47.0",
   "PyYAML>=6.0.2",  # we need to register our types with yaml, jsonargparse uses yaml for config files


### PR DESCRIPTION
Fixes #9982.

shtab 1.8.2 and 1.9.0 generate broken zsh completions, so exclude just those two releases (same shape as the existing `blake3>=1.0.0,!=1.0.9` exclusion right below).

## Cause

shtab replaced `escape_zsh()` with `shlex.quote()` for the zsh help text ([tqdm/shtab@1590207](https://github.com/tqdm/shtab/commit/15902075f32f591abd33e84c7f959b717713d378)) but still interpolates the result **inside** a double-quoted `_arguments` spec. `shlex.quote` returns a self-contained shell *word* — single-quoted, with `'` written as `'"'"'` — which is only valid at the top level. Inside `"…"` those quotes are literal, the parity flips, and the rest of the spec goes unquoted.

Every description with a space gained stray literal quotes, and an apostrophe anywhere left an *unterminated* quote that cascaded down to shtab's own `default='*::: :->{name}'`, whose `->` then parsed as a redirection:

```console
$ borg completion zsh | zsh -n
(stdin):715: parse error near `>'
```

Line 715 is our `borg diff --sort-by` help, which contains `'>size_added,path'` — that's what tripped `test_zsh_completion_syntax`.

## Why it looked macOS-only

Nothing platform-specific — `zsh -n` is pure parsing, and our Linux CI does install zsh. shtab was unpinned above 1.8.0 and is absent from `development.lock.txt`, while `.tox` is cached on `hashFiles('…lock.txt', 'pyproject.toml')`. Jobs hitting a warm cache kept the working 1.8.1; macOS 15 missed and resolved 1.8.2 fresh. The rest would have followed as caches expired.

Touching `pyproject.toml` changes that cache key, so this also busts the stale envs.

## Upstream

Reported as [tqdm/shtab#224](https://github.com/tqdm/shtab/issues/224), fix proposed in [tqdm/shtab#225](https://github.com/tqdm/shtab/pull/225) (green, unmerged at time of writing). Drop the exclusions once a release carries it.

Note the exclusion style is deliberate per TW: `!=1.8.2,!=1.9.0` rather than `<1.8.2`, so a fixed 1.9.1+ is picked up automatically. The flip side is that a future release *without* the fix would be allowed again.

## Verification

```console
$ pip install "shtab>=1.8.0,!=1.8.2,!=1.9.0"   # resolves to 1.8.1
$ borg completion zsh | zsh -n                  # exit 0
$ pytest src/borg/testsuite/archiver/completion_cmd_test.py
```

`test_zsh_completion_syntax` passes again. (Locally two `test_bash_*_completion` tests fail on this machine's bash 3.2 regardless of shtab version — unrelated, and they pass in CI.)
