### PR TITLE
mailmap: merge duplicate contributor identities, add scripts/fame.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,10 +5,35 @@ Mark Edgington <edgimar@gmail.com>
 Leo Famulari <leo@famulari.name>
 Marian Beermann <public@enkore.de>
 Thomas Waldmann <tw@waldmann-edv.de>
+Andrey Bienkowski <hexagon-recursion@posteo.net>
+Ebuzer Celil Durmaz <durmazs540@gmail.com>
+Manuel Riel <manu@snapdragon.cc>
+Narendra Vardi <narendravardi1127@gmail.com>
+Nehalenniæ Oudin <oudin@crans.org>
+Samuel BF <36996277+Samuel-BF@users.noreply.github.com>
+Suryansh Pal <defnvary@gmail.com>
+Ted Lawson <big.tedde@gmail.com>
+Vaskebjoern <190291379+vaskebjoern@users.noreply.github.com>
 Dan Christensen <jdc@uwo.ca> <jdc+github@uwo.ca>
+Alexander-N <a.niederbuehl@gmail.com> <A.Niederbuehl@gmail.com>
+Andrey Bienkowski <hexagon-recursion@posteo.net> <hexagonrecursion@gmail.com>
 Antoine Beaupré <anarcat@koumbit.org> <anarcat@debian.org> <anarcat@users.noreply.github.com>
+Divyansh Agrawal <154041893+div-dev123@users.noreply.github.com> <your.email@example.com>
+Franco Ayala <franco.a98@outlook.com> <frma98@gmail.com>
+Gianfranco Costamagna <costamagnagianfranco@yahoo.it> <locutusofborg@debian.org>
 Hartmut Goebel <h.goebel@crazy-compilers.com> <htgoebel@users.noreply.github.com>
+Ken Kundert <ken@theKunderts.net> <thenurd@nurdletech.com>
+Manuel Riel <manu@snapdragon.cc> <3916435+m3nu@users.noreply.github.com>
+Michael Deyaso <mdeyaso@fusioniq.io> <60641399+Michael-Girma@users.noreply.github.com>
 Michael Gajda <michaelg@speciesm.net> <michael.gajda@tu-dortmund.de>
 Milkey Mouse <milkeymouse@meme.institute> <milkey-mouse@users.noreply.github.com>
+Narendra Vardi <narendravardi1127@gmail.com> <texehef@payperex2.com>
+Nehalenniæ Oudin <oudin@crans.org> <remi.oudin@lip6.fr>
 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de> <ronny.pfannschmidt@redhat.com>
+Russell Davis <551404+russelldavis@users.noreply.github.com> <russelldavis@users.noreply.github.com>
 Stefan Tatschner <rumpelsepp@sevenbyte.org> <stefan@sevenbyte.org>
+Stephan Herbers <github@sherbers.de> <stephan13360@users.noreply.github.com>
+Thalian <github@fantasya-pbem.de> <39634976+fantasya-pbem@users.noreply.github.com>
+Thomas Portmann <thomas@portmann.org> <59793129+alfredo08154711@users.noreply.github.com>
+infectormp <infectormp@gmail.com> <infectormp@users.noreply.github.com>
+step21 <step21@devtal.de> <step21@users.noreply.github.com>

