### PR TITLE
benchmark cpu: throughput column, buffer sizes, section selection

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -201,6 +201,9 @@ New features:
 - repo-compress: was temporarily gone, re-added now with pack support, #9663
 - version: add --json output, #10004
 - benchmark cpu: add a throughput column (MB/s), #10049
+- benchmark cpu: measure hashes and compressors at several buffer sizes, and
+  add --chunking / --hashing / --encryption / --compression / --msgpack to run
+  only a subset, #10050
 - completion: generate fish completions, remove hand-written ones, #9989
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -204,6 +204,7 @@ New features:
 - benchmark cpu: measure hashes and compressors at several buffer sizes, and
   add --chunking / --hashing / --encryption / --compression / --msgpack to run
   only a subset, #10050
+- benchmark cpu: compress deterministic compressible data instead of random noise
 - completion: generate fish completions, remove hand-written ones, #9989
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -205,6 +205,8 @@ New features:
   add --chunking / --hashing / --encryption / --compression / --msgpack to run
   only a subset, #10050
 - benchmark cpu: compress deterministic compressible data instead of random noise
+- benchmark cpu: measure blake3 the way borg uses it (multi-threaded only above
+  BORG_BLAKE3_MT_THRESHOLD)
 - completion: generate fish completions, remove hand-written ones, #9989
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -202,8 +202,8 @@ New features:
 - version: add --json output, #10004
 - benchmark cpu: add a throughput column (MB/s), #10049
 - benchmark cpu: measure hashes and compressors at several buffer sizes, and
-  add --chunking / --hashing / --encryption / --compression / --msgpack to run
-  only a subset, #10050
+  add --chunking / --hashing / --encrypting / --compressing / --msgpacking to
+  run only a subset, #10050
 - benchmark cpu: compress deterministic compressible data instead of random noise
 - benchmark cpu: measure blake3 the way borg uses it (multi-threaded only above
   BORG_BLAKE3_MT_THRESHOLD)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -200,6 +200,7 @@ New features:
 - analyze: report deduplicated size of a set of archives, #5741
 - repo-compress: was temporarily gone, re-added now with pack support, #9663
 - version: add --json output, #10004
+- benchmark cpu: add a throughput column (MB/s), #10049
 - completion: generate fish completions, remove hand-written ones, #9989
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -308,7 +308,14 @@ class BenchmarkMixIn:
 
         if "hashing" in selected:
             from ..crypto.low_level import hmac_sha256, blake2b_256
+            from ..crypto.key import get_blake3_mt_threshold
             import blake3
+
+            def blake3_hash(d):
+                # mirror what borg does per chunk (see AESKeyBase.id_hash): below the
+                # threshold multi-threading costs more than it gains, so it is not used
+                max_threads = blake3.blake3.AUTO if len(d) >= get_blake3_mt_threshold() else 1
+                return blake3.blake3(d, key=key_256, max_threads=max_threads).digest()
 
             section_header("hashes", "Cryptographic hashes / MACs")
             # only blake3 uses multiple threads, and only above a size threshold,
@@ -316,12 +323,7 @@ class BenchmarkMixIn:
             hashes_tests = [
                 ("hmac-sha256", one_size, lambda d: hmac_sha256(key_256, d)),
                 ("blake2b-256", one_size, lambda d: blake2b_256(key_256, d)),
-                ("blake3", hash_sizes, lambda d: blake3.blake3(d, key=key_256).digest()),
-                (
-                    "blake3-mt",
-                    hash_sizes,
-                    lambda d: blake3.blake3(d, key=key_256, max_threads=blake3.blake3.AUTO).digest(),
-                ),
+                ("blake3", hash_sizes, blake3_hash),
             ]
             for spec, sizes, func in hashes_tests:
                 for label, nbytes in sizes:

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -7,6 +7,7 @@ import time
 
 from ..constants import *  # NOQA
 from ..helpers import format_file_size, CompressionSpec
+from ..helpers import sizeof_fmt_iec
 from ..helpers import FilesystemDirSpec
 from ..helpers import json_print
 from ..helpers import msgpack
@@ -161,17 +162,21 @@ class BenchmarkMixIn:
         if not selected:
             selected = set(sections)
 
+        KIB, MIB, GIB = 1024, 1024 * 1024, 1024 * 1024 * 1024
+
         is_test = "_BORG_BENCHMARK_CPU_TEST" in os.environ
         # Use minimal data and one iteration in test mode to keep CI fast.
-        number_default = 1 if is_test else 100
-        chunk_data_size = 100 * 1000 if is_test else 10 * 1000 * 1000
+        chunk_data_size = 128 * KIB if is_test else 8 * MIB
+        number_default = 1 if is_test else GIB // chunk_data_size
 
         # Buffer sizes matter where an algorithm switches to multiple threads:
         # blake3 and zstd do so above a threshold, so a size below it, one the
         # size of a typical borg chunk and one the size of a borg pack behave
-        # quite differently. Each row processes about as many bytes in total,
-        # so the throughput column stays comparable across sizes.
-        SMALL, CHUNK, PACK = ("100kiB", 100 * 1024), ("2MiB", 2 * 1024 * 1024), ("50MiB", 50 * 1024 * 1024)
+        # quite differently. Every row processes the same total either way, so
+        # the throughput column stays comparable across sizes.
+        # powers of two, so every row processes exactly 1 GiB (or 10 MiB for the
+        # compressors) rather than an awkward fraction of it
+        SMALL, CHUNK, PACK = ("128kiB", 128 * KIB), ("2MiB", 2 * MIB), ("64MiB", 64 * MIB)
         if is_test:
             hash_sizes = comp_sizes = one_size = [SMALL]
             hash_total = comp_total = SMALL[1]
@@ -179,10 +184,10 @@ class BenchmarkMixIn:
             hash_sizes = [SMALL, CHUNK, PACK]
             comp_sizes = [SMALL, CHUNK]
             one_size = [CHUNK]  # for algorithms where the buffer size does not change behaviour
-            hash_total = 1000 * 1000 * 1000
+            hash_total = GIB
             # compressible data means the codecs actually work, so the slow ones
             # (lzma, high zstd levels) need fewer bytes to stay bearable
-            comp_total = 10 * 1000 * 1000
+            comp_total = 10 * MIB
 
         buffers = {}
 
@@ -225,6 +230,16 @@ class BenchmarkMixIn:
                 compressible[nbytes] = bytes(out[:nbytes])
             return compressible[nbytes]
 
