### PR TITLE
chunkers: add AVX-512 / VAES scan kernels

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -188,9 +188,10 @@ New features:
   - fastcdc is the new and faster default chunker, #9957
   - fastcdc / buzhash64: SIMD-accelerated scan kernel, #10034, #10043:
 
-    - NEON on aarch64 (e.g. Apple Silicon)
     - AVX-512 / AVX2 on x86-64 (Intel / AMD)
-    - blocked scalar elsewhere
+    - fastcdc also NEON on aarch64 (e.g. Apple Silicon); buzhash64 is faster
+      blockwise there, so it has no vector kernel on aarch64
+    - blockwise scalar elsewhere
   - toeplitz-aes, rabin-aes, goldilocks-aes: fingerprinting-resistant chunkers
     (UHF-then-PRF), with direct AES hw acceleration or via OpenSSL, #9987
   - toeplitz-aes, rabin-aes, goldilocks-aes: VAES/AVX-512 scan path on x86-64

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -186,13 +186,15 @@ New features:
 - Chunkers:
 
   - fastcdc is the new and faster default chunker, #9957
-  - fastcdc / buzhash64: SIMD-accelerated scan kernel, #10034:
+  - fastcdc / buzhash64: SIMD-accelerated scan kernel, #10034, #10043:
 
     - NEON on aarch64 (e.g. Apple Silicon)
-    - AVX2 on x86-64 (Intel / AMD)
+    - AVX-512 / AVX2 on x86-64 (Intel / AMD)
     - blocked scalar elsewhere
   - toeplitz-aes, rabin-aes, goldilocks-aes: fingerprinting-resistant chunkers
     (UHF-then-PRF), with direct AES hw acceleration or via OpenSSL, #9987
+  - toeplitz-aes, rabin-aes, goldilocks-aes: VAES/AVX-512 scan path on x86-64
+    (4 AES blocks per instruction), #10043
   - zero-copy fill and lazy buffer compaction optimizations
 - webdav: serve archives via WebDAV / HTTP, including PAX tar downloads - this is a nice
   replacement for `borg mount` in some use cases, #9942

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -189,9 +189,11 @@ New features:
   - fastcdc / buzhash64: SIMD-accelerated scan kernel, #10034, #10043:
 
     - AVX-512 / AVX2 on x86-64 (Intel / AMD)
-    - fastcdc also NEON on aarch64 (e.g. Apple Silicon); buzhash64 is faster
-      blockwise there, so it has no vector kernel on aarch64
+    - NEON on aarch64 (e.g. Apple Silicon); the default for fastcdc, but not
+      for buzhash64, which is faster blockwise on the cores measured so far
     - blockwise scalar elsewhere
+    - the kernel can be pinned via BORG_FASTCDC_KERNEL / BORG_BUZHASH64_KERNEL
+      / BORG_AES_CHUNKER_KERNEL
   - toeplitz-aes, rabin-aes, goldilocks-aes: fingerprinting-resistant chunkers
     (UHF-then-PRF), with direct AES hw acceleration or via OpenSSL, #9987
   - toeplitz-aes, rabin-aes, goldilocks-aes: VAES/AVX-512 scan path on x86-64

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -188,12 +188,12 @@ New features:
   - fastcdc is the new and faster default chunker, #9957
   - fastcdc / buzhash64: SIMD-accelerated scan kernel, #10034, #10043:
 
-    - AVX-512 / AVX2 on x86-64 (Intel / AMD)
-    - NEON on aarch64 (e.g. Apple Silicon); the default for fastcdc, but not
-      for buzhash64, which is faster blockwise on the cores measured so far
-    - blockwise scalar elsewhere
-    - the kernel can be pinned via BORG_FASTCDC_KERNEL / BORG_BUZHASH64_KERNEL
-      / BORG_AES_CHUNKER_KERNEL
+    - AVX-512 / AVX2 on x86-64 (Intel / AMD), NEON on aarch64, plus a portable
+      blockwise one; all bit-identical to the sequential loop
+    - the sequential loop is what runs unless BORG_FASTCDC_KERNEL /
+      BORG_BUZHASH64_KERNEL / BORG_AES_CHUNKER_KERNEL selects another kernel:
+      which one is fastest depends on the CPU *and* the compiler, so nothing
+      is chosen automatically
   - toeplitz-aes, rabin-aes, goldilocks-aes: fingerprinting-resistant chunkers
     (UHF-then-PRF), with direct AES hw acceleration or via OpenSSL, #9987
   - toeplitz-aes, rabin-aes, goldilocks-aes: VAES/AVX-512 scan path on x86-64

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -182,6 +182,32 @@ General:
         +0.05% archive size for 1MiB chunks, +0.64% for 8MiB ones, more at higher levels), and
         it uses more cpu time in total to reduce the wallclock time. Set it to 1 if you would
         rather have the smaller archive, or if borg has to share the cpu with other work.
+    BORG_FASTCDC_KERNEL / BORG_BUZHASH64_KERNEL
+        Select the scan kernel the ``fastcdc`` / ``buzhash64`` chunker uses (default:
+        ``scalar``, the plain sequential loop). Accepted values are ``avx512``, ``avx2``,
+        ``neon``, ``blockwise`` and ``scalar``.
+        All kernels chunk identically - same cut points, same chunk ids - and differ only in
+        speed, so this is safe to change at any time, also for an existing repository.
+        Which kernel is fastest is not predictable from the instruction set: it depends on the
+        cpu and on the compiler that built borg, and the sequential loop wins on some machines.
+        Nothing is selected automatically, so measure on your own hardware with
+        ``borg benchmark cpu --chunking`` before setting these.
+        ``avx512`` and ``avx2`` exist only on x86-64, ``neon`` only on aarch64, and only if the
+        compiler that built borg supported them; ``scalar`` and ``blockwise`` are portable C
+        and always available.
+        Requesting a kernel that this build or this cpu cannot run is an error rather than a
+        silent fallback, so a benchmark can not accidentally measure a different kernel.
+        ``borg create --debug`` logs the chunker and the kernel it was created with.
+    BORG_AES_CHUNKER_KERNEL
+        Select the scan kernel used by the AES based chunkers - one variable for all three of
+        ``toeplitz-aes``, ``rabin-aes`` and ``goldilocks-aes`` (default: ``evp``, the portable
+        OpenSSL path). Accepted values are ``vaes``, ``aes-ni``, ``aes-arm64`` and ``evp``.
+        As with the chunker kernels above, all of them chunk identically and differ only in
+        speed, nothing is selected automatically, and a kernel that can not run here is an
+        error rather than a silent fallback.
+        ``vaes`` and ``aes-ni`` exist only on x86-64, ``aes-arm64`` only on aarch64.
+        ``vaes`` additionally needs a compiler that knows it (gcc >= 11 / clang >= 14), so a
+        cpu supporting VAES is not by itself enough to have that kernel available.
     BORG_SHOW_SYSINFO
         When set to no (default: yes), system information (like OS, Python version, ...) in
         exceptions is not shown.

--- a/scripts/borg.exe.spec
+++ b/scripts/borg.exe.spec
@@ -14,12 +14,16 @@ if is_win32:
 else:
     hiddenimports = ['borg.platform.posix', 'borghash', 'rich._unicode_data.unicode17-0-0']
 
-# The chunkers cimport their shared base classes (ChunkerBase, and ChunkerPHTE
-# for the *-aes chunkers), so they import those modules at C level when
-# initializing - PyInstaller can not see this by static analysis of the Python
-# sources.
+# Anything a compiled chunker module pulls in has to be listed here: the
+# chunkers are Cython extensions, so PyInstaller's static analysis of the
+# Python sources cannot see their imports at all. That covers both the base
+# classes they cimport (ChunkerBase, and ChunkerPHTE for the *-aes chunkers),
+# which are imported at C level during module init, and plain Python modules
+# imported from a .pyx, such as kernel_env - it is imported ONLY from .pyx
+# files, so nothing else would drag it in.
 hiddenimports.append('borg.chunkers.base')
 hiddenimports.append('borg.chunkers.phte_chunker')
+hiddenimports.append('borg.chunkers.kernel_env')
 
 block_cipher = None
 

--- a/src/borg/chunkers/__init__.py
+++ b/src/borg/chunkers/__init__.py
@@ -8,6 +8,31 @@ from .failing import ChunkerFailing
 from .fixed import ChunkerFixed
 from .reader import *  # noqa
 
+from .. import logger as _logger
+
+logger = _logger.create_logger()
+
+
+def _made(algo, chunker):
+    """Log which chunker was constructed and which scan kernel it ended up with.
+
+    The kernel is worth seeing because it is not implied by the platform: it
+    defaults to the simplest implementation and is only changed by the
+    BORG_*_KERNEL env vars (see kernel_env.py).
+
+    Chunkers that have nothing to select - buzhash and fixed have exactly one
+    implementation each - say so rather than omitting the field, so that a
+    missing kernel cannot be mistaken for a reporting bug.
+
+    Chunkers can be built before setup_logging() has run (tests do it, and so
+    does anything using borg as a library), and create_logger() raises rather
+    than log at that point - so say nothing when there is nowhere to say it.
+    """
+    if _logger.configured:
+        kernel = getattr(chunker, "kernel", None) or "n/a (single implementation)"
+        logger.debug("chunker: %s, scan kernel: %s", algo, kernel)
+    return chunker
+
 
 def get_chunker(algo, *params, **kw):
     key = kw.get("key", None)
@@ -15,7 +40,7 @@ def get_chunker(algo, *params, **kw):
     # key.chunk_seed only has 32 bits
     seed = key.chunk_seed if key is not None else 0
     if algo == "buzhash":
-        return Chunker(seed, *params, sparse=sparse)
+        return _made(algo, Chunker(seed, *params, sparse=sparse))
     if algo == "buzhash64":
         # for buzhash64, we want a much longer key, so we derive it from the id key.
         # params is (chunk_min_exp, chunk_max_exp, hash_mask_bits, hash_window_size, nc_level);
@@ -23,14 +48,14 @@ def get_chunker(algo, *params, **kw):
         bh64_key = (
             key.derive_key(salt=b"", domain=b"buzhash64", size=32, from_id_key=True) if key is not None else b"\0" * 32
         )
-        return ChunkerBuzHash64(bh64_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse)
+        return _made(algo, ChunkerBuzHash64(bh64_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse))
     if algo == "fastcdc":
         # keyed gear table, derived from the id key (own domain). params is
         # (chunk_min_exp, chunk_max_exp, hash_mask_bits, nc_level) - no window (Gear is window-less).
         fc_key = (
             key.derive_key(salt=b"", domain=b"fastcdc", size=32, from_id_key=True) if key is not None else b"\0" * 32
         )
-        return ChunkerFastCDC(fc_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse)
+        return _made(algo, ChunkerFastCDC(fc_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse))
     if algo == "rabin-aes":
         # UHF-then-PRF chunker (secret Rabin polynomial + AES-128), derived from
         # the id key (own domain). params is (chunk_min_exp, chunk_max_exp,
@@ -38,7 +63,7 @@ def get_chunker(algo, *params, **kw):
         ra_key = (
             key.derive_key(salt=b"", domain=b"rabin-aes", size=32, from_id_key=True) if key is not None else b"\0" * 32
         )
-        return ChunkerRabinAES(ra_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse)
+        return _made(algo, ChunkerRabinAES(ra_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse))
     if algo == "goldilocks-aes":
         # like rabin-aes, but with the Goldilocks prime-field polynomial hash as
         # the UHF (the reference construction of eprint 2025/558). Same param
@@ -48,7 +73,7 @@ def get_chunker(algo, *params, **kw):
             if key is not None
             else b"\0" * 32
         )
-        return ChunkerGoldilocksAES(gl_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse)
+        return _made(algo, ChunkerGoldilocksAES(gl_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse))
     if algo == "toeplitz-aes":
         # like rabin-aes, but with a tabulated LFSR/Toeplitz hash as the UHF
         # (secret 2 KiB table, fixed public polynomial). Same param shape:
@@ -58,9 +83,9 @@ def get_chunker(algo, *params, **kw):
             if key is not None
             else b"\0" * 32
         )
-        return ChunkerToeplitzAES(tp_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse)
+        return _made(algo, ChunkerToeplitzAES(tp_key, *params, normal_size=kw.get("normal_size", 0), sparse=sparse))
     if algo == "fixed":
-        return ChunkerFixed(*params, sparse=sparse)
+        return _made(algo, ChunkerFixed(*params, sparse=sparse))
     if algo == "fail":
-        return ChunkerFailing(*params)
+        return _made(algo, ChunkerFailing(*params))
     raise TypeError("unsupported chunker algo %r" % algo)

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -155,7 +155,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'neon', 'avx2', 'blocked' or 'scalar'."""
+        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blocked' or 'scalar'."""
         return (<bytes>bz64_kernel_name(self.force_scalar)).decode("ascii")
 
     cdef object process(self):

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -17,8 +17,13 @@ from .base cimport ChunkerBase
 cdef extern from "buzhash64_impl.h":
     size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                      const uint8_t *p_rem, const uint8_t *p_add,
-                     size_t n, uint64_t *sum, uint64_t mask, int force_scalar) nogil
-    const char *bz64_kernel_name(int force_scalar)
+                     size_t n, uint64_t *sum, uint64_t mask, int kernel) nogil
+    const char *bz64_kernel_name(int kernel)
+    int bz64_kernel_select(const char *name, int *out_id)
+    const char *bz64_kernel_names()
+    int BZ_K_AUTO
+
+from .kernel_env import kernel_error, requested_kernel
 
 # Cyclic polynomial / buzhash
 #
@@ -101,6 +106,20 @@ cdef uint64_t _buzhash64_update(uint64_t sum, unsigned char remove, unsigned cha
     return BARREL_SHIFT64(sum, 1) ^ BARREL_SHIFT64(h[remove], lenmod) ^ h[add]
 
 
+cdef int _select_kernel() except -1:
+    """Resolve BORG_BUZHASH64_KERNEL to a kernel id, raising if it cannot be honoured."""
+    cdef int kid = BZ_K_AUTO
+    cdef int rc
+    want = requested_kernel("BORG_BUZHASH64_KERNEL")
+    if want is None:
+        return BZ_K_AUTO
+    rc = bz64_kernel_select(want.encode("ascii"), &kid)
+    if rc != 0:
+        raise kernel_error("BORG_BUZHASH64_KERNEL", want, rc,
+                           (<bytes>bz64_kernel_names()).decode("ascii"))
+    return kid
+
+
 cdef class ChunkerBuzHash64(ChunkerBase):
     """
     Content-Defined Chunker, variable chunk sizes.
@@ -118,7 +137,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
     """
     cdef uint64_t* table
     cdef uint64_t* table_rot
-    cdef int force_scalar
+    cdef int kernel_id
     cdef size_t window_size
 
     def __cinit__(self, bytes key, int chunk_min_exp, int chunk_max_exp, int hash_mask_bits, int hash_window_size, int nc_level=0, size_t normal_size=0, bint sparse=False):
@@ -139,7 +158,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
         lenmod = <uint64_t>hash_window_size & 0x3f
         for i_rot in range(256):
             self.table_rot[i_rot] = BARREL_SHIFT64(self.table[i_rot], lenmod)
-        self.force_scalar = 1 if os.environ.get("BORG_BUZHASH64_FORCE_SCALAR", "") not in ("", "0") else 0
+        self.kernel_id = _select_kernel()
         # buzhash64 output is uniform, so contiguous low-bit masks are used (high_masks=False)
         self._setup_common("buzhash64", chunk_min_exp, chunk_max_exp, hash_mask_bits,
                            nc_level, normal_size, False, sparse)
@@ -155,8 +174,12 @@ cdef class ChunkerBuzHash64(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'avx512', 'avx2', 'blockwise' or 'scalar'."""
-        return (<bytes>bz64_kernel_name(self.force_scalar)).decode("ascii")
+        """Which scan kernel this chunker uses: 'avx512', 'avx2', 'blockwise' or 'scalar'.
+
+        With BORG_BUZHASH64_KERNEL set to anything but "auto", this is always the
+        requested kernel - creating the chunker fails otherwise.
+        """
+        return (<bytes>bz64_kernel_name(self.kernel_id)).decode("ascii")
 
     cdef object process(self):
         """Process the chunker's buffer and return the next chunk."""
@@ -169,7 +192,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
         cdef uint8_t* stop_at
         cdef uint8_t* nc_stop
         cdef size_t did_bytes, span
-        cdef int force_scalar = self.force_scalar
+        cdef int kernel_id = self.kernel_id
 
         if self.done:
             if self.bytes_read == self.bytes_yielded:
@@ -229,7 +252,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
             span = stop_at - p
             with nogil:
                 did_bytes = bz64_scan(self.table, self.table_rot, p, p + window_size,
-                                      span, &sum, mask, force_scalar)
+                                      span, &sum, mask, kernel_id)
             self.position += did_bytes
             self.remaining -= did_bytes
 

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -21,7 +21,7 @@ cdef extern from "buzhash64_impl.h":
     const char *bz64_kernel_name(int kernel)
     int bz64_kernel_select(const char *name, int *out_id)
     const char *bz64_kernel_names()
-    int BZ_K_AUTO
+    int BZ_K_SCALAR
 
 from .kernel_env import kernel_error, requested_kernel
 
@@ -107,12 +107,16 @@ cdef uint64_t _buzhash64_update(uint64_t sum, unsigned char remove, unsigned cha
 
 
 cdef int _select_kernel() except -1:
-    """Resolve BORG_BUZHASH64_KERNEL to a kernel id, raising if it cannot be honoured."""
-    cdef int kid = BZ_K_AUTO
+    """Resolve BORG_BUZHASH64_KERNEL to a kernel id, raising if it cannot be honoured.
+
+    Unset means the simplest implementation, not the fastest one: nothing here
+    guesses which kernel a given CPU and compiler make fastest.
+    """
+    cdef int kid = BZ_K_SCALAR
     cdef int rc
     want = requested_kernel("BORG_BUZHASH64_KERNEL")
     if want is None:
-        return BZ_K_AUTO
+        return BZ_K_SCALAR
     rc = bz64_kernel_select(want.encode("ascii"), &kid)
     if rc != 0:
         raise kernel_error("BORG_BUZHASH64_KERNEL", want, rc,
@@ -176,11 +180,8 @@ cdef class ChunkerBuzHash64(ChunkerBase):
     def kernel(self):
         """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'.
 
-        'neon' exists on aarch64 but is never auto-selected (it loses to
-        'blockwise' there); BORG_BUZHASH64_KERNEL=neon selects it.
-
-        With BORG_BUZHASH64_KERNEL set to anything but "auto", this is always the
-        requested kernel - creating the chunker fails otherwise.
+        'scalar' unless BORG_BUZHASH64_KERNEL names another one, in which case
+        this is always that one - creating the chunker fails otherwise.
         """
         return (<bytes>bz64_kernel_name(self.kernel_id)).decode("ascii")
 

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -155,7 +155,7 @@ cdef class ChunkerBuzHash64(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blocked' or 'scalar'."""
+        """Which scan kernel this chunker uses: 'avx512', 'avx2', 'blockwise' or 'scalar'."""
         return (<bytes>bz64_kernel_name(self.force_scalar)).decode("ascii")
 
     cdef object process(self):

--- a/src/borg/chunkers/buzhash64.pyx
+++ b/src/borg/chunkers/buzhash64.pyx
@@ -174,7 +174,10 @@ cdef class ChunkerBuzHash64(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'avx512', 'avx2', 'blockwise' or 'scalar'.
+        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'.
+
+        'neon' exists on aarch64 but is never auto-selected (it loses to
+        'blockwise' there); BORG_BUZHASH64_KERNEL=neon selects it.
 
         With BORG_BUZHASH64_KERNEL set to anything but "auto", this is always the
         requested kernel - creating the chunker fails otherwise.

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -22,14 +22,15 @@
  * also removes one rotate per byte from the sequential path.
  *
  * Kernel dispatch mirrors fastcdc_impl.c: NEON on aarch64 (baseline there),
- * AVX2 on x86-64 (runtime-detected), blocked scalar elsewhere, sequential
- * when forced. Measured on Apple M-series (64 MiB, window 4095, 21-bit
+ * AVX-512 or AVX2 on x86-64 (runtime-detected), blocked scalar elsewhere,
+ * sequential when forced. Measured on Apple M-series (64 MiB, window 4095, 21-bit
  * mask): sequential 1150, blocked scalar 2340, NEON 2260 MB/s - NEON and
  * blocked are a tie here (throughput and energy, within noise), because the
  * XOR/AND/compare test also runs well on the scalar ALUs; the symmetric
  * dispatch is kept for consistency across the SIMD chunker kernels.
  * All kernels return bit-identical results. */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "buzhash64_impl.h"
@@ -209,8 +210,56 @@ bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
+/* --- AVX-512 (x86-64, runtime detected) ---------------------------------- */
+
+#define BZ_KIND_512 "avx512"
+
+/* The same 8-lane test as the AVX2 kernel in one 512-bit vector: vptestnmq
+ * fuses the AND and the ==0 test per lane into a mask register. Only the
+ * test narrows; the scalar prefix work (bz64_block_prefix) is shared. */
+__attribute__((target("avx512f"))) static size_t
+bz64_scan_simd512(const uint64_t *T, const uint64_t *Trot,
+                  const uint8_t *pr, const uint8_t *pa,
+                  size_t n, uint64_t *sum_io, uint64_t mask)
+{
+    uint64_t sum = *sum_io;
+    uint64_t s[8];
+    size_t j = 0;
+    /* _mm512_set_epi64 takes arguments high lane first: lane k = ROTL(mask, 7-k) */
+    __m512i M = _mm512_set_epi64((long long)mask, (long long)BZ_ROTL(mask, 1),
+                                 (long long)BZ_ROTL(mask, 2), (long long)BZ_ROTL(mask, 3),
+                                 (long long)BZ_ROTL(mask, 4), (long long)BZ_ROTL(mask, 5),
+                                 (long long)BZ_ROTL(mask, 6), (long long)BZ_ROTL(mask, 7));
+
+    while (j + 8 <= n && (sum & mask) != 0) {
+        bz64_block_prefix(T, Trot, pr + j, pa + j, s);
+        uint64_t c = BZ_ROTL(sum, 8);
+        __m512i H = _mm512_xor_si512(_mm512_set1_epi64((long long)c),
+                                     _mm512_loadu_si512((const void *)s));
+        if (_mm512_testn_epi64_mask(H, M)) {
+            size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
+            *sum_io = sum;
+            return j + r;
+        }
+        sum = c ^ s[7];
+        j += 8;
+    }
+    if (j < n)
+        j += bz64_scan_seq(T, Trot, pr + j, pa + j, n - j, &sum, mask);
+    *sum_io = sum;
+    return j;
+}
+
 static int bz64_simd_available(void)
 {
+    /* BORG_BUZHASH64_NO_AVX512 caps dispatch at AVX2 (for benchmarking the
+     * kernels against each other); like the detection itself it is read
+     * once per process, so it must be set before the first chunker use. */
+    if (__builtin_cpu_supports("avx512f")) {
+        const char *e = getenv("BORG_BUZHASH64_NO_AVX512");
+        if (e == NULL || e[0] == 0 || strcmp(e, "0") == 0)
+            return 2;
+    }
     return __builtin_cpu_supports("avx2");
 }
 
@@ -233,7 +282,8 @@ static int bz64_simd_available(void)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* resolved once; a racy double-init writes the same value, so it is benign */
+/* resolved once (0 = blocked, 1 = BZ_KIND, 2 = BZ_KIND_512 where defined);
+ * a racy double-init writes the same value, so it is benign */
 static int bz64_use_simd = -1;
 
 size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
@@ -244,6 +294,10 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
         return bz64_scan_seq(table, table_rot, p_rem, p_add, n, sum, mask);
     if (bz64_use_simd < 0)
         bz64_use_simd = bz64_simd_available();
+#ifdef BZ_KIND_512
+    if (bz64_use_simd == 2)
+        return bz64_scan_simd512(table, table_rot, p_rem, p_add, n, sum, mask);
+#endif
     if (bz64_use_simd)
         return bz64_scan_simd(table, table_rot, p_rem, p_add, n, sum, mask);
     return bz64_scan_blocked(table, table_rot, p_rem, p_add, n, sum, mask);
@@ -255,5 +309,9 @@ const char *bz64_kernel_name(int force_scalar)
         return "scalar";
     if (bz64_use_simd < 0)
         bz64_use_simd = bz64_simd_available();
+#ifdef BZ_KIND_512
+    if (bz64_use_simd == 2)
+        return BZ_KIND_512;
+#endif
     return bz64_use_simd ? BZ_KIND : "blocked";
 }

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -22,8 +22,8 @@
  * also removes one rotate per byte from the sequential path.
  *
  * Kernel dispatch: AVX-512 or AVX2 on x86-64 (runtime-detected), blockwise
- * scalar everywhere else including aarch64 (which has no vector kernel, see
- * the note where it would go), sequential when forced.
+ * scalar everywhere else, including aarch64 by default - its NEON kernel is
+ * selectable by name but not auto-selected, see the note above it.
  * All kernels return bit-identical results. */
 
 #include <stdlib.h>
@@ -114,29 +114,79 @@ static size_t bz64_scan_blockwise(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-/* --- aarch64: no vector kernel ------------------------------------------
+/* --- NEON (aarch64, selectable but not the default) ---------------------
  *
- * There was a NEON kernel here doing the 8-lane test in vector registers.
- * It is gone because it lost to the blockwise scalar kernel: measured on an
- * Apple M3 Pro (48 MiB, window 4095), blockwise 2590 MB/s vs NEON 2360 MB/s,
- * the same ~9% gap at every mask size from 17 to 23 bits.
+ * This kernel is NOT auto-selected: on an Apple M3 Pro it loses to the
+ * blockwise scalar one (2590 vs 2360 MB/s, the same ~9% gap at every mask
+ * size from 17 to 23 bits), so bz64_simd_available() returns 0 here and
+ * BZ_K_AUTO resolves to blockwise. BORG_BUZHASH64_KERNEL=neon selects it.
  *
- * The reason is that nothing here needs a vector register in the first
- * place. clang keeps the block's eight prefix XORs in general registers and
- * the scalar test is xor/and/compare per lane, which the wide scalar ALUs
- * retire at more than one lane per cycle; the vector form has to move those
- * eight values across to the SIMD side and then reduce the 8-lane result
- * back to one condition flag (umaxv, ~4 cycles) before the loop branch can
- * resolve. The move-and-reduce round trip costs more than the parallel test
- * saves. fastcdc keeps its NEON kernel because its test is add/and/compare
- * with per-lane shifted masks - enough extra per-lane work to pay for the
- * trip - and there it wins by 2x.
+ * Why it loses there: the 16 table lookups per block have to happen in
+ * general registers (NEON has no gather), so the vector form only ADDS the
+ * move to the SIMD side plus a cross-lane reduce (umaxv) before the loop
+ * branch can resolve - all it saves is the 8-lane test, three cheap ops per
+ * lane, which Apple's very wide scalar ALUs retire at more than one lane per
+ * cycle anyway. fastcdc keeps NEON as its default because its per-lane test
+ * work is larger (add plus per-lane shifted masks), enough to pay for the
+ * trip; there it wins by 2x.
  *
- * So aarch64 falls through to the blockwise scalar kernel below. */
+ * It is kept because that reasoning is about core width, and the measurement
+ * comes from the widest scalar ARM core there is. Neoverse (Graviton,
+ * Ampere), Cortex-A7x and friends are 3-4 wide on the scalar side with
+ * comparatively healthy NEON, which is exactly where this should get
+ * competitive - on this machine's much narrower E-cores the 9% gap already
+ * collapses into measurement noise. If you have such hardware, compare
+ * BORG_BUZHASH64_KERNEL=neon against =blockwise and please report; flipping
+ * the default is then a one-line change here. */
+
+#if defined(__aarch64__)
+#define BZ_KIND "neon"
+
+#include <arm_neon.h>
+
+static size_t bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
+                             const uint8_t *pr, const uint8_t *pa,
+                             size_t n, uint64_t *sum_io, uint64_t mask)
+{
+    uint64_t sum = *sum_io;
+    uint64_t s[8];
+    size_t j = 0;
+    uint64x2_t M12 = {BZ_ROTL(mask, 7), BZ_ROTL(mask, 6)};
+    uint64x2_t M34 = {BZ_ROTL(mask, 5), BZ_ROTL(mask, 4)};
+    uint64x2_t M56 = {BZ_ROTL(mask, 3), BZ_ROTL(mask, 2)};
+    uint64x2_t M78 = {BZ_ROTL(mask, 1), mask};
+
+    while (j + 8 <= n && (sum & mask) != 0) {
+        bz64_block_prefix(T, Trot, pr + j, pa + j, s);
+        uint64_t c = BZ_ROTL(sum, 8);
+        uint64x2_t Cv = vdupq_n_u64(c);
+        uint64x2_t z12 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[0], s[1]}), M12));
+        uint64x2_t z34 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[2], s[3]}), M34));
+        uint64x2_t z56 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[4], s[5]}), M56));
+        uint64x2_t z78 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[6], s[7]}), M78));
+        uint64x2_t any = vorrq_u64(vorrq_u64(z12, z34), vorrq_u64(z56, z78));
+        if (vmaxvq_u32(vreinterpretq_u32_u64(any))) {
+            size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
+            *sum_io = sum;
+            return j + r;
+        }
+        sum = c ^ s[7];
+        j += 8;
+    }
+    if (j < n)
+        j += bz64_scan_seq(T, Trot, pr + j, pa + j, n - j, &sum, mask);
+    *sum_io = sum;
+    return j;
+}
+
+static int bz64_simd_available(void)
+{
+    return 0; /* see above: selectable by name, but never auto-selected */
+}
 
 /* --- AVX2 (x86-64, runtime detected) ------------------------------------ */
 
