### PR TITLE
PackReader.read(): return a memoryview of the in-memory pack instead of copying

### DIFF
--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -160,11 +160,11 @@ class RepoObj:
         hdr_packed = self.obj_header.pack(*hdr)
         return hdr_packed + meta_encrypted + data_encrypted
 
-    def parse_meta(self, id: bytes, cdata: bytes, ro_type: str) -> dict:
+    def parse_meta(self, id: bytes, cdata: bytes | memoryview, ro_type: str) -> dict:
         # when calling parse_meta, enough cdata needs to be supplied to contain completely the
         # meta_len_hdr and the encrypted, packed metadata. it is allowed to provide more cdata.
         assert isinstance(id, bytes)
-        assert isinstance(cdata, bytes)
+        assert isinstance(cdata, (bytes, memoryview))
         assert isinstance(ro_type, str)
         obj = memoryview(cdata)
         hdr_size = self.obj_header.size
@@ -192,7 +192,7 @@ class RepoObj:
     def parse(
         self,
         id: bytes,
-        cdata: bytes,
+        cdata: bytes | memoryview,
         decompress: bool = True,
         want_compressed: bool = False,
         ro_type: str = None,
@@ -215,7 +215,7 @@ class RepoObj:
         assert isinstance(ro_type, str)
         assert not (not decompress and not want_compressed), "invalid parameter combination!"
         assert isinstance(id, bytes)
-        assert isinstance(cdata, bytes)
+        assert isinstance(cdata, (bytes, memoryview))
         obj = memoryview(cdata)
         hdr_size = self.obj_header.size
         if len(obj) < hdr_size:

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -225,9 +225,9 @@ class PackReader:
         self.pack_contents = pack_contents
 
     def read(self, offset, size):
-        # read from the in-memory pack if we have it, else range-read from the store
+        # in-memory pack: return a memoryview into pack_contents. store: range-read bytes.
         if self.pack_contents is not None:
-            return self.pack_contents[offset : offset + size]
+            return memoryview(self.pack_contents)[offset : offset + size]
         return self.store.load(self.key, offset=offset, size=size)
 
     def iter_headers(self):
@@ -990,7 +990,8 @@ class Repository:
                 meta = obj[hdr_size : hdr_size + meta_size]
                 if len(meta) != meta_size:
                     raise IntegrityError(f"Object too small [id {id_hex}]: expected {meta_size}, got {len(meta)} bytes")
-                return hdr + meta
+                # hdr, meta are memoryviews for an in-memory pack; return them concatenated as bytes.
+                return bytes(hdr) + bytes(meta)
         except StoreObjectNotFound:
             if raise_missing:
                 raise self.ObjectNotFound(id, str(self._location)) from None

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -351,9 +351,12 @@ def test_get_reuses_cached_pack(repo_fixtures, request):
         list(repository.get_many([H(0), H(1)]))  # loads the whole pack into the cache
 
         loads_before = repository.store.stats["load_calls"]
-        assert repository.get(H(0)) == reference
+        cached = repository.get(H(0))
+        assert cached == reference
+        assert isinstance(cached, memoryview)  # a cached-pack read returns a memoryview into the pack
         assert repository.store.stats["load_calls"] - loads_before == 0  # sliced from the cached pack
-        assert repository.get(H(1), read_data=False)  # read_data=False also peeks the cache
+        meta_only = repository.get(H(1), read_data=False)
+        assert meta_only and isinstance(meta_only, bytes)  # read_data=False returns header+meta bytes
         assert repository.store.stats["load_calls"] - loads_before == 0
 
 
@@ -1234,3 +1237,16 @@ def test_pack_reader_iter_headers_reads_through_store(tmp_path):
         repository.store_store("packs/" + bin_to_hex(pack_id), pack)
         reader = PackReader(repository.store, pack_id)
         assert list(reader.iter_headers()) == [(H(47), 0, len(obj1)), (H(48), len(obj1), len(obj2))]
+
+
+def test_pack_reader_in_memory_read_returns_view():
+    # read() over an in-memory pack returns a memoryview into pack_contents.
+    obj1 = fchunk(b"payload-one", meta=b"meta1", chunk_id=H(1))
+    obj2 = fchunk(b"d2", meta=b"m2", chunk_id=H(2))
+    pack = bytearray(obj1 + obj2)  # bytearray so a write shows through a view
+    reader = PackReader(pack_contents=pack)
+    view = reader.read(len(obj1), len(obj2))
+    assert isinstance(view, memoryview)
+    assert bytes(view) == obj2
+    pack[len(obj1)] ^= 0xFF  # a write to pack_contents is visible through the view
+    assert view[0] == obj2[0] ^ 0xFF


### PR DESCRIPTION
## Description

`PackReader.read()` read chunks from the in-memory pack by slicing `pack_contents`, a `bytes` object, so every read allocated and copied. It now returns a `memoryview` slice, which is a view into the pack with no copy. On a profiled 6 GiB extract that copy cost about 1.3% of extract CPU.

Supporting changes:
- `parse()` and `parse_meta()` take `bytes` or `memoryview` for `cdata` (both wrap it in `memoryview()` anyway).
- `get(read_data=False)` returns header plus meta as `bytes`.

The store range-read path is unchanged and still returns `bytes`. Re-put and key detection already accept the buffer protocol.

fixes #10030

## Checklist

- [x] PR is against `master`
- [x] New code has tests and docs where appropriate
- [x] Tests pass (repository, repoobj, and extract/check/debug consumer subsets)
- [x] Commit messages are clean and reference related issues