+        def data_size_str(size):
+            """The benchmark's own data volumes, always in IEC units.
+
+            These are fixed constants of the benchmark rather than user data, so
+            they do not follow BORG_UNITS - that would make two people's output
+            incomparable and would render binary sizes as awkward decimals
+            (1 GiB as "1.07 GB").
+            """
+            return sizeof_fmt_iec(size, suffix="B", sep=" ", precision=2)
+
         def throughput(size, dt):
             """Rate as MB/s, always - so numbers stay comparable between rows."""
             return f"{size / dt / 1e6:>8.1f} MB/s"
@@ -233,7 +248,7 @@ class BenchmarkMixIn:
             if args.json:
                 result[section].append({"size": size, "time": dt, **extra})
             else:
-                print(f"{spec:<{width}} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
+                print(f"{spec:<{width}} {data_size_str(size):<11} {dt:.3f}s  {throughput(size, dt)}")
 
         def section_header(section, title):
             if args.json:

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -164,18 +164,23 @@ class BenchmarkMixIn:
 
         KIB, MIB, GIB = 1024, 1024 * 1024, 1024 * 1024 * 1024
 
+        # width of the spec column, wide enough for the longest row of any section, so
+        # that all sections line up with each other
+        WIDTH = 26
+
         is_test = "_BORG_BENCHMARK_CPU_TEST" in os.environ
         # Use minimal data and one iteration in test mode to keep CI fast.
         chunk_data_size = 128 * KIB if is_test else 8 * MIB
         number_default = 1 if is_test else GIB // chunk_data_size
 
         # Buffer sizes matter where an algorithm switches to multiple threads:
-        # blake3 and zstd do so above a threshold, so a size below it, one the
-        # size of a typical borg chunk and one the size of a borg pack behave
-        # quite differently. Every row processes the same total either way, so
-        # the throughput column stays comparable across sizes.
-        # powers of two, so every row processes exactly 1 GiB (or 10 MiB for the
-        # compressors) rather than an awkward fraction of it
+        # blake3 and zstd do so above a threshold, so a buffer below it and one
+        # above it behave quite differently. The hashes are measured at pack and
+        # chunk size (both above blake3's threshold), the compressors at chunk
+        # size and below zstd's threshold. Within a section every row processes
+        # the same total, so the throughput column stays comparable across sizes.
+        # All powers of two, so that total is exactly 1 GiB (or 10 MiB for the
+        # compressors) rather than an awkward fraction of it.
         SMALL, CHUNK, PACK = ("128kiB", 128 * KIB), ("2MiB", 2 * MIB), ("64MiB", 64 * MIB)
         if is_test:
             hash_sizes = comp_sizes = one_size = [SMALL]
@@ -245,11 +250,11 @@ class BenchmarkMixIn:
             """Rate as MB/s, always - so numbers stay comparable between rows."""
             return f"{size / dt / 1e6:>8.1f} MB/s"
 
-        def report(section, spec, size, dt, width, **extra):
+        def report(section, spec, size, dt, **extra):
             if args.json:
                 result[section].append({"size": size, "time": dt, **extra})
             else:
-                print(f"{spec:<{width}} {data_size_str(size):<11} {dt:.3f}s  {throughput(size, dt)}")
+                print(f"{spec:<{WIDTH}} {data_size_str(size):<11} {dt:.3f}s  {throughput(size, dt)}")
 
         def section_header(section, title):
             if args.json:
@@ -320,7 +325,7 @@ class BenchmarkMixIn:
             ]:
                 dt = timeit(func, setup, number=number_default, globals=vars)
                 algo, _, algo_params = spec.partition(",")
-                report("chunkers", spec, size, dt, 26, algo=algo, algo_params=algo_params)
+                report("chunkers", spec, size, dt, algo=algo, algo_params=algo_params)
 
         if "hashing" in selected:
             from ..crypto.low_level import hmac_sha256, blake2b_256
@@ -346,7 +351,7 @@ class BenchmarkMixIn:
                     data = buffer(nbytes)
                     number = max(1, hash_total // nbytes)
                     dt = timeit(lambda: func(data), number=number)
-                    report("hashes", f"{spec} ({label})", nbytes * number, dt, 26, algo=spec, buffer_size=nbytes)
+                    report("hashes", f"{spec} ({label})", nbytes * number, dt, algo=spec, buffer_size=nbytes)
 
         if "encryption" in selected:
             from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
@@ -382,7 +387,7 @@ class BenchmarkMixIn:
             ]
             for spec, func in tests:
                 dt = timeit(func, number=number_default)
-                report("encryption", spec, size, dt, 26, algo=spec)
+                report("encryption", spec, size, dt, algo=spec)
 
         if "compression" in selected:
             section_header("compression", "Compression")
@@ -415,7 +420,6 @@ class BenchmarkMixIn:
                         f"{spec} ({label})",
                         nbytes * number,
                         dt,
-                        20,
                         algo=algo,
                         algo_params=algo_params,
                         buffer_size=nbytes,