-#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
 #define BZ_KIND "avx2"
 
 #include <immintrin.h>
@@ -328,7 +378,9 @@ static int bz64_simd_available(void)
 
 const char *bz64_kernel_names(void)
 {
-#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__aarch64__)
+    return "auto, neon, blockwise, scalar";
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
     return "auto, avx512, avx2, blockwise, scalar";
 #else
     return "auto, blockwise, scalar";
@@ -349,7 +401,12 @@ int bz64_kernel_select(const char *name, int *out_id)
         *out_id = BZ_K_BLOCKWISE;
         return BZ_KSEL_OK;
     }
-#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__aarch64__)
+    if (strcmp(name, "neon") == 0) {
+        *out_id = BZ_K_VECTOR; /* baseline on aarch64, always runnable */
+        return BZ_KSEL_OK;
+    }
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
     if (strcmp(name, "avx2") == 0) {
         if (!__builtin_cpu_supports("avx2"))
             return BZ_KSEL_NOCPU;

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -250,16 +250,22 @@ bz64_scan_simd512(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
+static int bz64_env_set(const char *name)
+{
+    const char *e = getenv(name);
+    return e != NULL && e[0] != 0 && strcmp(e, "0") != 0;
+}
+
 static int bz64_simd_available(void)
 {
-    /* BORG_BUZHASH64_NO_AVX512 caps dispatch at AVX2 (for benchmarking the
-     * kernels against each other); like the detection itself it is read
-     * once per process, so it must be set before the first chunker use. */
-    if (__builtin_cpu_supports("avx512f")) {
-        const char *e = getenv("BORG_BUZHASH64_NO_AVX512");
-        if (e == NULL || e[0] == 0 || strcmp(e, "0") == 0)
-            return 2;
-    }
+    /* BORG_BUZHASH64_NO_AVX512 caps dispatch at AVX2, BORG_BUZHASH64_NO_AVX2
+     * at the blocked scalar kernel (for benchmarking the kernels against
+     * each other); like the detection itself they are read once per process,
+     * so they must be set before the first chunker use. */
+    if (bz64_env_set("BORG_BUZHASH64_NO_AVX2"))
+        return 0;
+    if (__builtin_cpu_supports("avx512f") && !bz64_env_set("BORG_BUZHASH64_NO_AVX512"))
+        return 2;
     return __builtin_cpu_supports("avx2");
 }
 

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -298,22 +298,12 @@ bz64_scan_simd512(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-static int bz64_env_set(const char *name)
-{
-    const char *e = getenv(name);
-    return e != NULL && e[0] != 0 && strcmp(e, "0") != 0;
-}
-
 static int bz64_simd_available(void)
 {
-    /* BORG_BUZHASH64_NO_AVX512 caps dispatch at AVX2, BORG_BUZHASH64_NO_AVX2
-     * at the blockwise scalar kernel (for benchmarking the kernels against
-     * each other); like the detection itself they are read once per process,
-     * so they must be set before the first chunker use. */
-    if (bz64_env_set("BORG_BUZHASH64_NO_AVX2"))
-        return 0;
-    if (__builtin_cpu_supports("avx512f") && !bz64_env_set("BORG_BUZHASH64_NO_AVX512"))
+#ifdef BZ_KIND_512
+    if (__builtin_cpu_supports("avx512f"))
         return 2;
+#endif
     return __builtin_cpu_supports("avx2");
 }
 
@@ -334,38 +324,102 @@ static int bz64_simd_available(void)
 
 #endif
 
+/* --- kernel selection --------------------------------------------------- */
+
+const char *bz64_kernel_names(void)
+{
+#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    return "auto, avx512, avx2, blockwise, scalar";
+#else
+    return "auto, blockwise, scalar";
+#endif
+}
+
+int bz64_kernel_select(const char *name, int *out_id)
+{
+    if (strcmp(name, "auto") == 0) {
+        *out_id = BZ_K_AUTO;
+        return BZ_KSEL_OK;
+    }
+    if (strcmp(name, "scalar") == 0) {
+        *out_id = BZ_K_SCALAR;
+        return BZ_KSEL_OK;
+    }
+    if (strcmp(name, "blockwise") == 0) {
+        *out_id = BZ_K_BLOCKWISE;
+        return BZ_KSEL_OK;
+    }
+#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    if (strcmp(name, "avx2") == 0) {
+        if (!__builtin_cpu_supports("avx2"))
+            return BZ_KSEL_NOCPU;
+        *out_id = BZ_K_VECTOR;
+        return BZ_KSEL_OK;
+    }
+    if (strcmp(name, "avx512") == 0) {
+#ifndef BZ_KIND_512
+        return BZ_KSEL_NOTBUILT; /* compiler too old for the target attribute */
+#else
+        if (!__builtin_cpu_supports("avx512f"))
+            return BZ_KSEL_NOCPU;
+        *out_id = BZ_K_VECTOR512;
+        return BZ_KSEL_OK;
+#endif
+    }
+#endif
+    return BZ_KSEL_UNKNOWN;
+}
+
 /* --- dispatch ----------------------------------------------------------- */
 
-/* resolved once (0 = blockwise, 1 = BZ_KIND, 2 = BZ_KIND_512 where defined);
- * a racy double-init writes the same value, so it is benign */
-static int bz64_use_simd = -1;
+/* the kernel BZ_K_AUTO resolves to, worked out once; a racy double-init
+ * writes the same value, so it is benign */
+static int bz64_auto = -1;
+
+static int bz64_auto_kernel(void)
+{
+    int a;
+    if (bz64_auto < 0) {
+        a = bz64_simd_available();
+        bz64_auto = (a == 2) ? BZ_K_VECTOR512 : (a ? BZ_K_VECTOR : BZ_K_BLOCKWISE);
+    }
+    return bz64_auto;
+}
 
 size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
-                 size_t n, uint64_t *sum, uint64_t mask, int force_scalar)
+                 size_t n, uint64_t *sum, uint64_t mask, int kernel)
 {
-    if (force_scalar)
+    if (kernel == BZ_K_AUTO)
+        kernel = bz64_auto_kernel();
+    switch (kernel) {
+    case BZ_K_SCALAR:
         return bz64_scan_seq(table, table_rot, p_rem, p_add, n, sum, mask);
-    if (bz64_use_simd < 0)
-        bz64_use_simd = bz64_simd_available();
+    case BZ_K_BLOCKWISE:
+        return bz64_scan_blockwise(table, table_rot, p_rem, p_add, n, sum, mask);
 #ifdef BZ_KIND_512
-    if (bz64_use_simd == 2)
+    case BZ_K_VECTOR512:
         return bz64_scan_simd512(table, table_rot, p_rem, p_add, n, sum, mask);
 #endif
-    if (bz64_use_simd)
+    default:
         return bz64_scan_simd(table, table_rot, p_rem, p_add, n, sum, mask);
-    return bz64_scan_blockwise(table, table_rot, p_rem, p_add, n, sum, mask);
+    }
 }
 
-const char *bz64_kernel_name(int force_scalar)
+const char *bz64_kernel_name(int kernel)
 {
-    if (force_scalar)
+    if (kernel == BZ_K_AUTO)
+        kernel = bz64_auto_kernel();
+    switch (kernel) {
+    case BZ_K_SCALAR:
         return "scalar";
-    if (bz64_use_simd < 0)
-        bz64_use_simd = bz64_simd_available();
+    case BZ_K_BLOCKWISE:
+        return "blockwise";
 #ifdef BZ_KIND_512
-    if (bz64_use_simd == 2)
+    case BZ_K_VECTOR512:
         return BZ_KIND_512;
 #endif
-    return bz64_use_simd ? BZ_KIND : "blockwise";
+    default:
+        return BZ_KIND;
+    }
 }

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -172,39 +172,99 @@ static int bz64_simd_available(void)
 
 #include <immintrin.h>
 
+/* Load the block's 8 per-byte deltas D_t = Trot[out_t] ^ T[in_t] (via two
+ * 8-byte data loads), without the rotations and the prefix XOR: the vector
+ * kernels do those in the vector domain. Endianness-independent. */
+static inline void bz64_block_delta(const uint64_t *T, const uint64_t *Trot,
+                                    const uint8_t *pr, const uint8_t *pa, uint64_t d[8])
+{
+    uint64_t wr, wa;
+    memcpy(&wr, pr, 8);
+    memcpy(&wa, pa, 8);
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    wr = __builtin_bswap64(wr);
+    wa = __builtin_bswap64(wa);
+#endif
+    d[0] = Trot[(uint8_t)wr] ^ T[(uint8_t)wa];
+    d[1] = Trot[(uint8_t)(wr >> 8)] ^ T[(uint8_t)(wa >> 8)];
+    d[2] = Trot[(uint8_t)(wr >> 16)] ^ T[(uint8_t)(wa >> 16)];
+    d[3] = Trot[(uint8_t)(wr >> 24)] ^ T[(uint8_t)(wa >> 24)];
+    d[4] = Trot[(uint8_t)(wr >> 32)] ^ T[(uint8_t)(wa >> 32)];
+    d[5] = Trot[(uint8_t)(wr >> 40)] ^ T[(uint8_t)(wa >> 40)];
+    d[6] = Trot[(uint8_t)(wr >> 48)] ^ T[(uint8_t)(wa >> 48)];
+    d[7] = Trot[(uint8_t)(wr >> 56)] ^ T[(uint8_t)(wa >> 56)];
+}
+
+/* AVX2 has no variable rotate, so ROTL(v, k) is built from a variable left
+ * and right shift. The k = 0 lane needs a 64-bit right shift, which
+ * vpsrlvq defines as zero - exactly what (v << 0) | 0 = v needs. */
+__attribute__((target("avx2"))) static inline __m256i bz64_rotl4(__m256i v, __m256i k, __m256i kc)
+{
+    return _mm256_or_si256(_mm256_sllv_epi64(v, k), _mm256_srlv_epi64(v, kc));
+}
+
+/* The 8-lane test in two 256-bit vectors, with the aligned domain built in
+ * the vector domain: per-lane rotations, then a prefix XOR inside each 4-lane
+ * half (two vpermq+vpxor steps) plus a broadcast of the low half's total into
+ * the high half.
+ *
+ * Only the 2x8 table lookups stay scalar, and they are done one block ahead
+ * into a double buffer: a 32-byte vector load placed right after the eight
+ * 8-byte scalar stores that filled it cannot use store-to-load forwarding and
+ * stalls, twice per block. Loading block j+1 while block j is tested puts a
+ * full loop body between the stores and the load, so the stall disappears. */
 __attribute__((target("avx2"))) static size_t
 bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
                const uint8_t *pr, const uint8_t *pa,
                size_t n, uint64_t *sum_io, uint64_t mask)
 {
     uint64_t sum = *sum_io;
-    uint64_t s[8];
+    uint64_t d[16]; /* double buffer: block being tested + block being loaded */
     size_t j = 0;
+    int cur = 0;
     /* _mm256_set_epi64x takes arguments high lane first */
-    __m256i M1 = _mm256_set_epi64x((long long)BZ_ROTL(mask, 4), (long long)BZ_ROTL(mask, 5),
-                                   (long long)BZ_ROTL(mask, 6), (long long)BZ_ROTL(mask, 7));
-    __m256i M2 = _mm256_set_epi64x((long long)mask, (long long)BZ_ROTL(mask, 1),
-                                   (long long)BZ_ROTL(mask, 2), (long long)BZ_ROTL(mask, 3));
-    __m256i zero = _mm256_setzero_si256();
+    const __m256i M1 = _mm256_set_epi64x((long long)BZ_ROTL(mask, 4), (long long)BZ_ROTL(mask, 5),
+                                         (long long)BZ_ROTL(mask, 6), (long long)BZ_ROTL(mask, 7));
+    const __m256i M2 = _mm256_set_epi64x((long long)mask, (long long)BZ_ROTL(mask, 1),
+                                         (long long)BZ_ROTL(mask, 2), (long long)BZ_ROTL(mask, 3));
+    const __m256i KL = _mm256_set_epi64x(4, 5, 6, 7); /* lanes 0..3 rotate by 7..4 */
+    const __m256i KH = _mm256_set_epi64x(0, 1, 2, 3); /* lanes 4..7 rotate by 3..0 */
+    const __m256i KLC = _mm256_set_epi64x(60, 59, 58, 57); /* 64 - KL */
+    const __m256i KHC = _mm256_set_epi64x(64, 63, 62, 61); /* 64 - KH */
+    const __m256i zero = _mm256_setzero_si256();
 
-    while (j + 8 <= n && (sum & mask) != 0) {
-        bz64_block_prefix(T, Trot, pr + j, pa + j, s);
-        uint64_t c = BZ_ROTL(sum, 8);
-        __m256i C = _mm256_set1_epi64x((long long)c);
-        __m256i H1 = _mm256_xor_si256(C, _mm256_loadu_si256((const __m256i *)&s[0]));
-        __m256i H2 = _mm256_xor_si256(C, _mm256_loadu_si256((const __m256i *)&s[4]));
-        __m256i z1 = _mm256_cmpeq_epi64(_mm256_and_si256(H1, M1), zero);
-        __m256i z2 = _mm256_cmpeq_epi64(_mm256_and_si256(H2, M2), zero);
-        __m256i any = _mm256_or_si256(z1, z2);
-        if (!_mm256_testz_si256(any, any)) {
-            size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
-            *sum_io = sum;
-            return j + r;
+    if (n >= 16 && (sum & mask) != 0) {
+        bz64_block_delta(T, Trot, pr, pa, d);
+        while (j + 16 <= n && (sum & mask) != 0) {
+            bz64_block_delta(T, Trot, pr + j + 8, pa + j + 8, d + (cur ^ 8)); /* one block ahead */
+            __m256i lo = bz64_rotl4(_mm256_loadu_si256((const __m256i *)(d + cur)), KL, KLC);
+            __m256i hi = bz64_rotl4(_mm256_loadu_si256((const __m256i *)(d + cur + 4)), KH, KHC);
+            /* prefix XOR inside each half: rotate the lanes up by 1 resp. 2
+             * (vpermq), zero the lanes rotated in, XOR */
+            lo = _mm256_xor_si256(lo, _mm256_blend_epi32(_mm256_permute4x64_epi64(lo, 0x93), zero, 0x03));
+            lo = _mm256_xor_si256(lo, _mm256_blend_epi32(_mm256_permute4x64_epi64(lo, 0x4E), zero, 0x0F));
+            hi = _mm256_xor_si256(hi, _mm256_blend_epi32(_mm256_permute4x64_epi64(hi, 0x93), zero, 0x03));
+            hi = _mm256_xor_si256(hi, _mm256_blend_epi32(_mm256_permute4x64_epi64(hi, 0x4E), zero, 0x0F));
+            hi = _mm256_xor_si256(hi, _mm256_permute4x64_epi64(lo, 0xFF)); /* carry s[3] */
+            uint64_t c = BZ_ROTL(sum, 8);
+            __m256i C = _mm256_set1_epi64x((long long)c);
+            __m256i H1 = _mm256_xor_si256(C, lo);
+            __m256i H2 = _mm256_xor_si256(C, hi);
+            __m256i z1 = _mm256_cmpeq_epi64(_mm256_and_si256(H1, M1), zero);
+            __m256i z2 = _mm256_cmpeq_epi64(_mm256_and_si256(H2, M2), zero);
+            __m256i any = _mm256_or_si256(z1, z2);
+            if (!_mm256_testz_si256(any, any)) {
+                size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
+                *sum_io = sum;
+                return j + r;
+            }
+            sum = c ^ (uint64_t)_mm_cvtsi128_si64(_mm256_castsi256_si128(
+                          _mm256_permute4x64_epi64(hi, 0xFF))); /* s[7] */
+            j += 8;
+            cur ^= 8;
         }
-        sum = c ^ s[7];
-        j += 8;
     }
-    if (j < n)
+    if (j < n) /* up to 15 bytes here (one block more than the scalar kernels) */
         j += bz64_scan_seq(T, Trot, pr + j, pa + j, n - j, &sum, mask);
     *sum_io = sum;
     return j;
@@ -214,37 +274,56 @@ bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
 
 #define BZ_KIND_512 "avx512"
 
-/* The same 8-lane test as the AVX2 kernel in one 512-bit vector: vptestnmq
- * fuses the AND and the ==0 test per lane into a mask register. Only the
- * test narrows; the scalar prefix work (bz64_block_prefix) is shared. */
+/* The same 8-lane test as the AVX2 kernel, but the aligned domain fits in one
+ * 512-bit vector: vprolvq applies the per-lane rotations (lane k by 7-k) in
+ * one instruction, three valignq+vpxorq steps turn the rotated deltas into
+ * the prefix XORs s[0..7] in one pass instead of two halves plus a carry, and
+ * vptestnmq fuses the AND and the ==0 test into a mask register.
+ *
+ * The table lookups are pipelined one block ahead exactly as in the AVX2
+ * kernel above, for the same store-to-load forwarding reason. */
 __attribute__((target("avx512f"))) static size_t
 bz64_scan_simd512(const uint64_t *T, const uint64_t *Trot,
                   const uint8_t *pr, const uint8_t *pa,
                   size_t n, uint64_t *sum_io, uint64_t mask)
 {
     uint64_t sum = *sum_io;
-    uint64_t s[8];
+    uint64_t d[16]; /* double buffer: block being tested + block being loaded */
     size_t j = 0;
+    int cur = 0;
     /* _mm512_set_epi64 takes arguments high lane first: lane k = ROTL(mask, 7-k) */
-    __m512i M = _mm512_set_epi64((long long)mask, (long long)BZ_ROTL(mask, 1),
-                                 (long long)BZ_ROTL(mask, 2), (long long)BZ_ROTL(mask, 3),
-                                 (long long)BZ_ROTL(mask, 4), (long long)BZ_ROTL(mask, 5),
-                                 (long long)BZ_ROTL(mask, 6), (long long)BZ_ROTL(mask, 7));
+    const __m512i M = _mm512_set_epi64((long long)mask, (long long)BZ_ROTL(mask, 1),
+                                       (long long)BZ_ROTL(mask, 2), (long long)BZ_ROTL(mask, 3),
+                                       (long long)BZ_ROTL(mask, 4), (long long)BZ_ROTL(mask, 5),
+                                       (long long)BZ_ROTL(mask, 6), (long long)BZ_ROTL(mask, 7));
+    const __m512i RT = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7); /* lane k: ROTL by 7-k */
+    const __m512i Z = _mm512_setzero_si512();
 
-    while (j + 8 <= n && (sum & mask) != 0) {
-        bz64_block_prefix(T, Trot, pr + j, pa + j, s);
-        uint64_t c = BZ_ROTL(sum, 8);
-        __m512i H = _mm512_xor_si512(_mm512_set1_epi64((long long)c),
-                                     _mm512_loadu_si512((const void *)s));
-        if (_mm512_testn_epi64_mask(H, M)) {
-            size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
-            *sum_io = sum;
-            return j + r;
+    if (n >= 16 && (sum & mask) != 0) {
+        bz64_block_delta(T, Trot, pr, pa, d);
+        while (j + 16 <= n && (sum & mask) != 0) {
+            bz64_block_delta(T, Trot, pr + j + 8, pa + j + 8, d + (cur ^ 8)); /* one block ahead */
+            /* u = rotated deltas, then the prefix XOR over the 8 lanes
+             * (shift lanes up by 1, 2, 4 and XOR; _mm512_alignr_epi64(u, Z,
+             * 8-k) shifts up by k, zero-filling) */
+            __m512i u = _mm512_rolv_epi64(_mm512_loadu_si512((const void *)(d + cur)), RT);
+            u = _mm512_xor_si512(u, _mm512_alignr_epi64(u, Z, 7));
+            u = _mm512_xor_si512(u, _mm512_alignr_epi64(u, Z, 6));
+            u = _mm512_xor_si512(u, _mm512_alignr_epi64(u, Z, 4));
+            uint64_t c = BZ_ROTL(sum, 8);
+            __m512i H = _mm512_xor_si512(_mm512_set1_epi64((long long)c), u);
+            if (_mm512_testn_epi64_mask(H, M)) {
+                size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
+                *sum_io = sum;
+                return j + r;
+            }
+            sum = c ^ (uint64_t)_mm_cvtsi128_si64(_mm512_castsi512_si128(
+                          _mm512_permutexvar_epi64(_mm512_set1_epi64(7), u))); /* s[7] */
+            j += 8;
+            cur ^= 8;
         }
-        sum = c ^ s[7];
-        j += 8;
     }
-    if (j < n)
+    if (j < n) /* up to 15 bytes here (one block more than the other kernels) */
         j += bz64_scan_seq(T, Trot, pr + j, pa + j, n - j, &sum, mask);
     *sum_io = sum;
     return j;

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -114,12 +114,13 @@ static size_t bz64_scan_blockwise(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-/* --- NEON (aarch64, selectable but not the default) ---------------------
+/* --- NEON (aarch64) ------------------------------------------------------
  *
- * This kernel is NOT auto-selected: on an Apple M3 Pro it loses to the
- * blockwise scalar one (2590 vs 2360 MB/s, the same ~9% gap at every mask
- * size from 17 to 23 bits), so bz64_simd_available() returns 0 here and
- * BZ_K_AUTO resolves to blockwise. BORG_BUZHASH64_KERNEL=neon selects it.
+ * Nothing selects this by default (the default is the sequential kernel
+ * everywhere); BORG_BUZHASH64_KERNEL=neon selects it. On an Apple M3 Pro it
+ * loses to the blockwise kernel - 2590 vs 2360 MB/s, the same ~9% gap at
+ * every mask size from 17 to 23 bits - so it is not the one to reach for
+ * there.
  *
  * Why it loses there: the 16 table lookups per block have to happen in
  * general registers (NEON has no gather), so the vector form only ADDS the
@@ -136,8 +137,7 @@ static size_t bz64_scan_blockwise(const uint64_t *T, const uint64_t *Trot,
  * comparatively healthy NEON, which is exactly where this should get
  * competitive - on this machine's much narrower E-cores the 9% gap already
  * collapses into measurement noise. If you have such hardware, compare
- * BORG_BUZHASH64_KERNEL=neon against =blockwise and please report; flipping
- * the default is then a one-line change here. */
+ * BORG_BUZHASH64_KERNEL=neon against =blockwise and please report. */
 
 #if defined(__aarch64__)
 #define BZ_KIND "neon"
@@ -179,10 +179,6 @@ static size_t bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-static int bz64_simd_available(void)
-{
-    return 0; /* see above: selectable by name, but never auto-selected */
-}
 
 /* --- AVX2 (x86-64, runtime detected) ------------------------------------ */
 
@@ -348,14 +344,6 @@ bz64_scan_simd512(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-static int bz64_simd_available(void)
-{
-#ifdef BZ_KIND_512
-    if (__builtin_cpu_supports("avx512f"))
-        return 2;
-#endif
-    return __builtin_cpu_supports("avx2");
-}
 
 #else
 #define BZ_KIND "blockwise"
@@ -367,10 +355,6 @@ static size_t bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
     return bz64_scan_blockwise(T, Trot, pr, pa, n, sum_io, mask);
 }
 
-static int bz64_simd_available(void)
-{
-    return 0;
-}
 
 #endif
 
@@ -379,20 +363,16 @@ static int bz64_simd_available(void)
 const char *bz64_kernel_names(void)
 {
 #if defined(__aarch64__)
-    return "auto, neon, blockwise, scalar";
+    return "neon,blockwise,scalar";
 #elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
-    return "auto, avx512, avx2, blockwise, scalar";
+    return "avx512,avx2,blockwise,scalar";
 #else
-    return "auto, blockwise, scalar";
+    return "blockwise,scalar";
 #endif
 }
 
 int bz64_kernel_select(const char *name, int *out_id)
 {
-    if (strcmp(name, "auto") == 0) {
-        *out_id = BZ_K_AUTO;
-        return BZ_KSEL_OK;
-    }
     if (strcmp(name, "scalar") == 0) {
         *out_id = BZ_K_SCALAR;
         return BZ_KSEL_OK;
@@ -429,26 +409,10 @@ int bz64_kernel_select(const char *name, int *out_id)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* the kernel BZ_K_AUTO resolves to, worked out once; a racy double-init
- * writes the same value, so it is benign */
-static int bz64_auto = -1;
-
-static int bz64_auto_kernel(void)
-{
-    int a;
-    if (bz64_auto < 0) {
-        a = bz64_simd_available();
-        bz64_auto = (a == 2) ? BZ_K_VECTOR512 : (a ? BZ_K_VECTOR : BZ_K_BLOCKWISE);
-    }
-    return bz64_auto;
-}
-
 size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
                  size_t n, uint64_t *sum, uint64_t mask, int kernel)
 {
-    if (kernel == BZ_K_AUTO)
-        kernel = bz64_auto_kernel();
     switch (kernel) {
     case BZ_K_SCALAR:
         return bz64_scan_seq(table, table_rot, p_rem, p_add, n, sum, mask);
@@ -465,8 +429,6 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
 
 const char *bz64_kernel_name(int kernel)
 {
-    if (kernel == BZ_K_AUTO)
-        kernel = bz64_auto_kernel();
     switch (kernel) {
     case BZ_K_SCALAR:
         return "scalar";

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -21,7 +21,7 @@
  * Trot[b] = ROTL(T[b], window_size % 64) is precomputed by the caller, which
  * also removes one rotate per byte from the sequential path.
  *
- * Kernel dispatch: AVX-512 or AVX2 on x86-64 (runtime-detected), blocked
+ * Kernel dispatch: AVX-512 or AVX2 on x86-64 (runtime-detected), blockwise
  * scalar everywhere else including aarch64 (which has no vector kernel, see
  * the note where it would go), sequential when forced.
  * All kernels return bit-identical results. */
@@ -82,9 +82,9 @@ static inline void bz64_block_prefix(const uint64_t *T, const uint64_t *Trot,
     s[7] = s8;
 }
 
-/* --- blocked scalar (the default kernel) --------------------------------- */
+/* --- blockwise scalar (the default kernel) --------------------------------- */
 
-static size_t bz64_scan_blocked(const uint64_t *T, const uint64_t *Trot,
+static size_t bz64_scan_blockwise(const uint64_t *T, const uint64_t *Trot,
                                 const uint8_t *pr, const uint8_t *pa,
                                 size_t n, uint64_t *sum_io, uint64_t mask)
 {
@@ -117,8 +117,8 @@ static size_t bz64_scan_blocked(const uint64_t *T, const uint64_t *Trot,
 /* --- aarch64: no vector kernel ------------------------------------------
  *
  * There was a NEON kernel here doing the 8-lane test in vector registers.
- * It is gone because it lost to the blocked scalar kernel: measured on an
- * Apple M3 Pro (48 MiB, window 4095), blocked 2590 MB/s vs NEON 2360 MB/s,
+ * It is gone because it lost to the blockwise scalar kernel: measured on an
+ * Apple M3 Pro (48 MiB, window 4095), blockwise 2590 MB/s vs NEON 2360 MB/s,
  * the same ~9% gap at every mask size from 17 to 23 bits.
  *
  * The reason is that nothing here needs a vector register in the first
@@ -132,7 +132,7 @@ static size_t bz64_scan_blocked(const uint64_t *T, const uint64_t *Trot,
  * with per-lane shifted masks - enough extra per-lane work to pay for the
  * trip - and there it wins by 2x.
  *
- * So aarch64 falls through to the blocked scalar kernel below. */
+ * So aarch64 falls through to the blockwise scalar kernel below. */
 
 /* --- AVX2 (x86-64, runtime detected) ------------------------------------ */
 
@@ -307,7 +307,7 @@ static int bz64_env_set(const char *name)
 static int bz64_simd_available(void)
 {
     /* BORG_BUZHASH64_NO_AVX512 caps dispatch at AVX2, BORG_BUZHASH64_NO_AVX2
-     * at the blocked scalar kernel (for benchmarking the kernels against
+     * at the blockwise scalar kernel (for benchmarking the kernels against
      * each other); like the detection itself they are read once per process,
      * so they must be set before the first chunker use. */
     if (bz64_env_set("BORG_BUZHASH64_NO_AVX2"))
@@ -318,13 +318,13 @@ static int bz64_simd_available(void)
 }
 
 #else
-#define BZ_KIND "blocked"
+#define BZ_KIND "blockwise"
 
 static size_t bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
                              const uint8_t *pr, const uint8_t *pa,
                              size_t n, uint64_t *sum_io, uint64_t mask)
 {
-    return bz64_scan_blocked(T, Trot, pr, pa, n, sum_io, mask);
+    return bz64_scan_blockwise(T, Trot, pr, pa, n, sum_io, mask);
 }
 
 static int bz64_simd_available(void)
@@ -336,7 +336,7 @@ static int bz64_simd_available(void)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* resolved once (0 = blocked, 1 = BZ_KIND, 2 = BZ_KIND_512 where defined);
+/* resolved once (0 = blockwise, 1 = BZ_KIND, 2 = BZ_KIND_512 where defined);
  * a racy double-init writes the same value, so it is benign */
 static int bz64_use_simd = -1;
 
@@ -354,7 +354,7 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
 #endif
     if (bz64_use_simd)
         return bz64_scan_simd(table, table_rot, p_rem, p_add, n, sum, mask);
-    return bz64_scan_blocked(table, table_rot, p_rem, p_add, n, sum, mask);
+    return bz64_scan_blockwise(table, table_rot, p_rem, p_add, n, sum, mask);
 }
 
 const char *bz64_kernel_name(int force_scalar)
@@ -367,5 +367,5 @@ const char *bz64_kernel_name(int force_scalar)
     if (bz64_use_simd == 2)
         return BZ_KIND_512;
 #endif
-    return bz64_use_simd ? BZ_KIND : "blocked";
+    return bz64_use_simd ? BZ_KIND : "blockwise";
 }

--- a/src/borg/chunkers/buzhash64_impl.c
+++ b/src/borg/chunkers/buzhash64_impl.c
@@ -21,13 +21,9 @@
  * Trot[b] = ROTL(T[b], window_size % 64) is precomputed by the caller, which
  * also removes one rotate per byte from the sequential path.
  *
- * Kernel dispatch mirrors fastcdc_impl.c: NEON on aarch64 (baseline there),
- * AVX-512 or AVX2 on x86-64 (runtime-detected), blocked scalar elsewhere,
- * sequential when forced. Measured on Apple M-series (64 MiB, window 4095, 21-bit
- * mask): sequential 1150, blocked scalar 2340, NEON 2260 MB/s - NEON and
- * blocked are a tie here (throughput and energy, within noise), because the
- * XOR/AND/compare test also runs well on the scalar ALUs; the symmetric
- * dispatch is kept for consistency across the SIMD chunker kernels.
+ * Kernel dispatch: AVX-512 or AVX2 on x86-64 (runtime-detected), blocked
+ * scalar everywhere else including aarch64 (which has no vector kernel, see
+ * the note where it would go), sequential when forced.
  * All kernels return bit-identical results. */
 
 #include <stdlib.h>
@@ -118,56 +114,29 @@ static size_t bz64_scan_blocked(const uint64_t *T, const uint64_t *Trot,
     return j;
 }
 
-/* --- NEON (aarch64 baseline, always available) -------------------------- */
-
-#if defined(__aarch64__)
-#define BZ_KIND "neon"
-
-#include <arm_neon.h>
-
-static size_t bz64_scan_simd(const uint64_t *T, const uint64_t *Trot,
-                             const uint8_t *pr, const uint8_t *pa,
-                             size_t n, uint64_t *sum_io, uint64_t mask)
-{
-    uint64_t sum = *sum_io;
-    uint64_t s[8];
-    size_t j = 0;
-    uint64x2_t M12 = {BZ_ROTL(mask, 7), BZ_ROTL(mask, 6)};
-    uint64x2_t M34 = {BZ_ROTL(mask, 5), BZ_ROTL(mask, 4)};
-    uint64x2_t M56 = {BZ_ROTL(mask, 3), BZ_ROTL(mask, 2)};
-    uint64x2_t M78 = {BZ_ROTL(mask, 1), mask};
-
-    while (j + 8 <= n && (sum & mask) != 0) {
-        bz64_block_prefix(T, Trot, pr + j, pa + j, s);
-        uint64_t c = BZ_ROTL(sum, 8);
-        uint64x2_t Cv = vdupq_n_u64(c);
-        uint64x2_t z12 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[0], s[1]}), M12));
-        uint64x2_t z34 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[2], s[3]}), M34));
-        uint64x2_t z56 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[4], s[5]}), M56));
-        uint64x2_t z78 = vceqzq_u64(vandq_u64(veorq_u64(Cv, (uint64x2_t){s[6], s[7]}), M78));
-        uint64x2_t any = vorrq_u64(vorrq_u64(z12, z34), vorrq_u64(z56, z78));
-        if (vmaxvq_u32(vreinterpretq_u32_u64(any))) {
-            size_t r = bz64_scan_seq(T, Trot, pr + j, pa + j, 8, &sum, mask); /* exact re-scan */
-            *sum_io = sum;
-            return j + r;
-        }
-        sum = c ^ s[7];
-        j += 8;
-    }
-    if (j < n)
-        j += bz64_scan_seq(T, Trot, pr + j, pa + j, n - j, &sum, mask);
-    *sum_io = sum;
-    return j;
-}
-
-static int bz64_simd_available(void)
-{
-    return 1;
-}
+/* --- aarch64: no vector kernel ------------------------------------------
+ *
+ * There was a NEON kernel here doing the 8-lane test in vector registers.
+ * It is gone because it lost to the blocked scalar kernel: measured on an
+ * Apple M3 Pro (48 MiB, window 4095), blocked 2590 MB/s vs NEON 2360 MB/s,
+ * the same ~9% gap at every mask size from 17 to 23 bits.
+ *
+ * The reason is that nothing here needs a vector register in the first
+ * place. clang keeps the block's eight prefix XORs in general registers and
+ * the scalar test is xor/and/compare per lane, which the wide scalar ALUs
+ * retire at more than one lane per cycle; the vector form has to move those
+ * eight values across to the SIMD side and then reduce the 8-lane result
+ * back to one condition flag (umaxv, ~4 cycles) before the loop branch can
+ * resolve. The move-and-reduce round trip costs more than the parallel test
+ * saves. fastcdc keeps its NEON kernel because its test is add/and/compare
+ * with per-lane shifted masks - enough extra per-lane work to pay for the
+ * trip - and there it wins by 2x.
+ *
+ * So aarch64 falls through to the blocked scalar kernel below. */
 
 /* --- AVX2 (x86-64, runtime detected) ------------------------------------ */
 
