### PR TITLE
chunkers, crypto: release the GIL in pure-C hot paths

### DIFF
--- a/src/borg/chunkers/buzhash.pyx
+++ b/src/borg/chunkers/buzhash.pyx
@@ -78,7 +78,7 @@ cdef extern from *:
    """
    #define BARREL_SHIFT(v, shift) (((v) << (shift)) | ((v) >> (((32 - (shift)) & 0x1f))))
    """
-   uint32_t BARREL_SHIFT(uint32_t v, uint32_t shift)
+   uint32_t BARREL_SHIFT(uint32_t v, uint32_t shift) nogil
 
 
 @cython.boundscheck(False)  # Deactivate bounds checking
@@ -97,7 +97,7 @@ cdef uint32_t* buzhash_init_table(uint32_t seed) except NULL:
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)  # Deactivate negative indexing.
 @cython.cdivision(True)  # Use C division/modulo semantics for integer division.
-cdef uint32_t _buzhash(const unsigned char* data, size_t len, const uint32_t* h):
+cdef uint32_t _buzhash(const unsigned char* data, size_t len, const uint32_t* h) noexcept nogil:
     """Calculate the buzhash of the given data."""
     cdef uint32_t i
     cdef uint32_t sum = 0, imod
@@ -113,7 +113,7 @@ cdef uint32_t _buzhash(const unsigned char* data, size_t len, const uint32_t* h)
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)  # Deactivate negative indexing.
 @cython.cdivision(True)  # Use C division/modulo semantics for integer division.
-cdef uint32_t _buzhash_update(uint32_t sum, unsigned char remove, unsigned char add, size_t len, const uint32_t* h):
+cdef uint32_t _buzhash_update(uint32_t sum, unsigned char remove, unsigned char add, size_t len, const uint32_t* h) noexcept nogil:
     """Update the buzhash with a new byte."""
     cdef uint32_t lenmod = len & 0x1f
     return BARREL_SHIFT(sum, 1) ^ BARREL_SHIFT(h[remove], lenmod) ^ h[add]
@@ -187,9 +187,11 @@ cdef class Chunker:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
         cdef object chunk
+        cdef const unsigned char* src
 
         # Move remaining data to the beginning of the buffer
-        memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
+        with nogil:
+            memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
         self.position -= self.last
         self.last = 0
         n = self.buf_size - self.position - self.remaining
@@ -205,10 +207,13 @@ cdef class Chunker:
             # Only copy data if it's not a hole
             if chunk.meta["allocation"] == CH_DATA:
                 # Copy data from chunk to our buffer
-                memcpy(self.data + self.position + self.remaining, <const unsigned char*>PyBytes_AsString(chunk.data), n)
+                src = <const unsigned char*>PyBytes_AsString(chunk.data)
+                with nogil:
+                    memcpy(self.data + self.position + self.remaining, src, n)
             else:
                 # For holes, fill with zeros using memset
-                memset(self.data + self.position + self.remaining, 0, n)
+                with nogil:
+                    memset(self.data + self.position + self.remaining, 0, n)
 
             self.remaining += n
             self.bytes_read += n
@@ -252,15 +257,17 @@ cdef class Chunker:
         # window starts at the potential cutting place.
         self.position += min_size
         self.remaining -= min_size
-        sum = _buzhash(self.data + self.position, window_size, self.table)
+        with nogil:
+            sum = _buzhash(self.data + self.position, window_size, self.table)
 
         while self.remaining > window_size and (sum & chunk_mask) and not (self.eof and self.remaining <= window_size):
             p = self.data + self.position
             stop_at = p + self.remaining - window_size
 
-            while p < stop_at and (sum & chunk_mask):
-                sum = _buzhash_update(sum, p[0], p[window_size], window_size, self.table)
-                p += 1
+            with nogil:
+                while p < stop_at and (sum & chunk_mask):
+                    sum = _buzhash_update(sum, p[0], p[window_size], window_size, self.table)
+                    p += 1
 
             did_bytes = p - (self.data + self.position)
             self.position += did_bytes

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -35,7 +35,7 @@ cdef extern from *:
    """
    #define BARREL_SHIFT64(v, shift) (((v) << (shift)) | ((v) >> (((64 - (shift)) & 0x3f))))
    """