--- a/FAME.md
+++ b/FAME.md
@@ -1,0 +1,391 @@
+# Contributors
+
+370 people have contributed to Borg, with 10,581 commits in total.
+Thanks to everyone who helped!
+
+Generated on 2026-08-01 by `scripts/fame.py`, which computes the statistics with
+[git-fame](https://github.com/casperdcl/git-fame), from the `master` branch
+only - commits that exist solely on other branches or in unmerged pull requests
+are not counted.
+
+This list is only a rough summary: it counts commits and lines, which say
+nothing about reviews, bug reports, translations, documentation review, support
+work or funding.  See `AUTHORS` for a manually maintained list of contributors.
+
+"Lines" are surviving lines of code: lines of the current master that
+`git blame` attributes to that author.  Code that was later rewritten does not
+show up there, so the number understates early contributions.  Generated files
+(such as the Excalidraw sources of the documentation figures) are excluded.
+
+| Contributor | Commits | Lines | Files |
+|:---|---:|---:|---:|
+| Thomas Waldmann | 7,020 | 73,353 | 451 |
+| Marian Beermann | 1,140 | 9,016 | 158 |
+| Jonas Borgström | 560 | 1,080 | 38 |
+| Antoine Beaupré | 285 | 456 | 35 |
+| Mrityunjay Raj | 198 | 7,988 | 102 |
+| Andrey Bienkowski | 72 | 243 | 17 |
+| Ted Lawson | 71 | 4,606 | 39 |
+| Thalian | 63 | 771 | 33 |
+| Martin Hostettler | 46 | 2,589 | 10 |
+| Milkey Mouse | 42 | 253 | 14 |
+| Dan Christensen | 40 | 5 | 2 |
+| dependabot[bot] | 37 | 46 | 7 |
+| Rayyan Ansari | 34 | 91 | 12 |
+| Abdel-Rahman | 30 | 4 | 3 |
+| Manuel Riel | 28 | 107 | 7 |
+| Nehalenniæ Oudin | 26 | 55 | 11 |
+| anarcat | 24 | 34 | 4 |
+| Hugo Wallenburg | 23 | 1,189 | 13 |
+| Michael Hanselmann | 22 | 151 | 3 |
+| Björn Ketelaars | 17 | 33 | 6 |
+| SanskritFritz | 17 | 258 | 1 |
+| Lee Bousfield | 14 | 169 | 10 |
+| Alan Jenkins | 14 | 47 | 2 |
+| Robin Schneider | 13 | 19 | 8 |
+| Daniel Rudolf | 13 | 230 | 14 |
+| Jürg Rast | 12 | 78 | 11 |
+| Elmar Hoffmann | 12 | 98 | 9 |
+| Ronny Pfannschmidt | 12 | 22 | 4 |
+| mh4ckt3mh4ckt1c4s | 11 | 0 | 0 |
+| Teemu Toivanen | 10 | 16 | 2 |
+| Lauri Niskanen | 10 | 5 | 2 |
+| finefoot | 10 | 18 | 3 |
+| James Buren | 10 | 10 | 2 |
+| Per Guth | 9 | 1 | 1 |
+| rugk | 9 | 13 | 5 |
+| Ed Blackman | 9 | 14 | 3 |
+| Carlo Teubner | 9 | 3 | 3 |
+| Emmo Emminghaus | 9 | 87 | 11 |
+| Josh Soref | 8 | 3 | 3 |
+| Jakob Schnitzer | 8 | 35 | 1 |
+| Gianfranco Costamagna | 7 | 10 | 6 |
+| Frank Sachsenheim | 7 | 3 | 1 |
+| Hartmut Goebel | 7 | 0 | 0 |
+| Michael Deyaso | 6 | 170 | 14 |
+| Alf Mikula | 6 | 19 | 1 |
+| William D. Jones | 6 | 250 | 6 |
+| Felix Schwarz | 6 | 5 | 2 |
+| Peter Gerber | 6 | 105 | 10 |
+| Alexander-N | 6 | 0 | 0 |
+| Paul D | 5 | 185 | 46 |
+| Mark Edgington | 5 | 11 | 3 |
+| Dominik Stadler | 5 | 77 | 1 |
+| infectormp | 5 | 18 | 2 |
+| remyabel | 5 | 25 | 3 |
+| Alexander 'Leo' Bergolth | 5 | 26 | 3 |
+| Simon Frei | 5 | 213 | 3 |
+| elandorr | 5 | 40 | 3 |
+| step21 | 5 | 2 | 2 |
+| Radu Ciorba | 5 | 0 | 0 |
+| Suryansh Pal | 4 | 36 | 9 |
+| 8bit | 4 | 30 | 5 |
+| Ryan Polley | 4 | 12 | 4 |
+| Steve Groesz | 4 | 22 | 1 |
+| Thomas Kluyver | 4 | 8 | 2 |
+| Robert Blenis | 4 | 90 | 4 |
+| Josh Holland | 4 | 3 | 2 |
+| Charlie Herz | 4 | 628 | 5 |
+| oxiedi | 4 | 26 | 1 |
+| Franco Ayala | 4 | 39 | 6 |
+| Ebuzer Celil Durmaz | 4 | 80 | 5 |
+| Artem Sheremet | 4 | 10 | 1 |
+| Narendra Vardi | 4 | 3 | 1 |
+| Alexander Pyhalov | 4 | 0 | 0 |
+| Will | 3 | 22 | 4 |
+| Lukas Fleischer | 3 | 23 | 2 |
+| Daniel Reichelt | 3 | 25 | 5 |
+| Stephen | 3 | 10 | 2 |
+| Stefan Tatschner | 3 | 3 | 1 |
+| Stephan Herbers | 3 | 49 | 2 |
+| ntova | 3 | 33 | 8 |
+| Dmitry Astapov | 3 | 8 | 1 |
+| Helmut Grohne | 3 | 11 | 1 |
+| Andrea Gelmini | 3 | 18 | 13 |
+| Martin Richtarsky | 3 | 34 | 4 |
+| Michael Gajda | 3 | 23 | 2 |
+| jungle-boogie | 3 | 13 | 1 |
+| Thomas Harold | 3 | 1 | 1 |
+| Gregor Kleen | 3 | 10 | 4 |
+| kmq | 3 | 15 | 1 |
+| Luke Dashjr | 3 | 4 | 1 |
+| Divyesh | 3 | 1 | 1 |
+| eoli3n | 3 | 22 | 1 |
+| Oleg Drokin | 3 | 16 | 1 |
+| Charmi Kadi | 3 | 46 | 2 |
+| valtron | 3 | 7 | 1 |
+| Danny Edel | 3 | 0 | 0 |
+| Jeff Rizzo | 3 | 0 | 0 |
+| Piotr Pawlow | 3 | 0 | 0 |
+| Simon Heath | 3 | 0 | 0 |
+| William Bonnaventure | 3 | 0 | 0 |
+| Zhuoyun Wei | 3 | 0 | 0 |
+| jhemmje | 3 | 0 | 0 |
+| Samuel | 2 | 4 | 3 |
+| trxvorr | 2 | 103 | 7 |
+| Jerry Jacobs | 2 | 12 | 3 |
+| jetchirag | 2 | 9 | 3 |
+| bbx0 | 2 | 3 | 1 |
+| wormingdead | 2 | 5 | 1 |
+| azrdev | 2 | 2 | 1 |
+| jan | 2 | 3 | 1 |
+| Samuel BF | 2 | 2 | 1 |
+| zDEFz | 2 | 27 | 1 |
+| Ioannis Cherouvim | 2 | 32 | 2 |
+| AJ Jordan | 2 | 2 | 1 |
+| Markus Engelbrecht | 2 | 3 | 1 |
+| Thomas Portmann | 2 | 257 | 5 |
+| Leo Famulari | 2 | 1 | 1 |
+| Fabian Fröhlich | 2 | 4 | 1 |
+| Andreas Gruhler | 2 | 3 | 1 |
+| Cthulhux | 2 | 1 | 1 |
+| Russell Davis | 2 | 1 | 1 |
+| Kurt Yoder | 2 | 8 | 1 |
+| Jonas Schäfer | 2 | 13 | 1 |
+| a1346054 | 2 | 4 | 3 |
+| Sophie Herold | 2 | 3 | 2 |
+| ReethuVinta | 2 | 20 | 2 |
+| textshell | 2 | 1 | 1 |
+| Saurav Sachidanand | 2 | 2 | 1 |
+| Łukasz Stelmach | 2 | 14 | 2 |
+| Vaskebjoern | 2 | 5 | 1 |
+| Joachim Breitner | 2 | 15 | 1 |
+| Matthew Glazar | 2 | 18 | 3 |
+| Max-Julian Pogner | 2 | 15 | 1 |
+| Atharva Varpe | 2 | 23 | 1 |
+| Lapinot | 2 | 30 | 4 |
+| Soumik Dutta | 2 | 85 | 3 |
+| Eric Wolf | 2 | 51 | 4 |
+| snsmac | 2 | 6 | 2 |
+| Syed Ali Ghazi Ejaz | 2 | 90 | 4 |
+| David Rambo | 2 | 87 | 3 |
+| Divyansh Agrawal | 2 | 43 | 4 |
+| kmille | 2 | 11 | 2 |
+| nain | 2 | 6 | 1 |
+| Ken Kundert | 2 | 149 | 4 |
+| Cam Hutchison | 2 | 1 | 1 |
+| MultisampledNight | 2 | 2 | 1 |
+| Abogical | 2 | 0 | 0 |
+| Andrew Skalski | 2 | 0 | 0 |
+| Brian Johnson | 2 | 0 | 0 |
+| Daniel Danner | 2 | 0 | 0 |
+| Donny Ward | 2 | 0 | 0 |
+| Herover | 2 | 0 | 0 |
+| James Clarke | 2 | 0 | 0 |
+| Jan Bader | 2 | 0 | 0 |
+| Janne K | 2 | 0 | 0 |
+| Jeremy Maitin-Shepard | 2 | 0 | 0 |
+| Mark Lopez | 2 | 0 | 0 |
+| Michael Herold | 2 | 0 | 0 |
+| Michael Rupert | 2 | 0 | 0 |
+| Mitch Bigelow | 2 | 0 | 0 |
+| Petros Moisiadis | 2 | 0 | 0 |
+| Radek Podgorny | 2 | 0 | 0 |
+| Stavros Korokithakis | 2 | 0 | 0 |
+| Yornik Heyl | 2 | 0 | 0 |
+| lyh16 | 2 | 0 | 0 |
+| motwok | 2 | 0 | 0 |
+| sven | 2 | 0 | 0 |
+| user062 | 2 | 0 | 0 |
+| Paweł Kotiuk | 1 | 2 | 1 |
+| borkd | 1 | 37 | 1 |
+| Daniel Dent | 1 | 2 | 1 |
+| Lars K.W. Gohlke | 1 | 1 | 1 |
+| Kevin Yin | 1 | 3 | 1 |
+| Benedikt Seidl | 1 | 117 | 2 |
+| Eddie Carswell | 1 | 4 | 1 |
+| vancheese | 1 | 28 | 8 |
+| Michael Bauer | 1 | 2 | 1 |
+| Aleksey Korol | 1 | 95 | 1 |
+| Coenraad Loubser | 1 | 1 | 1 |
+| ebabcock93 | 1 | 84 | 1 |
+| Tavlor | 1 | 3 | 1 |
+| dataprolet | 1 | 5 | 1 |
+| Tom Denley | 1 | 2 | 2 |
+| Uriel | 1 | 30 | 1 |
+| Jonathan Rascher | 1 | 1 | 1 |
+| Fredrik Mikker | 1 | 1 | 1 |
+| Robert Marcano | 1 | 1 | 1 |
+| Jubjub | 1 | 6 | 1 |
+| Alexander Meshcheryakov | 1 | 2 | 1 |
+| Stefano Probst | 1 | 1 | 1 |
+| jminer74 | 1 | 2 | 1 |
+| tree-wall | 1 | 2 | 1 |
+| Florent Hemmi | 1 | 5 | 1 |
+| Svein Ove Aas | 1 | 1 | 1 |
+| Antonio Larrosa | 1 | 12 | 1 |
+| Andreas Vögele | 1 | 1 | 1 |
+| ahtaarra | 1 | 1 | 1 |
+| Jens Diemer | 1 | 1 | 1 |
+| Dee Newcum | 1 | 1 | 1 |
+| Marc Kohaupt | 1 | 1 | 1 |
+| abebeos | 1 | 4 | 1 |
+| remyabel2 | 1 | 13 | 1 |
+| James Rowell | 1 | 8 | 1 |
+| targhs | 1 | 1 | 1 |
+| Alexandr Kozlinskiy | 1 | 4 | 1 |
+| Christian Paul | 1 | 1 | 1 |
+| Sitaram Chamarty | 1 | 23 | 1 |
+| philippje | 1 | 2 | 1 |
+| Mateusz Konieczny | 1 | 3 | 1 |
+| James Vasile | 1 | 36 | 1 |
+| Maltimore | 1 | 2 | 1 |
+| Greg Grossmeier | 1 | 7 | 1 |
+| Jonathan Zacsh | 1 | 21 | 1 |
+| Rohan salunke | 1 | 76 | 9 |
+| Stefan Majewsky | 1 | 1 | 1 |
+| Atemu | 1 | 11 | 2 |
+| Dominik Tugend | 1 | 3 | 1 |
+| Reiko Asakura | 1 | 12 | 2 |
+| Mher Kazandjian | 1 | 6 | 1 |
+| Mike | 1 | 23 | 1 |
+| Ceesjan Luiten | 1 | 1 | 1 |
+| Vagrant Cascadian | 1 | 1 | 1 |
+| Nic Donaldson | 1 | 26 | 1 |
+| TawfeeqShaik | 1 | 6 | 1 |
+| Xiaocheng Song | 1 | 60 | 4 |
+| Jim Paris | 1 | 2 | 1 |
+| vhadzhiev | 1 | 2 | 1 |
+| Tarrailt | 1 | 371 | 8 |
+| Romain Vimont | 1 | 4 | 3 |
+| Sam H | 1 | 27 | 2 |
+| Leo Antunes | 1 | 8 | 1 |
+| Matt Van Horn | 1 | 1 | 1 |
+| Mike Mason | 1 | 38 | 3 |
+| edvatar | 1 | 16 | 2 |
+| goebbe | 1 | 4 | 1 |
+| MartinKurtz | 1 | 1 | 1 |
+| nyuszika7h | 1 | 3 | 1 |
+| Divyansh Singh | 1 | 1 | 1 |
+| Phil Kulin | 1 | 4 | 1 |
+| Félix Sipma | 1 | 14 | 1 |
+| Graham Stockton | 1 | 13 | 1 |
+| Peter Zangerl | 1 | 1 | 1 |
+| lexa-a | 1 | 31 | 1 |
+| Nikolaus Rath | 1 | 7 | 1 |
+| axapaxa | 1 | 117 | 2 |
+| Swanand01 | 1 | 1 | 1 |
+| Abhijeet | 1 | 1 | 1 |
+| Dark Dragon | 1 | 7 | 1 |
+| Emil M George | 1 | 2 | 1 |
+| Hauke Rehfeld | 1 | 1 | 1 |
+| Henry-Joseph Audéoud | 1 | 1 | 1 |
+| Ivan Shapovalov | 1 | 1 | 1 |
+| Zhou Qiankang | 1 | 3 | 1 |
+| Adam Kouse | 1 | 0 | 0 |
+| Aidan Woods | 1 | 0 | 0 |
+| Aiman | 1 | 0 | 0 |
+| Alex Vorona | 1 | 0 | 0 |
+| Andraz Brodnik | 1 | 0 | 0 |
+| Andrew Engelbrecht | 1 | 0 | 0 |
+| André-Patrick Bubel | 1 | 0 | 0 |
+| Ashmodei | 1 | 0 | 0 |
+| Ben Creasy | 1 | 0 | 0 |
+| Benedikt Heine | 1 | 0 | 0 |
+| Benedikt Neuffer | 1 | 0 | 0 |
+| Benjamin Pereto | 1 | 0 | 0 |
+| Birkhoff Lee | 1 | 0 | 0 |
+| Bruno Behnken | 1 | 0 | 0 |
+| Chen Yufei | 1 | 0 | 0 |
+| Chris Lamb | 1 | 0 | 0 |
+| Christoph Trassl | 1 | 0 | 0 |
+| Christopher Klooz | 1 | 0 | 0 |
+| Cyril Roussillon | 1 | 0 | 0 |
+| Dan Helfman | 1 | 0 | 0 |
+| Dan Hipschman | 1 | 0 | 0 |
+| David Fries | 1 | 0 | 0 |
+| DifficultDerek | 1 | 0 | 0 |
+| Eli Schwartz | 1 | 0 | 0 |
+| Ellis Michael | 1 | 0 | 0 |
+| Endareth | 1 | 0 | 0 |
+| Evan Hempel | 1 | 0 | 0 |
+| Fabian Weisshaar | 1 | 0 | 0 |
+| Fabio Pedretti | 1 | 0 | 0 |
+| Flachz | 1 | 0 | 0 |
+| Florian Klink | 1 | 0 | 0 |
+| Hans-Peter Jansen | 1 | 0 | 0 |
+| Jakub Wilk | 1 | 0 | 0 |
+| Jan | 1 | 0 | 0 |
+| Jens Rantil | 1 | 0 | 0 |
+| Jesus Fernandez Manzano | 1 | 0 | 0 |
+| Joey | 1 | 0 | 0 |
+| Johann Bauer | 1 | 0 | 0 |
+| Johann Klähn | 1 | 0 | 0 |
+| Johannes Wienke | 1 | 0 | 0 |
+| Jonas Wunderlich | 1 | 0 | 0 |
+| Julian Andres Klode | 1 | 0 | 0 |
+| Julian Picht | 1 | 0 | 0 |
+| Julien Lamy | 1 | 0 | 0 |
+| Jürgen Gmach | 1 | 0 | 0 |
+| KN4CK3R | 1 | 0 | 0 |
+| Kevin | 1 | 0 | 0 |
+| Kevin Puetz | 1 | 0 | 0 |
+| Lars-Magnus Skog | 1 | 0 | 0 |
+| Laurent | 1 | 0 | 0 |
+| Lauri Alanko | 1 | 0 | 0 |
+| Luke Murphy | 1 | 0 | 0 |
+| Marcin Zajączkowski | 1 | 0 | 0 |
+| Martin Stone | 1 | 0 | 0 |
+| Marvin Gaube | 1 | 0 | 0 |
+| Matthew R. Trower | 1 | 0 | 0 |
+| Michael G. Noll | 1 | 0 | 0 |
+| Nathan Musoke | 1 | 0 | 0 |
+| Nick Cleaton | 1 | 0 | 0 |
+| Niels Ole Salscheider | 1 | 0 | 0 |
+| Niklas Meinzer | 1 | 0 | 0 |
+| Nils Steinger | 1 | 0 | 0 |
+| OEM Configuration (temporary user) | 1 | 0 | 0 |
+| Ori Livneh | 1 | 0 | 0 |
+| Pankaj Garg | 1 | 0 | 0 |
+| Patrick Goering | 1 | 0 | 0 |
+| Philip Kozeny | 1 | 0 | 0 |
+| Philip Waritschlager | 1 | 0 | 0 |
+| Philippe MIOSSEC | 1 | 0 | 0 |
+| Profpatsch | 1 | 0 | 0 |
+| RR | 1 | 0 | 0 |
+| Ricardo M. Correia | 1 | 0 | 0 |
+| Roberto Polli | 1 | 0 | 0 |
+| Ruben Rodriguez | 1 | 0 | 0 |
+| Sebastiaan Lokhorst | 1 | 0 | 0 |
+| Serghei Iakovlev | 1 | 0 | 0 |
+| Thiago Macieira | 1 | 0 | 0 |
+| Thomas Deutschmann | 1 | 0 | 0 |
+| Thomas Schwinge | 1 | 0 | 0 |
+| Tiago Donato | 1 | 0 | 0 |
+| Tim Düsterhus | 1 | 0 | 0 |
+| Timothy Burchfield | 1 | 0 | 0 |
+| Tommy Nguyen | 1 | 0 | 0 |
+| Tomás Andrighetti | 1 | 0 | 0 |
+| TuXicc | 1 | 0 | 0 |
+| Tung Dao | 1 | 0 | 0 |
+| Viktor Bale | 1 | 0 | 0 |
+| Vlad | 1 | 0 | 0 |
+| Vladimir Malinovskii | 1 | 0 | 0 |
+| Wladimir Palant | 1 | 0 | 0 |
+| Yuri D'Elia | 1 | 0 | 0 |
+| adrian5 | 1 | 0 | 0 |
+| alex3d | 1 | 0 | 0 |
+| alexskc | 1 | 0 | 0 |
+| ash | 1 | 0 | 0 |
+| ashmodei | 1 | 0 | 0 |
+| bobthebadguy | 1 | 0 | 0 |
+| cornop | 1 | 0 | 0 |
+| eike-fokken | 1 | 0 | 0 |
+| henfri | 1 | 0 | 0 |
+| hiijoshi | 1 | 0 | 0 |
+| jenkins | 1 | 0 | 0 |
+| jeroen tiebout | 1 | 0 | 0 |
+| kannes | 1 | 0 | 0 |
+| klemens | 1 | 0 | 0 |
+| lumbric | 1 | 0 | 0 |
+| mirobertod | 1 | 0 | 0 |
+| nain-F49FF806 | 1 | 0 | 0 |
+| newtonne | 1 | 0 | 0 |
+| nod0n | 1 | 0 | 0 |
+| ololoru | 1 | 0 | 0 |
+| pamaron | 1 | 0 | 0 |
+| petrcech | 1 | 0 | 0 |
+| schuft69 | 1 | 0 | 0 |
+| sothix | 1 | 0 | 0 |
+| sw9719 | 1 | 0 | 0 |
+| viq | 1 | 0 | 0 |

--- a/scripts/fame.py
+++ b/scripts/fame.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regenerate FAME.md, a contributor summary produced by git-fame.
+
+Usage: python scripts/fame.py [--top N]
+
+Requires `git-fame` (pip install git-fame) and a full (non-shallow) clone,
+because the line counts come from `git blame` over the whole history.
+
+The statistics always describe the master branch, no matter which branch the
+script is run from, so that FAME.md does not change depending on the checkout.
+
+Contributors are sorted by commit count.  git-fame also reports "surviving"
+lines of code, i.e. lines of the current checkout that `git blame` attributes
+to an author; that is useful context, but it silently discounts work that was
+later refactored away, so it is not what we rank by.
+
+Author identities are merged via .mailmap, so fix duplicates there rather than
+here.
+"""
+
+import argparse
+import json
+import subprocess
+from datetime import date
+from pathlib import Path
+
+BRANCH = "master"
+
+# Generated and binary-ish files would drown out hand-written code.  Excalidraw
+# scenes are the worst offenders: they are pretty-printed JSON, so a single
+# diagram of a few boxes and arrows is over 10000 lines.  Image formats are
+# listed for good measure - git-fame skips binary files by itself, but .svg is
+# text and would count.
+EXCLUDE = r".*\.(excalidraw|png|jpg|jpeg|gif|svg|ico)$"
+
+HEADERS = ("Contributor", "Commits", "Lines", "Files")
+
+PREAMBLE = """\
+# Contributors
+
+{count} people have contributed to Borg, with {commits} commits in total.
+Thanks to everyone who helped!
+
+Generated on {date} by `scripts/fame.py`, which computes the statistics with
+[git-fame](https://github.com/casperdcl/git-fame), from the `{branch}` branch
+only - commits that exist solely on other branches or in unmerged pull requests
+are not counted.
+
+This list is only a rough summary: it counts commits and lines, which say
+nothing about reviews, bug reports, translations, documentation review, support
+work or funding.  See `AUTHORS` for a manually maintained list of contributors.
+
+"Lines" are surviving lines of code: lines of the current master that
+`git blame` attributes to that author.  Code that was later rewritten does not
+show up there, so the number understates early contributions.  Generated files
+(such as the Excalidraw sources of the documentation figures) are excluded.
+
+"""
+
+
+def collect():
+    """Run git-fame and return (rows, total), all contributors, most commits first."""
+    out = subprocess.check_output(
+        ["git-fame", "--silent-progress", "--format=json", "--sort=commits", f"--excl={EXCLUDE}", f"--branch={BRANCH}"],
+        text=True,
+    )
+    fame = json.loads(out)
+    rows = [(name, commits, loc, files) for name, loc, commits, files, *_percentages in fame["data"]]
+    return rows, fame["total"]
+
+
+def render(rows, total, contributors):
+    """Return the full FAME.md contents, listing `rows` out of `contributors` people."""
+    preamble = PREAMBLE.format(
+        count=f"{contributors:,}", commits=f"{total['commits']:,}", date=date.today().isoformat(), branch=BRANCH
+    )
+    if len(rows) < contributors:
+        preamble += f"Only the top {len(rows):,} contributors by commit count are listed here.\n\n"
+    table = ["| " + " | ".join(HEADERS) + " |", "|:---" + "|---:" * (len(HEADERS) - 1) + "|"]
+    for name, commits, loc, files in rows:
+        # escape the markdown table delimiter, names are commit-controlled input
+        escaped = name.replace("|", "\\|")
+        table.append(f"| {escaped} | {commits:,} | {loc:,} | {files:,} |")
+    return preamble + "\n".join(table) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--top", type=int, default=0, metavar="N", help="only list the top N contributors")
+    args = parser.parse_args()
+
+    repo = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+    rows, total = collect()
+    contributors = len(rows)
+    if args.top:
+        rows = rows[: args.top]
+    output = repo / "FAME.md"
+    output.write_text(render(rows, total, contributors), encoding="utf-8")
+    print(f"wrote {output} ({len(rows)} of {contributors} contributors)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## .mailmap

`git shortlog` / `git blame` listed a number of contributors twice, either
because the same address was used with different spellings of the name, or
because the same person committed from several addresses. Merging them brings
the number of distinct authors down from **380 to 370**.

After this change there are no remaining cases of one address with several
names, or one name with several addresses.

Two of the merges are judgement calls and I'd like a second opinion on them
(the entries are visible in the diff):

- one address was used with two different real names and a handle; the most
  recent non-handle name is used.
- another address was used mostly with a handle and three times with a real
  name; the real name is used.

Two further entries in the diff are also worth a glance: one merge spans a
personal address and what looks like a disposable one (the name is identical
in both), and another folds in an obviously unconfigured placeholder address.

## scripts/fame.py and FAME.md

`scripts/fame.py` writes `FAME.md` from [git-fame](https://github.com/casperdcl/git-fame)
output, sorted by commit count. Run it with `python scripts/fame.py` (needs
`pip install git-fame` and a full clone); `--top N` limits the table.

The script bakes in an exclusion pattern for generated files. Without it the
numbers are actively misleading: the three Excalidraw sources of the pack
format figures are pretty-printed JSON and contribute **39230 lines** - about a
third of the repository - to a single contributor, putting them in second place
overall. Excluding them, that contributor has 7988 lines.

Ranking by commit count rather than surviving lines is deliberate, for the same
reason: surviving lines discount work that was later refactored away, which
penalises exactly the earliest contributors.

`FAME.md` goes stale as commits land. This PR just adds the generated file and
the script to regenerate it; wiring it into CI (a full run takes ~11s) can
follow if you want it kept current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
