### PR TITLE
remove avoidable per-chunk memory copies on the hot data path

### DIFF
--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -146,12 +146,11 @@ cdef class CompressorBase:
 
     def compress(self, meta, data):
         """
-        Compress *data* (bytes) and return compression metadata and compressed bytes.
+        Compress *data* (bytes or memoryview) and return compression metadata and compressed data.
         """
-        if not isinstance(data, bytes):
-            data = bytes(data)  # code below does not work with memoryview
         if self.legacy_mode:
-            return None, bytes((self.ID, self.level)) + data
+            # the ID/level prefix concatenation needs bytes (bytes() is a no-op for bytes input)
+            return None, bytes((self.ID, self.level)) + bytes(data)
         else:
             meta["ctype"] = self.ID
             meta["clevel"] = self.level
@@ -276,12 +275,15 @@ class LZ4(DecidingCompressor):
 
         *lz4_data* is the LZ4 result if *compressor* is LZ4 as well, otherwise it is None.
         """
-        if not isinstance(idata, bytes):
-            idata = bytes(idata)  # code below does not work with memoryview
-        cdef int isize = len(idata)
+        cdef const unsigned char[::1] iview = idata
+        cdef int isize = iview.shape[0]
         cdef int osize
-        cdef char *source = idata
+        cdef const char *source
         cdef char *dest
+        if isize == 0:
+            # empty input cannot shrink (and an empty view has no address to take below)
+            return NONE_COMPRESSOR, (meta, None)
+        source = <const char *> &iview[0]
         osize = LZ4_compressBound(isize)
         buf = get_buffer().get(osize)
         dest = <char *> buf
@@ -630,8 +632,11 @@ class ObfuscateSize(CompressorBase):
         addtl_size = self._obfuscate(compr_size) if meta["type"] == ROBJ_FILE_STREAM else 0
         addtl_size = max(0, addtl_size)  # we can only make it longer, not shorter!
         addtl_size = min(MAX_DATA_SIZE - 1024 - compr_size, addtl_size)  # stay away from MAX_DATA_SIZE
-        trailer = bytes(addtl_size)
-        obfuscated_data = compressed_data + trailer
+        if addtl_size:
+            # join, not +: compressed_data may be a memoryview (CNONE passes the input through)
+            obfuscated_data = b"".join([compressed_data, bytes(addtl_size)])
+        else:
+            obfuscated_data = compressed_data
         meta["csize"] = len(obfuscated_data)  # csize is the overall output size of this "obfuscation compressor"
         meta["olevel"] = self.level  # remember the obfuscation level, useful for repo-compress
         return meta, obfuscated_data  # for borg2 it is enough that we have the payload size in meta["psize"]

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -23,6 +23,8 @@ import sys
 import threading
 import zlib
 
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AsString
+
 try:
     import lzma
 except ImportError:
@@ -306,6 +308,21 @@ class LZ4(DecidingCompressor):
         cdef int rsize
         cdef char *source = idata
         cdef char *dest
+        size = None if meta is None else meta.get("size")
+        if size is not None and 0 <= size <= 2 ** 31 - 1:
+            # borg2 stores the exact plaintext size in the (authenticated) object metadata:
+            # decompress directly into the result bytes object - no scratch buffer, no copy,
+            # no output size guessing. rsize != size means corrupt (or misdescribed) data,
+            # this also covers everything check_fix_size would assert.
+            ret = PyBytes_FromStringAndSize(NULL, size)
+            dest = PyBytes_AsString(ret)
+            osize = size
+            with nogil:
+                rsize = LZ4_decompress_safe(source, dest, isize, osize)
+            if rsize != osize:
+                raise DecompressionError('lz4 decompress failed')
+            return meta, ret
+        # no size known up front (borg 1.x repos in legacy mode): guess and retry.
         # a bit more than 8MB is enough for the usual data sizes yielded by the chunker.
         # allocate more if isize * 3 is already bigger, to avoid having to resize often.
         osize = max(int(1.1 * 2**23), isize * 3)

--- a/src/borg/crypto/low_level.pyx
+++ b/src/borg/crypto/low_level.pyx
@@ -514,10 +514,11 @@ cdef class _AEAD_BASE:
         cdef int rc
 
         try:
-            odata = <unsigned char *>PyMem_Malloc(hlen + self.mac_len +
-                                                  ilen + self.cipher_blk_len)
-            if not odata:
-                raise MemoryError
+            # Our AEAD ciphers (OCB, chacha20-poly1305) are padding-free: the ciphertext is
+            # exactly as long as the plaintext. Thus the result can be allocated up front
+            # and the cipher writes directly into it - no scratch buffer, no copy.
+            ret = PyBytes_FromStringAndSize(NULL, hlen + self.mac_len + ilen)
+            odata = <unsigned char *>PyBytes_AsString(ret)
 
             idata = ro_buffer(data)
             idata_acquired = True
@@ -545,16 +546,19 @@ cdef class _AEAD_BASE:
             if not rc:
                 raise CryptoError('EVP_EncryptUpdate failed')
             offset += olen
+            # Final can emit a buffered partial block (OCB does). Our AEAD modes are
+            # padding-free, so it never writes more than the space left in the
+            # exact-size result buffer.
             if not EVP_EncryptFinal_ex(self.ctx, odata+offset, &olen):
                 raise CryptoError('EVP_EncryptFinal_ex failed')
             offset += olen
             if not EVP_CIPHER_CTX_ctrl(self.ctx, EVP_CTRL_AEAD_GET_TAG, self.mac_len, odata + hlen):
                 raise CryptoError('EVP_CIPHER_CTX_ctrl GET TAG failed')
+            if offset != hlen + self.mac_len + ilen:
+                raise CryptoError('unexpected ciphertext length')
             self.blocks = block_count
-            return odata[:offset]
+            return ret
         finally:
-            if odata:
-                PyMem_Free(odata)
             if hdata_acquired:
                 PyBuffer_Release(&hdata)
             if idata_acquired:
@@ -591,9 +595,11 @@ cdef class _AEAD_BASE:
         cdef int rc
 
         try:
-            odata = <unsigned char *>PyMem_Malloc(ilen + self.cipher_blk_len)
-            if not odata:
-                raise MemoryError
+            # Our AEAD ciphers (OCB, chacha20-poly1305) are padding-free: the plaintext is
+            # exactly as long as the ciphertext. Thus the result can be allocated up front
+            # and the cipher writes directly into it - no scratch buffer, no copy.
+            ret = PyBytes_FromStringAndSize(NULL, ilen - hlen - self.mac_len)
+            odata = <unsigned char *>PyBytes_AsString(ret)
 
             idata = ro_buffer(envelope)
             idata_acquired = True
@@ -619,15 +625,18 @@ cdef class _AEAD_BASE:
             offset += olen
             if not EVP_CIPHER_CTX_ctrl(self.ctx, EVP_CTRL_AEAD_SET_TAG, self.mac_len, <unsigned char *> idata.buf + hlen):
                 raise CryptoError('EVP_CIPHER_CTX_ctrl SET TAG failed')
+            # Final can emit a buffered partial block (OCB does). Our AEAD modes are
+            # padding-free, so it never writes more than the space left in the
+            # exact-size result buffer.
             if not EVP_DecryptFinal_ex(self.ctx, odata+offset, &olen):
                 # a failure here means corrupted or tampered tag (mac) or data.
                 raise IntegrityError('Authentication / EVP_DecryptFinal_ex failed')
             offset += olen
+            if offset != ilen - hlen - self.mac_len:
+                raise CryptoError('unexpected plaintext length')
             self.blocks = self.block_count(offset)
-            return odata[:offset]
+            return ret
         finally:
-            if odata:
-                PyMem_Free(odata)
             if idata_acquired:
                 PyBuffer_Release(&idata)
             if aadata_acquired:


### PR DESCRIPTION
Analysis of where `borg create` / `borg extract` copy or allocate big amounts of memory (chunk-sized buffers) found several avoidable full-chunk copies per chunk. This PR removes the easy ones; three commits, each independently tested:

**compress: do not copy chunk data to bytes, use the buffer protocol**
The chunker hands chunk data to the compressors as a memoryview into its scan buffer, but `LZ4._decide` (default compression) coerced it to bytes first — one full plaintext copy + allocation per chunk. Now uses a typed memoryview. `CompressorBase.compress` only materializes bytes in legacy mode (the prefix concat needs it), which also removes a second full copy for incompressible chunks (LZ4→CNONE fallback). `ObfuscateSize.compress` joins instead of concatenating (and skips the copy for zero padding), as CNONE may now pass a memoryview through.

**crypto: AEAD encrypt/decrypt directly into the result bytes object**
`_AEAD_BASE.encrypt/decrypt` used a PyMem_Malloc'd scratch buffer and created the returned bytes by slicing it — one ciphertext-sized (encrypt) / plaintext-sized (decrypt) copy plus a malloc/free round-trip per chunk. Our AEAD ciphers are padding-free, so the output size is known exactly: allocate the result via `PyBytes_FromStringAndSize(NULL, n)` and let OpenSSL write into it directly. Caveat (caught by the tests): OpenSSL's OCB emits the buffered partial final block from `EVP_EncryptFinal_ex`, not from Update. As our AEAD modes are padding-free, Final can never write more than the space left in the exact-size result buffer, so it writes directly into it (review feedback); a length check afterwards verifies the total.

**compress: lz4 decompresses directly into the result bytes object**
`LZ4.decompress` guessed the output size, decompressed into a scratch buffer (growing/retrying) and copied the plaintext into the returned bytes. borg2 stores the exact plaintext size in the authenticated object metadata, so decompress straight into an exactly-sized result. The guess-and-retry loop remains as fallback for borg 1.x data read in legacy mode (`borg transfer`).

**Measurements** (20 GiB, half incompressible / half compressible non-deduplicating data, lz4, aes256-ocb, page-cache-warm, 4 alternating A/B runs each on Apple Silicon; every PR run was faster than every master run):

|  | master | PR | delta |
|---|---|---|---|
| `borg create` | 48.13 ± 0.86 s (426 MiB/s) | 44.48 ± 0.12 s (460 MiB/s) | **−7.6%** |
| `borg extract --stdout` | 15.40 ± 0.13 s (1330 MiB/s) | 14.40 ± 0.26 s (1422 MiB/s) | **−6.4%** |

The extract gain also benefits `borg mount` and `check --verify-data`.

cProfile confirms the savings come entirely out of the compression/crypto path (chunker, id_hash unchanged).

Noticed while working on this (pre-existing on master, not addressed here): `--compression auto,...` raises ZeroDivisionError in `Auto.compress` for empty input; not reachable via the chunker (it never yields empty chunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

