### PR TITLE
tests: benchmark crud json-lines: io throughput may round to 0

### DIFF
--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -44,7 +44,9 @@ def test_benchmark_crud_json_lines(archiver, monkeypatch):
         assert isinstance(entry["time"], float)
         assert entry["time"] > 0
         assert isinstance(entry["io"], int)
-        assert entry["io"] > 0
+        # io is int(bytes/second); with this test's 1-byte samples it is 0
+        # whenever the operation takes >= 1s (seen on a loaded OpenBSD CI VM).
+        assert entry["io"] >= 0
 
 
 def test_benchmark_cpu(archiver, monkeypatch):


### PR DESCRIPTION
`test_benchmark_crud_json_lines` asserts `entry["io"] > 0`, but `io` is `int(total_size / dt)` — with the test's 1-byte samples it rounds to 0 whenever a CRUD operation takes ≥ 1 second. Seen failing on a loaded OpenBSD CI VM with 4 pytest-xdist workers in the [PR #10064 CI run](https://github.com/borgbackup/borg/actions/runs/31321983597) (the op took just over a second; everything else passed).

Relax the assertion to `>= 0` with a comment; the type check stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)