### PR TITLE
BORG_PROGRESS_FPS: how often --progress output is updated, #8041

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -179,6 +179,7 @@ New features:
 - mount: expose POSIX ACLs on Linux mounts (not enforced), #1042
 - analyze: report deduplicated size of a set of archives, #5741
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
+- BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041
 
 Fixes:
 

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -86,6 +86,12 @@ General:
 
         ``BORG_UNITS=iec`` is the replacement for the removed ``BORG_IEC`` environment
         variable (and for the ``--iec`` command line option removed before that).
+    BORG_PROGRESS_FPS
+        How often the ``--progress`` output is updated at most, in updates per
+        second (default: 5). Fractional values are allowed, e.g.
+        ``BORG_PROGRESS_FPS=0.1`` limits it to one update every 10 seconds.
+        Lower values are useful when the output goes into a logfile rather than
+        to an interactive terminal.
     BORG_DEBUG_PROFILE
         When set to a filename, write an execution profile in Borg format into that file
         (see :ref:`debugging`). If the filename ends with ``.pyprof``, a Python-compatible

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -41,7 +41,7 @@ from .helpers import safe_encode, make_path_safe, remove_surrogates, text_to_jso
 from .helpers import StableDict
 from .helpers import bin_to_hex
 from .helpers import safe_ns
-from .helpers import ellipsis_truncate, ProgressIndicatorPercent, log_multi
+from .helpers import ellipsis_truncate, ProgressIndicatorPercent, log_multi, get_progress_dt
 from .helpers import os_open, flags_normal, flags_dir
 from .helpers import os_stat
 from .helpers import msgpack
@@ -713,7 +713,7 @@ Duration: {0.duration}
         if show_progress and self.show_progress:
             if stats is None:
                 stats = self.stats
-            stats.show_progress(item=item, dt=0.2)
+            stats.show_progress(item=item, dt=get_progress_dt())
         self.items_buffer.add(item)
 
     def save(self, name=None, comment=None, timestamp=None, stats=None, additional_metadata=None):
@@ -1329,7 +1329,7 @@ class ChunksProcessor:
             chunk_entry = chunk_processor(chunk)
             item.chunks.append(chunk_entry)
             if show_progress:
-                stats.show_progress(item=item, dt=0.2)
+                stats.show_progress(item=item, dt=get_progress_dt())
 
 
 def maybe_exclude_by_attr(item):

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -109,7 +109,7 @@ class Statistics:
     def __init__(self, output_json=False):
         self.output_json = output_json
         self.osize = self.usize = self.nfiles = 0
-        self.last_progress = 0  # timestamp when last progress was shown
+        self.last_progress = float("-inf")  # monotonic timestamp when progress was last shown, -inf: never
         self.files_stats = defaultdict(int)
         self.chunking_time = 0.0
         self.hashing_time = 0.0
@@ -195,9 +195,9 @@ Files changed while reading: {files_changed_while_reading}
     def usize_fmt(self):
         return format_file_size(self.usize)
 
-    def show_progress(self, item=None, final=False, stream=None, dt=None):
+    def show_progress(self, item=None, final=False, stream=None):
         now = time.monotonic()
-        if dt is None or now - self.last_progress > dt:
+        if final or now - self.last_progress > get_progress_dt():
             stream = stream or sys.stderr
             self.last_progress = now
             if self.output_json:
@@ -713,7 +713,7 @@ Duration: {0.duration}
         if show_progress and self.show_progress:
             if stats is None:
                 stats = self.stats
-            stats.show_progress(item=item, dt=get_progress_dt())
+            stats.show_progress(item=item)
         self.items_buffer.add(item)
 
     def save(self, name=None, comment=None, timestamp=None, stats=None, additional_metadata=None):
@@ -1329,7 +1329,7 @@ class ChunksProcessor:
             chunk_entry = chunk_processor(chunk)
             item.chunks.append(chunk_entry)
             if show_progress:
-                stats.show_progress(item=item, dt=get_progress_dt())
+                stats.show_progress(item=item)
 
 
 def maybe_exclude_by_attr(item):

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -52,7 +52,7 @@ from .parseformat import Highlander, MakePathSafeAction
 from .process import daemonize, daemonizing, ThreadRunner
 from .process import signal_handler, raising_signal_handler, sig_int, ignore_sigint, SigHup, SigTerm
 from .process import popen_with_error_handling, is_terminal, prepare_subprocess_env, create_filter_process
-from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage
+from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, get_progress_dt
 from .time import parse_timestamp, timestamp, safe_timestamp, safe_s, safe_ns, MAX_S, SUPPORT_32BIT_PLATFORMS
 from .time import format_time, format_timedelta, OutputTimestamp, archive_ts_now
 from .yes_no import yes, TRUISH, FALSISH, DEFAULTISH

--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -1,10 +1,31 @@
 import logging
 import json
+import os
 import time
 
 from ..logger import create_logger
 
 logger = create_logger()
+
+DEFAULT_PROGRESS_FPS = 5.0  # progress updates per second, the traditional rate
+
+_warned_fps: set[str] = set()  # invalid BORG_PROGRESS_FPS values already complained about
+
+
+def get_progress_dt():
+    """Minimum time between progress updates [seconds], 1 / BORG_PROGRESS_FPS [updates per second]."""
+    fps_str = os.environ.get("BORG_PROGRESS_FPS", "").strip()
+    if fps_str:
+        try:
+            fps = float(fps_str)
+        except ValueError:
+            fps = 0.0
+        if fps > 0.0:
+            return 1.0 / fps
+        if fps_str not in _warned_fps:
+            _warned_fps.add(fps_str)
+            logger.warning(f"Invalid BORG_PROGRESS_FPS value {fps_str!r}, must be a number > 0. Ignoring it.")
+    return 1.0 / DEFAULT_PROGRESS_FPS
 
 
 class ProgressIndicatorBase:

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -29,6 +29,12 @@ def stats():
     return stats
 
 
+def show_progress_force(stats, **kwargs):
+    # bypass the BORG_PROGRESS_FPS rate limiting, so every call produces output
+    stats.last_progress = float("-inf")
+    stats.show_progress(**kwargs)
+
+
 def test_stats_basic(stats):
     assert stats.osize == 20
     assert stats.usize == 20
@@ -44,20 +50,20 @@ def test_stats_progress_tty(stats, monkeypatch, columns=80):
 
     monkeypatch.setenv("COLUMNS", str(columns))
     out = TTYStringIO()
-    stats.show_progress(stream=out)
+    show_progress_force(stats, stream=out)
     s = "20 B O 20 B U 1 N "
     buf = " " * (columns - len(s))
     assert out.getvalue() == s + buf + "\r"
 
     out = TTYStringIO()
     stats.update(10**3, unique=False)
-    stats.show_progress(item=Item(path="foo"), final=False, stream=out)
+    show_progress_force(stats, item=Item(path="foo"), final=False, stream=out)
     s = "1.02 kB O 20 B U 1 N foo"
     buf = " " * (columns - len(s))
     assert out.getvalue() == s + buf + "\r"
 
     out = TTYStringIO()
-    stats.show_progress(item=Item(path="foo" * 40), final=False, stream=out)
+    show_progress_force(stats, item=Item(path="foo" * 40), final=False, stream=out)
     s = "1.02 kB O 20 B U 1 N foofoofoofoofoofoofoofoofo...foofoofoofoofoofoofoofoofoofoo"
     buf = " " * (columns - len(s))
     assert out.getvalue() == s + buf + "\r"
@@ -65,22 +71,34 @@ def test_stats_progress_tty(stats, monkeypatch, columns=80):
 
 def test_stats_progress_file(stats, monkeypatch):
     out = StringIO()
-    stats.show_progress(stream=out)
+    show_progress_force(stats, stream=out)
     s = "20 B O 20 B U 1 N "
     assert out.getvalue() == s + "\n"
 
     out = StringIO()
     stats.update(10**3, unique=False)
     path = "foo"
-    stats.show_progress(item=Item(path=path), final=False, stream=out)
+    show_progress_force(stats, item=Item(path=path), final=False, stream=out)
     s = f"1.02 kB O 20 B U 1 N {path}"
     assert out.getvalue() == s + "\n"
 
     out = StringIO()
     path = "foo" * 40