-#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
 #define BZ_KIND "avx2"
 
 #include <immintrin.h>

--- a/src/borg/chunkers/buzhash64_impl.h
+++ b/src/borg/chunkers/buzhash64_impl.h
@@ -21,14 +21,34 @@
  * ROTL(table[b], window_size % 64) (precomputed by the caller).
  * p_rem points at the byte leaving the window, p_add at the byte entering
  * (p_add = p_rem + window_size); both must have n readable bytes.
- * force_scalar != 0 selects the sequential reference loop (for tests);
- * all kernels return bit-identical results. */
+ * kernel is one of BZ_K_*; BZ_K_AUTO picks the best one this CPU can run.
+ * All kernels return bit-identical results. */
+/* Scan kernel ids, a tier ladder; see fastcdc_impl.h for the rationale. */
+#define BZ_K_AUTO 0      /* best kernel this CPU can run */
+#define BZ_K_SCALAR 1    /* sequential reference loop */
+#define BZ_K_BLOCKWISE 2 /* portable 8-lane C */
+#define BZ_K_VECTOR 3    /* avx2 (there is no aarch64 vector kernel) */
+#define BZ_K_VECTOR512 4 /* avx512 */
+
+/* Results of bz64_kernel_select(). */
+#define BZ_KSEL_OK 0
+#define BZ_KSEL_UNKNOWN 1  /* not a kernel name on this platform */
+#define BZ_KSEL_NOTBUILT 2 /* known, but not compiled into this binary */
+#define BZ_KSEL_NOCPU 3    /* known and built, but this CPU cannot run it */
+
+/* Resolve a kernel name for this build; see fc_kernel_select(). */
+int bz64_kernel_select(const char *name, int *out_id);
+
+/* Comma-separated list of the kernel names this build accepts. */
+const char *bz64_kernel_names(void);
+
 size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
-                 size_t n, uint64_t *sum, uint64_t mask, int force_scalar);
+                 size_t n, uint64_t *sum, uint64_t mask, int kernel);
 
-/* Name of the kernel bz64_scan would use: "avx512", "avx2", "blockwise" or "scalar"
- * (there is no vector kernel on aarch64, see buzhash64_impl.c). */
-const char *bz64_kernel_name(int force_scalar);
+/* Name of the kernel <kernel> selects: "avx512", "avx2", "blockwise" or
+ * "scalar" (there is no vector kernel on aarch64, see buzhash64_impl.c).
+ * For BZ_K_AUTO, the auto-selected one. */
+const char *bz64_kernel_name(int kernel);
 
 #endif

--- a/src/borg/chunkers/buzhash64_impl.h
+++ b/src/borg/chunkers/buzhash64_impl.h
@@ -21,14 +21,14 @@
  * ROTL(table[b], window_size % 64) (precomputed by the caller).
  * p_rem points at the byte leaving the window, p_add at the byte entering
  * (p_add = p_rem + window_size); both must have n readable bytes.
- * kernel is one of BZ_K_*; BZ_K_AUTO picks the best one this CPU can run.
+ * kernel is one of BZ_K_*.
  * All kernels return bit-identical results. */
-/* Scan kernel ids, a tier ladder; see fastcdc_impl.h for the rationale. */
-#define BZ_K_AUTO 0      /* best kernel this CPU can run */
-#define BZ_K_SCALAR 1    /* sequential reference loop */
-#define BZ_K_BLOCKWISE 2 /* portable 8-lane C */
-#define BZ_K_VECTOR 3    /* neon / avx2 (neon is not auto-selected) */
-#define BZ_K_VECTOR512 4 /* avx512 */
+/* Scan kernel ids; see fastcdc_impl.h for the rationale. There is no
+ * automatic selection - the caller says which kernel to run. */
+#define BZ_K_SCALAR 0    /* sequential reference loop */
+#define BZ_K_BLOCKWISE 1 /* portable 8-lane C */
+#define BZ_K_VECTOR 2    /* neon / avx2 (neon is not auto-selected) */
+#define BZ_K_VECTOR512 3 /* avx512 */
 
 /* Results of bz64_kernel_select(). */
 #define BZ_KSEL_OK 0
@@ -46,9 +46,8 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
                  size_t n, uint64_t *sum, uint64_t mask, int kernel);
 
-/* Name of the kernel <kernel> selects: "neon", "avx512", "avx2", "blockwise"
- * or "scalar"; for BZ_K_AUTO, the auto-selected one. Note "neon" is never
- * auto-selected, see buzhash64_impl.c. */
+/* Name of the kernel <kernel> selects: "neon", "avx512", "avx2",
+ * "blockwise" or "scalar". */
 const char *bz64_kernel_name(int kernel);
 
 #endif

--- a/src/borg/chunkers/buzhash64_impl.h
+++ b/src/borg/chunkers/buzhash64_impl.h
@@ -27,7 +27,7 @@
 #define BZ_K_AUTO 0      /* best kernel this CPU can run */
 #define BZ_K_SCALAR 1    /* sequential reference loop */
 #define BZ_K_BLOCKWISE 2 /* portable 8-lane C */
-#define BZ_K_VECTOR 3    /* avx2 (there is no aarch64 vector kernel) */
+#define BZ_K_VECTOR 3    /* neon / avx2 (neon is not auto-selected) */
 #define BZ_K_VECTOR512 4 /* avx512 */
 
 /* Results of bz64_kernel_select(). */
@@ -46,9 +46,9 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
                  size_t n, uint64_t *sum, uint64_t mask, int kernel);
 
-/* Name of the kernel <kernel> selects: "avx512", "avx2", "blockwise" or
- * "scalar" (there is no vector kernel on aarch64, see buzhash64_impl.c).
- * For BZ_K_AUTO, the auto-selected one. */
+/* Name of the kernel <kernel> selects: "neon", "avx512", "avx2", "blockwise"
+ * or "scalar"; for BZ_K_AUTO, the auto-selected one. Note "neon" is never
+ * auto-selected, see buzhash64_impl.c. */
 const char *bz64_kernel_name(int kernel);
 
 #endif

--- a/src/borg/chunkers/buzhash64_impl.h
+++ b/src/borg/chunkers/buzhash64_impl.h
@@ -27,7 +27,7 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
                  size_t n, uint64_t *sum, uint64_t mask, int force_scalar);
 
-/* Name of the kernel bz64_scan would use: "neon", "avx2", "blocked" or "scalar". */
+/* Name of the kernel bz64_scan would use: "neon", "avx512", "avx2", "blocked" or "scalar". */
 const char *bz64_kernel_name(int force_scalar);
 
 #endif

--- a/src/borg/chunkers/buzhash64_impl.h
+++ b/src/borg/chunkers/buzhash64_impl.h
@@ -1,5 +1,5 @@
 /* buzhash64 chunker scan kernel: the cyclic-polynomial rolling hash inner
- * loop, with blocked/SIMD implementations that are bit-identical to the
+ * loop, with blockwise/SIMD implementations that are bit-identical to the
  * plain sequential loop (see buzhash64_impl.c for the algebra).
  *
  * The cut decision granularity stays at 1 byte: every position is tested
@@ -27,7 +27,8 @@ size_t bz64_scan(const uint64_t *table, const uint64_t *table_rot,
                  const uint8_t *p_rem, const uint8_t *p_add,
                  size_t n, uint64_t *sum, uint64_t mask, int force_scalar);
 
-/* Name of the kernel bz64_scan would use: "neon", "avx512", "avx2", "blocked" or "scalar". */
+/* Name of the kernel bz64_scan would use: "avx512", "avx2", "blockwise" or "scalar"
+ * (there is no vector kernel on aarch64, see buzhash64_impl.c). */
 const char *bz64_kernel_name(int force_scalar);
 
 #endif

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -33,11 +33,11 @@ cdef extern from "fastcdc_impl.h":
 # class only provides the keyed Gear table and the _scan() hook calling the C kernel.
 #
 # The inner scan runs in a C kernel (fastcdc_impl.c) with SIMD implementations (NEON on
-# aarch64, AVX-512 or AVX2 on x86-64, blocked scalar elsewhere) that are bit-identical to
+# aarch64, AVX-512 or AVX2 on x86-64, blockwise scalar elsewhere) that are bit-identical to
 # the plain sequential Gear loop: every byte position is tested, cuts and hash state are
 # exactly the same, only faster. BORG_FASTCDC_FORCE_SCALAR=1 forces the sequential loop
 # (for tests); BORG_FASTCDC_NO_AVX512=1 caps dispatch at AVX2 and BORG_FASTCDC_NO_AVX2=1
-# at the blocked scalar kernel (for benchmarking, must be set before the first chunker use).
+# at the blockwise scalar kernel (for benchmarking, must be set before the first chunker use).
 
 
 @cython.boundscheck(False)
@@ -87,7 +87,7 @@ cdef class ChunkerFastCDC(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blocked' or 'scalar'."""
+        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'."""
         return (<bytes>fc_kernel_name(self.force_scalar)).decode("ascii")
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -13,8 +13,13 @@ from ..crypto.low_level import CSPRNG
 from .base cimport ChunkerBase
 
 cdef extern from "fastcdc_impl.h":
-    int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar) nogil
-    const char *fc_kernel_name(int force_scalar)
+    int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int kernel) nogil
+    const char *fc_kernel_name(int kernel)
+    int fc_kernel_select(const char *name, int *out_id)
+    const char *fc_kernel_names()
+    int FC_K_AUTO
+
+from .kernel_env import kernel_error, requested_kernel
 
 # FastCDC content-defined chunker (Xia et al., USENIX ATC 2016).
 #
@@ -35,9 +40,8 @@ cdef extern from "fastcdc_impl.h":
 # The inner scan runs in a C kernel (fastcdc_impl.c) with SIMD implementations (NEON on
 # aarch64, AVX-512 or AVX2 on x86-64, blockwise scalar elsewhere) that are bit-identical to
 # the plain sequential Gear loop: every byte position is tested, cuts and hash state are
-# exactly the same, only faster. BORG_FASTCDC_FORCE_SCALAR=1 forces the sequential loop
-# (for tests); BORG_FASTCDC_NO_AVX512=1 caps dispatch at AVX2 and BORG_FASTCDC_NO_AVX2=1
-# at the blockwise scalar kernel (for benchmarking, must be set before the first chunker use).
+# exactly the same, only faster. BORG_FASTCDC_KERNEL pins the kernel instead of letting it
+# be auto-selected; see kernel_env.py and the .kernel property.
 
 
 @cython.boundscheck(False)
@@ -60,6 +64,20 @@ cdef uint64_t* fastcdc_init_gear(bytes key) except NULL:
     return gear
 
 
+cdef int _select_kernel() except -1:
+    """Resolve BORG_FASTCDC_KERNEL to a kernel id, raising if it cannot be honoured."""
+    cdef int kid = FC_K_AUTO
+    cdef int rc
+    want = requested_kernel("BORG_FASTCDC_KERNEL")
+    if want is None:
+        return FC_K_AUTO
+    rc = fc_kernel_select(want.encode("ascii"), &kid)
+    if rc != 0:
+        raise kernel_error("BORG_FASTCDC_KERNEL", want, rc,
+                           (<bytes>fc_kernel_names()).decode("ascii"))
+    return kid
+
+
 cdef class ChunkerFastCDC(ChunkerBase):
     """
     FastCDC content-defined chunker, variable chunk sizes, keyed Gear hash.
@@ -67,11 +85,11 @@ cdef class ChunkerFastCDC(ChunkerBase):
     Unlike the buzhash chunkers, Gear is window-less, so there is no hash_window_size parameter.
     """
     cdef uint64_t* gear
-    cdef int force_scalar
+    cdef int kernel_id
 
     def __cinit__(self, bytes key, int chunk_min_exp, int chunk_max_exp, int hash_mask_bits, int nc_level=0, size_t normal_size=0, bint sparse=False):
         self.gear = NULL
-        self.force_scalar = 1 if os.environ.get("BORG_FASTCDC_FORCE_SCALAR", "") not in ("", "0") else 0
+        self.kernel_id = _select_kernel()
         self.gear = fastcdc_init_gear(key)
         # Gear accumulates information in its high bits, so the cut-decision
         # masks must use the high bits of the hash (high_masks=True). The Gear
