### PR TITLE
list: add {blake3} format key, validate --format keys, fixes #9984

### DIFF
--- a/docs/man/borg-list.1
+++ b/docs/man/borg-list.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg-list" "1" "2026-07-21" "" "borg backup tool"
+.TH "borg-list" "1" "2026-07-31" "" "borg backup tool"
 .SH Name
 borg-list \- List archive contents.
 .SH SYNOPSIS
@@ -198,6 +198,8 @@ fingerprint: Fingerprint of the file content (may have false negatives), format:
 blake2b
 .IP \(bu 2
 blake2s
+.IP \(bu 2
+blake3
 .IP \(bu 2
 md5
 .IP \(bu 2

--- a/docs/usage/list.rst.inc
+++ b/docs/usage/list.rst.inc
@@ -142,6 +142,7 @@ Keys available only when listing files in an archive:
 - fingerprint: Fingerprint of the file content (may have false negatives), format: H(conditions)-H(chunk_ids)
 - blake2b
 - blake2s
+- blake3
 - md5
 - sha1
 - sha224

--- a/src/borg/archiver/list_cmd.py
+++ b/src/borg/archiver/list_cmd.py
@@ -27,6 +27,8 @@ class ListMixIn:
             format = "{path}{NL}"
         else:
             format = os.environ.get("BORG_LIST_FORMAT", "{mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")
+        # check the format before doing any work with it (also: the ItemFormatter is only built later)
+        ItemFormatter.validate_format(format)
 
         archive_info = manifest.archives.get_one([args.name])
 

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -22,6 +22,7 @@ from ..logger import create_logger
 logger = create_logger()
 
 import yaml
+from blake3 import blake3
 
 from .errors import Error, CommandError
 from .fs import make_path_safe, slashify
@@ -1061,9 +1062,9 @@ class ArchiveFormatter(BaseFormatter):
 
 
 class ItemFormatter(BaseFormatter):
-    # we provide the hash algos from python stdlib (except shake_*).
+    # we provide the hash algos from python stdlib (except shake_*) and blake3.
     # shake_* is not provided because it uses an incompatible .digest() method to support variable length.
-    hash_algorithms = set(hashlib.algorithms_guaranteed).difference({"shake_128", "shake_256"})
+    hash_algorithms = set(hashlib.algorithms_guaranteed).difference({"shake_128", "shake_256"}) | {"blake3"}
     KEY_DESCRIPTIONS = {
         "type": "file type (file, dir, symlink, ...)",
         "mode": "file mode (as in stat)",
@@ -1193,7 +1194,9 @@ class ItemFormatter(BaseFormatter):
     def hash_item(self, hash_function, item):
         if "chunks" not in item:
             return ""
-        if hash_function in self.hash_algorithms:
+        if hash_function == "blake3":
+            hash = blake3()
+        else:
             hash = hashlib.new(hash_function)
         for data in self.archive.pipeline.fetch_many(item.chunks, ro_type=ROBJ_FILE_STREAM):
             hash.update(data)

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -925,6 +925,7 @@ class BaseFormatter(metaclass=abc.ABCMeta):
     KEY_GROUPS: ClassVar[tuple[tuple[str, ...], ...]] = (("NEWLINE", "NL", "NUL", "SPACE", "TAB", "CR", "LF"),)
 
     def __init__(self, format: str, static: dict[str, Any]) -> None:
+        self.validate_format(format)
         self.format = partial_format(format, static)
         self.static_data = static
 
@@ -957,13 +958,22 @@ class BaseFormatter(metaclass=abc.ABCMeta):
         return "\n".join(help)
 
     @classmethod
+    def known_keys(cls) -> set[str]:
+        """the keys this formatter supports in a format string"""
+        # some keys are only in KEY_GROUPS (e.g. the hash keys of ItemFormatter), thus we look at both.
+        keys = set(cls.KEY_DESCRIPTIONS)
+        keys.update(key for group in cls.KEY_GROUPS for key in group)
+        keys.update(cls.FIXED_KEYS)
+        return keys
+
+    @classmethod
     def validate_format(cls, format):
         """raise a CommandError if format is malformed or uses keys this formatter does not know"""
         try:
             format_keys = {key for _, key, _, _ in Formatter().parse(format) if key}
         except ValueError as err:
             raise CommandError(f"Invalid format string: {err}")
-        unknown_keys = format_keys - set(cls.KEY_DESCRIPTIONS) - set(cls.FIXED_KEYS)
+        unknown_keys = format_keys - cls.known_keys()
         if unknown_keys:
             raise CommandError(f"Invalid format keys: {', '.join(sorted(unknown_keys))}")
 

--- a/src/borg/testsuite/archiver/list_cmd_test.py
+++ b/src/borg/testsuite/archiver/list_cmd_test.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from ...constants import *  # NOQA
+from ...helpers import CommandError
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION, requires_hardlinks
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
@@ -30,6 +31,34 @@ def test_list_hash(archivers, request):
     output = cmd(archiver, "list", "test", "--format", "{sha256} {path}{NL}")
     assert "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0 input/amb" in output
     assert "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 input/empty_file" in output
+
+
+def test_list_format_invalid_key(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    if archiver.FORK_DEFAULT:
+        expected_ec = CommandError().exit_code
+        output = cmd(archiver, "list", "test", "--format", "{nosuchkey}", exit_code=expected_ec)
+        assert "Invalid format keys: nosuchkey" in output
+    else:
+        with pytest.raises(CommandError, match="Invalid format keys: nosuchkey"):
+            cmd(archiver, "list", "test", "--format", "{nosuchkey}")
+
+
+def test_list_format_invalid_format_string(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    if archiver.FORK_DEFAULT:
+        expected_ec = CommandError().exit_code
+        output = cmd(archiver, "list", "test", "--format", "{path", exit_code=expected_ec)
+        assert "Invalid format string" in output
+    else:
+        with pytest.raises(CommandError, match="Invalid format string"):
+            cmd(archiver, "list", "test", "--format", "{path")
 
 
 def test_list_hash_blake3(archivers, request):

--- a/src/borg/testsuite/archiver/list_cmd_test.py
+++ b/src/borg/testsuite/archiver/list_cmd_test.py
@@ -32,6 +32,17 @@ def test_list_hash(archivers, request):
     assert "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 input/empty_file" in output
 
 
+def test_list_hash_blake3(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "empty_file", size=0)
+    create_regular_file(archiver.input_path, "amb", contents=b"a" * 1000000)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    output = cmd(archiver, "list", "test", "--format", "{blake3} {path}{NL}")
+    assert "616f575a1b58d4c9797d4217b9730ae5e6eb319d76edef6549b46f4efe31ff8b input/amb" in output
+    assert "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262 input/empty_file" in output
+
+
 def test_list_chunk_counts(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "empty_file", size=0)

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -31,7 +31,11 @@ from ...helpers.parseformat import (
     ChunkerParams,
     get_size_units,
     normalize_local_path,
+    ArchiveFormatter,
+    DiffFormatter,
+    ItemFormatter,
 )
+from ...helpers.errors import CommandError
 from ...helpers.time import format_timedelta, parse_timestamp
 from ...platformflags import is_win32, is_darwin
 
@@ -735,6 +739,25 @@ def test_format_line_erroneous():
         assert format_line("{now!r}", data)
     with pytest.raises(PlaceholderError):
         assert format_line("{now.__class__.__module__.__builtins__}", data)
+
+
+@pytest.mark.parametrize("formatter", (ArchiveFormatter, DiffFormatter, ItemFormatter))
+def test_validate_format(formatter):
+    formatter.validate_format("")
+    formatter.validate_format("{NL}{TAB}")
+    for key in formatter.known_keys():
+        formatter.validate_format("{" + key + "}")
+    with pytest.raises(CommandError, match="Invalid format keys: nosuchkey"):
+        formatter.validate_format("{nosuchkey}")
+    with pytest.raises(CommandError, match="Invalid format string"):
+        formatter.validate_format("{NL")
+
+
+def test_validate_format_item_hashes():
+    # the hash keys are only in KEY_GROUPS, not in KEY_DESCRIPTIONS, see known_keys()
+    for key in ("blake3", "md5", "sha256"):
+        assert key in ItemFormatter.known_keys()
+        ItemFormatter.validate_format("{" + key + "} {path}{NL}")
 
 
 def test_replace_placeholders():


### PR DESCRIPTION
`borg list --format '{blake3} {path}{NL}'` crashed with `KeyError: 'blake3'`, see #9984.

**1) add the `{blake3}` format key**

`ItemFormatter.hash_algorithms` only contained the python stdlib hashes
(minus `shake_*`), so `blake3` never got registered as a call key, although
borg2 uses blake3 elsewhere and has the `blake3` package as a hard dependency
anyway.

- add `blake3` to `hash_algorithms`, use `blake3()` instead of `hashlib.new()` for it
- output is the default 256bit hexdigest, like the other hash keys
- add a test and regenerate the list usage docs / man page

**2) validate `--format` keys**

An unknown key crashed with that same ugly `KeyError` traceback (and a malformed
format string with a `ValueError` one). `BaseFormatter.validate_format` existed,
but was only used by `borg check` and did not know about keys that are only in
`KEY_GROUPS` (like the hash keys), so it could not be used as-is elsewhere.

- add `BaseFormatter.known_keys()` (`KEY_DESCRIPTIONS` + `KEY_GROUPS` + `FIXED_KEYS`)
  and validate against that
- validate in `BaseFormatter.__init__`, so `list`, `repo-list`, `diff`, `prune` and
  `check` all give a `CommandError` now:
  `Command error: Invalid format keys: nosuchkey`
- `borg list` validates early, because `format_needs_cache` parses the format
  before the `ItemFormatter` gets built