### PR TITLE
chunkers: zero-copy fill via FileReader.readinto() (+15-40%)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -197,6 +197,10 @@ New features:
     bit-identical (1-byte granularity, same golden chunk points)
   - buzhash64: SIMD scan kernel (same technique and dispatch), ~1.5x faster
     on Apple Silicon; cut points stay bit-identical
+  - zero-copy fill: the file reader writes data (and zeros for sparse holes)
+    directly into the chunker's scan buffer, replacing several per-byte copy
+    chains; fastcdc ~+40%, buzhash64 ~+20%, buzhash ~+15%,
+    rabin-aes/toeplitz-aes ~+16%, goldilocks-aes ~+9%
 - webdav: serve archives via WebDAV / HTTP, including PAX tar downloads - this is a nice
   replacement for `borg mount` in some use cases, #9942
 - mount: expose POSIX ACLs on Linux mounts (not enforced), #1042

--- a/src/borg/chunkers/buzhash.pyx
+++ b/src/borg/chunkers/buzhash.pyx
@@ -186,8 +186,6 @@ cdef class Chunker:
     cdef int fill(self) except 0:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
-        cdef object chunk
-        cdef const unsigned char* src
 
         # Move remaining data to the beginning of the buffer
         with nogil:
@@ -199,22 +197,13 @@ cdef class Chunker:
         if self.eof or n == 0:
             return 1
 
-        # Use FileReader to read data
-        chunk = self.file_reader.read(n)
-        n = chunk.meta["size"]
-
         if n > 0:
-            # Only copy data if it's not a hole
-            if chunk.meta["allocation"] == CH_DATA:
-                # Copy data from chunk to our buffer
-                src = <const unsigned char*>PyBytes_AsString(chunk.data)
-                with nogil:
-                    memcpy(self.data + self.position + self.remaining, src, n)
-            else:
-                # For holes, fill with zeros using memset
-                with nogil:
-                    memset(self.data + self.position + self.remaining, 0, n)
-
+            # zero-copy path: the reader writes file data (and zeros for holes)
+            # directly into the scan buffer - one memcpy per byte instead of
+            # slice/join/copy chains through intermediate bytes objects.
+            n = self.file_reader.readinto(
+                <uint8_t[:n]>(self.data + self.position + self.remaining), n)
+        if n > 0:
             self.remaining += n
             self.bytes_read += n
         else:

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -217,8 +217,6 @@ cdef class ChunkerBuzHash64:
     cdef int fill(self) except 0:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
-        cdef object chunk
-        cdef const unsigned char* src
 
         # Move remaining data to the beginning of the buffer
         with nogil:
@@ -230,22 +228,13 @@ cdef class ChunkerBuzHash64:
         if self.eof or n == 0:
             return 1
 
-        # Use FileReader to read data
-        chunk = self.file_reader.read(n)
-        n = chunk.meta["size"]
-
         if n > 0:
-            # Only copy data if it's not a hole
-            if chunk.meta["allocation"] == CH_DATA:
-                # Copy data from chunk to our buffer
-                src = <const unsigned char*>PyBytes_AsString(chunk.data)
-                with nogil:
-                    memcpy(self.data + self.position + self.remaining, src, n)
-            else:
-                # For holes, fill with zeros using memset
-                with nogil:
-                    memset(self.data + self.position + self.remaining, 0, n)
-
+            # zero-copy path: the reader writes file data (and zeros for holes)
+            # directly into the scan buffer - one memcpy per byte instead of
+            # slice/join/copy chains through intermediate bytes objects.
+            n = self.file_reader.readinto(
+                <uint8_t[:n]>(self.data + self.position + self.remaining), n)
+        if n > 0:
             self.remaining += n
             self.bytes_read += n
         else:

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -150,8 +150,6 @@ cdef class ChunkerFastCDC:
     cdef int fill(self) except 0:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