@@ -433,7 +437,7 @@ class BenchmarkMixIn:
             else:
                 # this one packs items, not bytes, so it gets a rate in its own unit
                 size = "%dk Items" % (count // 1000)
-                print(f"{spec:<20} {size:<10} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
+                print(f"{spec:<{WIDTH}} {size:<11} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
 
         if args.json:
             json_print(result)
@@ -517,10 +521,17 @@ class BenchmarkMixIn:
         --encryption, --compression, --msgpack to run only those.
 
         Some algorithms use multiple threads only above a size threshold, so the
-        hashes and compressors are measured at several buffer sizes: 100kiB (below
-        the threshold), 2MiB (a typical borg chunk) and, for hashes, 50MiB (a borg
-        pack). Every row processes roughly the same total number of bytes, so the
-        throughput column is comparable between them.
+        hashes and the compressors are measured at more than one buffer size: the
+        hashes at 64MiB (a borg pack) and 2MiB (a typical borg chunk), both above
+        blake3's threshold, the compressors at 2MiB and 128kiB, which is below
+        zstd's. Within a section every row processes the same total number of
+        bytes - 1 GiB, or 10 MiB for the compressors - so the throughput column is
+        comparable between rows.
+
+        The compressors work on synthetic text-like data that compresses about 4x
+        at zstd,3. Random data would be the worst possible input: no codec can
+        compress it, so all of them would take their incompressible fast path and
+        the levels would barely differ.
         """
         )
         subparser = ArgumentParser(

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -181,7 +181,8 @@ class BenchmarkMixIn:
             hash_sizes = comp_sizes = one_size = [SMALL]
             hash_total = comp_total = SMALL[1]
         else:
-            hash_sizes = [SMALL, CHUNK, PACK]
+            # blake3: a borg pack, then a borg chunk - both above its MT threshold
+            hash_sizes = [PACK, CHUNK]
             comp_sizes = [SMALL, CHUNK]
             one_size = [CHUNK]  # for algorithms where the buffer size does not change behaviour
             hash_total = GIB
@@ -334,11 +335,11 @@ class BenchmarkMixIn:
 
             section_header("hashes", "Cryptographic hashes / MACs")
             # only blake3 uses multiple threads, and only above a size threshold,
-            # so it is the one worth measuring at several buffer sizes.
+            # so it is the one worth measuring at more than one buffer size.
             hashes_tests = [
+                ("blake3", hash_sizes, blake3_hash),
                 ("hmac-sha256", one_size, lambda d: hmac_sha256(key_256, d)),
                 ("blake2b-256", one_size, lambda d: blake2b_256(key_256, d)),
-                ("blake3", hash_sizes, blake3_hash),
             ]
             for spec, sizes, func in hashes_tests:
                 for label, nbytes in sizes:

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -385,10 +385,6 @@ class BenchmarkMixIn:
 
         if "compression" in selected:
             section_header("compression", "Compression")
-            if not args.json:
-                sample = compressible_buffer(comp_sizes[-1][1])
-                ratio = len(sample) / len(CompressionSpec("zstd,3").compressor.compress({}, sample)[1])
-                print(f"(test data is compressible, {ratio:.1f}x at zstd,3)")
             # grouped by buffer size rather than by codec, so the codecs can be
             # compared against each other at a glance; chunk-sized first, as
             # that is what borg actually compresses
@@ -403,7 +399,7 @@ class BenchmarkMixIn:
                     "zstd,10",
                     "zstd,16",
                     "zstd,22",
-                    "zlib,0",
+                    "zlib,1",
                     "zlib,6",
                     "zlib,9",
                     "lzma,0",

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -157,7 +157,7 @@ class BenchmarkMixIn:
         result = {} if args.json else None
 
         # no section selected means: run them all
-        sections = ("chunking", "hashing", "encryption", "compression", "msgpack")
+        sections = ("chunking", "hashing", "encrypting", "compressing", "msgpacking")
         selected = {name for name in sections if getattr(args, name)}
         if not selected:
             selected = set(sections)
@@ -353,7 +353,7 @@ class BenchmarkMixIn:
                     dt = timeit(lambda: func(data), number=number)
                     report("hashes", f"{spec} ({label})", nbytes * number, dt, algo=spec, buffer_size=nbytes)
 
-        if "encryption" in selected:
+        if "encrypting" in selected:
             from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
             from ..crypto.low_level import AES256_OCB, CHACHA20_POLY1305
 
@@ -389,7 +389,7 @@ class BenchmarkMixIn:
                 dt = timeit(func, number=number_default)
                 report("encryption", spec, size, dt, algo=spec)
 
-        if "compression" in selected:
+        if "compressing" in selected:
             section_header("compression", "Compression")
             # grouped by buffer size rather than by codec, so the codecs can be
             # compared against each other at a glance; chunk-sized first, as
@@ -425,7 +425,7 @@ class BenchmarkMixIn:
                         buffer_size=nbytes,
                     )
 
-        if "msgpack" in selected:
+        if "msgpacking" in selected:
             section_header("msgpack", "msgpack")
             item = Item(path="foo/bar/baz", mode=660, mtime=1234567)
             items = [item.as_dict()] * 1000
@@ -518,7 +518,7 @@ class BenchmarkMixIn:
         - enough free memory so there will be no slow down due to paging activity
 
         By default all benchmarks run. Give one or more of --chunking, --hashing,
-        --encryption, --compression, --msgpack to run only those.
+        --encrypting, --compressing, --msgpacking to run only those.
 
         Some algorithms use multiple threads only above a size threshold, so the
         hashes and the compressors are measured at more than one buffer size: the
@@ -541,6 +541,6 @@ class BenchmarkMixIn:
         subparser.add_argument("--json", action="store_true", help="format output as JSON")
         subparser.add_argument("--chunking", action="store_true", help="benchmark the chunkers")
         subparser.add_argument("--hashing", action="store_true", help="benchmark the hashes / MACs")
-        subparser.add_argument("--encryption", action="store_true", help="benchmark the encryption modes")
-        subparser.add_argument("--compression", action="store_true", help="benchmark the compressors")
-        subparser.add_argument("--msgpack", action="store_true", help="benchmark msgpack item packing")
+        subparser.add_argument("--encrypting", action="store_true", help="benchmark the encryption modes")
+        subparser.add_argument("--compressing", action="store_true", help="benchmark the compressors")
+        subparser.add_argument("--msgpacking", action="store_true", help="benchmark msgpack item packing")

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -153,187 +153,229 @@ class BenchmarkMixIn:
         """Benchmark CPU-bound operations."""
         from timeit import timeit
 
+        result = {} if args.json else None
+
+        # no section selected means: run them all
+        sections = ("chunking", "hashing", "encryption", "compression", "msgpack")
+        selected = {name for name in sections if getattr(args, name)}
+        if not selected:
+            selected = set(sections)
+
+        is_test = "_BORG_BENCHMARK_CPU_TEST" in os.environ
+        # Use minimal data and one iteration in test mode to keep CI fast.
+        number_default = 1 if is_test else 100
+        chunk_data_size = 100 * 1000 if is_test else 10 * 1000 * 1000
+
+        # Buffer sizes matter where an algorithm switches to multiple threads:
+        # blake3 and zstd do so above a threshold, so a size below it, one the
+        # size of a typical borg chunk and one the size of a borg pack behave
+        # quite differently. Each row processes about as many bytes in total,
+        # so the throughput column stays comparable across sizes.
+        SMALL, CHUNK, PACK = ("100kiB", 100 * 1024), ("2MiB", 2 * 1024 * 1024), ("50MiB", 50 * 1024 * 1024)
+        if is_test:
+            hash_sizes = comp_sizes = one_size = [SMALL]
+            hash_total = comp_total = SMALL[1]
+        else:
+            hash_sizes = [SMALL, CHUNK, PACK]
+            comp_sizes = [SMALL, CHUNK]
+            one_size = [CHUNK]  # for algorithms where the buffer size does not change behaviour
+            hash_total = 1000 * 1000 * 1000
+            comp_total = 50 * 1000 * 1000
+
+        buffers = {}
+
+        def buffer(nbytes):
+            """Random data of the given size, made once and reused."""
+            if nbytes not in buffers:
+                buffers[nbytes] = os.urandom(nbytes)
+            return buffers[nbytes]
+
         def throughput(size, dt):
             """Rate as MB/s, always - so numbers stay comparable between rows."""
             return f"{size / dt / 1e6:>8.1f} MB/s"
 
-        result = {} if args.json else None
+        def report(section, spec, size, dt, width, **extra):
+            if args.json:
+                result[section].append({"size": size, "time": dt, **extra})
+            else:
+                print(f"{spec:<{width}} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
 
-        is_test = "_BORG_BENCHMARK_CPU_TEST" in os.environ
-        # Use minimal iterations and data size in test mode to keep CI fast.
-        number_default = 1 if is_test else 100
-        number_compression = 1 if is_test else 10
-        data_size = 100 * 1000 if is_test else 10 * 1000 * 1000
+        def section_header(section, title):
+            if args.json:
+                result[section] = []
+            else:
+                print(f"{title} ".ljust(64, "="))
 
-        random_10M = os.urandom(data_size)
+        random_10M = buffer(chunk_data_size)
         key_256 = os.urandom(32)
         key_128 = os.urandom(16)
         key_96 = os.urandom(12)
 
-        import io
-        from ..chunkers import get_chunker, release_chunk_data  # noqa
+        if "chunking" in selected:
+            import io
+            from ..chunkers import get_chunker, release_chunk_data  # noqa
 
-        if not args.json:
-            print("Chunkers =======================================================")
-        else:
-            result["chunkers"] = []
-        size = data_size * number_default
+            section_header("chunkers", "Chunkers")
+            size = chunk_data_size * number_default
 
-        def chunkit(ch):
-            with io.BytesIO(random_10M) as data_file:
-                for chunk in ch.chunkify(fd=data_file):
-                    release_chunk_data(chunk.data)
+            def chunkit(ch):
+                with io.BytesIO(random_10M) as data_file:
+                    for chunk in ch.chunkify(fd=data_file):
+                        release_chunk_data(chunk.data)
 
-        for spec, setup, func, vars in [
-            ("fixed,1048576", "ch = get_chunker('fixed', 1048576, sparse=False)", "chunkit(ch)", locals()),
-            # fastcdc (window-less keyed gear hash); gear table creation is slow, keep it in setup
-            ("fastcdc,19,23,21,2", "ch = get_chunker('fastcdc', 19, 23, 21, 2, sparse=False)", "chunkit(ch)", locals()),
-            # note: the buzhash64 chunker creation is rather slow, so we must keep it in setup
-            (
-                "buzhash64,19,23,21,4095,2",
-                "ch = get_chunker('buzhash64', 19, 23, 21, 4095, 2, sparse=False)",
-                "chunkit(ch)",
-                locals(),
-            ),
-            (
-                "buzhash,19,23,21,4095",
-                "ch = get_chunker('buzhash', 19, 23, 21, 4095, sparse=False)",
-                "chunkit(ch)",
-                locals(),
-            ),
-            # toeplitz-aes (UHF-then-PRF, tabulated Toeplitz hash); table creation in setup
-            (
-                "toeplitz-aes,19,23,21,2",
-                "ch = get_chunker('toeplitz-aes', 19, 23, 21, 2, sparse=False)",
-                "chunkit(ch)",
-                locals(),
-            ),
-            # rabin-aes (UHF-then-PRF); polynomial sampling / table creation is slow, keep it in setup
-            (
-                "rabin-aes,19,23,21,2",
-                "ch = get_chunker('rabin-aes', 19, 23, 21, 2, sparse=False)",
-                "chunkit(ch)",
-                locals(),
-            ),
-            # goldilocks-aes (UHF-then-PRF, prime-field comparison chunker); table creation in setup
-            (
-                "goldilocks-aes,19,23,21,2",
-                "ch = get_chunker('goldilocks-aes', 19, 23, 21, 2, sparse=False)",
-                "chunkit(ch)",
-                locals(),
-            ),
-        ]:
-            dt = timeit(func, setup, number=number_default, globals=vars)
-            if args.json:
+            for spec, setup, func, vars in [
+                ("fixed,1048576", "ch = get_chunker('fixed', 1048576, sparse=False)", "chunkit(ch)", locals()),
+                # fastcdc (window-less keyed gear hash); gear table creation is slow, keep it in setup
+                (
+                    "fastcdc,19,23,21,2",
+                    "ch = get_chunker('fastcdc', 19, 23, 21, 2, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+                # note: the buzhash64 chunker creation is rather slow, so we must keep it in setup
+                (
+                    "buzhash64,19,23,21,4095,2",
+                    "ch = get_chunker('buzhash64', 19, 23, 21, 4095, 2, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+                (
+                    "buzhash,19,23,21,4095",
+                    "ch = get_chunker('buzhash', 19, 23, 21, 4095, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+                # toeplitz-aes (UHF-then-PRF, tabulated Toeplitz hash); table creation in setup
+                (
+                    "toeplitz-aes,19,23,21,2",
+                    "ch = get_chunker('toeplitz-aes', 19, 23, 21, 2, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+                # rabin-aes (UHF-then-PRF); polynomial sampling / table creation is slow, keep it in setup
+                (
+                    "rabin-aes,19,23,21,2",
+                    "ch = get_chunker('rabin-aes', 19, 23, 21, 2, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+                # goldilocks-aes (UHF-then-PRF, prime-field comparison chunker); table creation in setup
+                (
+                    "goldilocks-aes,19,23,21,2",
+                    "ch = get_chunker('goldilocks-aes', 19, 23, 21, 2, sparse=False)",
+                    "chunkit(ch)",
+                    locals(),
+                ),
+            ]:
+                dt = timeit(func, setup, number=number_default, globals=vars)
                 algo, _, algo_params = spec.partition(",")
-                result["chunkers"].append({"algo": algo, "algo_params": algo_params, "size": size, "time": dt})
-            else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
+                report("chunkers", spec, size, dt, 26, algo=algo, algo_params=algo_params)
 
-        from ..crypto.low_level import hmac_sha256, blake2b_256
-        import blake3
+        if "hashing" in selected:
+            from ..crypto.low_level import hmac_sha256, blake2b_256
+            import blake3
 
-        if not args.json:
-            print("Cryptographic hashes / MACs ====================================")
-        else:
-            result["hashes"] = []
-        size = data_size * number_default
-        hashes_tests = [
-            ("hmac-sha256", lambda: hmac_sha256(key_256, random_10M)),
-            ("blake2b-256", lambda: blake2b_256(key_256, random_10M)),
-            ("blake3", lambda: blake3.blake3(random_10M, key=key_256).digest()),
-            ("blake3-mt", lambda: blake3.blake3(random_10M, key=key_256, max_threads=blake3.blake3.AUTO).digest()),
-        ]
-        for spec, func in hashes_tests:
-            dt = timeit(func, number=number_default)
-            if args.json:
-                result["hashes"].append({"algo": spec, "size": size, "time": dt})
-            else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
-
-        from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
-        from ..crypto.low_level import AES256_OCB, CHACHA20_POLY1305
-
-        if not args.json:
-            print("Encryption =====================================================")
-        else:
-            result["encryption"] = []
-        size = data_size * number_default
-
-        tests = [
-            (
-                "aes-256-ctr-hmac-sha256",
-                lambda: AES256_CTR_HMAC_SHA256(key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
-                    random_10M, header=b"X"
+            section_header("hashes", "Cryptographic hashes / MACs")
+            # only blake3 uses multiple threads, and only above a size threshold,
+            # so it is the one worth measuring at several buffer sizes.
+            hashes_tests = [
+                ("hmac-sha256", one_size, lambda d: hmac_sha256(key_256, d)),
+                ("blake2b-256", one_size, lambda d: blake2b_256(key_256, d)),
+                ("blake3", hash_sizes, lambda d: blake3.blake3(d, key=key_256).digest()),
+                (
+                    "blake3-mt",
+                    hash_sizes,
+                    lambda d: blake3.blake3(d, key=key_256, max_threads=blake3.blake3.AUTO).digest(),
                 ),
-            ),
-            (
-                "aes-256-ctr-blake2b",
-                lambda: AES256_CTR_BLAKE2b(key_256 * 4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
-                    random_10M, header=b"X"
-                ),
-            ),
-            (
-                "aes-256-ocb",
-                lambda: AES256_OCB(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b"X"),
-            ),
-            (
-                "chacha20-poly1305",
-                lambda: CHACHA20_POLY1305(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(
-                    random_10M, header=b"X"
-                ),
-            ),
-        ]
-        for spec, func in tests:
-            dt = timeit(func, number=number_default)
-            if args.json:
-                result["encryption"].append({"algo": spec, "size": size, "time": dt})
-            else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
+            ]
+            for spec, sizes, func in hashes_tests:
+                for label, nbytes in sizes:
+                    data = buffer(nbytes)
+                    number = max(1, hash_total // nbytes)
+                    dt = timeit(lambda: func(data), number=number)
+                    report("hashes", f"{spec} ({label})", nbytes * number, dt, 26, algo=spec, buffer_size=nbytes)
 
-        if not args.json:
-            print("Compression ====================================================")
-        else:
-            result["compression"] = []
-        for spec in [
-            "lz4",
-            "zstd,1",
-            "zstd,3",
-            "zstd,5",
-            "zstd,10",
-            "zstd,16",
-            "zstd,22",
-            "zlib,0",
-            "zlib,6",
-            "zlib,9",
-            "lzma,0",
-            "lzma,6",
-            "lzma,9",
-        ]:
-            compressor = CompressionSpec(spec).compressor
-            size = data_size * number_compression
-            dt = timeit(lambda: compressor.compress({}, random_10M), number=number_compression)
-            if args.json:
-                algo, _, algo_params = spec.partition(",")
-                result["compression"].append({"algo": algo, "algo_params": algo_params, "size": size, "time": dt})
-            else:
-                print(f"{spec:<12} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
+        if "encryption" in selected:
+            from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
+            from ..crypto.low_level import AES256_OCB, CHACHA20_POLY1305
 
-        if not args.json:
-            print("msgpack ========================================================")
-        else:
-            result["msgpack"] = []
-        item = Item(path="foo/bar/baz", mode=660, mtime=1234567)
-        items = [item.as_dict()] * 1000
-        count = 1000 * number_default
-        size = "%dk Items" % (count // 1000)
-        spec = "msgpack"
-        dt = timeit(lambda: msgpack.packb(items), number=number_default)
-        if args.json:
-            result["msgpack"].append({"algo": spec, "count": count, "time": dt})
-        else:
-            # this one packs items, not bytes, so it gets a rate in its own unit
-            print(f"{spec:<12} {size:<10} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
+            section_header("encryption", "Encryption")
+            size = chunk_data_size * number_default
+            tests = [
+                (
+                    "aes-256-ctr-hmac-sha256",
+                    lambda: AES256_CTR_HMAC_SHA256(key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
+                        random_10M, header=b"X"
+                    ),
+                ),
+                (
+                    "aes-256-ctr-blake2b",
+                    lambda: AES256_CTR_BLAKE2b(key_256 * 4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
+                        random_10M, header=b"X"
+                    ),
+                ),
+                (
+                    "aes-256-ocb",
+                    lambda: AES256_OCB(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b"X"),
+                ),
+                (
+                    "chacha20-poly1305",
+                    lambda: CHACHA20_POLY1305(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(
+                        random_10M, header=b"X"
+                    ),
+                ),
+            ]
+            for spec, func in tests:
+                dt = timeit(func, number=number_default)
+                report("encryption", spec, size, dt, 26, algo=spec)
+
+        if "compression" in selected:
+            section_header("compression", "Compression")
+            for spec in [
+                "lz4",
+                "zstd,1",
+                "zstd,3",
+                "zstd,5",
+                "zstd,10",
+                "zstd,16",
+                "zstd,22",
+                "zlib,0",
+                "zlib,6",
+                "zlib,9",
+                "lzma,0",
+                "lzma,6",
+                "lzma,9",
+            ]:
+                compressor = CompressionSpec(spec).compressor
+                for label, nbytes in comp_sizes:
+                    data = buffer(nbytes)
+                    number = max(1, comp_total // nbytes)
+                    dt = timeit(lambda: compressor.compress({}, data), number=number)
+                    algo, _, algo_params = spec.partition(",")
+                    report(
+                        "compression",
+                        f"{spec} ({label})",
+                        nbytes * number,
+                        dt,
+                        20,
+                        algo=algo,
+                        algo_params=algo_params,
+                        buffer_size=nbytes,
+                    )
+
+        if "msgpack" in selected:
+            section_header("msgpack", "msgpack")
+            item = Item(path="foo/bar/baz", mode=660, mtime=1234567)
+            items = [item.as_dict()] * 1000
+            count = 1000 * number_default
+            spec = "msgpack"
+            dt = timeit(lambda: msgpack.packb(items), number=number_default)
+            if args.json:
+                result["msgpack"].append({"algo": spec, "count": count, "time": dt})
+            else:
+                # this one packs items, not bytes, so it gets a rate in its own unit
+                size = "%dk Items" % (count // 1000)
+                print(f"{spec:<20} {size:<10} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
 
         if args.json:
             json_print(result)
@@ -412,6 +454,15 @@ class BenchmarkMixIn:
 
         - an otherwise as idle as possible machine
         - enough free memory so there will be no slow down due to paging activity
+
+        By default all benchmarks run. Give one or more of --chunking, --hashing,
+        --encryption, --compression, --msgpack to run only those.
+
+        Some algorithms use multiple threads only above a size threshold, so the
+        hashes and compressors are measured at several buffer sizes: 100kiB (below
+        the threshold), 2MiB (a typical borg chunk) and, for hashes, 50MiB (a borg
+        pack). Every row processes roughly the same total number of bytes, so the
+        throughput column is comparable between them.
         """
         )
         subparser = ArgumentParser(
@@ -419,3 +470,8 @@ class BenchmarkMixIn:
         )
         benchmark_parsers.add_subcommand("cpu", subparser, help="benchmarks Borg CPU-bound operations.")
         subparser.add_argument("--json", action="store_true", help="format output as JSON")
+        subparser.add_argument("--chunking", action="store_true", help="benchmark the chunkers")
+        subparser.add_argument("--hashing", action="store_true", help="benchmark the hashes / MACs")
+        subparser.add_argument("--encryption", action="store_true", help="benchmark the encryption modes")
+        subparser.add_argument("--compression", action="store_true", help="benchmark the compressors")
+        subparser.add_argument("--msgpack", action="store_true", help="benchmark msgpack item packing")

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -180,7 +180,9 @@ class BenchmarkMixIn:
             comp_sizes = [SMALL, CHUNK]
             one_size = [CHUNK]  # for algorithms where the buffer size does not change behaviour
             hash_total = 1000 * 1000 * 1000
-            comp_total = 50 * 1000 * 1000
+            # compressible data means the codecs actually work, so the slow ones
+            # (lzma, high zstd levels) need fewer bytes to stay bearable
+            comp_total = 10 * 1000 * 1000
 
         buffers = {}
 
@@ -189,6 +191,39 @@ class BenchmarkMixIn:
             if nbytes not in buffers:
                 buffers[nbytes] = os.urandom(nbytes)
             return buffers[nbytes]
+
+        compressible = {}
+
+        def compressible_buffer(nbytes):
+            """Deterministic, text-like, compressible data of the given size.
+
+            Random bytes are the worst possible input for a compression benchmark:
+            nothing compresses, so every codec takes its incompressible fast path,
+            the levels barely differ, and zstd's multi-threading looks like a large
+            loss when on real data it is a 1.7 .. 3x win. This is a word soup built
+            from a fixed seed - identical on every machine and every run, so numbers
+            stay comparable - which compresses about 4x at zstd,3.
+
+            The xorshift is written out rather than using random.Random so that the
+            bytes do not depend on the Python version's PRNG internals.
+            """
+            if nbytes not in compressible:
+                words = (
+                    b"backup archive chunk repository compress encrypt index cache manifest "
+                    b"the and of a to in is it for with data borg file path size key id hash "
+                    b"item repo object segment directory user group mtime mode owner content"
+                ).split()
+                out = bytearray()
+                state = 0x2545F4914F6CDD1D
+                mask = 0xFFFFFFFFFFFFFFFF
+                while len(out) < nbytes:
+                    state ^= (state << 13) & mask
+                    state ^= state >> 7
+                    state ^= (state << 17) & mask
+                    out += words[state % len(words)]
+                    out += b"\n" if state & 0xF == 0 else b" "
+                compressible[nbytes] = bytes(out[:nbytes])
+            return compressible[nbytes]
 
         def throughput(size, dt):
             """Rate as MB/s, always - so numbers stay comparable between rows."""
@@ -331,6 +366,10 @@ class BenchmarkMixIn:
 
         if "compression" in selected:
             section_header("compression", "Compression")
+            if not args.json:
+                sample = compressible_buffer(comp_sizes[-1][1])
+                ratio = len(sample) / len(CompressionSpec("zstd,3").compressor.compress({}, sample)[1])
+                print(f"(test data is compressible, {ratio:.1f}x at zstd,3)")
             for spec in [
                 "lz4",
                 "zstd,1",
@@ -348,8 +387,8 @@ class BenchmarkMixIn:
             ]:
                 compressor = CompressionSpec(spec).compressor
                 for label, nbytes in comp_sizes:
-                    data = buffer(nbytes)
-                    number = max(1, comp_total // nbytes)
+                    data = compressible_buffer(nbytes)
+                    number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
                     dt = timeit(lambda: compressor.compress({}, data), number=number)
                     algo, _, algo_params = spec.partition(",")
                     report(

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -353,7 +353,19 @@ class BenchmarkMixIn:
 
             section_header("encryption", "Encryption")
             size = chunk_data_size * number_default
+            # AEAD modes first (what borg uses by default), then the legacy
+            # encrypt-then-MAC ones
             tests = [
+                (
+                    "aes-256-ocb",
+                    lambda: AES256_OCB(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b"X"),
+                ),
+                (
+                    "chacha20-poly1305",
+                    lambda: CHACHA20_POLY1305(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(
+                        random_10M, header=b"X"
+                    ),
+                ),
                 (
                     "aes-256-ctr-hmac-sha256",
                     lambda: AES256_CTR_HMAC_SHA256(key_256, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
@@ -363,16 +375,6 @@ class BenchmarkMixIn:
                 (
                     "aes-256-ctr-blake2b",
                     lambda: AES256_CTR_BLAKE2b(key_256 * 4, key_256, iv=key_128, header_len=1, aad_offset=1).encrypt(
-                        random_10M, header=b"X"
-                    ),
-                ),
-                (
-                    "aes-256-ocb",
-                    lambda: AES256_OCB(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(random_10M, header=b"X"),
-                ),
-                (
-                    "chacha20-poly1305",
-                    lambda: CHACHA20_POLY1305(key_256, iv=key_96, header_len=1, aad_offset=1).encrypt(
                         random_10M, header=b"X"
                     ),
                 ),

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -389,25 +389,28 @@ class BenchmarkMixIn:
                 sample = compressible_buffer(comp_sizes[-1][1])
                 ratio = len(sample) / len(CompressionSpec("zstd,3").compressor.compress({}, sample)[1])
                 print(f"(test data is compressible, {ratio:.1f}x at zstd,3)")
-            for spec in [
-                "lz4",
-                "zstd,1",
-                "zstd,3",
-                "zstd,5",
-                "zstd,10",
-                "zstd,16",
-                "zstd,22",
-                "zlib,0",
-                "zlib,6",
-                "zlib,9",
-                "lzma,0",
-                "lzma,6",
-                "lzma,9",
-            ]:
-                compressor = CompressionSpec(spec).compressor
-                for label, nbytes in comp_sizes:
-                    data = compressible_buffer(nbytes)
-                    number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
+            # grouped by buffer size rather than by codec, so the codecs can be
+            # compared against each other at a glance; chunk-sized first, as
+            # that is what borg actually compresses
+            for label, nbytes in reversed(comp_sizes):
+                data = compressible_buffer(nbytes)
+                number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
+                for spec in [
+                    "lz4",
+                    "zstd,1",
+                    "zstd,3",
+                    "zstd,5",
+                    "zstd,10",
+                    "zstd,16",
+                    "zstd,22",
+                    "zlib,0",
+                    "zlib,6",
+                    "zlib,9",
+                    "lzma,0",
+                    "lzma,6",
+                    "lzma,9",
+                ]:
+                    compressor = CompressionSpec(spec).compressor
                     dt = timeit(lambda: compressor.compress({}, data), number=number)
                     algo, _, algo_params = spec.partition(",")
                     report(

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -153,6 +153,10 @@ class BenchmarkMixIn:
         """Benchmark CPU-bound operations."""
         from timeit import timeit
 
+        def throughput(size, dt):
+            """Rate as MB/s, always - so numbers stay comparable between rows."""
+            return f"{size / dt / 1e6:>8.1f} MB/s"
+
         result = {} if args.json else None
 
         is_test = "_BORG_BENCHMARK_CPU_TEST" in os.environ
@@ -173,7 +177,7 @@ class BenchmarkMixIn:
             print("Chunkers =======================================================")
         else:
             result["chunkers"] = []
-        size = 1000000000
+        size = data_size * number_default
 
         def chunkit(ch):
             with io.BytesIO(random_10M) as data_file:
@@ -224,7 +228,7 @@ class BenchmarkMixIn:
                 algo, _, algo_params = spec.partition(",")
                 result["chunkers"].append({"algo": algo, "algo_params": algo_params, "size": size, "time": dt})
             else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s")
+                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
 
         from ..crypto.low_level import hmac_sha256, blake2b_256
         import blake3
@@ -233,7 +237,7 @@ class BenchmarkMixIn:
             print("Cryptographic hashes / MACs ====================================")
         else:
             result["hashes"] = []
-        size = 1000000000
+        size = data_size * number_default
         hashes_tests = [
             ("hmac-sha256", lambda: hmac_sha256(key_256, random_10M)),
             ("blake2b-256", lambda: blake2b_256(key_256, random_10M)),
@@ -245,7 +249,7 @@ class BenchmarkMixIn:
             if args.json:
                 result["hashes"].append({"algo": spec, "size": size, "time": dt})
             else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s")
+                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
 
         from ..crypto.low_level import AES256_CTR_BLAKE2b, AES256_CTR_HMAC_SHA256
         from ..crypto.low_level import AES256_OCB, CHACHA20_POLY1305
@@ -254,7 +258,7 @@ class BenchmarkMixIn:
             print("Encryption =====================================================")
         else:
             result["encryption"] = []
-        size = 1000000000
+        size = data_size * number_default
 
         tests = [
             (
@@ -285,7 +289,7 @@ class BenchmarkMixIn:
             if args.json:
                 result["encryption"].append({"algo": spec, "size": size, "time": dt})
             else:
-                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s")
+                print(f"{spec:<26} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
 
         if not args.json:
             print("Compression ====================================================")
@@ -307,13 +311,13 @@ class BenchmarkMixIn:
             "lzma,9",
         ]:
             compressor = CompressionSpec(spec).compressor
-            size = 100000000
+            size = data_size * number_compression
             dt = timeit(lambda: compressor.compress({}, random_10M), number=number_compression)
             if args.json:
                 algo, _, algo_params = spec.partition(",")
                 result["compression"].append({"algo": algo, "algo_params": algo_params, "size": size, "time": dt})
             else:
-                print(f"{spec:<12} {format_file_size(size):<10} {dt:.3f}s")
+                print(f"{spec:<12} {format_file_size(size):<10} {dt:.3f}s  {throughput(size, dt)}")
 
         if not args.json:
             print("msgpack ========================================================")
@@ -321,13 +325,15 @@ class BenchmarkMixIn:
             result["msgpack"] = []
         item = Item(path="foo/bar/baz", mode=660, mtime=1234567)
         items = [item.as_dict()] * 1000
-        size = "100k Items"
+        count = 1000 * number_default
+        size = "%dk Items" % (count // 1000)
         spec = "msgpack"
         dt = timeit(lambda: msgpack.packb(items), number=number_default)
         if args.json:
-            result["msgpack"].append({"algo": spec, "count": 100000, "time": dt})
+            result["msgpack"].append({"algo": spec, "count": count, "time": dt})
         else:
-            print(f"{spec:<12} {size:<10} {dt:.3f}s")
+            # this one packs items, not bytes, so it gets a rate in its own unit
+            print(f"{spec:<12} {size:<10} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
 
         if args.json:
             json_print(result)

--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -63,9 +63,9 @@ def test_benchmark_cpu(archiver, monkeypatch):
     [
         ("--chunking", "Chunkers"),
         ("--hashing", "Cryptographic hashes / MACs"),
-        ("--encryption", "Encryption"),
-        ("--compression", "Compression"),
-        ("--msgpack", "msgpack"),
+        ("--encrypting", "Encryption"),
+        ("--compressing", "Compression"),
+        ("--msgpacking", "msgpack"),
     ],
 )
 def test_benchmark_cpu_section_selection(archiver, monkeypatch, flag, header):

--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from ...constants import *  # NOQA
 from . import cmd, RK_ENCRYPTION
 
@@ -54,6 +56,27 @@ def test_benchmark_cpu(archiver, monkeypatch):
     assert "Encryption" in output
     assert "Compression" in output
     assert "msgpack" in output
+
+
+@pytest.mark.parametrize(
+    "flag, header",
+    [
+        ("--chunking", "Chunkers"),
+        ("--hashing", "Cryptographic hashes / MACs"),
+        ("--encryption", "Encryption"),
+        ("--compression", "Compression"),
+        ("--msgpack", "msgpack"),
+    ],
+)
+def test_benchmark_cpu_section_selection(archiver, monkeypatch, flag, header):
+    # a flag runs that section and only that one
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    all_headers = ["Chunkers", "Cryptographic hashes / MACs", "Encryption", "Compression", "msgpack"]
+    output = cmd(archiver, "benchmark", "cpu", flag)
+    assert header in output
+    for other in all_headers:
+        if other != header:
+            assert other not in output
 
 
 def test_benchmark_cpu_json(archiver, monkeypatch):


### PR DESCRIPTION
Implements #10049 (throughput column) and #10050 (buffer sizes, section selection), plus some follow-up fixes to make the numbers mean something.

## Output

```
Chunkers =======================================================
fixed,1048576              1.00 GiB    0.065s   16631.3 MB/s
fastcdc,19,23,21,2         1.00 GiB    0.311s    3452.0 MB/s
buzhash64,19,23,21,4095,2  1.00 GiB    0.434s    2475.9 MB/s
buzhash,19,23,21,4095      1.00 GiB    0.778s    1380.5 MB/s
toeplitz-aes,19,23,21,2    1.00 GiB    1.328s     808.5 MB/s
rabin-aes,19,23,21,2       1.00 GiB    1.238s     867.0 MB/s
goldilocks-aes,19,23,21,2  1.00 GiB    2.193s     489.7 MB/s
Cryptographic hashes / MACs ====================================
blake3 (64MiB)             1.00 GiB    0.060s   17909.1 MB/s
blake3 (2MiB)              1.00 GiB    0.086s   12443.6 MB/s
hmac-sha256 (2MiB)         1.00 GiB    0.348s    3089.4 MB/s
blake2b-256 (2MiB)         1.00 GiB    1.016s    1056.7 MB/s
Encryption =====================================================
aes-256-ocb                1.00 GiB    0.448s    2395.9 MB/s
chacha20-poly1305          1.00 GiB    0.533s    2012.8 MB/s
aes-256-ctr-hmac-sha256    1.00 GiB    0.516s    2079.0 MB/s
aes-256-ctr-blake2b        1.00 GiB    1.235s     869.7 MB/s
Compression ====================================================
lz4 (2MiB)           10.00 MiB   0.012s     864.6 MB/s
zstd,1 (2MiB)        10.00 MiB   0.008s    1312.1 MB/s
zstd,3 (2MiB)        10.00 MiB   0.008s    1253.3 MB/s
zstd,5 (2MiB)        10.00 MiB   0.020s     518.6 MB/s
zstd,10 (2MiB)       10.00 MiB   0.065s     161.5 MB/s
zstd,16 (2MiB)       10.00 MiB   1.529s       6.9 MB/s
zstd,22 (2MiB)       10.00 MiB   2.159s       4.9 MB/s
zlib,1 (2MiB)        10.00 MiB   0.052s     201.5 MB/s
zlib,6 (2MiB)        10.00 MiB   0.337s      31.2 MB/s
zlib,9 (2MiB)        10.00 MiB   0.575s      18.2 MB/s
lzma,0 (2MiB)        10.00 MiB   0.212s      49.4 MB/s
lzma,6 (2MiB)        10.00 MiB   2.618s       4.0 MB/s
lzma,9 (2MiB)        10.00 MiB   2.585s       4.1 MB/s
lz4 (128kiB)         10.00 MiB   0.010s    1000.4 MB/s
zstd,1 (128kiB)      10.00 MiB   0.019s     543.9 MB/s
...
msgpack ========================================================
msgpack              128k Items 0.050s    2553.3 kItems/s
```

Whole run takes about 29 s, down from ~50 s before, despite having more rows.

## #10049 - throughput column

Every row ends in MB/s - always MB/s, never rescaled, so a chunker at 3452 and lzma at 4.0 stay comparable. msgpack reports kItems/s, since it packs items rather than bytes.

The reported sizes are now derived from the work actually done rather than hardcoded. Under `_BORG_BENCHMARK_CPU_TEST` (one iteration over a small buffer, used to keep CI fast) the old constants claimed 1 GB for 100 kB of work, which would have made the new column wrong by four orders of magnitude.

## #10050 - buffer sizes and section selection

blake3 and zstd only use multiple threads above a size threshold, so a single buffer size hid most of what there is to see. Hashes are measured at 64MiB (a borg pack) and 2MiB (a borg chunk), compressors at 2MiB and 128kiB (below zstd's 768 KiB threshold). Every row processes exactly 1 GiB, or 10 MiB for the compressors, so the throughput column is comparable across sizes.

`--chunking`, `--hashing`, `--encrypting`, `--compressing`, `--msgpacking` run only those sections; none given runs everything.

## Follow-ups that changed what is measured

**Compressible test data.** The compression section fed `os.urandom()` to every codec. Nothing compresses, so they all took their incompressible fast path: levels barely differed, and zstd's multi-threading looked like a 2-5x loss when on real data it is a 1.7-3x win. It now compresses a deterministic word soup (fixed seed, hand-written xorshift so the bytes do not depend on the Python version's PRNG), which compresses about 4.3x at zstd,3. The threshold now shows with the right sign - `zstd,1` 544 MB/s at 128kiB vs 1312 at 2MiB.

**blake3 as borg uses it.** There were two rows, `blake3` and `blake3-mt`, but borg has no such choice: `AESKeyBase.id_hash` passes `max_threads=AUTO` only above `get_blake3_mt_threshold()`. One row now applies that same rule, calling the helper rather than hardcoding the size, so `BORG_BLAKE3_MT_THRESHOLD` moves borg and the benchmark together.

**zlib,1 instead of zlib,0.** zlib level 0 stores rather than compresses (ratio 1.00x), so that row measured memcpy speed dressed up as a compressor - it reported ~7900 MB/s. (`lzma,0` is kept: unlike zlib it is not a store mode, it compresses to the same size as `lzma,6` on repetitive input.)

**Binary data sizes.** 1 GiB and 10 MiB rather than decimal 10^9/10^7, with buffer sizes as powers of two so every row lands on exactly those figures instead of "998.24 MB". The size column prints IEC units directly rather than via `format_file_size`: these are constants of the benchmark, not user data, and following `BORG_UNITS` would make two people's output incomparable and render 1 GiB as "1.07 GB".

**Ordering.** AEAD encryption modes first; hashes fastest first; compression grouped by buffer size (all codecs at 2MiB, then all at 128kiB) so codecs can be compared down a column.

## Notes

- JSON output gains `buffer_size` on the hashes and compression entries, without which rows for the same algorithm could not be told apart. Throughput is not added - it is `size/time`, so consumers can compute it.
- The compressors process 10 MiB per row rather than 1 GiB: with real work to do, at 50 MB the section alone took 91 s.
- Tests cover the new flags (each runs its section and only its section); 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