-   uint64_t BARREL_SHIFT64(uint64_t v, uint64_t shift)
+   uint64_t BARREL_SHIFT64(uint64_t v, uint64_t shift) nogil
 
 
 @cython.boundscheck(False)  # Deactivate bounds checking
@@ -74,7 +74,7 @@ cdef uint64_t* buzhash64_init_table(bytes key) except NULL:
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)  # Deactivate negative indexing.
 @cython.cdivision(True)  # Use C division/modulo semantics for integer division.
-cdef uint64_t _buzhash64(const unsigned char* data, size_t len, const uint64_t* h):
+cdef uint64_t _buzhash64(const unsigned char* data, size_t len, const uint64_t* h) noexcept nogil:
     """Calculate the buzhash of the given data."""
     cdef uint64_t i
     cdef uint64_t sum = 0, imod
@@ -90,7 +90,7 @@ cdef uint64_t _buzhash64(const unsigned char* data, size_t len, const uint64_t* 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)  # Deactivate negative indexing.
 @cython.cdivision(True)  # Use C division/modulo semantics for integer division.
-cdef uint64_t _buzhash64_update(uint64_t sum, unsigned char remove, unsigned char add, size_t len, const uint64_t* h):
+cdef uint64_t _buzhash64_update(uint64_t sum, unsigned char remove, unsigned char add, size_t len, const uint64_t* h) noexcept nogil:
     """Update the buzhash with a new byte."""
     cdef uint64_t lenmod = len & 0x3f
     return BARREL_SHIFT64(sum, 1) ^ BARREL_SHIFT64(h[remove], lenmod) ^ h[add]
@@ -188,9 +188,11 @@ cdef class ChunkerBuzHash64:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
         cdef object chunk
+        cdef const unsigned char* src
 
         # Move remaining data to the beginning of the buffer
-        memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
+        with nogil:
+            memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
         self.position -= self.last
         self.last = 0
         n = self.buf_size - self.position - self.remaining
@@ -206,10 +208,13 @@ cdef class ChunkerBuzHash64:
             # Only copy data if it's not a hole
             if chunk.meta["allocation"] == CH_DATA:
                 # Copy data from chunk to our buffer
-                memcpy(self.data + self.position + self.remaining, <const unsigned char*>PyBytes_AsString(chunk.data), n)
+                src = <const unsigned char*>PyBytes_AsString(chunk.data)
+                with nogil:
+                    memcpy(self.data + self.position + self.remaining, src, n)
             else:
                 # For holes, fill with zeros using memset
-                memset(self.data + self.position + self.remaining, 0, n)
+                with nogil:
+                    memset(self.data + self.position + self.remaining, 0, n)
 
             self.remaining += n
             self.bytes_read += n
@@ -257,7 +262,8 @@ cdef class ChunkerBuzHash64:
         # window starts at the potential cutting place.
         self.position += min_size
         self.remaining -= min_size
-        sum = _buzhash64(self.data + self.position, window_size, self.table)
+        with nogil:
+            sum = _buzhash64(self.data + self.position, window_size, self.table)
 
         # Normalized chunking: pick the mask based on how far we are into the current chunk.
         # While below normal_size use the strict mask (lower cut probability), afterward the
@@ -284,9 +290,10 @@ cdef class ChunkerBuzHash64:
                 if nc_stop < stop_at:
                     stop_at = nc_stop
 
-            while p < stop_at and (sum & mask):
-                sum = _buzhash64_update(sum, p[0], p[window_size], window_size, self.table)
-                p += 1
+            with nogil:
+                while p < stop_at and (sum & mask):
+                    sum = _buzhash64_update(sum, p[0], p[window_size], window_size, self.table)
+                    p += 1
 
             did_bytes = p - (self.data + self.position)
             self.position += did_bytes

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -133,8 +133,10 @@ cdef class ChunkerFastCDC:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
         cdef object chunk