-        cdef object chunk
-        cdef const unsigned char* src
 
         with nogil:
             memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
@@ -162,17 +160,13 @@ cdef class ChunkerFastCDC:
         if self.eof or n == 0:
             return 1
 
-        chunk = self.file_reader.read(n)
-        n = chunk.meta["size"]
-
         if n > 0:
-            if chunk.meta["allocation"] == CH_DATA:
-                src = <const unsigned char*>PyBytes_AsString(chunk.data)
-                with nogil:
-                    memcpy(self.data + self.position + self.remaining, src, n)
-            else:
-                with nogil:
-                    memset(self.data + self.position + self.remaining, 0, n)
+            # zero-copy path: the reader writes file data (and zeros for holes)
+            # directly into the scan buffer - one memcpy per byte instead of
+            # slice/join/copy chains through intermediate bytes objects.
+            n = self.file_reader.readinto(
+                <uint8_t[:n]>(self.data + self.position + self.remaining), n)
+        if n > 0:
             self.remaining += n
             self.bytes_read += n
         else:

--- a/src/borg/chunkers/phte_chunker.pyx
+++ b/src/borg/chunkers/phte_chunker.pyx
@@ -103,7 +103,6 @@ cdef class ChunkerPHTE:
     cdef int fill(self) except 0:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
-        cdef object chunk
 
         memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
         self.position -= self.last
@@ -113,14 +112,13 @@ cdef class ChunkerPHTE:
         if self.eof or n == 0:
             return 1
 
-        chunk = self.file_reader.read(n)
-        n = chunk.meta["size"]
-
         if n > 0:
-            if chunk.meta["allocation"] == CH_DATA:
-                memcpy(self.data + self.position + self.remaining, <const unsigned char*>PyBytes_AsString(chunk.data), n)
-            else:
-                memset(self.data + self.position + self.remaining, 0, n)
+            # zero-copy path: the reader writes file data (and zeros for holes)
+            # directly into the scan buffer - one memcpy per byte instead of
+            # slice/join/copy chains through intermediate bytes objects.
+            n = self.file_reader.readinto(
+                <uint8_t[:n]>(self.data + self.position + self.remaining), n)
+        if n > 0:
             self.remaining += n
             self.bytes_read += n
         else:

--- a/src/borg/chunkers/reader.pyx
+++ b/src/borg/chunkers/reader.pyx
@@ -358,4 +358,73 @@ class FileReader:
             # Otherwise, all chunks were CH_ALLOC
             return Chunk(None, size=bytes_read, allocation=CH_ALLOC)
 
+    def readinto(self, target, size):
+        """
+        Read up to 'size' bytes from the file directly into 'target' (a writable
+        buffer, e.g. a memoryview over the caller's scan buffer).
+
+        Unlike read(), this does not allocate or combine intermediate byte
+        objects: each byte is copied exactly once, from the buffered file block
+        into 'target'. Ranges stemming from holes / all-zero blocks are written
+        as zero bytes ('target' may contain stale data). The caller detects
+        all-zero chunks itself at chunk granularity, so no allocation type is
+        returned.
+
+        :param target: writable buffer, len(target) >= size
+        :param size: number of bytes to read
+        :return: number of bytes written to target (0 at EOF).
+        """
+        # Initialize if not already done
+        if self.blockify_gen is None:
+            self.buffer = []
+            self.offset = 0
+            self.remaining_bytes = 0
+            self.blockify_gen = self.reader.blockify()
+
+        # If we don't have enough data in the buffer, try to fill it
+        while self.remaining_bytes < size:
+            if not self._fill_buffer():
+                # No more data available, return what we have
+                break
+
+        if not self.buffer:
+            return 0
+
+        with memoryview(target) as tv:
+            bytes_to_read = min(size, self.remaining_bytes)
+            bytes_read = 0
+            while bytes_read < bytes_to_read and self.buffer:
+                chunk = self.buffer[0]
+                chunk_size = chunk.meta["size"]
+                allocation = chunk.meta["allocation"]
+                data = chunk.data
+
+                if allocation not in (CH_DATA, CH_HOLE, CH_ALLOC):
+                    raise ValueError(f"Invalid allocation type: {allocation}")
+
+                # Calculate how much we can read from this chunk
+                available = chunk_size - self.offset
+                to_read = min(available, bytes_to_read - bytes_read)
+
+                if allocation == CH_DATA:
+                    assert data is not None
+                    # one memcpy: block -> target (the source slice is a view, not a copy)
+                    with memoryview(data) as dv:
+                        tv[bytes_read:bytes_read + to_read] = dv[self.offset:self.offset + to_read]
+                else:
+                    # holes / all-zero blocks: write zeros (target may contain stale data)
+                    tv[bytes_read:bytes_read + to_read] = zeros[:to_read]
+
+                bytes_read += to_read
+
+                # Update offset or remove chunk if fully consumed
+                if to_read < available:
+                    self.offset += to_read
+                else:
+                    self.offset = 0
+                    self.buffer.pop(0)
+
+                self.remaining_bytes -= to_read
+
+        return bytes_read
 


