### PR TITLE
fame.py: order contributors deterministically, drop the push trigger

### DIFF
--- a/.github/workflows/fame.yml
+++ b/.github/workflows/fame.yml
@@ -10,19 +10,16 @@
 # is fine for generated files, but keep it in mind if this workflow ever starts
 # touching code.
 #
-# Merging such a pull request pushes FAME.md and triggers this workflow again;
-# that run regenerates the same files, finds no diff and opens nothing, so it
-# just costs a minute of runner time.
+# Deliberately not triggered by pushes to FAME.md: the "Lines" column is blame
+# of the current checkout, so it moves with almost every commit, and merging one
+# of these pull requests would immediately produce the next one.  Both files are
+# always written by the same run, so they cannot drift apart on their own.
 
 name: FAME
 
 on:
   schedule:
     - cron: '17 4 * * 1'  # Mondays at 04:17 UTC
-  push:
-    branches: [ master ]
-    paths:
-    - 'FAME.md'           # keep the chart in sync when the table changes
   workflow_dispatch:      # Allow manual trigger
 
 concurrency:

--- a/scripts/fame.py
+++ b/scripts/fame.py
@@ -125,6 +125,10 @@ def collect():
     )
     fame = json.loads(out)
     rows = [(name, commits, loc, files) for name, loc, commits, files, *_percentages in fame["data"]]
+    # git-fame leaves people with the same commit count in its own order, which
+    # is stable for a given checkout but not across checkouts, so equal ranks
+    # would shuffle from one run to the next.  Break the tie ourselves.
+    rows.sort(key=lambda row: (-row[1], -row[2], row[0]))
     return rows, fame["total"]
 
 


### PR DESCRIPTION
Two fixes to the FAME workflow from #10007, which turned out to open pull
requests far more often than weekly.

**The `push` trigger on `FAME.md` cascades.** Merging one of the generated
pull requests pushes `FAME.md`, which triggers the workflow again; since the
"Lines" column is `git blame` of the current checkout and master sees 23-76
commits a week, that run finds real changes and opens the next pull request
straight away. It happened immediately after #10007 was merged: #10008 was
merged at 10:26:09 and #10009 was opened at 10:26:46.

The trigger is removed. It was meant to keep `FAME.svg` in sync with
`FAME.md`, but both files are always written by the same run, so they cannot
drift apart on their own; the weekly run and `workflow_dispatch` cover the
rest.

**Tied ranks shuffled.** git-fame leaves contributors with the same commit
count in its own order, which is stable for a given checkout but not across
checkouts, so equal ranks moved around between runs and added noise to the
diff. `collect()` now sorts by commits, then surviving lines, then name.

`FAME.md` / `FAME.svg` are deliberately not regenerated here, to avoid a
conflict with the open #10009 - the next scheduled run picks up the new
ordering.