### PR TITLE
feat: add JSON output to borg version

### DIFF
--- a/src/borg/archiver/version_cmd.py
+++ b/src/borg/archiver/version_cmd.py
@@ -1,3 +1,5 @@
+import json
+
 from .. import __version__
 from ..constants import *  # NOQA
 from ..helpers.argparsing import ArgumentParser
@@ -20,7 +22,12 @@ class VersionMixIn:
                 server_version = repository.server_version
         else:
             server_version = client_version
-        print(f"{format_version(client_version)} / {format_version(server_version)}")
+        client_version = format_version(client_version)
+        server_version = format_version(server_version)
+        if getattr(args, "json", False):
+            print(json.dumps({"client": client_version, "server": server_version}))
+        else:
+            print(f"{client_version} / {server_version}")
 
     def build_parser_version(self, subparsers, common_parser, mid_common_parser):
         from ._common import process_epilog
@@ -45,6 +52,10 @@ class VersionMixIn:
             $ borg version --from-borg1 ssh://borg@borgbackup:repo
             1.4.0a / 1.2.7
 
+            # machine-readable output
+            $ borg version --json /mnt/backup
+            {"client": "1.4.0a", "server": "1.4.0a"}
+
         Due to the version tuple format used in Borg client/server negotiation, only
         a simplified version is displayed (as provided by borg.version.format_version).
 
@@ -52,4 +63,7 @@ class VersionMixIn:
         """
         )
         subparser = ArgumentParser(parents=[common_parser], description=self.do_version.__doc__, epilog=version_epilog)
+        subparser.add_argument(
+            "--json", action="store_true", help="display the client and server versions as a JSON object"
+        )
         subparsers.add_subcommand("version", subparser, help="display the Borg client and server versions")

--- a/src/borg/testsuite/archiver/version_cmd_test.py
+++ b/src/borg/testsuite/archiver/version_cmd_test.py
@@ -1,0 +1,26 @@
+import json
+from types import SimpleNamespace
+
+from ...archiver.version_cmd import VersionMixIn
+from ... import __version__
+from ...version import format_version, parse_version
+
+
+def test_version_json(capsys):
+    args = SimpleNamespace(location=SimpleNamespace(proto="file"), json=True)
+
+    VersionMixIn().do_version(args)
+
+    assert json.loads(capsys.readouterr().out) == {
+        "client": format_version(parse_version(__version__)),
+        "server": format_version(parse_version(__version__)),
+    }
+
+
+def test_version_text_is_unchanged(capsys):
+    args = SimpleNamespace(location=SimpleNamespace(proto="file"), json=False)
+
+    VersionMixIn().do_version(args)
+
+    version = format_version(parse_version(__version__))
+    assert capsys.readouterr().out == f"{version} / {version}\n"


### PR DESCRIPTION
## Summary\n\n- add org version --json with client and server fields\n- preserve the existing human-readable output\n- add focused tests for JSON and text output\n\nCloses #9993\n\n## Validation\n\n- git diff --check\n- python -m compileall -q src/borg/archiver/version_cmd.py src/borg/testsuite/archiver/version_cmd_test.py\n- Full pytest could not run in this Windows checkout because Borg's native crypto extension is not built and the editable install requires unavailable pkg-config; CI should provide the supported build environment.