### PR DESCRIPTION
Every data byte previously travelled through **up to five userspace copies** on its way into a chunker's scan buffer: `os.read` into a block bytes object → a slice copy in `FileReader.read()` → `bytearray.extend` → `bytes(result)` → the chunker's `memcpy` into its buffer. For the fast chunkers this copy chain costs as much as or more than the rolling-hash scan itself.

`FileReader` gains **`readinto(target, size)`**: it walks its buffered file blocks and copies each byte **exactly once**, directly into the caller's buffer (a memoryview over the chunker's scan buffer). Ranges stemming from sparse holes or all-zero blocks are written as zeros. All content-defined chunkers' `fill()` (buzhash, buzhash64, fastcdc, and the shared ChunkerPHTE fill of rabin-aes/goldilocks-aes/toeplitz-aes) use it instead of `read()` + memcpy/memset. `read()` itself is unchanged; the fixed chunker stays on it by design — it yields sparse holes without materializing zeros, which `readinto` would have to write out.

### Correctness

Cut behavior is untouched — the scan sees exactly the same bytes:

- all frozen golden chunk-point tests pass unchanged;
- `readinto` verified equal to `read()` over 30 random read-size sequences on files with mixed data/hole fmaps, with holes correctly zeroing a deliberately dirtied target buffer;
- end-to-end `borg create --sparse` + extract round-trip incl. a sparse file.

### Performance (Apple M-series, 1 GiB random, params 19,23,21, best of 3)

| chunker | before (plain/nc2) | after (plain/nc2) | gain |
|---|---|---|---|
| fastcdc | ~1210 / 1290 | **~1730 / 1820** | +40% |
| buzhash64 | ~975 / 1060 | **~1220 / 1300** | +20% |
| buzhash | ~1050 | **~1225** | +15% |
| toeplitz-aes | 668 / 704 | **776 / 825** | +16% |
| rabin-aes | 656 / 696 | **751 / 817** | +16% |
| goldilocks-aes | 361 / 389 | **391 / 424** | +9% |

(The AES chunkers gain although they are AES-bound in the scan: the copy chain cost was additive on top.)

Now rebased onto master including the merged SIMD kernels (#10034), so this branch *is* the stacked configuration. Measured on the rebased branch (same protocol):

| chunker | stacked (plain/nc2) |
|---|---|
| fastcdc | **2933 / 3150 MB/s** |
| buzhash64 | **2091 / 2212 MB/s** |
| toeplitz-aes | 776 / 830 MB/s |

i.e. ~2.4x fastcdc and ~2.1x buzhash64 versus before either PR, with fastcdc crossing 3 GB/s at normalized chunking level 2. All 93 chunker golden tests pass with SIMD kernels and zero-copy fill active together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