+        cdef const unsigned char* src
 
-        memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
+        with nogil:
+            memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
         self.position -= self.last
         self.last = 0
         n = self.buf_size - self.position - self.remaining
@@ -147,9 +149,12 @@ cdef class ChunkerFastCDC:
 
         if n > 0:
             if chunk.meta["allocation"] == CH_DATA:
-                memcpy(self.data + self.position + self.remaining, <const unsigned char*>PyBytes_AsString(chunk.data), n)
+                src = <const unsigned char*>PyBytes_AsString(chunk.data)
+                with nogil:
+                    memcpy(self.data + self.position + self.remaining, src, n)
             else:
-                memset(self.data + self.position + self.remaining, 0, n)
+                with nogil:
+                    memset(self.data + self.position + self.remaining, 0, n)
             self.remaining += n
             self.bytes_read += n
         else:
@@ -220,12 +225,13 @@ cdef class ChunkerFastCDC:
                     stop = self.data + normal_pos
 
             cut = NULL
-            while p < stop:
-                fp = (fp << 1) + gear[p[0]]
-                if (fp & mask) == 0:
-                    cut = p
-                    break
-                p += 1
+            with nogil:
+                while p < stop:
+                    fp = (fp << 1) + gear[p[0]]
+                    if (fp & mask) == 0:
+                        cut = p
+                        break
+                    p += 1
 
             if cut != NULL:
                 p = cut + 1  # cut right after the byte that triggered the boundary

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -49,13 +49,13 @@ from libc.string cimport memset, memcpy
 
 
 
-cdef extern from "openssl/crypto.h":
+cdef extern from "openssl/crypto.h" nogil:
     int CRYPTO_memcmp(const void *a, const void *b, size_t len)
 
 cdef extern from "openssl/opensslv.h":
     long OPENSSL_VERSION_NUMBER
 
-cdef extern from "openssl/evp.h":
+cdef extern from "openssl/evp.h" nogil:
     ctypedef struct EVP_MD:
         pass
     ctypedef struct EVP_CIPHER:
@@ -298,6 +298,7 @@ cdef class AES256_CTR_BASE:
         cdef unsigned char *odata = NULL
         cdef int olen
         cdef int offset
+        cdef int rc
         cdef unsigned char mac_buf[32]
         assert sizeof(mac_buf) == self.mac_len
 
@@ -317,9 +318,11 @@ cdef class AES256_CTR_BASE:
             if not EVP_DecryptInit_ex(self.ctx, EVP_aes_256_ctr(), NULL, self.enc_key, iv):
                 raise CryptoError('EVP_DecryptInit_ex failed')
             offset = 0
-            if not EVP_DecryptUpdate(self.ctx, odata+offset, &olen,
-                                     <const unsigned char*> idata.buf+hlen+self.mac_len+self.iv_len_short,
-                                     ilen-hlen-self.mac_len-self.iv_len_short):
+            with nogil:
+                rc = EVP_DecryptUpdate(self.ctx, odata+offset, &olen,
+                                       <const unsigned char*> idata.buf+hlen+self.mac_len+self.iv_len_short,
+                                       ilen-hlen-self.mac_len-self.iv_len_short)
+            if not rc:
                 raise CryptoError('EVP_DecryptUpdate failed')
             offset += olen
             if not EVP_DecryptFinal_ex(self.ctx, odata+offset, &olen):
@@ -508,6 +511,7 @@ cdef class _AEAD_BASE:
         cdef unsigned char *odata = NULL
         cdef int olen
         cdef int offset
