### PR TITLE
lrucache: allow replacing an entry, make it thread-safe

### DIFF
--- a/src/borg/helpers/lrucache.py
+++ b/src/borg/helpers/lrucache.py
@@ -1,9 +1,12 @@
+import threading
 from collections import OrderedDict
 from collections.abc import Callable, ItemsView, Iterator, KeysView, MutableMapping, ValuesView
-from typing import TypeVar
+from typing import Any, TypeVar
 
 K = TypeVar("K")
 V = TypeVar("V")
+
+_MISSING = object()
 
 
 class LRUCache(MutableMapping[K, V]):
@@ -13,6 +16,16 @@ class LRUCache(MutableMapping[K, V]):
     A value that leaves the cache - evicted, deleted, or replaced by another value under
     the same key - is passed to *dispose* first, so that a cache of e.g. open files can
     close them. Use replace() to update an entry while keeping its old value alive.
+
+    Thread safety: getting, setting, deleting, popping, replacing and clearing are each
+    atomic, so several threads can share one cache without corrupting it. A *sequence* of
+    them is not: two threads can miss on the same key and both compute and store a value,
+    which for a cache is wasteful, not wrong - and the mixin methods built on top of the
+    above (setdefault, popitem, update) inherit that. Iterating (also via keys(), values(),
+    items()) yields a live view of the underlying dict, so it needs external
+    synchronization if another thread may write meanwhile.
+
+    *dispose* is called while the lock is held, so it must not use the cache.
     """
 
     _cache: OrderedDict[K, V]
@@ -25,32 +38,48 @@ class LRUCache(MutableMapping[K, V]):
         self._cache = OrderedDict()
         self._capacity = capacity
         self._dispose = dispose
+        self._lock = threading.Lock()
 
     def __setitem__(self, key: K, value: V) -> None:
-        try:
-            previous = self._cache.pop(key)
-        except KeyError:
-            pass
-        else:
-            # the old value is no longer in the cache, so it is disposed like a deleted one.
-            if previous is not value:
-                self._dispose(previous)
-        while len(self._cache) >= self._capacity:
-            self._dispose(self._cache.popitem(last=False)[1])
-        self._cache[key] = value  # add the new (or refreshed) entry at the end
+        with self._lock:
+            try:
+                previous = self._cache.pop(key)
+            except KeyError:
+                pass
+            else:
+                # the old value is no longer in the cache, so it is disposed like a deleted one.
+                if previous is not value:
+                    self._dispose(previous)
+            while len(self._cache) >= self._capacity:
+                self._dispose(self._cache.popitem(last=False)[1])
+            self._cache[key] = value  # add the new (or refreshed) entry at the end
 
     def __getitem__(self, key: K) -> V:
-        self._cache.move_to_end(key)  # raise KeyError if not found
-        return self._cache[key]
+        with self._lock:
+            self._cache.move_to_end(key)  # raise KeyError if not found
+            return self._cache[key]
 
     def __delitem__(self, key: K) -> None:
-        self._dispose(self._cache.pop(key))
+        with self._lock:
+            self._dispose(self._cache.pop(key))
 
     def __contains__(self, key: object) -> bool:
         return key in self._cache
 
     def __len__(self) -> int:
         return len(self._cache)
+
+    def pop(self, key: K, default: Any = _MISSING) -> Any:
+        """Remove *key* and return its value, without disposing it."""
+        # MutableMapping would implement this as __getitem__ + __delitem__, which is not
+        # atomic (and would dispose the value).
+        with self._lock:
+            try:
+                return self._cache.pop(key)
+            except KeyError:
+                if default is _MISSING:
+                    raise
+                return default
 
     def replace(self, key: K, value: V) -> None:
         """Replace the value of an entry that is present, without disposing the old value.
@@ -61,13 +90,15 @@ class LRUCache(MutableMapping[K, V]):
         is in the LRU order, i.e. it does not count as a use. Everything else should just
         assign to the cache.
         """
-        assert key in self._cache, "Unexpected attempt to update a non-existing item."
-        self._cache[key] = value
+        with self._lock:
+            assert key in self._cache, "Unexpected attempt to update a non-existing item."
+            self._cache[key] = value
 
     def clear(self) -> None:
-        for value in self._cache.values():
-            self._dispose(value)
-        self._cache.clear()
+        with self._lock:
+            for value in self._cache.values():
+                self._dispose(value)
+            self._cache.clear()
 
     def __iter__(self) -> Iterator[K]:
         return iter(self._cache)

--- a/src/borg/helpers/lrucache.py
+++ b/src/borg/helpers/lrucache.py
@@ -9,8 +9,10 @@ V = TypeVar("V")
 class LRUCache(MutableMapping[K, V]):
     """
     Mapping which maintains a maximum size by removing the least recently used value.