@@ -87,13 +105,17 @@ cdef class ChunkerFastCDC(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'."""
-        return (<bytes>fc_kernel_name(self.force_scalar)).decode("ascii")
+        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'.
+
+        With BORG_FASTCDC_KERNEL set to anything but "auto", this is always the
+        requested kernel - creating the chunker fails otherwise.
+        """
+        return (<bytes>fc_kernel_name(self.kernel_id)).decode("ascii")
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:
         cdef int64_t r
         with nogil:
-            r = fc_scan(self.gear, p, n, digest, mask, self.force_scalar)
+            r = fc_scan(self.gear, p, n, digest, mask, self.kernel_id)
         return r
 
 

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -36,8 +36,8 @@ cdef extern from "fastcdc_impl.h":
 # aarch64, AVX-512 or AVX2 on x86-64, blocked scalar elsewhere) that are bit-identical to
 # the plain sequential Gear loop: every byte position is tested, cuts and hash state are
 # exactly the same, only faster. BORG_FASTCDC_FORCE_SCALAR=1 forces the sequential loop
-# (for tests); BORG_FASTCDC_NO_AVX512=1 caps dispatch at AVX2 (for benchmarking, must be
-# set before the first chunker use).
+# (for tests); BORG_FASTCDC_NO_AVX512=1 caps dispatch at AVX2 and BORG_FASTCDC_NO_AVX2=1
+# at the blocked scalar kernel (for benchmarking, must be set before the first chunker use).
 
 
 @cython.boundscheck(False)

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -17,7 +17,7 @@ cdef extern from "fastcdc_impl.h":
     const char *fc_kernel_name(int kernel)
     int fc_kernel_select(const char *name, int *out_id)
     const char *fc_kernel_names()
-    int FC_K_AUTO
+    int FC_K_SCALAR
 
 from .kernel_env import kernel_error, requested_kernel
 
@@ -40,8 +40,8 @@ from .kernel_env import kernel_error, requested_kernel
 # The inner scan runs in a C kernel (fastcdc_impl.c) with SIMD implementations (NEON on
 # aarch64, AVX-512 or AVX2 on x86-64, blockwise scalar elsewhere) that are bit-identical to
 # the plain sequential Gear loop: every byte position is tested, cuts and hash state are
-# exactly the same, only faster. BORG_FASTCDC_KERNEL pins the kernel instead of letting it
-# be auto-selected; see kernel_env.py and the .kernel property.
+# exactly the same, only faster. The sequential loop is what runs by default; the others
+# are selected via BORG_FASTCDC_KERNEL, see kernel_env.py and the .kernel property.
 
 
 @cython.boundscheck(False)
@@ -65,12 +65,16 @@ cdef uint64_t* fastcdc_init_gear(bytes key) except NULL:
 
 
 cdef int _select_kernel() except -1:
-    """Resolve BORG_FASTCDC_KERNEL to a kernel id, raising if it cannot be honoured."""
-    cdef int kid = FC_K_AUTO
+    """Resolve BORG_FASTCDC_KERNEL to a kernel id, raising if it cannot be honoured.
+
+    Unset means the simplest implementation, not the fastest one: nothing here
+    guesses which kernel a given CPU and compiler make fastest.
+    """
+    cdef int kid = FC_K_SCALAR
     cdef int rc
     want = requested_kernel("BORG_FASTCDC_KERNEL")
     if want is None:
-        return FC_K_AUTO
+        return FC_K_SCALAR
     rc = fc_kernel_select(want.encode("ascii"), &kid)
     if rc != 0:
         raise kernel_error("BORG_FASTCDC_KERNEL", want, rc,
@@ -107,8 +111,8 @@ cdef class ChunkerFastCDC(ChunkerBase):
     def kernel(self):
         """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blockwise' or 'scalar'.
 
-        With BORG_FASTCDC_KERNEL set to anything but "auto", this is always the
-        requested kernel - creating the chunker fails otherwise.
+        'scalar' unless BORG_FASTCDC_KERNEL names another one, in which case
+        this is always that one - creating the chunker fails otherwise.
         """
         return (<bytes>fc_kernel_name(self.kernel_id)).decode("ascii")
 

--- a/src/borg/chunkers/fastcdc.pyx
+++ b/src/borg/chunkers/fastcdc.pyx
@@ -33,9 +33,11 @@ cdef extern from "fastcdc_impl.h":
 # class only provides the keyed Gear table and the _scan() hook calling the C kernel.
 #
 # The inner scan runs in a C kernel (fastcdc_impl.c) with SIMD implementations (NEON on
-# aarch64, AVX2 on x86-64, blocked scalar elsewhere) that are bit-identical to the plain
-# sequential Gear loop: every byte position is tested, cuts and hash state are exactly the
-# same, only faster. BORG_FASTCDC_FORCE_SCALAR=1 forces the sequential loop (for tests).
+# aarch64, AVX-512 or AVX2 on x86-64, blocked scalar elsewhere) that are bit-identical to
+# the plain sequential Gear loop: every byte position is tested, cuts and hash state are
+# exactly the same, only faster. BORG_FASTCDC_FORCE_SCALAR=1 forces the sequential loop
+# (for tests); BORG_FASTCDC_NO_AVX512=1 caps dispatch at AVX2 (for benchmarking, must be
+# set before the first chunker use).
 
 
 @cython.boundscheck(False)
@@ -85,7 +87,7 @@ cdef class ChunkerFastCDC(ChunkerBase):
 
     @property
     def kernel(self):
-        """Which scan kernel this chunker uses: 'neon', 'avx2', 'blocked' or 'scalar'."""
+        """Which scan kernel this chunker uses: 'neon', 'avx512', 'avx2', 'blocked' or 'scalar'."""
         return (<bytes>fc_kernel_name(self.force_scalar)).decode("ascii")
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -121,24 +121,35 @@ static int64_t fc_scan_blocked(const uint64_t *gear, const uint8_t *p, size_t n,
 
 #include <arm_neon.h>
 
+/* Per lane, "(x & M) == 0" is replaced by "x <= ~M", turning the and plus
+ * compare-against-zero into one unsigned compare against a limit computed
+ * once per scan.
+ *
+ * (x & M) == 0 means x's set bits are a subset of ~M's, which implies
+ * x <= ~M for any M - so this never loses a cut, whatever the mask looks
+ * like. For the contiguous high-bit masks the chunker actually uses (mask
+ * has its one-bits at the top and shifting left only drops bits off the top,
+ * so ~M is 2^(64-k)-1) the two are exactly equivalent, and this stays the
+ * same superset test as the masked form: the block's exact sequential
+ * recheck resolves candidates either way. */
 static int64_t fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
     uint64_t fp = *fp_io;
     uint64_t s[8];
-    uint64x2_t M12 = {mask << 7, mask << 6};
-    uint64x2_t M34 = {mask << 5, mask << 4};
-    uint64x2_t M56 = {mask << 3, mask << 2};
-    uint64x2_t M78 = {mask << 1, mask};
+    uint64x2_t L12 = {~(mask << 7), ~(mask << 6)};
+    uint64x2_t L34 = {~(mask << 5), ~(mask << 4)};
+    uint64x2_t L56 = {~(mask << 3), ~(mask << 2)};
+    uint64x2_t L78 = {~(mask << 1), ~mask};
     size_t i = 0;
 
     for (; i + 8 <= n; i += 8) {
         fc_block_prefix(gear, p + i, s);
         uint64_t c = fp << 8;
         uint64x2_t C = vdupq_n_u64(c);
-        uint64x2_t z12 = vceqzq_u64(vandq_u64(vaddq_u64(C, (uint64x2_t){s[0], s[1]}), M12));
-        uint64x2_t z34 = vceqzq_u64(vandq_u64(vaddq_u64(C, (uint64x2_t){s[2], s[3]}), M34));
-        uint64x2_t z56 = vceqzq_u64(vandq_u64(vaddq_u64(C, (uint64x2_t){s[4], s[5]}), M56));
-        uint64x2_t z78 = vceqzq_u64(vandq_u64(vaddq_u64(C, (uint64x2_t){s[6], s[7]}), M78));
+        uint64x2_t z12 = vcgeq_u64(L12, vaddq_u64(C, (uint64x2_t){s[0], s[1]}));
+        uint64x2_t z34 = vcgeq_u64(L34, vaddq_u64(C, (uint64x2_t){s[2], s[3]}));
+        uint64x2_t z56 = vcgeq_u64(L56, vaddq_u64(C, (uint64x2_t){s[4], s[5]}));
+        uint64x2_t z78 = vcgeq_u64(L78, vaddq_u64(C, (uint64x2_t){s[6], s[7]}));
         uint64x2_t any = vorrq_u64(vorrq_u64(z12, z34), vorrq_u64(z56, z78));
         if (vmaxvq_u32(vreinterpretq_u32_u64(any))) {
             int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -262,16 +262,22 @@ fc_scan_simd512(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_i
     return -1;
 }
 
+static int fc_env_set(const char *name)
+{
+    const char *e = getenv(name);
+    return e != NULL && e[0] != 0 && strcmp(e, "0") != 0;
+}
+
 static int fc_simd_available(void)
 {
-    /* BORG_FASTCDC_NO_AVX512 caps dispatch at AVX2 (for benchmarking the
-     * kernels against each other); like the detection itself it is read
-     * once per process, so it must be set before the first chunker use. */
-    if (__builtin_cpu_supports("avx512f")) {
-        const char *e = getenv("BORG_FASTCDC_NO_AVX512");
-        if (e == NULL || e[0] == 0 || strcmp(e, "0") == 0)
-            return 2;
-    }
+    /* BORG_FASTCDC_NO_AVX512 caps dispatch at AVX2, BORG_FASTCDC_NO_AVX2 at
+     * the blocked scalar kernel (for benchmarking the kernels against each
+     * other); like the detection itself they are read once per process, so
+     * they must be set before the first chunker use. */
+    if (fc_env_set("BORG_FASTCDC_NO_AVX2"))
+        return 0;
+    if (__builtin_cpu_supports("avx512f") && !fc_env_set("BORG_FASTCDC_NO_AVX512"))
+        return 2;
     return __builtin_cpu_supports("avx2");
 }
 

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -21,7 +21,7 @@
  * which an exact sequential recheck of the block resolves. The per-lane
  * masks (mask << 7 .. mask << 0) are constants of the scan.
  *
- * All kernels (sequential, blocked scalar, NEON, AVX2, AVX-512) return
+ * All kernels (sequential, blockwise scalar, NEON, AVX2, AVX-512) return
  * bit-identical cut positions and fp values; the chunker's golden tests
  * depend on this. */
 
@@ -76,9 +76,9 @@ static inline void fc_block_prefix(const uint64_t *gear, const uint8_t *p, uint6
     s[7] = s8;
 }
 
-/* --- blocked scalar (portable C, no intrinsics) ------------------------- */
+/* --- blockwise scalar (portable C, no intrinsics) ------------------------- */
 
-static int64_t fc_scan_blocked(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
+static int64_t fc_scan_blockwise(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
     uint64_t fp = *fp_io;
     uint64_t M[8];
@@ -215,7 +215,7 @@ static inline void fc_block_gear(const uint64_t *gear, const uint8_t *p, uint64_
  * forwarding and stalls, twice per block. Loading block i+1 while block i is
  * tested puts a full loop body between the stores and the load, so the stores
  * have retired by then and the stall disappears. Before this, the stalls made
- * the AVX2 kernel slower than the blocked scalar one. */
+ * the AVX2 kernel slower than the blockwise scalar one. */
 __attribute__((target("avx2"))) static int64_t
 fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
@@ -351,7 +351,7 @@ static int fc_env_set(const char *name)
 static int fc_simd_available(void)
 {
     /* BORG_FASTCDC_NO_AVX512 caps dispatch at AVX2, BORG_FASTCDC_NO_AVX2 at
-     * the blocked scalar kernel (for benchmarking the kernels against each
+     * the blockwise scalar kernel (for benchmarking the kernels against each
      * other); like the detection itself they are read once per process, so
      * they must be set before the first chunker use. */
     if (fc_env_set("BORG_FASTCDC_NO_AVX2"))
@@ -362,11 +362,11 @@ static int fc_simd_available(void)
 }
 
 #else
-#define FC_KIND "blocked"
+#define FC_KIND "blockwise"
 
 static int64_t fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
-    return fc_scan_blocked(gear, p, n, fp_io, mask);
+    return fc_scan_blockwise(gear, p, n, fp_io, mask);
 }
 
 static int fc_simd_available(void)
@@ -378,7 +378,7 @@ static int fc_simd_available(void)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* resolved once (0 = blocked, 1 = FC_KIND, 2 = FC_KIND_512 where defined);
+/* resolved once (0 = blockwise, 1 = FC_KIND, 2 = FC_KIND_512 where defined);
  * a racy double-init writes the same value, so it is benign */
 static int fc_use_simd = -1;
 
@@ -394,7 +394,7 @@ int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, 
 #endif
     if (fc_use_simd)
         return fc_scan_simd(gear, p, n, fp, mask);
-    return fc_scan_blocked(gear, p, n, fp, mask);
+    return fc_scan_blockwise(gear, p, n, fp, mask);
 }
 
 const char *fc_kernel_name(int force_scalar)
@@ -407,5 +407,5 @@ const char *fc_kernel_name(int force_scalar)
     if (fc_use_simd == 2)
         return FC_KIND_512;
 #endif
-    return fc_use_simd ? FC_KIND : "blocked";
+    return fc_use_simd ? FC_KIND : "blockwise";
 }

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -172,10 +172,6 @@ static int64_t fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, ui
     return -1;
 }
 
-static int fc_simd_available(void)
-{
-    return 1;
-}
 
 /* --- AVX2 (x86-64, runtime detected) ------------------------------------ */
 
@@ -342,14 +338,6 @@ fc_scan_simd512(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_i
     return -1;
 }
 
-static int fc_simd_available(void)
-{
-#ifdef FC_KIND_512
-    if (__builtin_cpu_supports("avx512f"))
-        return 2;
-#endif
-    return __builtin_cpu_supports("avx2");
-}
 
 #else
 #define FC_KIND "blockwise"
@@ -359,10 +347,6 @@ static int64_t fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, ui
     return fc_scan_blockwise(gear, p, n, fp_io, mask);
 }
 
-static int fc_simd_available(void)
-{
-    return 0;
-}
 
 #endif
 
@@ -371,20 +355,16 @@ static int fc_simd_available(void)
 const char *fc_kernel_names(void)
 {
 #if defined(__aarch64__)
-    return "auto, neon, blockwise, scalar";
+    return "neon,blockwise,scalar";
 #elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
-    return "auto, avx512, avx2, blockwise, scalar";
+    return "avx512,avx2,blockwise,scalar";
 #else
-    return "auto, blockwise, scalar";
+    return "blockwise,scalar";
 #endif
 }
 
 int fc_kernel_select(const char *name, int *out_id)
 {
-    if (strcmp(name, "auto") == 0) {
-        *out_id = FC_K_AUTO;
-        return FC_KSEL_OK;
-    }
     if (strcmp(name, "scalar") == 0) {
         *out_id = FC_K_SCALAR;
         return FC_KSEL_OK;
@@ -421,24 +401,8 @@ int fc_kernel_select(const char *name, int *out_id)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* the kernel FC_K_AUTO resolves to, worked out once; a racy double-init
- * writes the same value, so it is benign */
-static int fc_auto = -1;
-
-static int fc_auto_kernel(void)
-{
-    int a;
-    if (fc_auto < 0) {
-        a = fc_simd_available();
-        fc_auto = (a == 2) ? FC_K_VECTOR512 : (a ? FC_K_VECTOR : FC_K_BLOCKWISE);
-    }
-    return fc_auto;
-}
-
 int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int kernel)
 {
-    if (kernel == FC_K_AUTO)
-        kernel = fc_auto_kernel();
     switch (kernel) {
     case FC_K_SCALAR:
         return fc_scan_seq(gear, p, n, fp, mask);
@@ -455,8 +419,6 @@ int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, 
 
 const char *fc_kernel_name(int kernel)
 {
-    if (kernel == FC_K_AUTO)
-        kernel = fc_auto_kernel();
     switch (kernel) {
     case FC_K_SCALAR:
         return "scalar";

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -173,39 +173,87 @@ static int fc_simd_available(void)
 
 #include <immintrin.h>
 
+/* Load the block's 8 gear values (via one 8-byte data load), without the
+ * shifts and the prefix sum: the vector kernels do those in the vector
+ * domain. Endianness-independent: bytes are extracted by shifting. */
+static inline void fc_block_gear(const uint64_t *gear, const uint8_t *p, uint64_t g[8])
+{
+    uint64_t w;
+    memcpy(&w, p, 8);
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    w = __builtin_bswap64(w);
+#endif
+    g[0] = gear[(uint8_t)w];
+    g[1] = gear[(uint8_t)(w >> 8)];
+    g[2] = gear[(uint8_t)(w >> 16)];
+    g[3] = gear[(uint8_t)(w >> 24)];
+    g[4] = gear[(uint8_t)(w >> 32)];
+    g[5] = gear[(uint8_t)(w >> 40)];
+    g[6] = gear[(uint8_t)(w >> 48)];
+    g[7] = gear[(uint8_t)(w >> 56)];
+}
+
+/* The 8-lane candidate test in two 256-bit vectors, with the aligned domain
+ * built in the vector domain: vpsllvq applies the per-lane shifts, then an
+ * inclusive prefix sum inside each 4-lane half (two vpermq+vpaddq steps) plus
+ * a broadcast of the low half's total into the high half.
+ *
+ * Only the 8 gear table lookups stay scalar, and they are done one block
+ * ahead into a double buffer: a 32-byte vector load placed right after the
+ * eight 8-byte scalar stores that filled it cannot use store-to-load
+ * forwarding and stalls, twice per block. Loading block i+1 while block i is
+ * tested puts a full loop body between the stores and the load, so the stores
+ * have retired by then and the stall disappears. Before this, the stalls made
+ * the AVX2 kernel slower than the blocked scalar one. */
 __attribute__((target("avx2"))) static int64_t
 fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
     uint64_t fp = *fp_io;
-    uint64_t s[8];
+    uint64_t g[16]; /* double buffer: block being tested + block being loaded */
     /* _mm256_set_epi64x takes arguments high lane first */
-    __m256i M1 = _mm256_set_epi64x((long long)(mask << 4), (long long)(mask << 5),
-                                   (long long)(mask << 6), (long long)(mask << 7));
-    __m256i M2 = _mm256_set_epi64x((long long)mask, (long long)(mask << 1),
-                                   (long long)(mask << 2), (long long)(mask << 3));
-    __m256i zero = _mm256_setzero_si256();
+    const __m256i M1 = _mm256_set_epi64x((long long)(mask << 4), (long long)(mask << 5),
+                                         (long long)(mask << 6), (long long)(mask << 7));
+    const __m256i M2 = _mm256_set_epi64x((long long)mask, (long long)(mask << 1),
+                                         (long long)(mask << 2), (long long)(mask << 3));
+    const __m256i SL = _mm256_set_epi64x(4, 5, 6, 7); /* lanes 0..3 <<= 7..4 */
+    const __m256i SH = _mm256_set_epi64x(0, 1, 2, 3); /* lanes 4..7 <<= 3..0 */
+    const __m256i zero = _mm256_setzero_si256();
     size_t i = 0;
+    int cur = 0;
 
-    for (; i + 8 <= n; i += 8) {
-        fc_block_prefix(gear, p + i, s);
-        uint64_t c = fp << 8;
-        __m256i C = _mm256_set1_epi64x((long long)c);
-        __m256i H1 = _mm256_add_epi64(C, _mm256_loadu_si256((const __m256i *)&s[0]));
-        __m256i H2 = _mm256_add_epi64(C, _mm256_loadu_si256((const __m256i *)&s[4]));
-        __m256i z1 = _mm256_cmpeq_epi64(_mm256_and_si256(H1, M1), zero);
-        __m256i z2 = _mm256_cmpeq_epi64(_mm256_and_si256(H2, M2), zero);
-        __m256i any = _mm256_or_si256(z1, z2);
-        if (!_mm256_testz_si256(any, any)) {
-            int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */
-            if (r >= 0) {
-                *fp_io = fp;
-                return (int64_t)i + r;
+    if (n >= 16) {
+        fc_block_gear(gear, p, g);
+        for (; i + 16 <= n; i += 8, cur ^= 8) {
+            fc_block_gear(gear, p + i + 8, g + (cur ^ 8)); /* one block ahead */
+            __m256i lo = _mm256_sllv_epi64(_mm256_loadu_si256((const __m256i *)(g + cur)), SL);
+            __m256i hi = _mm256_sllv_epi64(_mm256_loadu_si256((const __m256i *)(g + cur + 4)), SH);
+            /* inclusive prefix sum inside each half: rotate the lanes up by 1
+             * resp. 2 (vpermq), zero the lanes rotated in, add */
+            lo = _mm256_add_epi64(lo, _mm256_blend_epi32(_mm256_permute4x64_epi64(lo, 0x93), zero, 0x03));
+            lo = _mm256_add_epi64(lo, _mm256_blend_epi32(_mm256_permute4x64_epi64(lo, 0x4E), zero, 0x0F));
+            hi = _mm256_add_epi64(hi, _mm256_blend_epi32(_mm256_permute4x64_epi64(hi, 0x93), zero, 0x03));
+            hi = _mm256_add_epi64(hi, _mm256_blend_epi32(_mm256_permute4x64_epi64(hi, 0x4E), zero, 0x0F));
+            hi = _mm256_add_epi64(hi, _mm256_permute4x64_epi64(lo, 0xFF)); /* carry s[3] */
+            uint64_t c = fp << 8;
+            __m256i C = _mm256_set1_epi64x((long long)c);
+            __m256i H1 = _mm256_add_epi64(C, lo);
+            __m256i H2 = _mm256_add_epi64(C, hi);
+            __m256i z1 = _mm256_cmpeq_epi64(_mm256_and_si256(H1, M1), zero);
+            __m256i z2 = _mm256_cmpeq_epi64(_mm256_and_si256(H2, M2), zero);
+            __m256i any = _mm256_or_si256(z1, z2);
+            if (!_mm256_testz_si256(any, any)) {
+                int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */
+                if (r >= 0) {
+                    *fp_io = fp;
+                    return (int64_t)i + r;
+                }
+            } else {
+                fp = c + (uint64_t)_mm_cvtsi128_si64(_mm256_castsi256_si128(
+                             _mm256_permute4x64_epi64(hi, 0xFF))); /* s[7] */
             }
-        } else {
-            fp = c + s[7];
         }
     }
-    if (i < n) {
+    if (i < n) { /* up to 15 bytes here (one block more than the scalar kernels) */
         int64_t r = fc_scan_seq(gear, p + i, n - i, &fp, mask);
         if (r >= 0) {
             *fp_io = fp;
@@ -220,38 +268,59 @@ fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, 
 
 #define FC_KIND_512 "avx512"
 
-/* The same 8-lane candidate test as the AVX2 kernel, in one 512-bit vector:
- * vptestnmq fuses the AND and the ==0 test per lane into a mask register,
- * so the whole test is broadcast + load + add + testn + branch. Only the
- * test narrows; the scalar prefix work (fc_block_prefix) is shared. */
+/* The same 8-lane candidate test as the AVX2 kernel, but the aligned domain
+ * fits in one 512-bit vector: vpsllvq applies the per-lane shifts (lane j <<
+ * (7-j)), three valignq+vpaddq steps turn the shifted gear values into the
+ * inclusive prefix sums s[0..7] in one pass instead of two halves plus a
+ * carry, and vptestnmq fuses the AND and the ==0 test into a mask register.
+ *
+ * The gear lookups are pipelined one block ahead exactly as in the AVX2
+ * kernel above, for the same store-to-load forwarding reason.
+ *
+ * The serial chain stays short: only fp = c + s[7] (scalar add + shift per
+ * 8 bytes) is carried across blocks, and s[7] is read out of the vector with
+ * vpermq off that chain. */
 __attribute__((target("avx512f"))) static int64_t
 fc_scan_simd512(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
 {
     uint64_t fp = *fp_io;
-    uint64_t s[8];
+    uint64_t g[16]; /* double buffer: block being tested + block being loaded */
     /* _mm512_set_epi64 takes arguments high lane first: lane j = mask << (7-j) */
-    __m512i M = _mm512_set_epi64((long long)mask, (long long)(mask << 1),
-                                 (long long)(mask << 2), (long long)(mask << 3),
-                                 (long long)(mask << 4), (long long)(mask << 5),
-                                 (long long)(mask << 6), (long long)(mask << 7));
+    const __m512i M = _mm512_set_epi64((long long)mask, (long long)(mask << 1),
+                                       (long long)(mask << 2), (long long)(mask << 3),
+                                       (long long)(mask << 4), (long long)(mask << 5),
+                                       (long long)(mask << 6), (long long)(mask << 7));
+    const __m512i SH = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7); /* lane j <<= 7-j */
+    const __m512i Z = _mm512_setzero_si512();
     size_t i = 0;
+    int cur = 0;
 
-    for (; i + 8 <= n; i += 8) {
-        fc_block_prefix(gear, p + i, s);
-        uint64_t c = fp << 8;
-        __m512i H = _mm512_add_epi64(_mm512_set1_epi64((long long)c),
-                                     _mm512_loadu_si512((const void *)s));
-        if (_mm512_testn_epi64_mask(H, M)) {
-            int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */
-            if (r >= 0) {
-                *fp_io = fp;
-                return (int64_t)i + r;
+    if (n >= 16) {
+        fc_block_gear(gear, p, g);
+        for (; i + 16 <= n; i += 8, cur ^= 8) {
+            fc_block_gear(gear, p + i + 8, g + (cur ^ 8)); /* one block ahead */
+            /* u = shifted gear values, then the inclusive prefix sum over the
+             * 8 lanes (Hillis-Steele: shift lanes up by 1, 2, 4 and add;
+             * _mm512_alignr_epi64(u, Z, 8-k) shifts up by k, zero-filling) */
+            __m512i u = _mm512_sllv_epi64(_mm512_loadu_si512((const void *)(g + cur)), SH);
+            u = _mm512_add_epi64(u, _mm512_alignr_epi64(u, Z, 7));
+            u = _mm512_add_epi64(u, _mm512_alignr_epi64(u, Z, 6));
+            u = _mm512_add_epi64(u, _mm512_alignr_epi64(u, Z, 4));
+            uint64_t c = fp << 8;
+            __m512i H = _mm512_add_epi64(_mm512_set1_epi64((long long)c), u);
+            if (_mm512_testn_epi64_mask(H, M)) {
+                int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */
+                if (r >= 0) {
+                    *fp_io = fp;
+                    return (int64_t)i + r;
+                }
+            } else {
+                fp = c + (uint64_t)_mm_cvtsi128_si64(_mm512_castsi512_si128(
+                             _mm512_permutexvar_epi64(_mm512_set1_epi64(7), u))); /* s[7] */
             }
-        } else {
-            fp = c + s[7];
         }
     }
-    if (i < n) {
+    if (i < n) { /* up to 15 bytes here (one block more than the other kernels) */
         int64_t r = fc_scan_seq(gear, p + i, n - i, &fp, mask);
         if (r >= 0) {
             *fp_io = fp;

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -21,9 +21,11 @@
  * which an exact sequential recheck of the block resolves. The per-lane
  * masks (mask << 7 .. mask << 0) are constants of the scan.
  *
- * All kernels (sequential, blocked scalar, NEON, AVX2) return bit-identical
- * cut positions and fp values; the chunker's golden tests depend on this. */
+ * All kernels (sequential, blocked scalar, NEON, AVX2, AVX-512) return
+ * bit-identical cut positions and fp values; the chunker's golden tests
+ * depend on this. */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "fastcdc_impl.h"
@@ -214,8 +216,62 @@ fc_scan_simd(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, 
     return -1;
 }
 
+/* --- AVX-512 (x86-64, runtime detected) --------------------------------- */
+
+#define FC_KIND_512 "avx512"
+
+/* The same 8-lane candidate test as the AVX2 kernel, in one 512-bit vector:
+ * vptestnmq fuses the AND and the ==0 test per lane into a mask register,
+ * so the whole test is broadcast + load + add + testn + branch. Only the
+ * test narrows; the scalar prefix work (fc_block_prefix) is shared. */
+__attribute__((target("avx512f"))) static int64_t
+fc_scan_simd512(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_io, uint64_t mask)
+{
+    uint64_t fp = *fp_io;
+    uint64_t s[8];
+    /* _mm512_set_epi64 takes arguments high lane first: lane j = mask << (7-j) */
+    __m512i M = _mm512_set_epi64((long long)mask, (long long)(mask << 1),
+                                 (long long)(mask << 2), (long long)(mask << 3),
+                                 (long long)(mask << 4), (long long)(mask << 5),
+                                 (long long)(mask << 6), (long long)(mask << 7));
+    size_t i = 0;
+
+    for (; i + 8 <= n; i += 8) {
+        fc_block_prefix(gear, p + i, s);
+        uint64_t c = fp << 8;
+        __m512i H = _mm512_add_epi64(_mm512_set1_epi64((long long)c),
+                                     _mm512_loadu_si512((const void *)s));
+        if (_mm512_testn_epi64_mask(H, M)) {
+            int64_t r = fc_scan_seq(gear, p + i, 8, &fp, mask); /* exact recheck */
+            if (r >= 0) {
+                *fp_io = fp;
+                return (int64_t)i + r;
+            }
+        } else {
+            fp = c + s[7];
+        }
+    }
+    if (i < n) {
+        int64_t r = fc_scan_seq(gear, p + i, n - i, &fp, mask);
+        if (r >= 0) {
+            *fp_io = fp;
+            return (int64_t)i + r;
+        }
+    }
+    *fp_io = fp;
+    return -1;
+}
+
 static int fc_simd_available(void)
 {
+    /* BORG_FASTCDC_NO_AVX512 caps dispatch at AVX2 (for benchmarking the
+     * kernels against each other); like the detection itself it is read
+     * once per process, so it must be set before the first chunker use. */
+    if (__builtin_cpu_supports("avx512f")) {
+        const char *e = getenv("BORG_FASTCDC_NO_AVX512");
+        if (e == NULL || e[0] == 0 || strcmp(e, "0") == 0)
+            return 2;
+    }
     return __builtin_cpu_supports("avx2");
 }
 
@@ -236,7 +292,8 @@ static int fc_simd_available(void)
 
 /* --- dispatch ----------------------------------------------------------- */
 
-/* resolved once; a racy double-init writes the same value, so it is benign */
+/* resolved once (0 = blocked, 1 = FC_KIND, 2 = FC_KIND_512 where defined);
+ * a racy double-init writes the same value, so it is benign */
 static int fc_use_simd = -1;
 
 int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar)
@@ -245,6 +302,10 @@ int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, 
         return fc_scan_seq(gear, p, n, fp, mask);
     if (fc_use_simd < 0)
         fc_use_simd = fc_simd_available();
+#ifdef FC_KIND_512
+    if (fc_use_simd == 2)
+        return fc_scan_simd512(gear, p, n, fp, mask);
+#endif
     if (fc_use_simd)
         return fc_scan_simd(gear, p, n, fp, mask);
     return fc_scan_blocked(gear, p, n, fp, mask);
@@ -256,5 +317,9 @@ const char *fc_kernel_name(int force_scalar)
         return "scalar";
     if (fc_use_simd < 0)
         fc_use_simd = fc_simd_available();
+#ifdef FC_KIND_512
+    if (fc_use_simd == 2)
+        return FC_KIND_512;
+#endif
     return fc_use_simd ? FC_KIND : "blocked";
 }

--- a/src/borg/chunkers/fastcdc_impl.c
+++ b/src/borg/chunkers/fastcdc_impl.c
@@ -342,22 +342,12 @@ fc_scan_simd512(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp_i
     return -1;
 }
 
-static int fc_env_set(const char *name)
-{
-    const char *e = getenv(name);
-    return e != NULL && e[0] != 0 && strcmp(e, "0") != 0;
-}
-
 static int fc_simd_available(void)
 {
-    /* BORG_FASTCDC_NO_AVX512 caps dispatch at AVX2, BORG_FASTCDC_NO_AVX2 at
-     * the blockwise scalar kernel (for benchmarking the kernels against each
-     * other); like the detection itself they are read once per process, so
-     * they must be set before the first chunker use. */
-    if (fc_env_set("BORG_FASTCDC_NO_AVX2"))
-        return 0;
-    if (__builtin_cpu_supports("avx512f") && !fc_env_set("BORG_FASTCDC_NO_AVX512"))
+#ifdef FC_KIND_512
+    if (__builtin_cpu_supports("avx512f"))
         return 2;
+#endif
     return __builtin_cpu_supports("avx2");
 }
 
@@ -376,36 +366,107 @@ static int fc_simd_available(void)
 
 #endif
 
-/* --- dispatch ----------------------------------------------------------- */
+/* --- kernel selection --------------------------------------------------- */
 
-/* resolved once (0 = blockwise, 1 = FC_KIND, 2 = FC_KIND_512 where defined);
- * a racy double-init writes the same value, so it is benign */
-static int fc_use_simd = -1;
-
-int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar)
+const char *fc_kernel_names(void)
 {
-    if (force_scalar)
-        return fc_scan_seq(gear, p, n, fp, mask);
-    if (fc_use_simd < 0)
-        fc_use_simd = fc_simd_available();
-#ifdef FC_KIND_512
-    if (fc_use_simd == 2)
-        return fc_scan_simd512(gear, p, n, fp, mask);
+#if defined(__aarch64__)
+    return "auto, neon, blockwise, scalar";
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    return "auto, avx512, avx2, blockwise, scalar";
+#else
+    return "auto, blockwise, scalar";
 #endif
-    if (fc_use_simd)
-        return fc_scan_simd(gear, p, n, fp, mask);
-    return fc_scan_blockwise(gear, p, n, fp, mask);
 }
 
-const char *fc_kernel_name(int force_scalar)
+int fc_kernel_select(const char *name, int *out_id)
 {
-    if (force_scalar)
-        return "scalar";
-    if (fc_use_simd < 0)
-        fc_use_simd = fc_simd_available();
+    if (strcmp(name, "auto") == 0) {
+        *out_id = FC_K_AUTO;
+        return FC_KSEL_OK;
+    }
+    if (strcmp(name, "scalar") == 0) {
+        *out_id = FC_K_SCALAR;
+        return FC_KSEL_OK;
+    }
+    if (strcmp(name, "blockwise") == 0) {
+        *out_id = FC_K_BLOCKWISE;
+        return FC_KSEL_OK;
+    }
+#if defined(__aarch64__)
+    if (strcmp(name, "neon") == 0) {
+        *out_id = FC_K_VECTOR; /* baseline on aarch64, always runnable */
+        return FC_KSEL_OK;
+    }
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    if (strcmp(name, "avx2") == 0) {
+        if (!__builtin_cpu_supports("avx2"))
+            return FC_KSEL_NOCPU;
+        *out_id = FC_K_VECTOR;
+        return FC_KSEL_OK;
+    }
+    if (strcmp(name, "avx512") == 0) {
+#ifndef FC_KIND_512
+        return FC_KSEL_NOTBUILT; /* compiler too old for the target attribute */
+#else
+        if (!__builtin_cpu_supports("avx512f"))
+            return FC_KSEL_NOCPU;
+        *out_id = FC_K_VECTOR512;
+        return FC_KSEL_OK;
+#endif
+    }
+#endif
+    return FC_KSEL_UNKNOWN;
+}
+
+/* --- dispatch ----------------------------------------------------------- */
+
+/* the kernel FC_K_AUTO resolves to, worked out once; a racy double-init
+ * writes the same value, so it is benign */
+static int fc_auto = -1;
+
+static int fc_auto_kernel(void)
+{
+    int a;
+    if (fc_auto < 0) {
+        a = fc_simd_available();
+        fc_auto = (a == 2) ? FC_K_VECTOR512 : (a ? FC_K_VECTOR : FC_K_BLOCKWISE);
+    }
+    return fc_auto;
+}
+
+int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int kernel)
+{
+    if (kernel == FC_K_AUTO)
+        kernel = fc_auto_kernel();
+    switch (kernel) {
+    case FC_K_SCALAR:
+        return fc_scan_seq(gear, p, n, fp, mask);
+    case FC_K_BLOCKWISE:
+        return fc_scan_blockwise(gear, p, n, fp, mask);
 #ifdef FC_KIND_512
-    if (fc_use_simd == 2)
+    case FC_K_VECTOR512:
+        return fc_scan_simd512(gear, p, n, fp, mask);
+#endif
+    default:
+        return fc_scan_simd(gear, p, n, fp, mask);
+    }
+}
+
+const char *fc_kernel_name(int kernel)
+{
+    if (kernel == FC_K_AUTO)
+        kernel = fc_auto_kernel();
+    switch (kernel) {
+    case FC_K_SCALAR:
+        return "scalar";
+    case FC_K_BLOCKWISE:
+        return "blockwise";
+#ifdef FC_KIND_512
+    case FC_K_VECTOR512:
         return FC_KIND_512;
 #endif
-    return fc_use_simd ? FC_KIND : "blockwise";
+    default:
+        return FC_KIND;
+    }
 }

--- a/src/borg/chunkers/fastcdc_impl.h
+++ b/src/borg/chunkers/fastcdc_impl.h
@@ -11,16 +11,42 @@
 #include <stdint.h>
 #include <stddef.h>
 
+/* Scan kernel ids, a tier ladder. Which names map onto them depends on the
+ * build: "neon" exists only on aarch64, "avx2"/"avx512" only on x86-64. */
+#define FC_K_AUTO 0      /* best kernel this CPU can run */
+#define FC_K_SCALAR 1    /* sequential reference loop */
+#define FC_K_BLOCKWISE 2 /* portable 8-lane C */
+#define FC_K_VECTOR 3    /* the platform's vector kernel: neon or avx2 */
+#define FC_K_VECTOR512 4 /* avx512 */
+
+/* Results of fc_kernel_select(). */
+#define FC_KSEL_OK 0
+#define FC_KSEL_UNKNOWN 1  /* not a kernel name on this platform */
+#define FC_KSEL_NOTBUILT 2 /* known, but not compiled into this binary */
+#define FC_KSEL_NOCPU 3    /* known and built, but this CPU cannot run it */
+
+/* Resolve a kernel name for this build. On FC_KSEL_OK the id is stored in
+ * *out_id, otherwise *out_id is left alone. The three failures are kept apart
+ * because they need different fixes: a typo, too old a compiler, or the wrong
+ * CPU. */
+int fc_kernel_select(const char *name, int *out_id);
+
+/* Comma-separated list of the kernel names this build accepts, for error
+ * messages. Names a CPU cannot run are still listed. */
+const char *fc_kernel_names(void);
+
 /* Scan up to n positions: for i = 0..n-1 advance fp = (fp << 1) + gear[p[i]]
  * and test (fp & mask) == 0.
  * Returns the first i that matched (fp is left at position i), or -1 if none
  * matched (fp is left at position n-1).
- * gear: the keyed 256-entry table. force_scalar != 0 selects the sequential
- * reference loop (for tests); otherwise the best kernel for this CPU is used.
+ * gear: the keyed 256-entry table. kernel is one of FC_K_*; FC_K_AUTO picks
+ * the best one this CPU can run. Callers are expected to have validated any
+ * explicit choice with fc_kernel_select() - an unrunnable one falls back to
+ * FC_K_AUTO rather than crashing.
  * All kernels return bit-identical results. */
-int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar);
+int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int kernel);
 
-/* Name of the kernel fc_scan would use: "neon", "avx512", "avx2", "blockwise" or "scalar". */
-const char *fc_kernel_name(int force_scalar);
+/* Name of the kernel <kernel> selects; for FC_K_AUTO, the auto-selected one. */
+const char *fc_kernel_name(int kernel);
 
 #endif

--- a/src/borg/chunkers/fastcdc_impl.h
+++ b/src/borg/chunkers/fastcdc_impl.h
@@ -20,7 +20,7 @@
  * All kernels return bit-identical results. */
 int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar);
 
-/* Name of the kernel fc_scan would use: "neon", "avx512", "avx2", "blocked" or "scalar". */
+/* Name of the kernel fc_scan would use: "neon", "avx512", "avx2", "blockwise" or "scalar". */
 const char *fc_kernel_name(int force_scalar);
 
 #endif

--- a/src/borg/chunkers/fastcdc_impl.h
+++ b/src/borg/chunkers/fastcdc_impl.h
@@ -11,13 +11,20 @@
 #include <stdint.h>
 #include <stddef.h>
 
-/* Scan kernel ids, a tier ladder. Which names map onto them depends on the
- * build: "neon" exists only on aarch64, "avx2"/"avx512" only on x86-64. */
-#define FC_K_AUTO 0      /* best kernel this CPU can run */
-#define FC_K_SCALAR 1    /* sequential reference loop */
-#define FC_K_BLOCKWISE 2 /* portable 8-lane C */
-#define FC_K_VECTOR 3    /* the platform's vector kernel: neon or avx2 */
-#define FC_K_VECTOR512 4 /* avx512 */
+/* Scan kernel ids. Which names map onto them depends on the build: "neon"
+ * exists only on aarch64, "avx2"/"avx512" only on x86-64.
+ *
+ * There is no automatic selection: the caller says which kernel to run, and
+ * that is what runs. FC_K_SCALAR, the plain sequential loop, is id 0 and the
+ * default everywhere - it is the simplest implementation and the one the
+ * others are checked against. Which of the rest is fastest turned out not to
+ * be predictable from the instruction set (on an Apple M3 the NEON kernel
+ * beats the sequential loop 2.1x; with gcc on a Zen 4 the sequential loop
+ * beats AVX-512 by 1.7x), so choosing one is left to whoever measured. */
+#define FC_K_SCALAR 0    /* sequential reference loop */
+#define FC_K_BLOCKWISE 1 /* portable 8-lane C */
+#define FC_K_VECTOR 2    /* the platform's vector kernel: neon or avx2 */
+#define FC_K_VECTOR512 3 /* avx512 */
 
 /* Results of fc_kernel_select(). */
 #define FC_KSEL_OK 0
@@ -39,14 +46,13 @@ const char *fc_kernel_names(void);
  * and test (fp & mask) == 0.
  * Returns the first i that matched (fp is left at position i), or -1 if none
  * matched (fp is left at position n-1).
- * gear: the keyed 256-entry table. kernel is one of FC_K_*; FC_K_AUTO picks
- * the best one this CPU can run. Callers are expected to have validated any
- * explicit choice with fc_kernel_select() - an unrunnable one falls back to
- * FC_K_AUTO rather than crashing.
+ * gear: the keyed 256-entry table. kernel is one of FC_K_*; callers are
+ * expected to have validated it with fc_kernel_select(), an unrunnable one
+ * falls back to the vector kernel rather than crashing.
  * All kernels return bit-identical results. */
 int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int kernel);
 
-/* Name of the kernel <kernel> selects; for FC_K_AUTO, the auto-selected one. */
+/* Name of the kernel <kernel> selects. */
 const char *fc_kernel_name(int kernel);
 
 #endif

--- a/src/borg/chunkers/fastcdc_impl.h
+++ b/src/borg/chunkers/fastcdc_impl.h
@@ -20,7 +20,7 @@
  * All kernels return bit-identical results. */
 int64_t fc_scan(const uint64_t *gear, const uint8_t *p, size_t n, uint64_t *fp, uint64_t mask, int force_scalar);
 
-/* Name of the kernel fc_scan would use: "neon", "avx2", "blocked" or "scalar". */
+/* Name of the kernel fc_scan would use: "neon", "avx512", "avx2", "blocked" or "scalar". */
 const char *fc_kernel_name(int force_scalar);
 
 #endif

--- a/src/borg/chunkers/goldilocks_aes.pyx
+++ b/src/borg/chunkers/goldilocks_aes.pyx
@@ -48,8 +48,8 @@ cdef extern from "goldilocks_aes_impl.h":
     GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t *aes_key, int kernel)
     int phte_kernel_select(const char *name, int *out_id)
     const char *phte_kernel_names()
-    int PHTE_K_AUTO
     int PHTE_K_EVP
+    int PHTE_K_HW
     void gl_free(GL_CTX *ctx)
     const char *gl_kind(const GL_CTX *ctx)
     uint64_t gl_digest64(const GL_CTX *ctx, const uint8_t *q)
@@ -118,11 +118,11 @@ cdef int _select_kernel() except -1:
     One selector for all three AES chunkers: they share phte_scan.h, so the
     available paths never differ between them.
     """
-    cdef int kid = PHTE_K_AUTO
+    cdef int kid = PHTE_K_EVP
     cdef int rc
     want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
     if want is None:
-        return PHTE_K_AUTO
+        return PHTE_K_EVP
     rc = phte_kernel_select(want.encode("ascii"), &kid)
     if rc != 0:
         raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,
@@ -214,7 +214,9 @@ def goldilocks_aes_scan_all(k, bytes aes_key, bytes data, mask, bint force_sw=Fa
 
     Returns the list of positions i where the cut condition matches, i.e.
     (AES(state of window data[i-63..i]) & mask) == 0 - independent of any
-    chunk min/max framing. force_sw selects the portable EVP path.
+    chunk min/max framing. force_sw selects the portable EVP path, otherwise
+    the AES hardware path is used (which falls back to EVP where the CPU has
+    no AES instructions).
     """
     cdef uint64_t c_tables[3 * 256]
     cdef GL_CTX *ctx
@@ -230,7 +232,7 @@ def goldilocks_aes_scan_all(k, bytes aes_key, bytes data, mask, bint force_sw=Fa
     for t in range(len(tables)):
         for i in range(256):
             c_tables[t * 256 + i] = tables[t][i]
-    ctx = gl_new(c_tables, k, (k * k) % _GL_P, <const uint8_t*>PyBytes_AsString(aes_key), PHTE_K_EVP if force_sw else PHTE_K_AUTO)
+    ctx = gl_new(c_tables, k, (k * k) % _GL_P, <const uint8_t*>PyBytes_AsString(aes_key), PHTE_K_EVP if force_sw else PHTE_K_HW)
     if ctx == NULL:
         raise MemoryError("Failed to set up goldilocks-aes kernel")
     try:

--- a/src/borg/chunkers/goldilocks_aes.pyx
+++ b/src/borg/chunkers/goldilocks_aes.pyx
@@ -45,7 +45,11 @@ cdef extern from "goldilocks_aes_impl.h":
     ctypedef struct GL_CTX:
         pass
     int GL_TABLES
-    GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t *aes_key, int force_sw)
+    GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t *aes_key, int kernel)
+    int phte_kernel_select(const char *name, int *out_id)
+    const char *phte_kernel_names()
+    int PHTE_K_AUTO
+    int PHTE_K_EVP
     void gl_free(GL_CTX *ctx)
     const char *gl_kind(const GL_CTX *ctx)
     uint64_t gl_digest64(const GL_CTX *ctx, const uint8_t *q)
@@ -105,6 +109,27 @@ def _derive(bytes key):
     return aes_key, k, tables
 
 
+from .kernel_env import kernel_error, requested_kernel
+
+
+cdef int _select_kernel() except -1:
+    """Resolve BORG_AES_CHUNKER_KERNEL to a scan path id, raising if it cannot be honoured.
+
+    One selector for all three AES chunkers: they share phte_scan.h, so the
+    available paths never differ between them.
+    """
+    cdef int kid = PHTE_K_AUTO
+    cdef int rc
+    want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
+    if want is None:
+        return PHTE_K_AUTO
+    rc = phte_kernel_select(want.encode("ascii"), &kid)
+    if rc != 0:
+        raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,
+                           (<bytes>phte_kernel_names()).decode("ascii"))
+    return kid
+
+
 cdef class ChunkerGoldilocksAES(ChunkerPHTE):
     """
     Content-Defined Chunker, variable chunk sizes, UHF-then-PRF cut decision.
@@ -128,8 +153,8 @@ cdef class ChunkerGoldilocksAES(ChunkerPHTE):
             for i in range(256):
                 c_tables[t * 256 + i] = tables[t][i]
 
-        force_sw = os.environ.get("BORG_GOLDILOCKS_AES_FORCE_EVP", "") not in ("", "0")
-        self.ctx = gl_new(c_tables, k, (k * k) % _GL_P, aes_key, 1 if force_sw else 0)
+        kernel = _select_kernel()
+        self.ctx = gl_new(c_tables, k, (k * k) % _GL_P, aes_key, kernel)
         if self.ctx == NULL:
             raise MemoryError("Failed to set up goldilocks-aes kernel")
         self.kernel_str = (<bytes>gl_kind(self.ctx)).decode("ascii")
@@ -176,7 +201,7 @@ def goldilocks_aes_digest64(k, bytes window):
         for i in range(256):
             c_tables[t * 256 + i] = tables[t][i]
     memset(aes_key, 0, 16)
-    ctx = gl_new(c_tables, k, (k * k) % _GL_P, aes_key, 1)
+    ctx = gl_new(c_tables, k, (k * k) % _GL_P, aes_key, PHTE_K_EVP)
     if ctx == NULL:
         raise MemoryError("Failed to set up goldilocks-aes kernel")
     d = gl_digest64(ctx, <const uint8_t*>PyBytes_AsString(window))
@@ -205,7 +230,7 @@ def goldilocks_aes_scan_all(k, bytes aes_key, bytes data, mask, bint force_sw=Fa
     for t in range(len(tables)):
         for i in range(256):
             c_tables[t * 256 + i] = tables[t][i]
-    ctx = gl_new(c_tables, k, (k * k) % _GL_P, <const uint8_t*>PyBytes_AsString(aes_key), 1 if force_sw else 0)
+    ctx = gl_new(c_tables, k, (k * k) % _GL_P, <const uint8_t*>PyBytes_AsString(aes_key), PHTE_K_EVP if force_sw else PHTE_K_AUTO)
     if ctx == NULL:
         raise MemoryError("Failed to set up goldilocks-aes kernel")
     try:

--- a/src/borg/chunkers/goldilocks_aes_impl.c
+++ b/src/borg/chunkers/goldilocks_aes_impl.c
@@ -35,14 +35,19 @@ struct GL_CTX {
  * AES verbatim, so a non-canonical representation of the same field element
  * would change cut decisions. */
 
+/* The reductions are data-dependent and unpredictable (~27% branch-miss rate
+ * measured), so they must not become branches. Writing them as if() or as a
+ * ternary lets GCC emit real conditional jumps - the mispredicts alone cost
+ * more than the arithmetic (gl_mul: 15.1 vs 4.4 cycles per call). The
+ * __builtin_*_overflow forms keep the carry/borrow in the flags, so the
+ * compiler settles on sbb/adc + mask instead. Results are unchanged: the
+ * value is still fully canonical, which matters because it is fed to AES. */
 static inline uint64_t gl_add(uint64_t a, uint64_t b)
 {
-    uint64_t s = a + b;
-    if (s < a)          /* carry out: 2^64 mod p = GL_EPS; cannot re-carry */
-        s += GL_EPS;
-    if (s >= GL_P)
-        s -= GL_P;
-    return s;
+    uint64_t s, u;
+    unsigned char carry = __builtin_add_overflow(a, b, &s);
+    s += ((uint64_t)0 - (uint64_t)carry) & GL_EPS; /* 2^64 mod p; cannot re-carry */
+    return __builtin_sub_overflow(s, GL_P, &u) ? s : u;
 }
 
 /* a * b mod p via the standard 2^64 = 2^32 - 1 folding (risc0/plonky2 style):
@@ -53,16 +58,13 @@ static inline uint64_t gl_mul(uint64_t a, uint64_t b)
     __uint128_t t = (__uint128_t)a * b;
     uint64_t lo = (uint64_t)t, hi = (uint64_t)(t >> 64);
     uint64_t hi_hi = hi >> 32, hi_lo = hi & GL_EPS;
-    uint64_t t0 = lo - hi_hi;
-    if (lo < hi_hi)     /* borrow: -2^64 = -eps (mod p) */
-        t0 -= GL_EPS;
-    uint64_t t1 = hi_lo * GL_EPS; /* < 2^64 - 2^33 + 2, no overflow */
-    uint64_t r = t0 + t1;
-    if (r < t1)         /* carry out; cannot re-carry (t1 <= 2^64 - 2^33 + 1) */
-        r += GL_EPS;
-    if (r >= GL_P)
-        r -= GL_P;
-    return r;
+    uint64_t t0, r, u;
+    unsigned char borrow = __builtin_sub_overflow(lo, hi_hi, &t0);
+    t0 -= ((uint64_t)0 - (uint64_t)borrow) & GL_EPS; /* -2^64 = -eps (mod p) */
+    /* t1 = hi_lo * eps < 2^64 - 2^33 + 2, no overflow */
+    unsigned char carry = __builtin_add_overflow(t0, hi_lo * GL_EPS, &r);
+    r += ((uint64_t)0 - (uint64_t)carry) & GL_EPS; /* cannot re-carry */
+    return __builtin_sub_overflow(r, GL_P, &u) ? r : u;
 }
 
 /* Advance the state by one byte. The state is the window's polynomial hash

--- a/src/borg/chunkers/goldilocks_aes_impl.c
+++ b/src/borg/chunkers/goldilocks_aes_impl.c
@@ -31,9 +31,11 @@ struct GL_CTX {
 
 /* --- Goldilocks field arithmetic ---------------------------------------
  *
- * All values are kept canonical (< p) at every step: the state is fed to
- * AES verbatim, so a non-canonical representation of the same field element
- * would change cut decisions. */
+ * Every digest the scan produces is canonical (< p): it is fed to AES
+ * verbatim, so a non-canonical representation of the same field element
+ * would change cut decisions. The rolls reach that via gl_add, which always
+ * canonicalizes; only the multiply inside them is allowed to hand on a
+ * merely reduced (< 2^64) representative, see gl_mul_lazy. */
 
 /* The reductions are data-dependent and unpredictable (~27% branch-miss rate
  * measured), so they must not become branches. Writing them as if() or as a
@@ -67,6 +69,30 @@ static inline uint64_t gl_mul(uint64_t a, uint64_t b)
     return __builtin_sub_overflow(r, GL_P, &u) ? r : u;
 }
 
+/* gl_mul without the final canonicalization: the result is congruent to a*b
+ * mod p but only bounded by 2^64, not by p.
+ *
+ * That is enough for the rolls, because both feed it straight into a gl_add
+ * whose other operand is canonical, and that gl_add canonicalizes anyway.
+ * The bound still holds with a non-canonical first operand: for a < 2^64 and
+ * b < p, a carry leaves a + b - 2^64 <= p - 2, so adding eps cannot carry a
+ * second time, and the one conditional subtraction of p then lands below p
+ * (r - p < 2^32). So the digest handed to AES stays canonical - which it must
+ * be, since it is fed to AES verbatim - while the multiply chain that limits
+ * this kernel loses its trailing compare and select. */
+static inline uint64_t gl_mul_lazy(uint64_t a, uint64_t b)
+{
+    __uint128_t t = (__uint128_t)a * b;
+    uint64_t lo = (uint64_t)t, hi = (uint64_t)(t >> 64);
+    uint64_t hi_hi = hi >> 32, hi_lo = hi & GL_EPS;
+    uint64_t t0, r;
+    unsigned char borrow = __builtin_sub_overflow(lo, hi_hi, &t0);
+    t0 -= ((uint64_t)0 - (uint64_t)borrow) & GL_EPS; /* -2^64 = -eps (mod p) */
+    unsigned char carry = __builtin_add_overflow(t0, hi_lo * GL_EPS, &r);
+    r += ((uint64_t)0 - (uint64_t)carry) & GL_EPS; /* cannot re-carry */
+    return r;
+}
+
 /* Advance the state by one byte. The state is the window's polynomial hash
  * s = sum b_j * K^(63-j) (oldest byte at K^63, newest at K^0), so
  *   s' = s*K - byte_out*K^64 + byte_in.
@@ -75,7 +101,7 @@ static inline uint64_t gl_mul(uint64_t a, uint64_t b)
 static inline uint64_t gl_roll(const GL_CTX *c, uint64_t s, uint8_t byte_out, uint8_t byte_in)
 {
     uint64_t delta = gl_add(c->nout64_tbl[byte_out], byte_in);
-    return gl_add(gl_mul(s, c->k1), delta);
+    return gl_add(gl_mul_lazy(s, c->k1), delta);
 }
 
 /* Advance the state by TWO bytes in one step (exact composition of two
@@ -89,7 +115,7 @@ static inline uint64_t gl_roll2(const GL_CTX *c, uint64_t s,
 {
     uint64_t delta = gl_add(gl_add(c->nout65_tbl[o0], c->nout64_tbl[o1]),
                             gl_add(c->in1_tbl[i0], i1));
-    return gl_add(gl_mul(s, c->k2), delta);
+    return gl_add(gl_mul_lazy(s, c->k2), delta);
 }
 
 uint64_t gl_digest64(const GL_CTX *c, const uint8_t *q)

--- a/src/borg/chunkers/goldilocks_aes_impl.c
+++ b/src/borg/chunkers/goldilocks_aes_impl.c
@@ -135,7 +135,7 @@ uint64_t gl_digest64(const GL_CTX *c, const uint8_t *q)
 #include "phte_scan.h"
 
 GL_CTX *gl_new(const uint64_t tables[GL_TABLES * 256], uint64_t k1, uint64_t k2,
-               const uint8_t aes_key[16], int force_sw)
+               const uint8_t aes_key[16], int kernel)
 {
     GL_CTX *c = calloc(1, sizeof(GL_CTX));
     if (c == NULL)
@@ -145,7 +145,7 @@ GL_CTX *gl_new(const uint64_t tables[GL_TABLES * 256], uint64_t k1, uint64_t k2,
     memcpy(c->in1_tbl, tables + 2 * 256, sizeof(c->in1_tbl));
     c->k1 = k1;
     c->k2 = k2;
-    if (!phte_base_init(&c->base, aes_key, force_sw)) {
+    if (!phte_base_init(&c->base, aes_key, kernel)) {
         free(c);
         return NULL;
     }

--- a/src/borg/chunkers/goldilocks_aes_impl.h
+++ b/src/borg/chunkers/goldilocks_aes_impl.h
@@ -43,7 +43,7 @@ GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t a
 
 void gl_free(GL_CTX *ctx);
 
-/* Which path this context uses: "aes-arm64", "aes-ni" or "evp". */
+/* Which path this context uses: "aes-arm64", "vaes", "aes-ni" or "evp". */
 const char *gl_kind(const GL_CTX *ctx);
 
 /* Full (non-rolling) polynomial hash of the 64 bytes at q (Horner): the

--- a/src/borg/chunkers/goldilocks_aes_impl.h
+++ b/src/borg/chunkers/goldilocks_aes_impl.h
@@ -39,7 +39,7 @@ typedef struct GL_CTX GL_CTX;
  * k1: the secret evaluation point K (canonical, 0 <= K < p).
  * k2: K^2 mod p.
  * aes_key: 16 bytes (AES-128).
- * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
+ * kernel: one of PHTE_K_*.
  * Returns NULL on allocation/OpenSSL failure. */
 GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t aes_key[16], int kernel);
 

--- a/src/borg/chunkers/goldilocks_aes_impl.h
+++ b/src/borg/chunkers/goldilocks_aes_impl.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "phte_kernel.h"
+
 typedef struct GL_CTX GL_CTX;
 
 /* Number of 256-entry rolling tables passed to gl_new, in this order:
@@ -37,9 +39,9 @@ typedef struct GL_CTX GL_CTX;
  * k1: the secret evaluation point K (canonical, 0 <= K < p).
  * k2: K^2 mod p.
  * aes_key: 16 bytes (AES-128).
- * force_sw: nonzero forces the portable OpenSSL path (for tests/benchmarks).
+ * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
  * Returns NULL on allocation/OpenSSL failure. */
-GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t aes_key[16], int force_sw);
+GL_CTX *gl_new(const uint64_t *tables, uint64_t k1, uint64_t k2, const uint8_t aes_key[16], int kernel);
 
 void gl_free(GL_CTX *ctx);
 

--- a/src/borg/chunkers/kernel_env.py
+++ b/src/borg/chunkers/kernel_env.py
@@ -1,14 +1,16 @@
 """Shared parsing for the BORG_*_KERNEL scan-kernel selection env vars.
 
-Each SIMD-accelerated chunker picks its inner scan kernel automatically. The
-env vars exist to pin it instead - for benchmarking one kernel against
-another, and for CI that wants to prove a particular kernel was exercised
-rather than hope it was.
+Each chunker runs the simplest implementation - the plain sequential loop, or
+the portable OpenSSL path for the AES chunkers - unless one of these env vars
+names a different one. There is no automatic selection: which kernel is
+fastest turned out not to be predictable from the instruction set (an Apple M3
+runs NEON 2.1x faster than the sequential loop; gcc on a Zen 4 runs the
+sequential loop 1.7x faster than AVX-512), so nothing guesses on the user's
+behalf.
 
-"auto" (the default) takes the best kernel the CPU can run. Any other value is
-a demand, not a preference: if that kernel cannot run here, chunker creation
-raises ValueError rather than quietly falling back, because a silent fallback
-turns a benchmark or a test into a measurement of something else.
+A value is a demand, not a preference: if that kernel cannot run here, chunker
+creation raises ValueError rather than quietly falling back, because a silent
+fallback turns a benchmark or a test into a measurement of something else.
 
 The C side resolves names, since which names exist depends on the build and
 the CPU; this module only turns its verdict into an exception.
@@ -37,6 +39,6 @@ def kernel_error(envvar, want, status, valid):
 
 
 def requested_kernel(envvar):
-    """The kernel name requested via <envvar>, or None for auto/unset."""
+    """The kernel name requested via <envvar>, or None if unset (use the default)."""
     want = os.environ.get(envvar, "").strip().lower()
-    return None if want in ("", "auto") else want
+    return want or None

--- a/src/borg/chunkers/kernel_env.py
+++ b/src/borg/chunkers/kernel_env.py
@@ -1,0 +1,42 @@
+"""Shared parsing for the BORG_*_KERNEL scan-kernel selection env vars.
+
+Each SIMD-accelerated chunker picks its inner scan kernel automatically. The
+env vars exist to pin it instead - for benchmarking one kernel against
+another, and for CI that wants to prove a particular kernel was exercised
+rather than hope it was.
+
+"auto" (the default) takes the best kernel the CPU can run. Any other value is
+a demand, not a preference: if that kernel cannot run here, chunker creation
+raises ValueError rather than quietly falling back, because a silent fallback
+turns a benchmark or a test into a measurement of something else.
+
+The C side resolves names, since which names exist depends on the build and
+the CPU; this module only turns its verdict into an exception.
+"""
+
+import os
+
+# must match the FC_KSEL_* / BZ_KSEL_* / PHTE_KSEL_* codes in the C headers
+KSEL_OK = 0
+KSEL_UNKNOWN = 1
+KSEL_NOTBUILT = 2
+KSEL_NOCPU = 3
+
+
+def kernel_error(envvar, want, status, valid):
+    """The ValueError for a kernel request that cannot be honoured."""
+    if status == KSEL_UNKNOWN:
+        detail = "not a kernel of this build"
+    elif status == KSEL_NOTBUILT:
+        detail = "not compiled into this build (needs a newer compiler)"
+    elif status == KSEL_NOCPU:
+        detail = "this CPU does not support it"
+    else:
+        detail = "unavailable"
+    return ValueError(f"{envvar}={want!r}: {detail}. Valid values: {valid}")
+
+
+def requested_kernel(envvar):
+    """The kernel name requested via <envvar>, or None for auto/unset."""
+    want = os.environ.get(envvar, "").strip().lower()
+    return None if want in ("", "auto") else want

--- a/src/borg/chunkers/phte_core.h
+++ b/src/borg/chunkers/phte_core.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <openssl/evp.h>
@@ -25,6 +26,7 @@ typedef struct {
     uint8_t rk[11][16];  /* AES-128 round keys, for the hardware paths */
     EVP_CIPHER_CTX *evp; /* portable path */
     int use_hw;
+    int use_hw512; /* VAES/AVX-512 variant of the hardware path (x86-64) */
 } PHTE_BASE;
 
 /* --- endianness-explicit helpers (byte loops, so cut points do not depend
@@ -130,8 +132,32 @@ phte_aes1_ni(const uint8_t rk[11][16], __m128i b)
     return _mm_aesenclast_si128(b, _mm_loadu_si128((const __m128i *)rk[10]));
 }
 
+/* VAES/AVX-512 variant of the hardware path (4 AES blocks per instruction).
+ * __builtin_cpu_supports("vaes") needs GCC >= 11 / clang >= 14; older
+ * compilers simply keep the 128-bit AES-NI path. */
+#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 11) || (defined(__clang__) && __clang_major__ >= 14)
+#define PHTE_HAVE_HW512 1
+#define PHTE_KIND_HW512 "vaes"
+
+static int phte_hw512_available(void)
+{
+    /* BORG_PHTE_NO_VAES caps the AES chunkers at the 128-bit AES-NI path
+     * (for benchmarking the paths against each other); it is read at
+     * context creation, ""/"0" mean off. */
+    const char *e;
+    if (!__builtin_cpu_supports("avx512f") || !__builtin_cpu_supports("vaes"))
+        return 0;
+    e = getenv("BORG_PHTE_NO_VAES");
+    return e == NULL || e[0] == 0 || strcmp(e, "0") == 0;
+}
+#endif
+
 #else
 #define PHTE_HAVE_HW 0
+#endif
+
+#ifndef PHTE_HAVE_HW512
+#define PHTE_HAVE_HW512 0
 #endif
 
 /* --- context base management ------------------------------------------- */
@@ -146,6 +172,11 @@ static int phte_base_init(PHTE_BASE *b, const uint8_t aes_key[16], int force_sw)
 #else
     (void)force_sw;
     b->use_hw = 0;
+#endif
+#if PHTE_HAVE_HW512
+    b->use_hw512 = b->use_hw && phte_hw512_available();
+#else
+    b->use_hw512 = 0;
 #endif
     b->evp = EVP_CIPHER_CTX_new();
     if (b->evp == NULL)
@@ -169,6 +200,10 @@ static void phte_base_free(PHTE_BASE *b)
 
 static const char *phte_base_kind(const PHTE_BASE *b)
 {
+#if PHTE_HAVE_HW512
+    if (b->use_hw512)
+        return PHTE_KIND_HW512;
+#endif
 #if PHTE_HAVE_HW
     if (b->use_hw)
         return PHTE_KIND_HW;

--- a/src/borg/chunkers/phte_core.h
+++ b/src/borg/chunkers/phte_core.h
@@ -165,20 +165,16 @@ static int phte_hw512_available(void)
 const char *phte_kernel_names(void)
 {
 #if defined(__aarch64__)
-    return "auto, aes-arm64, evp";
+    return "aes-arm64,evp";
 #elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
-    return "auto, vaes, aes-ni, evp";
+    return "vaes,aes-ni,evp";
 #else
-    return "auto, evp";
+    return "evp";
 #endif
 }
 
 int phte_kernel_select(const char *name, int *out_id)
 {
-    if (strcmp(name, "auto") == 0) {
-        *out_id = PHTE_K_AUTO;
-        return PHTE_KSEL_OK;
-    }
     if (strcmp(name, "evp") == 0) {
         *out_id = PHTE_K_EVP;
         return PHTE_KSEL_OK;
@@ -209,18 +205,18 @@ int phte_kernel_select(const char *name, int *out_id)
 /* --- context base management ------------------------------------------- */
 
 /* Expand the AES key, select the scan path and set up the OpenSSL context.
- * kernel is one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
+ * kernel is one of PHTE_K_*.
  * Returns 0 on failure (caller frees its context). */
 static int phte_base_init(PHTE_BASE *b, const uint8_t aes_key[16], int kernel)
 {
     phte_aes128_expand(aes_key, b->rk);
 #if PHTE_HAVE_HW
-    b->use_hw = (kernel == PHTE_K_AUTO || kernel == PHTE_K_HW || kernel == PHTE_K_HW512) && phte_hw_available();
+    b->use_hw = (kernel == PHTE_K_HW || kernel == PHTE_K_HW512) && phte_hw_available();
 #else
     b->use_hw = 0;
 #endif
 #if PHTE_HAVE_HW512
-    b->use_hw512 = b->use_hw && kernel != PHTE_K_HW && phte_hw512_available();
+    b->use_hw512 = b->use_hw && kernel == PHTE_K_HW512 && phte_hw512_available();
 #else
     b->use_hw512 = 0;
 #endif

--- a/src/borg/chunkers/phte_core.h
+++ b/src/borg/chunkers/phte_core.h
@@ -13,6 +13,8 @@
 #ifndef BORG_PHTE_CORE_H
 #define BORG_PHTE_CORE_H
 
+#include "phte_kernel.h"
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -141,14 +143,7 @@ phte_aes1_ni(const uint8_t rk[11][16], __m128i b)
 
 static int phte_hw512_available(void)
 {
-    /* BORG_PHTE_NO_VAES caps the AES chunkers at the 128-bit AES-NI path
-     * (for benchmarking the paths against each other); it is read at
-     * context creation, ""/"0" mean off. */
-    const char *e;
-    if (!__builtin_cpu_supports("avx512f") || !__builtin_cpu_supports("vaes"))
-        return 0;
-    e = getenv("BORG_PHTE_NO_VAES");
-    return e == NULL || e[0] == 0 || strcmp(e, "0") == 0;
+    return __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("vaes");
 }
 #endif
 
@@ -160,24 +155,76 @@ static int phte_hw512_available(void)
 #define PHTE_HAVE_HW512 0
 #endif
 
+/* --- kernel selection ---------------------------------------------------
+ *
+ * Shared by all three AES chunkers: the scan path lives in phte_scan.h and
+ * only the rolling hash differs between them, so there is no machine on which
+ * one of them has a hardware path and another does not. Hence one selector
+ * (BORG_AES_CHUNKER_KERNEL) rather than one per chunker. */
+
+const char *phte_kernel_names(void)
+{
+#if defined(__aarch64__)
+    return "auto, aes-arm64, evp";
+#elif (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    return "auto, vaes, aes-ni, evp";
+#else
+    return "auto, evp";
+#endif
+}
+
+int phte_kernel_select(const char *name, int *out_id)
+{
+    if (strcmp(name, "auto") == 0) {
+        *out_id = PHTE_K_AUTO;
+        return PHTE_KSEL_OK;
+    }
+    if (strcmp(name, "evp") == 0) {
+        *out_id = PHTE_K_EVP;
+        return PHTE_KSEL_OK;
+    }
+#if PHTE_HAVE_HW
+    if (strcmp(name, PHTE_KIND_HW) == 0) {
+        if (!phte_hw_available())
+            return PHTE_KSEL_NOCPU;
+        *out_id = PHTE_K_HW;
+        return PHTE_KSEL_OK;
+    }
+#endif
+#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+    if (strcmp(name, "vaes") == 0) {
+#if !PHTE_HAVE_HW512
+        return PHTE_KSEL_NOTBUILT; /* compiler too old for the VAES intrinsics */
+#else
+        if (!phte_hw512_available())
+            return PHTE_KSEL_NOCPU;
+        *out_id = PHTE_K_HW512;
+        return PHTE_KSEL_OK;
+#endif
+    }
+#endif
+    return PHTE_KSEL_UNKNOWN;
+}
+
 /* --- context base management ------------------------------------------- */
 
 /* Expand the AES key, select the scan path and set up the OpenSSL context.
+ * kernel is one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
  * Returns 0 on failure (caller frees its context). */
-static int phte_base_init(PHTE_BASE *b, const uint8_t aes_key[16], int force_sw)
+static int phte_base_init(PHTE_BASE *b, const uint8_t aes_key[16], int kernel)
 {
     phte_aes128_expand(aes_key, b->rk);
 #if PHTE_HAVE_HW
-    b->use_hw = !force_sw && phte_hw_available();
+    b->use_hw = (kernel == PHTE_K_AUTO || kernel == PHTE_K_HW || kernel == PHTE_K_HW512) && phte_hw_available();
 #else
-    (void)force_sw;
     b->use_hw = 0;
 #endif
 #if PHTE_HAVE_HW512
-    b->use_hw512 = b->use_hw && phte_hw512_available();
+    b->use_hw512 = b->use_hw && kernel != PHTE_K_HW && phte_hw512_available();
 #else
     b->use_hw512 = 0;
 #endif
+    (void)kernel;
     b->evp = EVP_CIPHER_CTX_new();
     if (b->evp == NULL)
         return 0;

--- a/src/borg/chunkers/phte_kernel.h
+++ b/src/borg/chunkers/phte_kernel.h
@@ -9,13 +9,17 @@
 #ifndef BORG_PHTE_KERNEL_H
 #define BORG_PHTE_KERNEL_H
 
-/* Scan path ids, a tier ladder. Which names map onto them depends on the
- * build: "vaes" only on x86-64, and the 128-bit hardware path is spelled
- * "aes-ni" on x86-64 and "aes-arm64" on aarch64. */
-#define PHTE_K_AUTO 0  /* best path this CPU can run */
-#define PHTE_K_EVP 1   /* portable OpenSSL EVP batch path */
-#define PHTE_K_HW 2    /* 128-bit AES instructions: aes-ni / aes-arm64 */
-#define PHTE_K_HW512 3 /* VAES/AVX-512, 4 AES blocks per instruction */
+/* Scan path ids. Which names map onto them depends on the build: "vaes" only
+ * on x86-64, and the 128-bit hardware path is spelled "aes-ni" on x86-64 and
+ * "aes-arm64" on aarch64.
+ *
+ * There is no automatic selection: the caller says which path to run.
+ * PHTE_K_EVP, the portable OpenSSL batch path, is id 0 and the default - it
+ * is the simplest implementation and the one the others are checked
+ * against. */
+#define PHTE_K_EVP 0   /* portable OpenSSL EVP batch path */
+#define PHTE_K_HW 1    /* 128-bit AES instructions: aes-ni / aes-arm64 */
+#define PHTE_K_HW512 2 /* VAES/AVX-512, 4 AES blocks per instruction */
 
 /* Results of phte_kernel_select(). */
 #define PHTE_KSEL_OK 0

--- a/src/borg/chunkers/phte_kernel.h
+++ b/src/borg/chunkers/phte_kernel.h
@@ -1,0 +1,36 @@
+/* Scan-path selection shared by the three UHF-then-PRF ("Chk-PHTE") chunkers
+ * (toeplitz-aes, rabin-aes, goldilocks-aes).
+ *
+ * They share phte_scan.h and differ only in their rolling hash, so the
+ * available scan paths are a property of the build and the CPU, never of the
+ * individual chunker: there is no machine where one of them has a hardware
+ * path and another does not. Hence one selector for all three. */
+
+#ifndef BORG_PHTE_KERNEL_H
+#define BORG_PHTE_KERNEL_H
+
+/* Scan path ids, a tier ladder. Which names map onto them depends on the
+ * build: "vaes" only on x86-64, and the 128-bit hardware path is spelled
+ * "aes-ni" on x86-64 and "aes-arm64" on aarch64. */
+#define PHTE_K_AUTO 0  /* best path this CPU can run */
+#define PHTE_K_EVP 1   /* portable OpenSSL EVP batch path */
+#define PHTE_K_HW 2    /* 128-bit AES instructions: aes-ni / aes-arm64 */
+#define PHTE_K_HW512 3 /* VAES/AVX-512, 4 AES blocks per instruction */
+
+/* Results of phte_kernel_select(). */
+#define PHTE_KSEL_OK 0
+#define PHTE_KSEL_UNKNOWN 1  /* not a scan path name on this platform */
+#define PHTE_KSEL_NOTBUILT 2 /* known, but not compiled into this binary */
+#define PHTE_KSEL_NOCPU 3    /* known and built, but this CPU cannot run it */
+
+/* Resolve a scan path name for this build. On PHTE_KSEL_OK the id is stored
+ * in *out_id, otherwise *out_id is left alone. The three failures are kept
+ * apart because they need different fixes: a typo, too old a compiler, or the
+ * wrong CPU. */
+int phte_kernel_select(const char *name, int *out_id);
+
+/* Comma-separated list of the scan path names this build accepts, for error
+ * messages. Names a CPU cannot run are still listed. */
+const char *phte_kernel_names(void);
+
+#endif /* BORG_PHTE_KERNEL_H */

--- a/src/borg/chunkers/phte_scan.h
+++ b/src/borg/chunkers/phte_scan.h
@@ -344,16 +344,25 @@ PH_FN(scan_hw)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint64_t
  * vectors of 4 AES blocks each - 4x fewer AES instructions than the 128-bit
  * path, the round keys stay register-resident (32 zmm registers instead of
  * 16 xmm, so no per-round key reloads), and the 8 independent chains hide
- * the vaesenc latency (2 chains would be latency-bound). vpexpandq places a
- * vector's 4 digests into its block-low qwords in one instruction, and a
- * masked vptestnmq tests the 4 ciphertext-low qwords against the mask
- * without extracting. Every digest is exact and every position is tested,
- * so cut points stay bit-identical to the other paths. */
+ * the vaesenc latency (2 chains would be latency-bound), and a masked
+ * vptestnmq tests the 4 ciphertext-low qwords against the mask without
+ * extracting. Every digest is exact and every position is tested, so cut
+ * points stay bit-identical to the other paths.
+ *
+ * The digests are stored pre-spread: an AES input block wants the digest in
+ * the low qword and zero in the high one, so dgs[] keeps a digest in every
+ * even slot and a zero in every odd one. The zeros are written once at entry
+ * and never touched again, which makes each vector's input a plain aligned
+ * 512-bit load. Packing the digests and spreading them with vpexpandq (eight
+ * of those per group) instead costs the same stores and measurably more
+ * time - about 9% of the whole toeplitz-aes scan, 6% of rabin-aes. */
 __attribute__((target("aes,sse2,vaes,avx512f"))) static int64_t
 PH_FN(scan_hw512)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
 {
     __m512i k[11];
     __m512i M = _mm512_set1_epi64((long long)mask);
+    /* digest at dgs[2j], zero at dgs[2j+1] (= AES input block bytes 8..15) */
+    uint64_t dgs[64] __attribute__((aligned(64)));
     uint64_t d = *digest, da, db;
     const uint8_t *qo = p - 64;
     size_t i = 0;
@@ -362,6 +371,8 @@ PH_FN(scan_hw512)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint6
     /* broadcast each 128-bit round key to all four block lanes */
     for (int j = 0; j < 11; j++)
         k[j] = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i *)c->base.rk[j]));
+    for (int j = 1; j < 64; j += 2)
+        dgs[j] = 0;
 
     if (n >= 34) {
         db = PH_ROLL(c, d, qo[0], p[0]);               /* d_0 */
@@ -370,32 +381,31 @@ PH_FN(scan_hw512)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint6
     }
 
     while (lanes_live && i + 34 <= n) {
-        uint64_t dg[32];
         __m512i b0, b1, b2, b3, b4, b5, b6, b7;
         __mmask8 h0, h1, h2, h3, h4, h5, h6, h7;
 
-        dg[0] = db;
-        dg[1] = da;
+        dgs[0] = db;
+        dgs[2] = da;
         for (int j = 2; j < 32; j += 2) {
             db = PH_ROLL2(c, db, qo[i + j - 1], qo[i + j], p[i + j - 1], p[i + j]);
-            dg[j] = db;
+            dgs[2 * j] = db;
             da = PH_ROLL2(c, da, qo[i + j], qo[i + j + 1], p[i + j], p[i + j + 1]);
-            dg[j + 1] = da;
+            dgs[2 * j + 2] = da;
         }
         /* prepare the next group's invariant (digests at i+32, i+33) */
         db = PH_ROLL2(c, db, qo[i + 31], qo[i + 32], p[i + 31], p[i + 32]);
         da = PH_ROLL2(c, da, qo[i + 32], qo[i + 33], p[i + 32], p[i + 33]);
 
-        /* qword lanes 0,2,4,6 take 4 digests, lanes 1,3,5,7 stay zero
-         * (= AES input block bytes 8..15, as in the other paths) */
-        b0 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg), k[0]);
-        b1 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 4), k[0]);
-        b2 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 8), k[0]);
-        b3 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 12), k[0]);
-        b4 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 16), k[0]);
-        b5 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 20), k[0]);
-        b6 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 24), k[0]);
-        b7 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 28), k[0]);
+        /* each vector's 4 blocks are already laid out in dgs (digest in the
+         * low qword of every block, zero in the high one) */
+        b0 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 0)), k[0]);
+        b1 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 8)), k[0]);
+        b2 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 16)), k[0]);
+        b3 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 24)), k[0]);
+        b4 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 32)), k[0]);
+        b5 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 40)), k[0]);
+        b6 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 48)), k[0]);
+        b7 = _mm512_xor_si512(_mm512_loadu_si512((const void *)(dgs + 56)), k[0]);
         for (int r = 1; r < 10; r++) {
             b0 = _mm512_aesenc_epi128(b0, k[r]);
             b1 = _mm512_aesenc_epi128(b1, k[r]);
@@ -420,7 +430,7 @@ PH_FN(scan_hw512)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint6
             const uint8_t hs[8] = {h0, h1, h2, h3, h4, h5, h6, h7};
             for (int j = 0; j < 32; j++) {
                 if ((hs[j >> 2] >> ((j & 3) * 2)) & 1) {
-                    *digest = dg[j];
+                    *digest = dgs[2 * j];
                     return (int64_t)(i + j);
                 }
             }

--- a/src/borg/chunkers/phte_scan.h
+++ b/src/borg/chunkers/phte_scan.h
@@ -19,9 +19,11 @@
  *  - a portable path batching digests through OpenSSL EVP AES-128-ECB,
  *  - a hardware path using AES instructions directly (arm64 crypto extension,
  *    x86-64 AES-NI), which interleaves the serial rolling-hash chain with
- *    pipelined AES so the AES work is (mostly) hidden behind it.
+ *    pipelined AES so the AES work is (mostly) hidden behind it,
+ *  - a VAES/AVX-512 variant of the x86-64 hardware path (runtime-detected)
+ *    encrypting 4 AES blocks per instruction.
  *
- * Both paths produce bit-identical cut points.
+ * All paths produce bit-identical cut points.
  */
 
 #define PH_CAT2(a, b) a##b
@@ -105,11 +107,12 @@ static int64_t PH_FN(scan_evp)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *
 
 /* --- hardware paths ----------------------------------------------------
  *
- * Both hardware paths process groups of 8 positions: the two rolling lanes
- * advance 4 stride-2 steps each (two independent dependency chains), then the
- * 8 digests are encrypted with interleaved AES instructions, which execute on
- * different ports than the rolling work and thus overlap with the next
- * group's.
+ * The 128-bit hardware paths process groups of 8 positions (the VAES/AVX-512
+ * path below uses the same structure with groups of 32): the two rolling
+ * lanes advance 4 stride-2 steps each (two independent dependency chains),
+ * then the 8 digests are encrypted with interleaved AES instructions, which
+ * execute on different ports than the rolling work and thus overlap with the
+ * next group's.
  *
  * Loop invariant: entering a group at position i, db = digest at i and
  * da = digest at i+1 (both already computed); the group emits digests for
@@ -334,10 +337,130 @@ PH_FN(scan_hw)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint64_t
 
 #endif /* PHTE_HAVE_HW */
 
+#if PHTE_HAVE_HW512
+
+/* VAES/AVX-512 variant of the x86-64 hardware path: the same two rolling
+ * lanes, but groups of 32 positions whose digests are encrypted as 8 zmm
+ * vectors of 4 AES blocks each - 4x fewer AES instructions than the 128-bit
+ * path, the round keys stay register-resident (32 zmm registers instead of
+ * 16 xmm, so no per-round key reloads), and the 8 independent chains hide
+ * the vaesenc latency (2 chains would be latency-bound). vpexpandq places a
+ * vector's 4 digests into its block-low qwords in one instruction, and a
+ * masked vptestnmq tests the 4 ciphertext-low qwords against the mask
+ * without extracting. Every digest is exact and every position is tested,
+ * so cut points stay bit-identical to the other paths. */
+__attribute__((target("aes,sse2,vaes,avx512f"))) static int64_t
+PH_FN(scan_hw512)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
+{
+    __m512i k[11];
+    __m512i M = _mm512_set1_epi64((long long)mask);
+    uint64_t d = *digest, da, db;
+    const uint8_t *qo = p - 64;
+    size_t i = 0;
+    int lanes_live = 0;
+
+    /* broadcast each 128-bit round key to all four block lanes */
+    for (int j = 0; j < 11; j++)
+        k[j] = _mm512_broadcast_i32x4(_mm_loadu_si128((const __m128i *)c->base.rk[j]));
+
+    if (n >= 34) {
+        db = PH_ROLL(c, d, qo[0], p[0]);               /* d_0 */
+        da = PH_ROLL2(c, d, qo[0], qo[1], p[0], p[1]); /* d_1 */
+        lanes_live = 1;
+    }
+
+    while (lanes_live && i + 34 <= n) {
+        uint64_t dg[32];
+        __m512i b0, b1, b2, b3, b4, b5, b6, b7;
+        __mmask8 h0, h1, h2, h3, h4, h5, h6, h7;
+
+        dg[0] = db;
+        dg[1] = da;
+        for (int j = 2; j < 32; j += 2) {
+            db = PH_ROLL2(c, db, qo[i + j - 1], qo[i + j], p[i + j - 1], p[i + j]);
+            dg[j] = db;
+            da = PH_ROLL2(c, da, qo[i + j], qo[i + j + 1], p[i + j], p[i + j + 1]);
+            dg[j + 1] = da;
+        }
+        /* prepare the next group's invariant (digests at i+32, i+33) */
+        db = PH_ROLL2(c, db, qo[i + 31], qo[i + 32], p[i + 31], p[i + 32]);
+        da = PH_ROLL2(c, da, qo[i + 32], qo[i + 33], p[i + 32], p[i + 33]);
+
+        /* qword lanes 0,2,4,6 take 4 digests, lanes 1,3,5,7 stay zero
+         * (= AES input block bytes 8..15, as in the other paths) */
+        b0 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg), k[0]);
+        b1 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 4), k[0]);
+        b2 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 8), k[0]);
+        b3 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 12), k[0]);
+        b4 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 16), k[0]);
+        b5 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 20), k[0]);
+        b6 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 24), k[0]);
+        b7 = _mm512_xor_si512(_mm512_maskz_expandloadu_epi64(0x55, dg + 28), k[0]);
+        for (int r = 1; r < 10; r++) {
+            b0 = _mm512_aesenc_epi128(b0, k[r]);
+            b1 = _mm512_aesenc_epi128(b1, k[r]);
+            b2 = _mm512_aesenc_epi128(b2, k[r]);
+            b3 = _mm512_aesenc_epi128(b3, k[r]);
+            b4 = _mm512_aesenc_epi128(b4, k[r]);
+            b5 = _mm512_aesenc_epi128(b5, k[r]);
+            b6 = _mm512_aesenc_epi128(b6, k[r]);
+            b7 = _mm512_aesenc_epi128(b7, k[r]);
+        }
+        h0 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b0, k[10]), M);
+        h1 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b1, k[10]), M);
+        h2 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b2, k[10]), M);
+        h3 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b3, k[10]), M);
+        h4 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b4, k[10]), M);
+        h5 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b5, k[10]), M);
+        h6 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b6, k[10]), M);
+        h7 = _mm512_mask_testn_epi64_mask(0x55, _mm512_aesenclast_epi128(b7, k[10]), M);
+
+        if (h0 | h1 | h2 | h3 | h4 | h5 | h6 | h7) {
+            /* block j of vector g is qword lane 2j and position i + 4g + j */
+            const uint8_t hs[8] = {h0, h1, h2, h3, h4, h5, h6, h7};
+            for (int j = 0; j < 32; j++) {
+                if ((hs[j >> 2] >> ((j & 3) * 2)) & 1) {
+                    *digest = dg[j];
+                    return (int64_t)(i + j);
+                }
+            }
+        }
+        i += 32;
+    }
+    /* tail: single positions, exactly as in the 128-bit path */
+    if (lanes_live && i < n) {
+        __m128i b = phte_aes1_ni(c->base.rk, _mm_set_epi64x(0, (long long)db));
+        if (((uint64_t)_mm_cvtsi128_si64(b) & mask) == 0) {
+            *digest = db;
+            return (int64_t)i;
+        }
+        d = db;
+        i++;
+    }
+    while (i < n) {
+        __m128i b;
+        d = PH_ROLL(c, d, qo[i], p[i]);
+        b = phte_aes1_ni(c->base.rk, _mm_set_epi64x(0, (long long)d));
+        if (((uint64_t)_mm_cvtsi128_si64(b) & mask) == 0) {
+            *digest = d;
+            return (int64_t)i;
+        }
+        i++;
+    }
+    *digest = d;
+    return -1;
+}
+
+#endif /* PHTE_HAVE_HW512 */
+
 /* --- dispatch (exported) ------------------------------------------------ */
 
 int64_t PH_FN(scan)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
 {
+#if PHTE_HAVE_HW512
+    if (c->base.use_hw512)
+        return PH_FN(scan_hw512)(c, p, n, digest, mask);
+#endif
 #if PHTE_HAVE_HW
     if (c->base.use_hw)
         return PH_FN(scan_hw)(c, p, n, digest, mask);

--- a/src/borg/chunkers/phte_scan.h
+++ b/src/borg/chunkers/phte_scan.h
@@ -181,18 +181,28 @@ static int64_t PH_FN(scan_hw)(PH_CTX *c, const uint8_t *p, size_t n, uint64_t *d
         b6 = veorq_u8(vaeseq_u8(b6, k[9]), k[10]);
         b7 = veorq_u8(vaeseq_u8(b7, k[9]), k[10]);
 
+        /* Test all 8 ciphertexts without leaving the vector domain: uzp1
+         * packs the low halves (the cut-decision uint64) of two blocks into
+         * one vector, then and/cmeq-zero/or-reduce. Moving the 8 values to
+         * general registers instead - one fmov each, plus 8 scalar and/cmp
+         * pairs - costs noticeably more on the common no-hit path, where
+         * nothing but the single "any lane hit" bit is ever needed. */
         {
-            uint64_t c0 = vgetq_lane_u64(vreinterpretq_u64_u8(b0), 0);
-            uint64_t c1 = vgetq_lane_u64(vreinterpretq_u64_u8(b1), 0);
-            uint64_t c2 = vgetq_lane_u64(vreinterpretq_u64_u8(b2), 0);
-            uint64_t c3 = vgetq_lane_u64(vreinterpretq_u64_u8(b3), 0);
-            uint64_t c4 = vgetq_lane_u64(vreinterpretq_u64_u8(b4), 0);
-            uint64_t c5 = vgetq_lane_u64(vreinterpretq_u64_u8(b5), 0);
-            uint64_t c6 = vgetq_lane_u64(vreinterpretq_u64_u8(b6), 0);
-            uint64_t c7 = vgetq_lane_u64(vreinterpretq_u64_u8(b7), 0);
-            if ((((c0 & mask) == 0) | ((c1 & mask) == 0) | ((c2 & mask) == 0) | ((c3 & mask) == 0) |
-                 ((c4 & mask) == 0) | ((c5 & mask) == 0) | ((c6 & mask) == 0) | ((c7 & mask) == 0))) {
-                uint64_t cs[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+            const uint64x2_t maskv = vdupq_n_u64(mask);
+            uint64x2_t h01 = vuzp1q_u64(vreinterpretq_u64_u8(b0), vreinterpretq_u64_u8(b1));
+            uint64x2_t h23 = vuzp1q_u64(vreinterpretq_u64_u8(b2), vreinterpretq_u64_u8(b3));
+            uint64x2_t h45 = vuzp1q_u64(vreinterpretq_u64_u8(b4), vreinterpretq_u64_u8(b5));
+            uint64x2_t h67 = vuzp1q_u64(vreinterpretq_u64_u8(b6), vreinterpretq_u64_u8(b7));
+            uint64x2_t any = vorrq_u64(vorrq_u64(vceqzq_u64(vandq_u64(h01, maskv)),
+                                                vceqzq_u64(vandq_u64(h23, maskv))),
+                                       vorrq_u64(vceqzq_u64(vandq_u64(h45, maskv)),
+                                                vceqzq_u64(vandq_u64(h67, maskv))));
+            if (vmaxvq_u32(vreinterpretq_u32_u64(any))) {
+                uint64_t cs[8];
+                vst1q_u64(cs + 0, h01);
+                vst1q_u64(cs + 2, h23);
+                vst1q_u64(cs + 4, h45);
+                vst1q_u64(cs + 6, h67);
                 for (int j = 0; j < 8; j++) {
                     if ((cs[j] & mask) == 0) {
                         *digest = dg[j];

--- a/src/borg/chunkers/rabin_aes.pyx
+++ b/src/borg/chunkers/rabin_aes.pyx
@@ -57,7 +57,11 @@ cdef extern from "rabin_aes_impl.h":
     ctypedef struct RA_CTX:
         pass
     int RA_TABLES
-    RA_CTX *ra_new(const uint64_t *tables, const uint8_t *aes_key, int force_sw)
+    RA_CTX *ra_new(const uint64_t *tables, const uint8_t *aes_key, int kernel)
+    int phte_kernel_select(const char *name, int *out_id)
+    const char *phte_kernel_names()
+    int PHTE_K_AUTO
+    int PHTE_K_EVP
     void ra_free(RA_CTX *ctx)
     const char *ra_kind(const RA_CTX *ctx)
     uint64_t ra_digest64(const RA_CTX *ctx, const uint8_t *q)
@@ -175,6 +179,27 @@ def _derive(bytes key):
     return aes_key, p, tables
 
 
+from .kernel_env import kernel_error, requested_kernel
+
+
+cdef int _select_kernel() except -1:
+    """Resolve BORG_AES_CHUNKER_KERNEL to a scan path id, raising if it cannot be honoured.
+
+    One selector for all three AES chunkers: they share phte_scan.h, so the
+    available paths never differ between them.
+    """
+    cdef int kid = PHTE_K_AUTO
+    cdef int rc
+    want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
+    if want is None:
+        return PHTE_K_AUTO
+    rc = phte_kernel_select(want.encode("ascii"), &kid)
+    if rc != 0:
+        raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,
+                           (<bytes>phte_kernel_names()).decode("ascii"))
+    return kid
+
+
 cdef class ChunkerRabinAES(ChunkerPHTE):
     """
     Content-Defined Chunker, variable chunk sizes, UHF-then-PRF cut decision.
@@ -198,8 +223,8 @@ cdef class ChunkerRabinAES(ChunkerPHTE):
             for i in range(256):
                 c_tables[t * 256 + i] = tables[t][i]
 
-        force_sw = os.environ.get("BORG_RABIN_AES_FORCE_EVP", "") not in ("", "0")
-        self.ctx = ra_new(c_tables, aes_key, 1 if force_sw else 0)
+        kernel = _select_kernel()
+        self.ctx = ra_new(c_tables, aes_key, kernel)
         if self.ctx == NULL:
             raise MemoryError("Failed to set up rabin-aes kernel")
         self.kernel_str = (<bytes>ra_kind(self.ctx)).decode("ascii")

--- a/src/borg/chunkers/rabin_aes.pyx
+++ b/src/borg/chunkers/rabin_aes.pyx
@@ -60,7 +60,6 @@ cdef extern from "rabin_aes_impl.h":
     RA_CTX *ra_new(const uint64_t *tables, const uint8_t *aes_key, int kernel)
     int phte_kernel_select(const char *name, int *out_id)
     const char *phte_kernel_names()
-    int PHTE_K_AUTO
     int PHTE_K_EVP
     void ra_free(RA_CTX *ctx)
     const char *ra_kind(const RA_CTX *ctx)
@@ -188,11 +187,11 @@ cdef int _select_kernel() except -1:
     One selector for all three AES chunkers: they share phte_scan.h, so the
     available paths never differ between them.
     """
-    cdef int kid = PHTE_K_AUTO
+    cdef int kid = PHTE_K_EVP
     cdef int rc
     want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
     if want is None:
-        return PHTE_K_AUTO
+        return PHTE_K_EVP
     rc = phte_kernel_select(want.encode("ascii"), &kid)
     if rc != 0:
         raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,

--- a/src/borg/chunkers/rabin_aes_impl.c
+++ b/src/borg/chunkers/rabin_aes_impl.c
@@ -66,7 +66,7 @@ uint64_t ra_digest64(const RA_CTX *c, const uint8_t *q)
 #define PH_DIGEST64 ra_digest64
 #include "phte_scan.h"
 
-RA_CTX *ra_new(const uint64_t tables[RA_TABLES * 256], const uint8_t aes_key[16], int force_sw)
+RA_CTX *ra_new(const uint64_t tables[RA_TABLES * 256], const uint8_t aes_key[16], int kernel)
 {
     RA_CTX *c = calloc(1, sizeof(RA_CTX));
     if (c == NULL)
@@ -76,7 +76,7 @@ RA_CTX *ra_new(const uint64_t tables[RA_TABLES * 256], const uint8_t aes_key[16]
     memcpy(c->w1_tbl, tables + 2 * 256, sizeof(c->w1_tbl));
     memcpy(c->out8_tbl, tables + 3 * 256, sizeof(c->out8_tbl));
     memcpy(c->out16_tbl, tables + 4 * 256, sizeof(c->out16_tbl));
-    if (!phte_base_init(&c->base, aes_key, force_sw)) {
+    if (!phte_base_init(&c->base, aes_key, kernel)) {
         free(c);
         return NULL;
     }

--- a/src/borg/chunkers/rabin_aes_impl.h
+++ b/src/borg/chunkers/rabin_aes_impl.h
@@ -40,7 +40,7 @@ RA_CTX *ra_new(const uint64_t *tables, const uint8_t aes_key[16], int force_sw);
 
 void ra_free(RA_CTX *ctx);
 
-/* Which path this context uses: "aes-arm64", "aes-ni" or "evp". */
+/* Which path this context uses: "aes-arm64", "vaes", "aes-ni" or "evp". */
 const char *ra_kind(const RA_CTX *ctx);
 
 /* Full (non-rolling) Rabin digest of the 64 bytes at q: the window warm-up at

--- a/src/borg/chunkers/rabin_aes_impl.h
+++ b/src/borg/chunkers/rabin_aes_impl.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "phte_kernel.h"
+
 typedef struct RA_CTX RA_CTX;
 
 /* Number of 256-entry rolling tables passed to ra_new, in this order:
@@ -34,9 +36,9 @@ typedef struct RA_CTX RA_CTX;
 /* Create a kernel context.
  * tables: RA_TABLES * 256 uint64 entries, see above.
  * aes_key: 16 bytes (AES-128).
- * force_sw: nonzero forces the portable OpenSSL path (for tests/benchmarks).
+ * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
  * Returns NULL on allocation/OpenSSL failure. */
-RA_CTX *ra_new(const uint64_t *tables, const uint8_t aes_key[16], int force_sw);
+RA_CTX *ra_new(const uint64_t *tables, const uint8_t aes_key[16], int kernel);
 
 void ra_free(RA_CTX *ctx);
 

--- a/src/borg/chunkers/rabin_aes_impl.h
+++ b/src/borg/chunkers/rabin_aes_impl.h
@@ -36,7 +36,7 @@ typedef struct RA_CTX RA_CTX;
 /* Create a kernel context.
  * tables: RA_TABLES * 256 uint64 entries, see above.
  * aes_key: 16 bytes (AES-128).
- * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
+ * kernel: one of PHTE_K_*.
  * Returns NULL on allocation/OpenSSL failure. */
 RA_CTX *ra_new(const uint64_t *tables, const uint8_t aes_key[16], int kernel);
 

--- a/src/borg/chunkers/toeplitz_aes.pyx
+++ b/src/borg/chunkers/toeplitz_aes.pyx
@@ -50,7 +50,11 @@ cdef extern from "toeplitz_aes_impl.h":
     ctypedef struct TP_CTX:
         pass
     int TP_TABLES
-    TP_CTX *tp_new(const uint64_t *tables, const uint8_t *aes_key, int force_sw)
+    TP_CTX *tp_new(const uint64_t *tables, const uint8_t *aes_key, int kernel)
+    int phte_kernel_select(const char *name, int *out_id)
+    const char *phte_kernel_names()
+    int PHTE_K_AUTO
+    int PHTE_K_EVP
     void tp_free(TP_CTX *ctx)
     const char *tp_kind(const TP_CTX *ctx)
     uint64_t tp_digest64(const TP_CTX *ctx, const uint8_t *q)
@@ -107,6 +111,27 @@ def _derive(bytes key):
     return aes_key, t, tables
 
 
+from .kernel_env import kernel_error, requested_kernel
+
+
+cdef int _select_kernel() except -1:
+    """Resolve BORG_AES_CHUNKER_KERNEL to a scan path id, raising if it cannot be honoured.
+
+    One selector for all three AES chunkers: they share phte_scan.h, so the
+    available paths never differ between them.
+    """
+    cdef int kid = PHTE_K_AUTO
+    cdef int rc
+    want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
+    if want is None:
+        return PHTE_K_AUTO
+    rc = phte_kernel_select(want.encode("ascii"), &kid)
+    if rc != 0:
+        raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,
+                           (<bytes>phte_kernel_names()).decode("ascii"))
+    return kid
+
+
 cdef class ChunkerToeplitzAES(ChunkerPHTE):
     """
     Content-Defined Chunker, variable chunk sizes, UHF-then-PRF cut decision.
@@ -130,8 +155,8 @@ cdef class ChunkerToeplitzAES(ChunkerPHTE):
             for i in range(256):
                 c_tables[t * 256 + i] = tables[t][i]
 
-        force_sw = os.environ.get("BORG_TOEPLITZ_AES_FORCE_EVP", "") not in ("", "0")
-        self.ctx = tp_new(c_tables, aes_key, 1 if force_sw else 0)
+        kernel = _select_kernel()
+        self.ctx = tp_new(c_tables, aes_key, kernel)
         if self.ctx == NULL:
             raise MemoryError("Failed to set up toeplitz-aes kernel")
         self.kernel_str = (<bytes>tp_kind(self.ctx)).decode("ascii")
@@ -177,7 +202,7 @@ def toeplitz_aes_digest64(bytes key, bytes window):
         for i in range(256):
             c_tables[t * 256 + i] = tables[t][i]
     memset(aes_key_c, 0, 16)
-    ctx = tp_new(c_tables, aes_key_c, 1)
+    ctx = tp_new(c_tables, aes_key_c, PHTE_K_EVP)
     if ctx == NULL:
         raise MemoryError("Failed to set up toeplitz-aes kernel")
     d = tp_digest64(ctx, <const uint8_t*>PyBytes_AsString(window))

--- a/src/borg/chunkers/toeplitz_aes.pyx
+++ b/src/borg/chunkers/toeplitz_aes.pyx
@@ -53,7 +53,6 @@ cdef extern from "toeplitz_aes_impl.h":
     TP_CTX *tp_new(const uint64_t *tables, const uint8_t *aes_key, int kernel)
     int phte_kernel_select(const char *name, int *out_id)
     const char *phte_kernel_names()
-    int PHTE_K_AUTO
     int PHTE_K_EVP
     void tp_free(TP_CTX *ctx)
     const char *tp_kind(const TP_CTX *ctx)
@@ -120,11 +119,11 @@ cdef int _select_kernel() except -1:
     One selector for all three AES chunkers: they share phte_scan.h, so the
     available paths never differ between them.
     """
-    cdef int kid = PHTE_K_AUTO
+    cdef int kid = PHTE_K_EVP
     cdef int rc
     want = requested_kernel("BORG_AES_CHUNKER_KERNEL")
     if want is None:
-        return PHTE_K_AUTO
+        return PHTE_K_EVP
     rc = phte_kernel_select(want.encode("ascii"), &kid)
     if rc != 0:
         raise kernel_error("BORG_AES_CHUNKER_KERNEL", want, rc,

--- a/src/borg/chunkers/toeplitz_aes_impl.c
+++ b/src/borg/chunkers/toeplitz_aes_impl.c
@@ -84,7 +84,7 @@ uint64_t tp_digest64(const TP_CTX *c, const uint8_t *q)
 #define PH_DIGEST64 tp_digest64
 #include "phte_scan.h"
 
-TP_CTX *tp_new(const uint64_t tables[TP_TABLES * 256], const uint8_t aes_key[16], int force_sw)
+TP_CTX *tp_new(const uint64_t tables[TP_TABLES * 256], const uint8_t aes_key[16], int kernel)
 {
     TP_CTX *c = calloc(1, sizeof(TP_CTX));
     if (c == NULL)
@@ -93,7 +93,7 @@ TP_CTX *tp_new(const uint64_t tables[TP_TABLES * 256], const uint8_t aes_key[16]
     memcpy(c->in1_tbl, tables + 1 * 256, sizeof(c->in1_tbl));
     memcpy(c->out64_tbl, tables + 2 * 256, sizeof(c->out64_tbl));
     memcpy(c->out65_tbl, tables + 3 * 256, sizeof(c->out65_tbl));
-    if (!phte_base_init(&c->base, aes_key, force_sw)) {
+    if (!phte_base_init(&c->base, aes_key, kernel)) {
         free(c);
         return NULL;
     }

--- a/src/borg/chunkers/toeplitz_aes_impl.h
+++ b/src/borg/chunkers/toeplitz_aes_impl.h
@@ -40,7 +40,7 @@ typedef struct TP_CTX TP_CTX;
 /* Create a kernel context.
  * tables: TP_TABLES * 256 uint64 entries, see above.
  * aes_key: 16 bytes (AES-128).
- * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
+ * kernel: one of PHTE_K_*.
  * Returns NULL on allocation/OpenSSL failure. */
 TP_CTX *tp_new(const uint64_t *tables, const uint8_t aes_key[16], int kernel);
 

--- a/src/borg/chunkers/toeplitz_aes_impl.h
+++ b/src/borg/chunkers/toeplitz_aes_impl.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "phte_kernel.h"
+
 typedef struct TP_CTX TP_CTX;
 
 /* Number of 256-entry rolling tables passed to tp_new, in this order:
@@ -38,9 +40,9 @@ typedef struct TP_CTX TP_CTX;
 /* Create a kernel context.
  * tables: TP_TABLES * 256 uint64 entries, see above.
  * aes_key: 16 bytes (AES-128).
- * force_sw: nonzero forces the portable OpenSSL path (for tests/benchmarks).
+ * kernel: one of PHTE_K_*; PHTE_K_AUTO picks the best path this CPU can run.
  * Returns NULL on allocation/OpenSSL failure. */
-TP_CTX *tp_new(const uint64_t *tables, const uint8_t aes_key[16], int force_sw);
+TP_CTX *tp_new(const uint64_t *tables, const uint8_t aes_key[16], int kernel);
 
 void tp_free(TP_CTX *ctx);
 

--- a/src/borg/chunkers/toeplitz_aes_impl.h
+++ b/src/borg/chunkers/toeplitz_aes_impl.h
@@ -44,7 +44,7 @@ TP_CTX *tp_new(const uint64_t *tables, const uint8_t aes_key[16], int force_sw);
 
 void tp_free(TP_CTX *ctx);
 
-/* Which path this context uses: "aes-arm64", "aes-ni" or "evp". */
+/* Which path this context uses: "aes-arm64", "vaes", "aes-ni" or "evp". */
 const char *tp_kind(const TP_CTX *ctx);
 
 /* Full (non-rolling) digest of the 64 bytes at q: the window warm-up at the

--- a/src/borg/testsuite/chunkers/__init__.py
+++ b/src/borg/testsuite/chunkers/__init__.py
@@ -1,9 +1,29 @@
 import os
 import tempfile
 
+import pytest
+
 from borg.constants import *  # noqa
 
 from ...chunkers import has_seek_hole
+
+
+def chunker_with_kernel(monkeypatch, envvar, kernel, make):
+    """Build a chunker with <envvar> set to <kernel>, or skip if it cannot run here.
+
+    Which kernels exist depends on the build (compiler support) and on the CPU, so a
+    kernel that cannot be selected is not a failure - the test is skipped, carrying
+    the reason the chunker gave, so `pytest -rs` shows which kernels a machine covered.
+    Requesting an unusable kernel raising (rather than falling back) is itself tested,
+    see test_kernel_env_rejects_unusable.
+    """
+    monkeypatch.setenv(envvar, kernel)
+    try:
+        chunker = make()
+    except ValueError as err:
+        pytest.skip(str(err))
+    assert chunker.kernel == kernel  # we must have got what we asked for, not a fallback
+    return chunker
 
 
 def cf(chunks):

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -142,24 +142,32 @@ def test_fuzz_bh64(worker):
             assert reconstructed == data
 
 
-def test_buzhash64_kernels_identical():
-    # the SIMD scan kernel (avx512/avx2/blockwise, auto-selected) and the plain sequential
-    # loop must produce identical cut points.
+ALL_BUZHASH64_KERNELS = ("auto", "neon", "avx512", "avx2", "blockwise", "scalar")
+
+
+def test_buzhash64_kernels_identical(monkeypatch):
+    # Every scan kernel this platform accepts must produce identical cut points;
+    # see the fastcdc counterpart. On aarch64 this is what keeps the NEON kernel
+    # verified - it is selectable but never auto-selected.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
     def sizes(chunker):
         return [c.meta["size"] for c in chunker.chunkify(BytesIO(data))]
 
-    default = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
-    sizes_default = sizes(default)
-    os.environ["BORG_BUZHASH64_KERNEL"] = "scalar"
-    try:
-        forced = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
-        assert forced.kernel == "scalar"
-        sizes_scalar = sizes(forced)
-    finally:
-        del os.environ["BORG_BUZHASH64_KERNEL"]
-    assert sizes_default == sizes_scalar
-    # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("avx512", "avx2", "blockwise", "scalar")
+    monkeypatch.delenv("BORG_BUZHASH64_KERNEL", raising=False)
+    reference = sizes(ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2))
+
+    tested = []
+    for name in ALL_BUZHASH64_KERNELS:
+        monkeypatch.setenv("BORG_BUZHASH64_KERNEL", name)
+        try:
+            chunker = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
+        except ValueError:
+            continue  # not available on this build/CPU
+        if name != "auto":
+            assert chunker.kernel == name
+        assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
+        tested.append(name)
+
+    assert "blockwise" in tested and "scalar" in tested

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -153,13 +153,13 @@ def test_buzhash64_kernels_identical():
 
     default = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
     sizes_default = sizes(default)
-    os.environ["BORG_BUZHASH64_FORCE_SCALAR"] = "1"
+    os.environ["BORG_BUZHASH64_KERNEL"] = "scalar"
     try:
         forced = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
         assert forced.kernel == "scalar"
         sizes_scalar = sizes(forced)
     finally:
-        del os.environ["BORG_BUZHASH64_FORCE_SCALAR"]
+        del os.environ["BORG_BUZHASH64_KERNEL"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
     assert default.kernel in ("avx512", "avx2", "blockwise", "scalar")

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 
-from . import cf, cf_expand
+from . import cf, cf_expand, chunker_with_kernel
 from ...chunkers import ChunkerBuzHash64
 from ...chunkers.buzhash64 import buzhash64_get_table
 from ...constants import *  # NOQA
@@ -103,10 +103,16 @@ def test_buzhash64_table():
         assert bit_count == 128  # 50% of 256 = 128
 
 
+ALL_BUZHASH64_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
+
+
 @pytest.mark.skipif("BORG_TESTS_SLOW" not in os.environ, reason="slow tests not enabled, use BORG_TESTS_SLOW=1")
+@pytest.mark.parametrize("kernel", ALL_BUZHASH64_KERNELS)
 @pytest.mark.parametrize("worker", range(os.cpu_count() or 1))
-def test_fuzz_bh64(worker):
+def test_fuzz_bh64(worker, kernel, monkeypatch):
     # Fuzz buzhash64 with random and uniform data of misc. sizes and misc keys.
+    # Every kernel gets fuzzed - see the fastcdc counterpart for why the odd
+    # sizes here matter more to the vector kernels than the identity test does.
     def rnd_key():
         return os.urandom(32)
 
@@ -118,7 +124,12 @@ def test_fuzz_bh64(worker):
     sizes = [random.randint(1, 4 * 1024 * 1024) for _ in range(50)]
 
     for key in keys:
-        chunker = ChunkerBuzHash64(key, min_exp, max_exp, mask_bits, win_size, nc_level)
+        chunker = chunker_with_kernel(
+            monkeypatch,
+            "BORG_BUZHASH64_KERNEL",
+            kernel,
+            lambda: ChunkerBuzHash64(key, min_exp, max_exp, mask_bits, win_size, nc_level),
+        )
         for size in sizes:
             # Random data
             data = os.urandom(size)
@@ -142,10 +153,8 @@ def test_fuzz_bh64(worker):
             assert reconstructed == data
 
 
-ALL_BUZHASH64_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
-
-
-def test_buzhash64_kernels_identical(monkeypatch):
+@pytest.mark.parametrize("kernel", ALL_BUZHASH64_KERNELS)
+def test_buzhash64_kernels_identical(kernel, monkeypatch):
     # Every scan kernel this platform accepts must produce identical cut points;
     # see the fastcdc counterpart. On aarch64 this is what keeps the NEON kernel
     # verified - it is selectable but never auto-selected.
@@ -158,15 +167,15 @@ def test_buzhash64_kernels_identical(monkeypatch):
     monkeypatch.delenv("BORG_BUZHASH64_KERNEL", raising=False)
     reference = sizes(ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2))
 
-    tested = []
-    for name in ALL_BUZHASH64_KERNELS:
-        monkeypatch.setenv("BORG_BUZHASH64_KERNEL", name)
-        try:
-            chunker = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
-        except ValueError:
-            continue  # not available on this build/CPU
-        assert chunker.kernel == name
-        assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
-        tested.append(name)
+    chunker = chunker_with_kernel(
+        monkeypatch, "BORG_BUZHASH64_KERNEL", kernel, lambda: ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
+    )
+    assert sizes(chunker) == reference, f"kernel {kernel} disagrees with the default one"
 
-    assert "blockwise" in tested and "scalar" in tested
+
+@pytest.mark.parametrize("kernel", ["blockwise", "scalar"])
+def test_buzhash64_portable_kernel_available(kernel, monkeypatch):
+    # portable C, so these two must be selectable everywhere - see the fastcdc counterpart.
+    key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
+    monkeypatch.setenv("BORG_BUZHASH64_KERNEL", kernel)
+    assert ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2).kernel == kernel

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -143,7 +143,7 @@ def test_fuzz_bh64(worker):
 
 
 def test_buzhash64_kernels_identical():
-    # the SIMD scan kernel (neon/avx512/avx2/blocked, auto-selected) and the plain sequential
+    # the SIMD scan kernel (avx512/avx2/blockwise, auto-selected) and the plain sequential
     # loop must produce identical cut points.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
@@ -162,4 +162,4 @@ def test_buzhash64_kernels_identical():
         del os.environ["BORG_BUZHASH64_FORCE_SCALAR"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("neon", "avx512", "avx2", "blocked", "scalar")
+    assert default.kernel in ("avx512", "avx2", "blockwise", "scalar")

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -142,7 +142,7 @@ def test_fuzz_bh64(worker):
             assert reconstructed == data
 
 
-ALL_BUZHASH64_KERNELS = ("auto", "neon", "avx512", "avx2", "blockwise", "scalar")
+ALL_BUZHASH64_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
 
 
 def test_buzhash64_kernels_identical(monkeypatch):
@@ -165,8 +165,7 @@ def test_buzhash64_kernels_identical(monkeypatch):
             chunker = ChunkerBuzHash64(key0, 10, 16, 14, 4095, 2)
         except ValueError:
             continue  # not available on this build/CPU
-        if name != "auto":
-            assert chunker.kernel == name
+        assert chunker.kernel == name
         assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
         tested.append(name)
 

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -143,7 +143,7 @@ def test_fuzz_bh64(worker):
 
 
 def test_buzhash64_kernels_identical():
-    # the blocked/AVX2 scan kernel (auto-selected) and the plain sequential
+    # the SIMD scan kernel (neon/avx512/avx2/blocked, auto-selected) and the plain sequential
     # loop must produce identical cut points.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
@@ -162,4 +162,4 @@ def test_buzhash64_kernels_identical():
         del os.environ["BORG_BUZHASH64_FORCE_SCALAR"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("neon", "avx2", "blocked", "scalar")
+    assert default.kernel in ("neon", "avx512", "avx2", "blocked", "scalar")

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -178,7 +178,7 @@ def test_fuzz_fastcdc(worker):
             assert b"".join(parts) == data
 
 
-ALL_FASTCDC_KERNELS = ("auto", "neon", "avx512", "avx2", "blockwise", "scalar")
+ALL_FASTCDC_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
 
 
 def test_fastcdc_kernels_identical(monkeypatch):
@@ -202,8 +202,7 @@ def test_fastcdc_kernels_identical(monkeypatch):
             chunker = ChunkerFastCDC(key0, 10, 16, 14, 2)
         except ValueError:
             continue  # not available on this build/CPU
-        if name != "auto":
-            assert chunker.kernel == name
+        assert chunker.kernel == name
         assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
         tested.append(name)
 
@@ -218,10 +217,10 @@ def test_kernel_env_rejects_unusable(envvar, monkeypatch):
     # means to pin one kernel, into a measurement of a different one.
     from ...chunkers import ChunkerBuzHash64, ChunkerToeplitzAES
 
-    make = {
-        "BORG_FASTCDC_KERNEL": lambda k: ChunkerFastCDC(k, 10, 16, 14, 2),
-        "BORG_BUZHASH64_KERNEL": lambda k: ChunkerBuzHash64(k, 10, 16, 14, 4095, 2),
-        "BORG_AES_CHUNKER_KERNEL": lambda k: ChunkerToeplitzAES(k, 10, 16, 14, 2),
+    make, default = {
+        "BORG_FASTCDC_KERNEL": (lambda k: ChunkerFastCDC(k, 10, 16, 14, 2), "scalar"),
+        "BORG_BUZHASH64_KERNEL": (lambda k: ChunkerBuzHash64(k, 10, 16, 14, 4095, 2), "scalar"),
+        "BORG_AES_CHUNKER_KERNEL": (lambda k: ChunkerToeplitzAES(k, 10, 16, 14, 2), "evp"),
     }[envvar]
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
@@ -229,12 +228,15 @@ def test_kernel_env_rejects_unusable(envvar, monkeypatch):
     with pytest.raises(ValueError, match="no-such-kernel"):
         make(key0)
 
-    # "auto" and an unset var both mean "pick the best one", and always work
+    # there is no automatic selection, so "auto" is not a kernel name either
     monkeypatch.setenv(envvar, "auto")
-    auto = make(key0).kernel
-    monkeypatch.delenv(envvar)
-    assert make(key0).kernel == auto
+    with pytest.raises(ValueError, match="auto"):
+        make(key0)
 
-    # asking for whatever auto-selection picked must yield exactly that
-    monkeypatch.setenv(envvar, auto)
-    assert make(key0).kernel == auto
+    # unset means the simplest implementation, on every platform
+    monkeypatch.delenv(envvar)
+    assert make(key0).kernel == default
+
+    # and asking for it explicitly gives the same thing
+    monkeypatch.setenv(envvar, default)
+    assert make(key0).kernel == default

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 
-from . import cf, cf_expand
+from . import cf, cf_expand, chunker_with_kernel
 from ...chunkers import ChunkerFastCDC, get_chunker
 from ...chunkers.fastcdc import fastcdc_get_gear_table
 from ...constants import *  # NOQA
@@ -142,10 +142,17 @@ def test_fastcdc_params_parsing():
         ChunkerParams("fastcdc,20,20,20,2")
 
 
+ALL_FASTCDC_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
+
+
 @pytest.mark.skipif("BORG_TESTS_SLOW" not in os.environ, reason="slow tests not enabled, use BORG_TESTS_SLOW=1")
+@pytest.mark.parametrize("kernel", ALL_FASTCDC_KERNELS)
 @pytest.mark.parametrize("worker", range(os.cpu_count() or 1))
-def test_fuzz_fastcdc(worker):
+def test_fuzz_fastcdc(worker, kernel, monkeypatch):
     # Fuzz fastcdc with random and uniform data of misc. sizes and misc keys.
+    # Every kernel gets fuzzed: the sizes here are not multiples of a block, so
+    # this is what covers the vector kernels' tails and their sub-block inputs,
+    # which the fixed-size buffer in test_fastcdc_kernels_identical never reaches.
     def rnd_key():
         return os.urandom(32)
 
@@ -157,7 +164,12 @@ def test_fuzz_fastcdc(worker):
     sizes = [random.randint(1, 4 * 1024 * 1024) for _ in range(50)]
 
     for key in keys:
-        chunker = ChunkerFastCDC(key, min_exp, max_exp, mask_bits, nc_level)
+        chunker = chunker_with_kernel(
+            monkeypatch,
+            "BORG_FASTCDC_KERNEL",
+            kernel,
+            lambda: ChunkerFastCDC(key, min_exp, max_exp, mask_bits, nc_level),
+        )
         for size in sizes:
             # Random data
             data = os.urandom(size)
@@ -178,16 +190,13 @@ def test_fuzz_fastcdc(worker):
             assert b"".join(parts) == data
 
 
-ALL_FASTCDC_KERNELS = ("neon", "avx512", "avx2", "blockwise", "scalar")
-
-
-def test_fastcdc_kernels_identical(monkeypatch):
+@pytest.mark.parametrize("kernel", ALL_FASTCDC_KERNELS)
+def test_fastcdc_kernels_identical(kernel, monkeypatch):
     # Every scan kernel this platform accepts must produce identical cut points.
-    # Kernels this build/CPU cannot run raise and are skipped, so the same test
-    # covers whatever tier the machine happens to have - including kernels that
-    # exist but are not auto-selected, which nothing else would exercise.
+    # Kernels this build/CPU cannot run are skipped, so the same test covers
+    # whatever tier the machine happens to have - including kernels that exist
+    # but are not auto-selected, which nothing else would exercise.
     data = os.urandom(4 * 1024 * 1024)
-    key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
     def sizes(chunker):
         return [c.meta["size"] for c in chunker.chunkify(BytesIO(data))]
@@ -195,19 +204,19 @@ def test_fastcdc_kernels_identical(monkeypatch):
     monkeypatch.delenv("BORG_FASTCDC_KERNEL", raising=False)
     reference = sizes(ChunkerFastCDC(key0, 10, 16, 14, 2))
 
-    tested = []
-    for name in ALL_FASTCDC_KERNELS:
-        monkeypatch.setenv("BORG_FASTCDC_KERNEL", name)
-        try:
-            chunker = ChunkerFastCDC(key0, 10, 16, 14, 2)
-        except ValueError:
-            continue  # not available on this build/CPU
-        assert chunker.kernel == name
-        assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
-        tested.append(name)
+    chunker = chunker_with_kernel(
+        monkeypatch, "BORG_FASTCDC_KERNEL", kernel, lambda: ChunkerFastCDC(key0, 10, 16, 14, 2)
+    )
+    assert sizes(chunker) == reference, f"kernel {kernel} disagrees with the default one"
 
-    # the portable kernels exist everywhere; if they were skipped, the loop is broken
-    assert "blockwise" in tested and "scalar" in tested
+
+@pytest.mark.parametrize("kernel", ["blockwise", "scalar"])
+def test_fastcdc_portable_kernel_available(kernel, monkeypatch):
+    # scalar and blockwise are portable C and exist in every build on every CPU.
+    # If one of them cannot be selected, kernel selection is broken rather than
+    # the platform being limited - so this must not skip the way the test above does.
+    monkeypatch.setenv("BORG_FASTCDC_KERNEL", kernel)
+    assert ChunkerFastCDC(key0, 10, 16, 14, 2).kernel == kernel
 
 
 @pytest.mark.parametrize("envvar", ["BORG_FASTCDC_KERNEL", "BORG_BUZHASH64_KERNEL", "BORG_AES_CHUNKER_KERNEL"])

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -189,13 +189,42 @@ def test_fastcdc_kernels_identical():
 
     default = ChunkerFastCDC(key0, 10, 16, 14, 2)
     sizes_default = sizes(default)
-    os.environ["BORG_FASTCDC_FORCE_SCALAR"] = "1"
+    os.environ["BORG_FASTCDC_KERNEL"] = "scalar"
     try:
         forced = ChunkerFastCDC(key0, 10, 16, 14, 2)
         assert forced.kernel == "scalar"
         sizes_scalar = sizes(forced)
     finally:
-        del os.environ["BORG_FASTCDC_FORCE_SCALAR"]
+        del os.environ["BORG_FASTCDC_KERNEL"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
     assert default.kernel in ("neon", "avx512", "avx2", "blockwise", "scalar")
+
+
+@pytest.mark.parametrize("envvar", ["BORG_FASTCDC_KERNEL", "BORG_BUZHASH64_KERNEL", "BORG_AES_CHUNKER_KERNEL"])
+def test_kernel_env_rejects_unusable(envvar, monkeypatch):
+    # A kernel that cannot run here must fail loudly instead of silently
+    # falling back - a silent fallback would turn a benchmark, or a CI job that
+    # means to pin one kernel, into a measurement of a different one.
+    from ...chunkers import ChunkerBuzHash64, ChunkerToeplitzAES
+
+    make = {
+        "BORG_FASTCDC_KERNEL": lambda k: ChunkerFastCDC(k, 10, 16, 14, 2),
+        "BORG_BUZHASH64_KERNEL": lambda k: ChunkerBuzHash64(k, 10, 16, 14, 4095, 2),
+        "BORG_AES_CHUNKER_KERNEL": lambda k: ChunkerToeplitzAES(k, 10, 16, 14, 2),
+    }[envvar]
+    key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
+
+    monkeypatch.setenv(envvar, "no-such-kernel")
+    with pytest.raises(ValueError, match="no-such-kernel"):
+        make(key0)
+
+    # "auto" and an unset var both mean "pick the best one", and always work
+    monkeypatch.setenv(envvar, "auto")
+    auto = make(key0).kernel
+    monkeypatch.delenv(envvar)
+    assert make(key0).kernel == auto
+
+    # asking for whatever auto-selection picked must yield exactly that
+    monkeypatch.setenv(envvar, auto)
+    assert make(key0).kernel == auto

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -179,7 +179,7 @@ def test_fuzz_fastcdc(worker):
 
 
 def test_fastcdc_kernels_identical():
-    # the SIMD scan kernel (neon/avx512/avx2/blocked, auto-selected) and the
+    # the SIMD scan kernel (neon/avx512/avx2/blockwise, auto-selected) and the
     # plain sequential Gear loop must produce identical cut points.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
@@ -198,4 +198,4 @@ def test_fastcdc_kernels_identical():
         del os.environ["BORG_FASTCDC_FORCE_SCALAR"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("neon", "avx512", "avx2", "blocked", "scalar")
+    assert default.kernel in ("neon", "avx512", "avx2", "blockwise", "scalar")

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -178,27 +178,37 @@ def test_fuzz_fastcdc(worker):
             assert b"".join(parts) == data
 
 
-def test_fastcdc_kernels_identical():
-    # the SIMD scan kernel (neon/avx512/avx2/blockwise, auto-selected) and the
-    # plain sequential Gear loop must produce identical cut points.
+ALL_FASTCDC_KERNELS = ("auto", "neon", "avx512", "avx2", "blockwise", "scalar")
+
+
+def test_fastcdc_kernels_identical(monkeypatch):
+    # Every scan kernel this platform accepts must produce identical cut points.
+    # Kernels this build/CPU cannot run raise and are skipped, so the same test
+    # covers whatever tier the machine happens to have - including kernels that
+    # exist but are not auto-selected, which nothing else would exercise.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
     def sizes(chunker):
         return [c.meta["size"] for c in chunker.chunkify(BytesIO(data))]
 
-    default = ChunkerFastCDC(key0, 10, 16, 14, 2)
-    sizes_default = sizes(default)
-    os.environ["BORG_FASTCDC_KERNEL"] = "scalar"
-    try:
-        forced = ChunkerFastCDC(key0, 10, 16, 14, 2)
-        assert forced.kernel == "scalar"
-        sizes_scalar = sizes(forced)
-    finally:
-        del os.environ["BORG_FASTCDC_KERNEL"]
-    assert sizes_default == sizes_scalar
-    # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("neon", "avx512", "avx2", "blockwise", "scalar")
+    monkeypatch.delenv("BORG_FASTCDC_KERNEL", raising=False)
+    reference = sizes(ChunkerFastCDC(key0, 10, 16, 14, 2))
+
+    tested = []
+    for name in ALL_FASTCDC_KERNELS:
+        monkeypatch.setenv("BORG_FASTCDC_KERNEL", name)
+        try:
+            chunker = ChunkerFastCDC(key0, 10, 16, 14, 2)
+        except ValueError:
+            continue  # not available on this build/CPU
+        if name != "auto":
+            assert chunker.kernel == name
+        assert sizes(chunker) == reference, f"kernel {name} disagrees with the default one"
+        tested.append(name)
+
+    # the portable kernels exist everywhere; if they were skipped, the loop is broken
+    assert "blockwise" in tested and "scalar" in tested
 
 
 @pytest.mark.parametrize("envvar", ["BORG_FASTCDC_KERNEL", "BORG_BUZHASH64_KERNEL", "BORG_AES_CHUNKER_KERNEL"])

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -179,8 +179,8 @@ def test_fuzz_fastcdc(worker):
 
 
 def test_fastcdc_kernels_identical():
-    # the SIMD scan kernel (neon/avx2/blocked, auto-selected) and the plain
-    # sequential Gear loop must produce identical cut points.
+    # the SIMD scan kernel (neon/avx512/avx2/blocked, auto-selected) and the
+    # plain sequential Gear loop must produce identical cut points.
     data = os.urandom(4 * 1024 * 1024)
     key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
@@ -198,4 +198,4 @@ def test_fastcdc_kernels_identical():
         del os.environ["BORG_FASTCDC_FORCE_SCALAR"]
     assert sizes_default == sizes_scalar
     # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("neon", "avx2", "blocked", "scalar")
+    assert default.kernel in ("neon", "avx512", "avx2", "blocked", "scalar")

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -44,27 +44,36 @@ def chunker_spec(request):
     return request.param
 
 
-def test_kernels_identical(chunker_spec):
-    # the OpenSSL EVP batch path and the AES hardware instruction path (if available
-    # on this platform) must produce identical cut points.
+ALL_AES_KERNELS = ("auto", "vaes", "aes-ni", "aes-arm64", "evp")
+
+
+def test_kernels_identical(chunker_spec, monkeypatch):
+    # Every scan path this platform accepts - OpenSSL EVP, the 128-bit AES
+    # instructions, VAES - must produce identical cut points. Paths this
+    # build/CPU cannot run raise and are skipped.
     cls, algo, params = chunker_spec
     data = os.urandom(4 * 1024 * 1024)
 
     def sizes(chunker):
         return [c.meta["size"] for c in chunker.chunkify(BytesIO(data))]
 
-    default = cls(key0, 10, 16, 14, 2)
-    sizes_default = sizes(default)
-    os.environ[KERNEL_ENV] = "evp"
-    try:
-        forced = cls(key0, 10, 16, 14, 2)
-        assert forced.kernel == "evp"
-        sizes_evp = sizes(forced)
-    finally:
-        del os.environ[KERNEL_ENV]
-    assert sizes_default == sizes_evp
-    # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("aes-arm64", "vaes", "aes-ni", "evp")
+    monkeypatch.delenv(KERNEL_ENV, raising=False)
+    reference = sizes(cls(key0, 10, 16, 14, 2))
+
+    tested = []
+    for name in ALL_AES_KERNELS:
+        monkeypatch.setenv(KERNEL_ENV, name)
+        try:
+            chunker = cls(key0, 10, 16, 14, 2)
+        except ValueError:
+            continue  # not available on this build/CPU
+        if name != "auto":
+            assert chunker.kernel == name
+        assert sizes(chunker) == reference, f"path {name} disagrees with the default one"
+        tested.append(name)
+
+    # the portable OpenSSL path exists everywhere
+    assert "evp" in tested
 
 
 def test_chunksize_distribution(chunker_spec):

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -44,7 +44,7 @@ def chunker_spec(request):
     return request.param
 
 
-ALL_AES_KERNELS = ("auto", "vaes", "aes-ni", "aes-arm64", "evp")
+ALL_AES_KERNELS = ("vaes", "aes-ni", "aes-arm64", "evp")
 
 
 def test_kernels_identical(chunker_spec, monkeypatch):
@@ -67,8 +67,7 @@ def test_kernels_identical(chunker_spec, monkeypatch):
             chunker = cls(key0, 10, 16, 14, 2)
         except ValueError:
             continue  # not available on this build/CPU
-        if name != "auto":
-            assert chunker.kernel == name
+        assert chunker.kernel == name
         assert sizes(chunker) == reference, f"path {name} disagrees with the default one"
         tested.append(name)
 

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -61,7 +61,7 @@ def test_kernels_identical(chunker_spec):
         del os.environ[env_var]
     assert sizes_default == sizes_evp
     # whatever kernel was selected by default, it must be a known one
-    assert default.kernel in ("aes-arm64", "aes-ni", "evp")
+    assert default.kernel in ("aes-arm64", "vaes", "aes-ni", "evp")
 
 
 def test_chunksize_distribution(chunker_spec):

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -23,13 +23,16 @@ from ...helpers import hex_to_bin
 # from os.urandom(32)
 key0 = hex_to_bin("ad9f89095817f0566337dc9ee292fcd59b70f054a8200151f1df5f21704824da")
 
-# (chunker class, algo name, default params constant, env var forcing the portable kernel)
+# all three share one scan-path selector, see phte_kernel.h
+KERNEL_ENV = "BORG_AES_CHUNKER_KERNEL"
+
+# (chunker class, algo name, default params constant)
 CHUNKERS = [
-    (ChunkerRabinAES, CH_RABIN_AES, RABIN_AES_PARAMS, "BORG_RABIN_AES_FORCE_EVP"),
-    (ChunkerGoldilocksAES, CH_GOLDILOCKS_AES, GOLDILOCKS_AES_PARAMS, "BORG_GOLDILOCKS_AES_FORCE_EVP"),
-    (ChunkerToeplitzAES, CH_TOEPLITZ_AES, TOEPLITZ_AES_PARAMS, "BORG_TOEPLITZ_AES_FORCE_EVP"),
+    (ChunkerRabinAES, CH_RABIN_AES, RABIN_AES_PARAMS),
+    (ChunkerGoldilocksAES, CH_GOLDILOCKS_AES, GOLDILOCKS_AES_PARAMS),
+    (ChunkerToeplitzAES, CH_TOEPLITZ_AES, TOEPLITZ_AES_PARAMS),
 ]
-IDS = [algo for _, algo, _, _ in CHUNKERS]
+IDS = [algo for _, algo, _ in CHUNKERS]
 
 
 def H(data):
@@ -44,7 +47,7 @@ def chunker_spec(request):
 def test_kernels_identical(chunker_spec):
     # the OpenSSL EVP batch path and the AES hardware instruction path (if available
     # on this platform) must produce identical cut points.
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
     data = os.urandom(4 * 1024 * 1024)
 
     def sizes(chunker):
@@ -52,20 +55,20 @@ def test_kernels_identical(chunker_spec):
 
     default = cls(key0, 10, 16, 14, 2)
     sizes_default = sizes(default)
-    os.environ[env_var] = "1"
+    os.environ[KERNEL_ENV] = "evp"
     try:
         forced = cls(key0, 10, 16, 14, 2)
         assert forced.kernel == "evp"
         sizes_evp = sizes(forced)
     finally:
-        del os.environ[env_var]
+        del os.environ[KERNEL_ENV]
     assert sizes_default == sizes_evp
     # whatever kernel was selected by default, it must be a known one
     assert default.kernel in ("aes-arm64", "vaes", "aes-ni", "evp")
 
 
 def test_chunksize_distribution(chunker_spec):
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
     data = os.urandom(1048576)
     min_exp, max_exp, mask, nc_level = 10, 16, 14, 2  # chunk size target 16 KiB, clip at 1 KiB and 64 KiB
     chunker = cls(key0, min_exp, max_exp, mask, nc_level)
@@ -95,7 +98,7 @@ def test_chunksize_distribution(chunker_spec):
 def test_shift_resilience(chunker_spec):
     # content-defined cuts must survive a prefix insertion (this also validates that the
     # rolling digest update and the per-chunk window warm-up agree with each other).
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
     data = os.urandom(4 * 1024 * 1024)
 
     def chunk_hashes(data):
@@ -110,7 +113,7 @@ def test_shift_resilience(chunker_spec):
 
 def test_get_chunker(chunker_spec):
     # without a key, get_chunker uses an all-zero key; chunking must still work and be deterministic
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
     data = os.urandom(2 * 1024 * 1024)
     a = cf_expand(get_chunker(*params, key=None).chunkify(BytesIO(data)))
     b = cf_expand(get_chunker(algo, 19, 23, 21, 2, key=None).chunkify(BytesIO(data)))
@@ -123,7 +126,7 @@ def test_params_parsing(chunker_spec):
 
     from ...helpers import ChunkerParams
 
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
 
     # <algo>, chunk_min, chunk_max, chunk_mask, nc_level (no window field)
     assert ChunkerParams(f"{algo},19,23,21,2") == (algo, 19, 23, 21, 2)
@@ -149,7 +152,7 @@ def test_params_parsing(chunker_spec):
 @pytest.mark.parametrize("worker", range(os.cpu_count() or 1))
 def test_fuzz(chunker_spec, worker):
     # Fuzz with random and uniform data of misc. sizes and misc keys.
-    cls, algo, params, env_var = chunker_spec
+    cls, algo, params = chunker_spec
 
     # decompose <ALGO>_PARAMS = (algo, min_exp, max_exp, mask_bits, nc_level)
     params_algo, min_exp, max_exp, mask_bits, nc_level = params

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -14,7 +14,7 @@ import random
 
 import pytest
 
-from . import cf, cf_expand
+from . import cf, cf_expand, chunker_with_kernel
 from ...chunkers import ChunkerRabinAES, ChunkerGoldilocksAES, ChunkerToeplitzAES, get_chunker
 from ...constants import *  # NOQA
 from ...helpers import hex_to_bin
@@ -47,10 +47,11 @@ def chunker_spec(request):
 ALL_AES_KERNELS = ("vaes", "aes-ni", "aes-arm64", "evp")
 
 
-def test_kernels_identical(chunker_spec, monkeypatch):
+@pytest.mark.parametrize("kernel", ALL_AES_KERNELS)
+def test_kernels_identical(chunker_spec, kernel, monkeypatch):
     # Every scan path this platform accepts - OpenSSL EVP, the 128-bit AES
     # instructions, VAES - must produce identical cut points. Paths this
-    # build/CPU cannot run raise and are skipped.
+    # build/CPU cannot run are skipped.
     cls, algo, params = chunker_spec
     data = os.urandom(4 * 1024 * 1024)
 
@@ -60,19 +61,17 @@ def test_kernels_identical(chunker_spec, monkeypatch):
     monkeypatch.delenv(KERNEL_ENV, raising=False)
     reference = sizes(cls(key0, 10, 16, 14, 2))
 
-    tested = []
-    for name in ALL_AES_KERNELS:
-        monkeypatch.setenv(KERNEL_ENV, name)
-        try:
-            chunker = cls(key0, 10, 16, 14, 2)
-        except ValueError:
-            continue  # not available on this build/CPU
-        assert chunker.kernel == name
-        assert sizes(chunker) == reference, f"path {name} disagrees with the default one"
-        tested.append(name)
+    chunker = chunker_with_kernel(monkeypatch, KERNEL_ENV, kernel, lambda: cls(key0, 10, 16, 14, 2))
+    assert sizes(chunker) == reference, f"path {kernel} disagrees with the default one"
 
-    # the portable OpenSSL path exists everywhere
-    assert "evp" in tested
+
+def test_evp_kernel_available(chunker_spec, monkeypatch):
+    # EVP is the portable OpenSSL path: it exists in every build on every CPU, so
+    # unlike the test above this must not skip - if it cannot be selected, path
+    # selection is broken rather than the platform being limited.
+    cls, algo, params = chunker_spec
+    monkeypatch.setenv(KERNEL_ENV, "evp")
+    assert cls(key0, 10, 16, 14, 2).kernel == "evp"
 
 
 def test_chunksize_distribution(chunker_spec):
@@ -157,9 +156,12 @@ def test_params_parsing(chunker_spec):
 
 
 @pytest.mark.skipif("BORG_TESTS_SLOW" not in os.environ, reason="slow tests not enabled, use BORG_TESTS_SLOW=1")
+@pytest.mark.parametrize("kernel", ALL_AES_KERNELS)
 @pytest.mark.parametrize("worker", range(os.cpu_count() or 1))
-def test_fuzz(chunker_spec, worker):
-    # Fuzz with random and uniform data of misc. sizes and misc keys.
+def test_fuzz(chunker_spec, worker, kernel, monkeypatch):
+    # Fuzz with random and uniform data of misc. sizes and misc keys, on every
+    # scan path: these odd sizes are what exercise the hardware paths' tails and
+    # their groups-of-8 handling, which test_kernels_identical does not reach.
     cls, algo, params = chunker_spec
 
     # decompose <ALGO>_PARAMS = (algo, min_exp, max_exp, mask_bits, nc_level)
@@ -170,7 +172,9 @@ def test_fuzz(chunker_spec, worker):
     sizes = [random.randint(1, 4 * 1024 * 1024) for _ in range(50)]
 
     for key in keys:
-        chunker = cls(key, min_exp, max_exp, mask_bits, nc_level)
+        chunker = chunker_with_kernel(
+            monkeypatch, KERNEL_ENV, kernel, lambda: cls(key, min_exp, max_exp, mask_bits, nc_level)
+        )
         for size in sizes:
             # Random data
             data = os.urandom(size)


### PR DESCRIPTION
Adds AVX-512 / VAES scan kernels for the chunkers on x86-64, plus a round of optimisation of the existing NEON / AVX2 / AES-NI ones. All kernels are bit-identical: same cut points, same chunk boundaries, same digests.

## Throughput

MB/s, higher is better. **before** is the PR base (`effa698a7`), **default** and **fastest** are this branch — borg now runs the simplest kernel unless an env var selects another one (see below), so both are shown.

| chunker | x86 before | x86 default | x86 fastest | arm before | arm default | arm fastest |
|---|---|---|---|---|---|---|
| fastcdc | 713 | **3851** | **3851** `scalar` | 3361 | 2159 | **3545** `neon` |
| buzhash64 | 1060 | **2516** | **2517** `scalar` | 2389 | 1558 | **2534** `blockwise` |
| toeplitz-aes | 847 | 224 | **892** `vaes` | 924 | 569 | **977** `aes-arm64` |
| rabin-aes | 738 | 213 | **843** `vaes` | 885 | 521 | **927** `aes-arm64` |
| goldilocks-aes | 107 | 180 | **466** `vaes` | 485 | 373 | **561** `aes-arm64` |

Measured with the chunker section of `borg benchmark cpu` — 100 chunkifications of 10 MB = 1 GB per data point, best of 3, after warm-up — on an **AMD Ryzen 5 8500GE** (Zen 4, avx512+vaes, gcc 14, Debian, pinned to one core) and an **Apple M3 Pro** (clang, macOS).

Treat differences under roughly 10% on x86 and 20% on arm as noise: re-measuring chunkers this PR does not touch moves them by about that much between runs. The arm figures are the shakier of the two — macOS offers no CPU affinity API, so the process is free to migrate, and on a hybrid CPU that alone can shift a result. The x86 machine is pinned to one core. Everything above 1.3x is far outside that band and reproduced across repeats, cores and rebuilds.

## How

- **A store-to-load forwarding stall** (x86, the biggest win — fastcdc 713 → 3851). The vector kernels computed each block's prefix work in scalar registers and handed it to the vector unit through the stack; eight 8-byte stores followed immediately by one 32/64-byte vector load cannot forward, so every block stalled. Fixed by doing the next block's table lookups while the current one is tested, and building the aligned domain in the vector domain.
- **Branch mispredicts in goldilocks' field reductions** (~27% miss rate, and it is 4.3x faster now). `if()` and ternaries both compile back to branches; `__builtin_*_overflow` keeps the carry in the flags. 15.1 → 4.4 cycles per multiply. A redundant canonicalisation was later dropped from the same multiply.
- **Cheaper per-lane tests**: digests stored pre-spread so each AES input is a plain load, `x <= ~M` instead of `(x & M) == 0` on aarch64, and the AES cut test kept in vector registers instead of moving 8 values to general registers.
- **New AVX-512 / VAES kernels**, which is what the `vaes` column buys over `aes-ni` on x86.

## Which kernel is fastest is not predictable, so nothing is auto-selected

Measuring every kernel, including the plain sequential loop, gave opposite answers on the two machines. Scanning every byte of 64 MiB with fastcdc, the sequential loop runs at 4733 MB/s on Zen 4 against 2792 for AVX-512 and 834 for the portable blocked kernel — while on the M3 the same sequential loop manages 1996 against 4292 for NEON. buzhash64 splits the same way.

gcc folds fastcdc's `fp = (fp << 1) + gear[b]` into one `leaq (%r9,%rdi,2), %rdi`, retiring in a single cycle on Zen 4 — so no dependency is left worth breaking and every block-parallel kernel loses. On Apple cores that update costs two cycles, the chain *is* the bottleneck, and NEON wins 2.1x. Intel's LEA timings differ again, and a compiler that doesn't emit that `leaq` lands elsewhere still.

So borg runs the simplest implementation by default and every kernel stays selectable, for whoever has measured their own hardware. **Numbers from other x86 boxes — Intel, Zen 5, clang — would be very welcome.**

## For beta testers

One env var per chunker family. `.kernel` reports the active kernel, and `borg create --debug` logs it (`chunker: fastcdc, scan kernel: scalar`).

| var | default | other values |
|---|---|---|
| `BORG_FASTCDC_KERNEL` | `scalar` | `avx512`, `avx2`, `neon`, `blockwise` |
| `BORG_BUZHASH64_KERNEL` | `scalar` | `avx512`, `avx2`, `neon`, `blockwise` |
| `BORG_AES_CHUNKER_KERNEL` | `evp` | `vaes`, `aes-ni`, `aes-arm64` |

`avx512`/`avx2`/`vaes`/`aes-ni` exist only on x86-64, `neon`/`aes-arm64` only on aarch64; `scalar`, `blockwise` and `evp` are portable C and always available.

A value is a demand, not a preference: if that kernel cannot run here, creating the chunker raises `ValueError` rather than quietly falling back, so a benchmark can never silently measure something else.

```
BORG_FASTCDC_KERNEL='neon': not a kernel of this build. Valid values: avx512,avx2,blockwise,scalar
BORG_FASTCDC_KERNEL='avx512': this CPU does not support it. Valid values: avx512,avx2,blockwise,scalar
BORG_AES_CHUNKER_KERNEL='vaes': not compiled into this build (needs a newer compiler). Valid values: vaes,aes-ni,evp
```

The last one is real: the VAES path needs gcc >= 11 / clang >= 14, so "my CPU lists vaes but I don't get it" is its own failure.

## Correctness

Every kernel must produce byte-for-byte identical chunking; that is the property the whole PR rests on.

- **Cross-kernel identity tests** are parametrized over *every* kernel and compare full chunk-boundary sequences. Kernels the build or CPU cannot run become skips carrying the reason, so a run states which tiers it actually covered instead of silently omitting them — and non-default kernels cannot bit-rot unnoticed.
- **The fuzz tests run per kernel too** (random sizes, all-zero and all-same data, random keys) — that is what reaches block tails and sub-block inputs on the vector kernels.
- **Full chunker suite incl. fuzz tests** passes on both architectures with `BORG_TESTS_SLOW=1`: **348 passed / 65 skipped** on Zen 4 (covering `avx512`, `avx2`, `vaes`, `aes-ni`) and **278 passed / 135 skipped** on Apple M3 (covering `neon`, `aes-arm64`). The two skip sets are complements — each machine skips exactly the other architecture's kernels — so between them every kernel is fuzzed.
- **Chunk-boundary digests** of all five keyed chunkers are identical across `avx512`/`avx2`/`neon`/`blockwise`/`scalar` and `vaes`/`aes-ni`/`aes-arm64`/`evp` over 64 MiB of random data, and unchanged from before this branch.
- **The right kernel really runs**: `perf record` per kernel shows each request landing in its own function, with zero samples in any SIMD kernel when a scalar one was requested; hardware cycle counters agree with wall-clock timings.
- Builds clean at `-Wall -Wextra` on aarch64 and cross-compiled x86-64; a pyinstaller binary was built and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

