### PR TITLE
CI: fix VM job hangs, use all runner cpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,9 @@ jobs:
           operating_system: ${{ matrix.os }}
           version: ${{ matrix.version }}
           shell: bash
+          # the default VM size (2 cpus) leaves half of the runner's 4 vcpus idle
+          cpu_count: 4
+          memory: 8G
 
       - name: Test on ${{ matrix.display_name }}
         shell: cpa.sh {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,9 @@ jobs:
 
       - name: Start VM for ${{ matrix.display_name }}
         id: cross_os
+        # a normal boot takes < 1 minute; sometimes the VM never becomes
+        # ssh-reachable and the action retries forever - fail early then.
+        timeout-minutes: 15
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,10 @@ jobs:
         run: |
           set -euxo pipefail
 
+          # a hung test must fail instead of stalling the suite until the
+          # job timeout (tox passes all env vars through to pytest).
+          export PYTEST_TIMEOUT=300
+
           case "${{ matrix.os }}" in
             freebsd)
               export IGNORE_OSVERSION=yes

--- a/requirements.d/development.lock.txt
+++ b/requirements.d/development.lock.txt
@@ -7,5 +7,6 @@ pytest-xdist==3.8.0
 coverage[toml]==7.15.0
 pytest-cov==7.1.0
 pytest-benchmark==5.2.3
+pytest-timeout==2.4.0
 pre-commit==4.6.1
 types-PyYAML==6.0.12.20260724

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -7,6 +7,7 @@ pytest-xdist
 coverage[toml]
 pytest-cov
 pytest-benchmark
+pytest-timeout
 pre-commit
 bandit[toml]
 types-PyYAML


### PR DESCRIPTION
The NetBSD vm_tests job looked chronically slow, but its normal runtime is 36–46 min (between FreeBSD and OpenBSD). The real problem is two intermittent hang modes that burn the full 180 min job timeout:

- **VM boot-loop**: the NetBSD VM sometimes never becomes ssh-reachable; cross-platform-actions retries "Waiting for VM to be ready..." forever (seen twice on master within one week, 142 retries over 3 h).
- **Test hang**: `test_create_read_special_symlink` (FIFO + feeder thread, already skip-marked "hangs on cygwin") started and never finished on one xdist worker; without pytest-timeout the suite stalls until the job timeout or manual cancel.

Three commits:

1. **Give the test VMs 4 cpus / 8 GiB RAM.** The cross-platform-actions default is 2 cpus, leaving half of the runner's 4 vcpus idle and limiting pytest-xdist to 2 workers (public-repo ubuntu runners have 4 vcpus / 16 GiB; the native jobs already use 4 workers). Should roughly halve test wall clock on all VM OSes — OpenBSD (43–60 min) benefits most.
2. **`timeout-minutes: 15` on the "Start VM" step.** A normal boot takes well under a minute; the boot-loop now fails in 15 min instead of 180.
3. **Install pytest-timeout, `PYTEST_TIMEOUT=300` for VM test runs.** A hung test now fails with a stack dump instead of stalling the suite — and the dump will show where the FIFO test hangs on NetBSD. tox passes env vars through (`pass_env = ["*"]`), and the env var also covers the direct-pytest haiku branch; native/windows jobs are unaffected since they don't set the variable.

All four VM OSes share the same job steps, so the changes apply to FreeBSD/OpenBSD/OmniOS as well; ci.yml is the only workflow using cross-platform-actions. The job-level 180 min timeout is unchanged because it covers the FreeBSD tag-day binary builds.

Example hang runs: [PR #10060 run](https://github.com/borgbackup/borg/actions/runs/31315995265) (test hang, attempt 1 cancelled at 87 min), plus two 180-min boot-loop cancellations on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)