+        cdef int rc
 
         try:
             odata = <unsigned char *>PyMem_Malloc(hlen + self.mac_len +
@@ -536,7 +540,9 @@ cdef class _AEAD_BASE:
                 raise CryptoError('EVP_EncryptUpdate failed')
             if not EVP_EncryptUpdate(self.ctx, NULL, &olen, <const unsigned char*> hdata.buf+aoffset, alen):
                 raise CryptoError('EVP_EncryptUpdate failed')
-            if not EVP_EncryptUpdate(self.ctx, odata+offset, &olen, <const unsigned char*> idata.buf, ilen):
+            with nogil:
+                rc = EVP_EncryptUpdate(self.ctx, odata+offset, &olen, <const unsigned char*> idata.buf, ilen)
+            if not rc:
                 raise CryptoError('EVP_EncryptUpdate failed')
             offset += olen
             if not EVP_EncryptFinal_ex(self.ctx, odata+offset, &olen):
@@ -582,6 +588,7 @@ cdef class _AEAD_BASE:
         cdef unsigned char *odata = NULL
         cdef int olen
         cdef int offset
+        cdef int rc
 
         try:
             odata = <unsigned char *>PyMem_Malloc(ilen + self.cipher_blk_len)
@@ -603,9 +610,11 @@ cdef class _AEAD_BASE:
             if not EVP_DecryptUpdate(self.ctx, NULL, &olen, <const unsigned char*> idata.buf+aoffset, alen):
                 raise CryptoError('EVP_DecryptUpdate failed')
             offset = 0
-            if not EVP_DecryptUpdate(self.ctx, odata+offset, &olen,
-                                     <const unsigned char*> idata.buf+hlen+self.mac_len,
-                                     ilen-hlen-self.mac_len):
+            with nogil:
+                rc = EVP_DecryptUpdate(self.ctx, odata+offset, &olen,
+                                       <const unsigned char*> idata.buf+hlen+self.mac_len,
+                                       ilen-hlen-self.mac_len)
+            if not rc:
                 raise CryptoError('EVP_DecryptUpdate failed')
             offset += olen
             if not EVP_CIPHER_CTX_ctrl(self.ctx, EVP_CTRL_AEAD_SET_TAG, self.mac_len, <unsigned char *> idata.buf + hlen):
@@ -868,30 +877,30 @@ cdef extern from *:
     const uint64_t BORG_XXH64_P5
 
 
-cdef inline uint64_t _xxh_rotl(uint64_t x, int r) noexcept:
+cdef inline uint64_t _xxh_rotl(uint64_t x, int r) noexcept nogil:
     return (x << r) | (x >> (64 - r))
 
 
-cdef inline uint64_t _xxh_round(uint64_t acc, uint64_t inp) noexcept:
+cdef inline uint64_t _xxh_round(uint64_t acc, uint64_t inp) noexcept nogil:
     acc += inp * BORG_XXH64_P2
     acc = _xxh_rotl(acc, 31)
     acc *= BORG_XXH64_P1
     return acc
 
 
-cdef inline uint64_t _xxh_merge(uint64_t acc, uint64_t val) noexcept:
+cdef inline uint64_t _xxh_merge(uint64_t acc, uint64_t val) noexcept nogil:
     acc ^= _xxh_round(0, val)
     acc = acc * BORG_XXH64_P1 + BORG_XXH64_P4
     return acc
 
 
 # read 64/32 bits little-endian, byte-wise, so this is correct on both little- and big-endian hosts.
-cdef inline uint64_t _xxh_read64(const uint8_t *p) noexcept:
+cdef inline uint64_t _xxh_read64(const uint8_t *p) noexcept nogil:
     return (<uint64_t>p[0] | (<uint64_t>p[1] << 8) | (<uint64_t>p[2] << 16) | (<uint64_t>p[3] << 24) |
             (<uint64_t>p[4] << 32) | (<uint64_t>p[5] << 40) | (<uint64_t>p[6] << 48) | (<uint64_t>p[7] << 56))
 
 
-cdef inline uint32_t _xxh_read32(const uint8_t *p) noexcept:
+cdef inline uint32_t _xxh_read32(const uint8_t *p) noexcept nogil:
     return (<uint32_t>p[0] | (<uint32_t>p[1] << 8) | (<uint32_t>p[2] << 16) | (<uint32_t>p[3] << 24))
 
 
@@ -926,11 +935,12 @@ cdef class XXH64:
         cdef Py_buffer view
         PyObject_GetBuffer(data, &view, PyBUF_SIMPLE)
         try:
-            self._update(<const uint8_t *> view.buf, view.len)
+            with nogil:
+                self._update(<const uint8_t *> view.buf, view.len)
         finally:
             PyBuffer_Release(&view)
 
-    cdef void _update(self, const uint8_t *p, Py_ssize_t length) noexcept:
+    cdef void _update(self, const uint8_t *p, Py_ssize_t length) noexcept nogil:
         cdef const uint8_t *end = p + length
         cdef const uint8_t *limit
         cdef unsigned int fill


### PR DESCRIPTION
Release the GIL in all the no-risk pure-C regions of the Cython kernels, so other threads (FUSE request handling, the lock-refresh thread, and future parallel create/transfer pipelines) are no longer blocked while borg chunks, hashes, or en/decrypts.

### What

**Chunkers (buzhash, buzhash64, fastcdc):**
- `_buzhash*` / `BARREL_SHIFT*` helpers declared `noexcept nogil` (pure arithmetic, cannot raise),
- `with nogil:` around the byte-scan loops, the initial window hash, and `fill()`'s bulk `memmove`/`memcpy`/`memset` (the `PyBytes_AsString` pointer is captured while holding the GIL).

**crypto/low_level.pyx:**
- OpenSSL extern blocks declared `nogil` (declaration-only),
- GIL released around only the *bulk* `EVP_EncryptUpdate`/`EVP_DecryptUpdate` calls (AEAD encrypt+decrypt, AES-CTR decrypt as used by `borg transfer`), using an `rc` variable so the error check/raise stays outside the block; the small Init/ctrl/Final/AAD calls are unchanged,
- XXH64: `_update` and the `_xxh_*` inline helpers marked `noexcept nogil`.

### Why this is safe

Every wrapped region is pure C on caller-owned buffers: no Python API use, no refcounting, no exceptions. No cipher or chunker object is used concurrently from multiple threads anywhere in borg: AEAD decrypt constructs a fresh cipher per call, the encrypt-side session cipher only runs on the single-threaded write paths, `borg mount` is read-only, and legacy repos cannot be mounted, so CTR decrypt only runs in single-threaded `borg transfer`.

Deliberately *not* converted: AES-CTR `encrypt()` (test-only), `platform/*.pyx` syscall wrappers (would need restructuring, not mechanical), `item.pyx`/`hashindex.pyx` (Python-object work), CSPRNG and `XXH64.digest()` (tiny buffers).

### Measurements

Two threads doing equal work each, 256 MiB random data per thread (Apple Silicon, py311); 2T/1T wall-time ratio: 2.0 = fully serialized, 1.0 = perfectly parallel:

| kernel | before | after |
|---|---|---|
| fastcdc chunker | 2.11 | 1.32 |
| buzhash64 chunker | 1.98 | 1.28 |
| buzhash chunker | 2.04 | 1.23 |
| xxh64 | 2.01 | 1.01 |
| aes256-ocb encrypt / decrypt | 2.02 / 1.98 | 1.04 / 1.09 |
| chacha20-poly1305 encrypt / decrypt | 2.08 / 2.04 | 1.07 / 1.08 |

Single-thread throughput is unchanged: the loop bodies are identical and the GIL is released once per scanned segment / bulk call, not per byte. The chunkers' residual ~1.3 is the per-chunk Python-level work (Chunk objects, reader), left for future work.

This is groundwork for a threaded create pipeline (#37).

### Verification

- chunkers + crypto test suites pass (287 tests), create/extract/transfer/compress archiver tests pass (167 tests),
- end-to-end smoke: repo-create (chacha20-poly1305) → create → check → extract → diff OK (startup selftests exercise the changed kernels in every borg process),
- the 2-thread scaling measurements above double as proof the GIL is actually released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)