### PR TITLE
give each thread its own LZ4 scratch buffer, see #10032

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -20,6 +20,7 @@ import os
 import random
 from struct import Struct
 import sys
+import threading
 import zlib
 
 try:
@@ -86,7 +87,30 @@ cdef extern from "lz4.h":
     int LZ4_decompress_safe(const char* source, char* dest, int inputSize, int maxOutputSize) nogil
     int LZ4_compressBound(int inputSize) nogil
 
-buffer = Buffer(bytearray, size=0)
+_thread_local = threading.local()
+
+
+def get_buffer():
+    """Return the scratch buffer of the calling thread, creating it on first use.
+
+    The LZ4 code below uses a scratch buffer to avoid allocating a new output buffer for
+    every single chunk. Chunks are (de)compressed concurrently by multiple threads, so
+    that buffer must not be shared: two threads getting the same bytearray would write
+    into it at the same time, silently corrupting each other's output.
+
+    Thread-locals are the right granularity here (rather than per compressor instance):
+    compressor instances are shared between threads (e.g. LZ4_COMPRESSOR, used by Auto),
+    while a buffer that belongs to a thread is by definition only used by that thread.
+
+    A thread's buffer stays allocated until the thread ends, and it only ever grows, so
+    a pool of N worker threads may hold N buffers. That is the same behaviour as before,
+    just no longer limited to the one buffer of the main thread.
+    """
+    try:
+        return _thread_local.buffer
+    except AttributeError:
+        buffer = _thread_local.buffer = Buffer(bytearray, size=0)
+        return buffer
 
 cdef class CompressorBase:
     """
@@ -259,7 +283,7 @@ class LZ4(DecidingCompressor):
         cdef char *source = idata
         cdef char *dest
         osize = LZ4_compressBound(isize)
-        buf = buffer.get(osize)
+        buf = get_buffer().get(osize)
         dest = <char *> buf
         with nogil:
             osize = LZ4_compress_default(source, dest, isize, osize)
@@ -283,6 +307,7 @@ class LZ4(DecidingCompressor):
         # a bit more than 8MB is enough for the usual data sizes yielded by the chunker.
         # allocate more if isize * 3 is already bigger, to avoid having to resize often.
         osize = max(int(1.1 * 2**23), isize * 3)
+        buffer = get_buffer()
         while True:
             try:
                 buf = buffer.get(osize)

--- a/src/borg/testsuite/compress_test.py
+++ b/src/borg/testsuite/compress_test.py
@@ -1,5 +1,7 @@
 import os
+import random
 import zlib
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -49,6 +51,35 @@ def test_lz4_buffer_allocation(monkeypatch):
     assert len(incompressible_data) == 50 * 2**20
     assert len(cdata) >= len(incompressible_data)
     assert incompressible_data == c.decompress(meta, cdata)[1]
+
+
+def test_lz4_threaded():
+    # LZ4 must not share one scratch buffer between threads, see issue #10032.
+    # Without a per-thread buffer, concurrent (de)compression silently produces wrong
+    # output: the threads write their results into the same bytearray.
+    threads = 8
+    rounds = 50
+
+    def make_data(seed):
+        # compressible (so that lz4 does not bail out to "no compression"), but distinct
+        # per thread, so that output of one thread showing up in another one is detected.
+        rnd = random.Random(seed)
+        words = [bytes([rnd.randrange(256)]) * 64 for _ in range(16)]
+        data = bytearray()
+        while len(data) < 2**20:
+            data += rnd.choice(words)
+        return bytes(data)
+
+    def roundtrip(seed):
+        c = Compressor("lz4")
+        data = make_data(seed)
+        for _ in range(rounds):
+            meta, cdata = c.compress({}, data)
+            assert c.decompress(meta, cdata)[1] == data
+
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        # list() so that exceptions raised in the worker threads are re-raised here
+        list(executor.map(roundtrip, range(threads)))
 
 
 @pytest.mark.parametrize("invalid_cdata", [b"\xff\xfftotalcrap", b"\x08\x00notreallyzlib"])


### PR DESCRIPTION
`LZ4` used one module-level `Buffer` for both directions - `_decide()` (compress) and `decompress()`. Two threads (de)compressing lz4 chunks concurrently get the *same* bytearray and write into it at the same time, silently corrupting each other's output.

This is the thread-safety blocker described in #10032. It has to land before (or with) any parallel consumer of the (de)compression code, and lz4 is not an exotic setting.

## Fix

A `threading.local()` holding one `Buffer` per thread, via `get_buffer()`.

Thread-locals rather than per compressor instance, because per-instance would not actually be safe: `LZ4_COMPRESSOR` is a module-level singleton shared between threads (used by `Auto._decide()`), so its compress path would still collide. A buffer that belongs to a *thread* is by definition only used by that thread.

The reuse that avoids a fresh allocation for every chunk is kept - each thread just grows its own buffer, as before. A pool of N worker threads may hold N buffers, which is the same behaviour as before, just no longer limited to the single buffer of the main thread.

## Verification

New test `test_lz4_threaded`: 8 threads, 50 roundtrips each, 1MiB of compressible but *distinct per thread* data, so cross-talk between threads is detected.

- fails 3/3 on master, passes 20/20 with the fix
- runs in ~0.06s

On master the corruption surfaces as the `assert meta["size"] == len(data)` in `check_fix_size()`. Note that with `python -O` that assert is gone and the corruption is silent - which is what the sha256-compared extract runs in #10032 showed.

Also checked:

- `compress_test.py`, `repoobj_test.py`, `helpers/`, create/extract archiver tests: 603 passed, 6 skipped
- real `borg create -C lz4` / `borg extract` of a 60MiB tree over `aes256-ocb`: byte-identical

No other module-level mutable state in `compress.pyx` is a hazard: zstd/zlib/lzma allocate per call, `_zstd_mt_workers` is an idempotent lazy cache, and `ObfuscateSize`'s `random` use is compress-only. Nothing outside `compress.pyx` referenced the removed `buffer` global.