-    stats.show_progress(item=Item(path=path), final=False, stream=out)
+    show_progress_force(stats, item=Item(path=path), final=False, stream=out)
     s = f"1.02 kB O 20 B U 1 N {path}"
     assert out.getvalue() == s + "\n"
+
+
+def test_stats_progress_rate_limited(stats):
+    out = StringIO()
+    stats.show_progress(stream=out)  # the first update is always shown
+    assert out.getvalue() != ""
+    out = StringIO()
+    stats.show_progress(stream=out)  # immediately after: suppressed by the BORG_PROGRESS_FPS rate limit
+    assert out.getvalue() == ""
+    out = StringIO()
+    stats.show_progress(stream=out, final=True)  # the final update is never suppressed
+    assert out.getvalue() != ""
 
 
 def test_stats_format(stats):
@@ -109,7 +127,7 @@ def test_stats_progress_json(stats):
     stats.output_json = True
 
     out = StringIO()
-    stats.show_progress(item=Item(path="foo"), stream=out)
+    show_progress_force(stats, item=Item(path="foo"), stream=out)
     result = json.loads(out.getvalue())
     assert result["type"] == "archive_progress"
     assert isinstance(result["time"], float)

--- a/src/borg/testsuite/helpers/progress_test.py
+++ b/src/borg/testsuite/helpers/progress_test.py
@@ -1,4 +1,33 @@
-from ...helpers.progress import ProgressIndicatorPercent
+import pytest
+
+from ...helpers import progress
+from ...helpers.progress import ProgressIndicatorPercent, get_progress_dt
+
+
+@pytest.mark.parametrize(
+    "fps_str,dt", [("10", 0.1), ("2", 0.5), ("0.1", 10.0), (" 5 ", 0.2)]  # surrounding whitespace is ignored
+)
+def test_progress_dt(monkeypatch, fps_str, dt):
+    monkeypatch.setenv("BORG_PROGRESS_FPS", fps_str)
+    assert get_progress_dt() == pytest.approx(dt)
+
+
+def test_progress_dt_default(monkeypatch):
+    monkeypatch.delenv("BORG_PROGRESS_FPS", raising=False)
+    assert get_progress_dt() == pytest.approx(0.2)
+    monkeypatch.setenv("BORG_PROGRESS_FPS", "")
+    assert get_progress_dt() == pytest.approx(0.2)
+
+
+@pytest.mark.parametrize("fps_str", ["banana", "0", "-5", "nan"])
+def test_progress_dt_invalid(monkeypatch, caplog, fps_str):
+    monkeypatch.setattr(progress, "_warned_fps", set())
+    monkeypatch.setenv("BORG_PROGRESS_FPS", fps_str)
+    assert get_progress_dt() == pytest.approx(0.2)
+    assert "Invalid BORG_PROGRESS_FPS" in caplog.text
+    caplog.clear()
+    assert get_progress_dt() == pytest.approx(0.2)  # only warn once per value
+    assert caplog.text == ""
 
 
 def test_progress_percentage(capfd):


### PR DESCRIPTION
Closes #8041.

Like restic's `RESTIC_PROGRESS_FPS`: `BORG_PROGRESS_FPS` sets the maximum number of `--progress` updates per second, default 5 (the traditional hardcoded 0.2s interval). Fractional values below 1 are allowed, e.g. `BORG_PROGRESS_FPS=0.1` for one update every 10 seconds — useful when the output goes into a logfile rather than to an interactive terminal.

- `get_progress_dt()` in `helpers/progress.py` parses the env var (warn once + fall back to default on invalid values, same pattern as `BORG_UNITS`) and is used at the two `Statistics.show_progress(dt=...)` call sites, covering create / recreate / transfer / import-tar in plain, non-tty and `--log-json` output.
- `ProgressIndicatorPercent` (check etc.) throttles by percent step, not by time, so it is unaffected.
- docs: new entry in `environment.rst.inc`, changelog line.
- tests for default / valid / fractional / invalid values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)