### PR TITLE
chunkers: lazy scan buffer compaction

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -201,6 +201,10 @@ New features:
     directly into the chunker's scan buffer, replacing several per-byte copy
     chains; fastcdc ~+40%, buzhash64 ~+20%, buzhash ~+15%,
     rabin-aes/toeplitz-aes ~+16%, goldilocks-aes ~+9%
+  - lazy buffer compaction: compact the scan buffer only when the free tail
+    gets too small for a full read block (instead of memmoving on every
+    refill), removing ~80% of the compaction copy traffic; cut points stay
+    bit-identical (all CDC chunkers)
 - webdav: serve archives via WebDAV / HTTP, including PAX tar downloads - this is a nice
   replacement for `borg mount` in some use cases, #9942
 - mount: expose POSIX ACLs on Linux mounts (not enforced), #1042

--- a/src/borg/chunkers/base.pyx
+++ b/src/borg/chunkers/base.pyx
@@ -116,14 +116,22 @@ cdef class ChunkerBase:
         """Fill the chunker's buffer with more data."""
         cdef ssize_t n
 
-        # Move remaining data to the beginning of the buffer
-        with nogil:
-            memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
-        self.position -= self.last
-        self.last = 0
-        n = self.buf_size - self.position - self.remaining
+        if self.eof:
+            return 1
 
-        if self.eof or n == 0:
+        n = self.buf_size - self.position - self.remaining
+        if n < <ssize_t>self.reader_block_size and self.last > 0:
+            # The free tail of the buffer is too small for a full read block:
+            # compact the buffer by dropping the already-yielded data before
+            # self.last. Compacting lazily (instead of on every fill) avoids
+            # memmoving roughly one byte per byte read.
+            with nogil:
+                memmove(self.data, self.data + self.last, self.position + self.remaining - self.last)
+            self.position -= self.last
+            self.last = 0
+            n = self.buf_size - self.position - self.remaining
+
+        if n == 0:
             return 1
 
         if n > 0:


### PR DESCRIPTION
Follow-up to #10039 (now merged), rebased onto current master.

### What

`fill()` used to memmove the live window `[last, position+remaining)` to the buffer start on **every** refill — even when the free tail could still take a full read block, even at eof, and even when `last == 0` (where the dst == src memmove is a full self-copy on most libcs).

Now the buffer is compacted only when the free tail is smaller than one reader block, so the memmove runs about once per buffer cycle instead of once per refill, removing ~80% of the compaction copy traffic.

Thanks to the ChunkerBase refactor this is a **single-point change in `ChunkerBase.fill()`**, used by all CDC chunkers, plus a changelog entry.

### Correctness

- Cut points stay **bit-identical**: verified per-chunker over 1 GiB of synthetic data (identical chunk-length sequences vs master, all 6 CDC chunkers), by the chunker test suite (incl. the buzhash golden sweep with its pinned hash), and by a 40-case buzhash edge matrix (negative seeds, forced max-size cuts, empty/tiny/sub-minimum inputs, all-zero data).
- The forced-cut-at-max_size behavior is preserved: when the tail is exhausted and `last == 0`, `fill()` cannot add data and the chunk is cut at `buf_size`, exactly as before. When `last > 0`, the tail-too-small condition triggers compaction first, so a cut below max_size cannot happen.

### Performance

Honest numbers: on Apple Silicon (M3 Pro) the wall-clock win is only ~1% (within noise) — memmove runs at ~50 GB/s there, and since #10035 `readinto` fills the whole free tail, so compactions were already down to about one per 6-7 MiB consumed. The value of this change is the removed memory traffic (~0.2 bytes/byte chunked → ~0.04), which matters more on memory-bandwidth-limited machines and once chunking runs multi-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)