-    Items are passed to dispose before being removed and setting an item which is
-    already in the cache has to be done using the replace method.
+
+    A value that leaves the cache - evicted, deleted, or replaced by another value under
+    the same key - is passed to *dispose* first, so that a cache of e.g. open files can
+    close them. Use replace() to update an entry while keeping its old value alive.
     """
 
     _cache: OrderedDict[K, V]
@@ -25,12 +27,17 @@ class LRUCache(MutableMapping[K, V]):
         self._dispose = dispose
 
     def __setitem__(self, key: K, value: V) -> None:
-        assert (
-            key not in self._cache
-        ), "Unexpected attempt to replace a cached item without first deleting the old item."
+        try:
+            previous = self._cache.pop(key)
+        except KeyError:
+            pass
+        else:
+            # the old value is no longer in the cache, so it is disposed like a deleted one.
+            if previous is not value:
+                self._dispose(previous)
         while len(self._cache) >= self._capacity:
             self._dispose(self._cache.popitem(last=False)[1])
-        self._cache[key] = value  # add new entry at the end
+        self._cache[key] = value  # add the new (or refreshed) entry at the end
 
     def __getitem__(self, key: K) -> V:
         self._cache.move_to_end(key)  # raise KeyError if not found
@@ -46,8 +53,14 @@ class LRUCache(MutableMapping[K, V]):
         return len(self._cache)
 
     def replace(self, key: K, value: V) -> None:
-        """Replace an item that is already present, not disposing it in the process."""
-        # this method complements __setitem__ which should be used for the normal use case.
+        """Replace the value of an entry that is present, without disposing the old value.
+
+        This is for the rare case where the old value must stay alive, e.g. because the new
+        value still refers to it (the legacy repository's fd cache re-times-stamps its
+        entries this way, keeping the open file object). It also keeps the entry where it
+        is in the LRU order, i.e. it does not count as a use. Everything else should just
+        assign to the cache.
+        """
         assert key in self._cache, "Unexpected attempt to update a non-existing item."
         self._cache[key] = value
 

--- a/src/borg/testsuite/helpers/lrucache_test.py
+++ b/src/borg/testsuite/helpers/lrucache_test.py
@@ -1,3 +1,5 @@
+import sys
+import threading
 from tempfile import TemporaryFile
 
 import pytest
@@ -81,3 +83,50 @@ class TestLRUCache:
         c.clear()
         assert c.items() == set()
         assert f3.closed
+
+    def test_pop(self):
+        disposed = []
+        c = LRUCache(2, dispose=disposed.append)
+        c["a"] = 1
+        assert c.pop("a") == 1  # pop hands the value to the caller, so it is not disposed
+        assert disposed == []
+        assert "a" not in c
+        assert c.pop("a", "default") == "default"
+        with pytest.raises(KeyError):
+            c.pop("a")
+
+    def test_threaded_access(self):
+        # several threads sharing one cache must not corrupt it or raise: they hit the same
+        # keys, so they race on inserting, refreshing, evicting and removing the same entries.
+        # e.g. popping via MutableMapping (get, then delete) raises KeyError here when
+        # another thread removes the key in between.
+        c: LRUCache = LRUCache(8)
+        keys = list(range(16))  # more keys than capacity, so entries keep getting evicted
+        errors: list[Exception] = []
+        start = threading.Barrier(8)
+
+        def worker(n):
+            start.wait()
+            try:
+                for _round in range(2000):
+                    for key in keys:
+                        c[key] = n
+                        c.get(key)
+                        c.pop(key, None)
+            except Exception as e:
+                errors.append(e)
+
+        # the default switch interval (5 ms) is longer than these loops, so threads would
+        # hardly ever switch inside one cache operation and the races would not show up.
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        finally:
+            sys.setswitchinterval(previous_interval)
+        assert errors == []
+        assert len(c) <= 8

--- a/src/borg/testsuite/helpers/lrucache_test.py
+++ b/src/borg/testsuite/helpers/lrucache_test.py
@@ -35,6 +35,33 @@ class TestLRUCache:
         c.clear()
         assert c.items() == set()
 
+    def test_assign_to_existing_key(self):
+        # assigning to a key that is present replaces the value and counts as a use,
+        # so the entry becomes the most recently used one.
+        c = LRUCache(2)
+        c["a"] = 1
+        c["b"] = 2
+        c["a"] = 3  # replaces, and refreshes "a"
+        assert len(c) == 2
+        assert c["a"] == 3
+        c["c"] = 4  # evicts the least recently used entry, which is "b" now
+        assert set(c.keys()) == {"a", "c"}
+
+    def test_dispose_on_replacement(self):
+        disposed = []
+        c = LRUCache(2, dispose=disposed.append)
+        c["a"] = "first"
+        c["a"] = "second"  # the replaced value leaves the cache, so it is disposed
+        assert disposed == ["first"]
+        assert c["a"] == "second"
+        value = "same object"
+        c["b"] = value
+        c["b"] = value  # assigning the identical object does not dispose it
+        assert disposed == ["first"]
+        c.replace("b", "replacement")  # replace() never disposes, see there
+        assert disposed == ["first"]
+        assert c["b"] == "replacement"
+
     def test_dispose(self):
         c = LRUCache(2, dispose=lambda f: f.close())
         f1 = TemporaryFile()


### PR DESCRIPTION
Follow-up to #10023, where a `LRUCache` blew up in the FUSE mount. Two commits, both on `helpers/lrucache.py` and its tests only - no call site changes, so this does not conflict with #10023.

### 1. Assigning to a key that is present replaces its value

`__setitem__` asserted `key not in self._cache`, so callers had to write

```python
if key in cache:
    cache.replace(key, value)
else:
    cache[key] = value
```

and a caller that just assigned crashed. That is a nasty failure mode for a cache: an operation that is correctness-neutral for the caller suddenly is not. It bites especially when several threads share one cache - two of them can miss on the same key and both store the value they fetched, which is how the mount in #10023 crashed (`hlfuse.py`: `self.data_cache[id] = data`).

Assignment now replaces the value, disposes the old one (it left the cache, exactly like a deleted one would) unless it is the identical object, and counts as a use.

`replace()` stays for the one case that needs it: updating an entry while keeping its old value alive - the legacy repository's fd cache re-timestamps its entries that way and must not have the open file closed.

#### Why the first commit can not break a working caller

The old behaviour for that case was to raise, and that was the only reachable one: borg refuses to
run with assertions disabled (`archiver/__init__.py` does `assert False` at import and exits with rc
2), so there is no `-O` mode in which the assignment quietly did something else. Only code that was
crashing changes behaviour.

The invariant the assertion protected - "dispose() is always called when necessary", the rationale in
9ba7daa9c that introduced it - is now enforced rather than forbidden: the replaced value is disposed.

Auditing every assignment into an LRUCache in the tree: the legacy repository's fd cache (the only
`dispose` user) assigns only inside `open_fd()`, i.e. on the KeyError path, and re-timestamps via
`replace()`; the `fuse.py` caches and `parsed_cache` / `_pack_cache` are all guarded by a preceding
lookup and reached single-threaded or under the repository lock. The sites that *can* reach the new
path are exactly the concurrent ones: `hlfuse.py`'s and `webdav.py`'s `data_cache`, and the global
`zero_chunk_ids` in `archive.py` - i.e. the bugs this fixes. Nothing catches the AssertionError, and
no test depended on it.


### 2. Thread safety

Several threads share one `LRUCache` in borg: mfusepy serves the FUSE requests of one mount from a thread pool, and `borg webdav` from one thread per connection. Until now every caller had to serialize access itself - a rule that is easy to miss, and missing it does not fail at the cache but far away from it (mfusepy turns any exception from a FUSE operation into EINVAL, so the mount reports "Invalid argument" for a perfectly healthy file).

Get, set, delete, pop, replace and clear now each hold a lock. A *sequence* of them still is not atomic - two threads can miss on the same key and both compute a value, which for a cache is wasteful, not wrong - and that is documented, together with the fact that iteration yields a live view and that `dispose` runs under the lock.

`pop()` is implemented here now rather than inherited: `MutableMapping` builds it from `__getitem__` + `__delitem__`, which is not atomic *and* disposed the value it hands to the caller (a cache of open files returned a closed file).

### Testing

- `test_threaded_access` is a real regression test: it fails without these changes and passes with them. It needs `sys.setswitchinterval(1e-6)` - at the default 5 ms these loops hardly ever switch inside one cache operation, which is why this class of bug stays hidden until it hits a mount.
- new tests for replacing an entry, for disposal on replacement, and for `pop`
- full test suite green; `mypy --ignore-missing-imports` reports exactly the same pre-existing errors as master

### Cost

About 75 ns per operation (timeit: get 70 -> 148 ns, set 148 -> 222 ns). Nothing next to what these caches guard - a chunk decrypt is in the milliseconds, an item unpack in the microseconds - and a borg mount read benchmark (1 GiB sequential, plus stat+read of 200 small files, mfusepy) shows no difference. It also makes the caches robust for free-threaded Python, where the GIL no longer papers over the check-then-act sequences these caches are full of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
