### PR TITLE
CI: add linux Python 3.15 jobs (non-blocking)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -27,6 +27,11 @@ jobs:
           - os: ubuntu-24.04
             python-version: '3.14'
             toxenv: py314-mfusepy
+          - os: ubuntu-24.04
+            # 3.15 is not released yet - fail-fast is off, so a broken prerelease
+            # python (or a dependency without 3.15 wheels) only reddens this entry.
+            python-version: '3.15-dev'
+            toxenv: py315-mfusepy
           - os: macos-15
             python-version: '3.14'
             toxenv: py314-none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
       id-token: write
       attestations: write
     strategy:
+      # entries with "allow-failure": true (e.g. prerelease pythons) do not fail
+      # the matrix, see continue-on-error below.
       fail-fast: true
       # noinspection YAMLSchemaValidation
       matrix: >-
@@ -145,7 +147,8 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "docs"},
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3", "store_cache": "1"},
-              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"}
+              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"},
+              {"os": "ubuntu-24.04", "python-version": "3.15-dev", "toxenv": "py315-mfusepy", "allow-failure": true}
             ]
           }' || '{
             "include": [
@@ -155,7 +158,8 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-x86_64-gh"},
               {"os": "ubuntu-24.04-arm", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-arm64-gh"},
               {"os": "macos-15", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-arm64-gh"},
-              {"os": "macos-15-intel", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-x86_64-gh"}
+              {"os": "macos-15-intel", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-x86_64-gh"},
+              {"os": "ubuntu-24.04", "python-version": "3.15-dev", "toxenv": "py315-mfusepy", "allow-failure": true}
             ]
           }'
         ) }}
@@ -163,6 +167,10 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
+    # Python 3.15 is not released yet, so do not fail the whole matrix if it (or a
+    # dependency not having wheels / not compiling for it yet) breaks.
+    # Remove the "allow-failure" matrix entries once 3.15 is final.
+    continue-on-error: ${{ matrix.allow-failure || false }}
     # macOS machines can be slow, if overloaded.
     timeout-minutes: 360
 


### PR DESCRIPTION
tox (`py315-*` envs) and `pyproject.toml` (3.15 classifier) already have 3.15
support from b9a0a33a6 — only the CI part of that commit had been reverted in
939568516, back when PyO3 did not support 3.15 yet. That is no longer the case
(borgstore's 3.15 CI job is green), so let's have 3.15 coverage again.

**ci.yml**: one `ubuntu-24.04` / `3.15-dev` / `py315-mfusepy` entry in each of the
two `native_tests` matrices (PR and push). Since that matrix runs with
`fail-fast: true`, the entry is marked `"allow-failure": true` and the job gets
`continue-on-error: ${{ matrix.allow-failure || false }}` — a broken prerelease
python, or a dependency without 3.15 wheels, then neither fails the build nor
cancels the rest of the matrix. Drop those two bits once 3.15 is final.

**canary.yml**: an additional (not replacing 3.14) `3.15-dev` / `py315-mfusepy`
entry. The canary installs the *unlocked* requirements, so it is where a
dependency gaining or losing 3.15 support shows up first. That matrix already
has `fail-fast: false`, so it needs no `continue-on-error`.

`mfusepy` in both cases because it is the pure-python FUSE binding, so it is the
variant least likely to need a source build against a moving 3.15 C API.

Heads-up: as of today blake3, msgpack, PyYAML, borghash, llfuse and pyfuse3
publish no cp315 wheels yet, so these jobs will source-build them and be
correspondingly slow.