### PR TITLE
shtab 1.9.1 is still broken, disallow it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.
   "argon2-cffi",
-  "shtab>=1.8.0,!=1.8.2,!=1.9.0",  # these generate broken zsh completions, see tqdm/shtab#224
+  "shtab>=1.8.0,!=1.8.2,!=1.9.0,!=1.9.1",  # these generate broken zsh completions, see tqdm/shtab#224
   "backports-zstd; python_version < '3.14'", # for python < 3.14.
   "jsonargparse>=4.47.0",
   "PyYAML>=6.0.2",  # we need to register our types with yaml, jsonargparse uses yaml for config files


### PR DESCRIPTION
same issue as previous fix that disallowed 1.8.2 and 1.9.0.
