### PR TITLE
check: detect missing packs referenced by the index (#9898)

### DIFF
--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -290,13 +290,9 @@ class ArchiveGarbageCollector:
             # keep these entries: they may be an archive's only pointer to a chunk. dropping them
             # (repairing the index) is not implemented yet, refs #8572.
             n = len(stale_ids)
-            if n == 1:
-                subject = "1 index entry references a missing pack file"
-            else:
-                subject = f"{n} index entries reference missing pack files"
             logger.warning(
-                f"{subject}. Repairing the index (dropping the stale references) is tracked in "
-                "https://github.com/borgbackup/borg/issues/8572."
+                f"index entries referencing a missing pack file: {n}. Repairing the index "
+                "(dropping the stale references) is tracked in https://github.com/borgbackup/borg/issues/8572."
             )
             if stale_used:
                 logger.error(f"{stale_used} of them are still in use: repository data is missing!")

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -287,20 +287,29 @@ class ArchiveGarbageCollector:
                     pack_used[pid] += entry.obj_size
 
         if stale_ids:
-            # keep these entries: they may be an archive's only pointer to a chunk. dropping them is
-            # "borg check --repair"'s call.
-            logger.warning(f'{len(stale_ids)} index entries reference missing pack files; run "borg check --repair".')
+            # keep these entries: they may be an archive's only pointer to a chunk. dropping them
+            # (repairing the index) is not implemented yet, refs #8572.
+            n = len(stale_ids)
+            if n == 1:
+                subject = "1 index entry references a missing pack file"
+            else:
+                subject = f"{n} index entries reference missing pack files"
+            logger.warning(
+                f"{subject}. Repairing the index (dropping the stale references) is tracked in "
+                "https://github.com/borgbackup/borg/issues/8572."
+            )
             if stale_used:
                 logger.error(f"{stale_used} of them are still in use: repository data is missing!")
                 set_ec(EXIT_ERROR)
 
         # bytes no index entry covers. compact_pack reclaims the redundant duplicates among them while
-        # rewriting a pack; the rest is left for "borg check --repair".
+        # rewriting a pack; reclaiming the rest is tracked in #8572.
         unindexed = sum(total - pack_indexed[pid] for pid, total in pack_total.items() if total > pack_indexed[pid])
         if unindexed:
             logger.info(
                 f"{format_file_size(unindexed)} in pack files is not covered by the index; "
-                'redundant copies are reclaimed on pack rewrite, the rest by "borg check --repair".'
+                "redundant copies are reclaimed on pack rewrite, reclaiming the rest is tracked in "
+                "https://github.com/borgbackup/borg/issues/8572."
             )
 
         # decide each pack's fate. a pack's reclaimable bytes are its indexed-but-unused bytes; the

--- a/src/borg/archiver/repo_compress_cmd.py
+++ b/src/borg/archiver/repo_compress_cmd.py
@@ -93,10 +93,17 @@ class PackRecompressor:
 
         stale_packs = set(per_pack) - {pack_id for pack_id, _ in packs}
         if stale_packs:
-            # keep these entries: they may be an archive's only pointer to a chunk. dropping them is
-            # "borg check --repair"'s call.
+            # keep these entries: they may be an archive's only pointer to a chunk. dropping them
+            # (repairing the index) is not implemented yet, refs #8572.
             stale = sum(len(per_pack[pack_id]) for pack_id in stale_packs)
-            logger.warning(f'{stale} index entries reference missing pack files; run "borg check --repair".')
+            if stale == 1:
+                subject = "1 index entry references a missing pack file"
+            else:
+                subject = f"{stale} index entries reference missing pack files"
+            logger.warning(
+                f"{subject}. Repairing the index (dropping the stale references) is tracked in "
+                "https://github.com/borgbackup/borg/issues/8572."
+            )
 
         pi = ProgressIndicatorPercent(
             total=len(packs), msg="Recompressing %3.1f%%", step=0.1, msgid="repo_compress.recompress"

--- a/src/borg/archiver/repo_compress_cmd.py
+++ b/src/borg/archiver/repo_compress_cmd.py
@@ -96,13 +96,9 @@ class PackRecompressor:
             # keep these entries: they may be an archive's only pointer to a chunk. dropping them
             # (repairing the index) is not implemented yet, refs #8572.
             stale = sum(len(per_pack[pack_id]) for pack_id in stale_packs)
-            if stale == 1:
-                subject = "1 index entry references a missing pack file"
-            else:
-                subject = f"{stale} index entries reference missing pack files"
             logger.warning(
-                f"{subject}. Repairing the index (dropping the stale references) is tracked in "
-                "https://github.com/borgbackup/borg/issues/8572."
+                f"index entries referencing a missing pack file: {stale}. Repairing the index "
+                "(dropping the stale references) is tracked in https://github.com/borgbackup/borg/issues/8572."
             )
 
         pi = ProgressIndicatorPercent(

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -778,8 +778,13 @@ def read_chunkindex_from_repo(repository, hash):
     else:
         if hashlib.sha256(chunks_data).digest() == hex_to_bin(hash):
             logger.debug(f"{index_name} is valid.")
-            with io.BytesIO(chunks_data) as f:
-                chunks = ChunkIndex.read(f)
+            try:
+                with io.BytesIO(chunks_data) as f:
+                    chunks = ChunkIndex.read(f)
+            except Exception:
+                # name matches the content hash, but the content does not deserialize into a ChunkIndex.
+                logger.warning(f"{index_name} has a valid name but unreadable content; treating it as invalid.")
+                return None
             return chunks
         else:
             logger.debug(f"{index_name} is invalid.")
@@ -839,8 +844,11 @@ def repack_chunkindex(repository):
 
 
 def build_chunkindex_from_repo(
-    repository, *, slow_rebuild=False, write_immediately=False, init_flags=ChunkIndex.F_USED
+    repository, *, slow_rebuild=False, fragments_only=False, write_immediately=False, init_flags=ChunkIndex.F_USED
 ):
+    # fragments_only: build the index from the index/ fragments only, returning None if they cannot be
+    # read completely, and never write to the repo.
+    assert not (slow_rebuild and fragments_only)
     # first, try to build a fresh, mostly complete chunk index from centrally stored index fragments:
     if not slow_rebuild:
         # a concurrent repack_chunkindex (another client, shared lock) deletes the small fragments it
@@ -852,6 +860,8 @@ def build_chunkindex_from_repo(
         # set (e.g. a persistently unreadable fragment), fall through to the slow rebuild instead.
         for _ in range(CHUNKINDEX_MERGE_ATTEMPTS):
             if chunkindex_is_invalid(repository):
+                if fragments_only:
+                    return None
                 # leftover fragments may be incomplete or stale. Finish the interrupted deletion
                 # (best-effort; a read-only client rebuilds in memory only), then rebuild from packs.
                 logger.warning("chunk index is invalid (interrupted operation), rebuilding it.")
@@ -862,6 +872,8 @@ def build_chunkindex_from_repo(
                 break
             hashes = list_chunkindex_hashes(repository)
             if not hashes:  # no chunk index fragments available
+                if fragments_only:
+                    return None
                 break
             chunks = ChunkIndex()  # we'll merge all fragments into this
             complete = True
@@ -887,6 +899,8 @@ def build_chunkindex_from_repo(
                 return chunks
             chunks.clear()  # free the partial merge before retrying
         else:
+            if fragments_only:
+                return None
             logger.warning("could not read a complete set of chunk index fragments, rebuilding the index.")
     # if we didn't get anything from the index fragments, compute the ChunkIndex the slow way:
     logger.debug("rebuilding the chunk index from the repo the slow way...")

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -768,6 +768,10 @@ def write_chunkindex_to_repo(
     return new_hashes
 
 
+class CorruptChunkIndexFragment(Exception):
+    """A chunk index fragment's name matches its content hash, but the content does not deserialize."""
+
+
 def read_chunkindex_from_repo(repository, hash):
     index_name = f"index/{hash}"
     logger.debug(f"trying to load {index_name} from the repo...")
@@ -781,10 +785,10 @@ def read_chunkindex_from_repo(repository, hash):
             try:
                 with io.BytesIO(chunks_data) as f:
                     chunks = ChunkIndex.read(f)
-            except Exception:
-                # name matches the content hash, but the content does not deserialize into a ChunkIndex.
-                logger.warning(f"{index_name} has a valid name but unreadable content; treating it as invalid.")
-                return None
+            except (ValueError, KeyError, struct.error) as err:
+                # the name matches the content hash, so the bytes are intact but do not deserialize
+                # into a ChunkIndex: the fragment is corrupt.
+                raise CorruptChunkIndexFragment(index_name) from err
             return chunks
         else:
             logger.debug(f"{index_name} is invalid.")
@@ -822,7 +826,11 @@ def repack_chunkindex(repository):
     merged = ChunkIndex()
     merged_hashes = []
     for name, _ in small:
-        fragment = read_chunkindex_from_repo(repository, name)
+        try:
+            fragment = read_chunkindex_from_repo(repository, name)
+        except CorruptChunkIndexFragment:
+            # a corrupt fragment cannot be merged; leave it in place and skip it.
+            continue
         if fragment is None:
             # gone or invalid (e.g. deleted by another client); just don't merge it.
             continue
@@ -849,6 +857,7 @@ def build_chunkindex_from_repo(
     # fragments_only: build the index from the index/ fragments only, returning None if they cannot be
     # read completely, and never write to the repo.
     assert not (slow_rebuild and fragments_only)
+    assert not (fragments_only and write_immediately)  # fragments_only never writes to the repo
     # first, try to build a fresh, mostly complete chunk index from centrally stored index fragments:
     if not slow_rebuild:
         # a concurrent repack_chunkindex (another client, shared lock) deletes the small fragments it
@@ -877,16 +886,29 @@ def build_chunkindex_from_repo(
                 break
             chunks = ChunkIndex()  # we'll merge all fragments into this
             complete = True
+            corrupt_fragment = None
             for hash in hashes:
-                chunks_to_merge = read_chunkindex_from_repo(repository, hash)
+                try:
+                    chunks_to_merge = read_chunkindex_from_repo(repository, hash)
+                except CorruptChunkIndexFragment as err:
+                    corrupt_fragment = err
+                    break
                 if chunks_to_merge is None:
-                    logger.debug(f"chunk index fragment {hash} vanished or is invalid, restarting the merge...")
+                    logger.debug(f"chunk index fragment {hash} vanished, restarting the merge...")
                     complete = False
                     break
                 logger.debug(f"chunk index fragment {hash} gets merged...")
                 for k, v in chunks_to_merge.items():
                     chunks[k] = v
                 chunks_to_merge.clear()
+            if corrupt_fragment is not None:
+                # retrying would re-read the same corrupt fragment; rebuild the whole index from
+                # the packs instead (or return None in fragments_only mode).
+                chunks.clear()
+                if fragments_only:
+                    return None
+                logger.warning(f"{corrupt_fragment} is corrupt, rebuilding the chunk index from the packs.")
+                break
             if complete:
                 if len(hashes) > 1 and write_immediately:
                     # consolidate small fragments on the repo so they don't pile up. this is a

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1095,13 +1095,12 @@ class Repository:
                     self.chunks = chunks
                     # index entries pointing to a pack absent from packs/: data loss.
                     missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
-                    # packs no index entry references: leftovers of an interrupted operation, not an error.
+                    # packs no index entry references: not an error, so info + ids at debug only.
                     orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
                     if orphan_pack_ids:
-                        logger.info(
-                            f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
-                            f"(leftovers from an interrupted operation)."
-                        )
+                        logger.info(f"{len(orphan_pack_ids)} pack(s) are not referenced by the index.")
+                        for pack_id in orphan_pack_ids:
+                            logger.debug(f"Orphan pack: {bin_to_hex(pack_id)}")
             if partial:
                 # a partial check stops after max_duration; verify the least-recently-checked packs
                 # first so repeated runs cover every pack. sort by recorded check time, unrecorded

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1037,8 +1037,8 @@ class Repository:
         # the index is checked first and in full, on partial checks too: it is small, and index errors
         # stop the pack check below.
         index_infos = store_list("index")
-        # an invalid chunk index means an interrupted fragment deletion; it will be rebuilt on next
-        # use, so warn rather than verify the leftover fragments.
+        # an interrupted fragment deletion leaves the invalid marker set; the index is rebuilt on next
+        # use, so warn rather than fail.
         from .cache import chunkindex_is_invalid, build_chunkindex_from_repo
 
         index_invalid = chunkindex_is_invalid(self)
@@ -1114,8 +1114,9 @@ class Repository:
             present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
             tracker.prune(present_pack_ids)
             pack_pi.finish()
-            # report packs the index references but that are absent from packs/ (refs #9898). an
-            # invalid index is rebuilt from the packs on next use, so its references are not checked.
+            # cross-check the chunk index against packs/ (refs #9898). skipped for an invalid index:
+            # its fragment set may be incomplete, and build_chunkindex_from_repo would delete fragments
+            # and rebuild (a write), which a read-only check must not do.
             if not index_invalid:
                 chunks = build_chunkindex_from_repo(self)
                 try:
@@ -1126,7 +1127,15 @@ class Repository:
                     }
                 finally:
                     chunks.clear()
+                # index entries pointing to a pack absent from packs/: data loss.
                 missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
+                # packs no index entry references: leftovers of an interrupted operation, not an error.
+                orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
+                if orphan_pack_ids:
+                    logger.info(
+                        f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
+                        f"(leftovers from an interrupted operation)."
+                    )
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
             logger.error("Repository index is corrupted and must be repaired; skipping the pack check.")
@@ -1142,7 +1151,7 @@ class Repository:
         logger.info(summary)
         if missing_pack_ids:
             # one id per line (the list can be long).
-            logger.error(f"Found {len(missing_pack_ids)} missing pack(s) referenced by the index:")
+            logger.error(f"{len(missing_pack_ids)} pack(s) referenced by the index are missing:")
             for pack_id in missing_pack_ids:
                 logger.error(f"Missing pack: {bin_to_hex(pack_id)}")
         # corrupt_ids() is every pack recorded corrupt, including from earlier runs. with a corrupt

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -987,9 +987,12 @@ class Repository:
         compact, or salvaged and dropped by repair; refs #8572); prune() does this from packs/.
 
         It also reports missing packs (refs #9898): pack ids the chunk index references but that are
-        absent from packs/. The chunk index is loaded and its referenced pack ids are compared with the
-        packs present in the store. A corrupt or invalid index is rebuilt from the packs on next use, so
-        its references are not checked here.
+        absent from packs/. The index is read from its fragments only and its referenced pack ids are
+        compared with the packs present in the store. This cross-check is skipped, and the check still
+        passes, when the index cannot be read from its fragments (an invalid index is regenerated from
+        the packs on next use, so it can never reference a missing pack; a pack that is truly gone then
+        surfaces as missing chunks in the archives check). It is also skipped on a partial run
+        (max_duration), which covers packs incrementally; the cross-check runs on the full check instead.
 
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
         max_age, accepting a future timestamp up to MAX_CLOCK_SKEW (clock skew). Results are recorded
@@ -1114,31 +1117,37 @@ class Repository:
             present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
             tracker.prune(present_pack_ids)
             pack_pi.finish()
-            # cross-check the chunk index against packs/ (refs #9898). skip it when the index is
-            # invalid (loading it rebuilds from packs, which writes, and a check must not write) or
-            # after Ctrl-C (sig_int), where building the whole index would negate the interrupt.
-            if not index_invalid and not sig_int:
-                chunks = build_chunkindex_from_repo(self)
-                try:
-                    referenced_pack_ids = {
-                        entry.pack_id
-                        for _, entry in chunks.iteritems()
-                        # F_PENDING means the chunk's pack location is unresolved, so pack_id is a
-                        # placeholder, not a real pack. Fragments should not hold pending entries;
-                        # skip them defensively.
-                        if not (entry.flags & ChunkIndex.F_PENDING)
-                    }
-                finally:
-                    chunks.clear()
-                # index entries pointing to a pack absent from packs/: data loss.
-                missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
-                # packs no index entry references: leftovers of an interrupted operation, not an error.
-                orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
-                if orphan_pack_ids:
-                    logger.info(
-                        f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
-                        f"(leftovers from an interrupted operation)."
+            # cross-check the chunk index against packs/ to find referenced-but-absent packs (refs #9898).
+            # read the index from its fragments only; if that fails, skip the cross-check (rebuilding from
+            # packs is too slow here, and a check must not write). also skip after Ctrl-C (sig_int) and on
+            # a partial run (--max-duration), which the full check's cross-check covers.
+            if not index_invalid and not sig_int and not partial:
+                chunks = build_chunkindex_from_repo(self, fragments_only=True)
+                if chunks is None:
+                    logger.warning(
+                        "Cannot cross-check packs against the chunk index: the index could not be loaded "
+                        "from its fragments; skipping missing-pack detection."
                     )
+                else:
+                    try:
+                        referenced_pack_ids = {
+                            entry.pack_id
+                            for _, entry in chunks.iteritems()
+                            # F_PENDING marks a chunk whose pack location is unresolved, so its pack_id
+                            # is a placeholder rather than a real pack; skip such entries.
+                            if not (entry.flags & ChunkIndex.F_PENDING)
+                        }
+                    finally:
+                        chunks.clear()
+                    # index entries pointing to a pack absent from packs/: data loss.
+                    missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
+                    # packs no index entry references: leftovers of an interrupted operation, not an error.
+                    orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
+                    if orphan_pack_ids:
+                        logger.info(
+                            f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
+                            f"(leftovers from an interrupted operation)."
+                        )
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
             logger.error("Repository index is corrupted and must be repaired; skipping the pack check.")

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -1114,16 +1114,19 @@ class Repository:
             present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
             tracker.prune(present_pack_ids)
             pack_pi.finish()
-            # cross-check the chunk index against packs/ (refs #9898). skipped for an invalid index:
-            # its fragment set may be incomplete, and build_chunkindex_from_repo would delete fragments
-            # and rebuild (a write), which a read-only check must not do.
-            if not index_invalid:
+            # cross-check the chunk index against packs/ (refs #9898). skip it when the index is
+            # invalid (loading it rebuilds from packs, which writes, and a check must not write) or
+            # after Ctrl-C (sig_int), where building the whole index would negate the interrupt.
+            if not index_invalid and not sig_int:
                 chunks = build_chunkindex_from_repo(self)
                 try:
                     referenced_pack_ids = {
                         entry.pack_id
                         for _, entry in chunks.iteritems()
-                        if not (entry.flags & ChunkIndex.F_PENDING)  # pending: pack_id not resolved yet
+                        # F_PENDING means the chunk's pack location is unresolved, so pack_id is a
+                        # placeholder, not a real pack. Fragments should not hold pending entries;
+                        # skip them defensively.
+                        if not (entry.flags & ChunkIndex.F_PENDING)
                     }
                 finally:
                     chunks.clear()
@@ -1144,8 +1147,6 @@ class Repository:
             f"Checked {index_files} index files ({index_errors} errors) "
             f"and {pack_files} packs ({pack_errors} errors)."
         )
-        if missing_pack_ids:
-            summary += f" {len(missing_pack_ids)} pack(s) referenced by the index are missing."
         if pack_skipped:
             summary += f" Reused {pack_skipped} recent pack check result(s)."
         logger.info(summary)
@@ -1154,6 +1155,10 @@ class Repository:
             logger.error(f"{len(missing_pack_ids)} pack(s) referenced by the index are missing:")
             for pack_id in missing_pack_ids:
                 logger.error(f"Missing pack: {bin_to_hex(pack_id)}")
+            logger.error(
+                "The chunks stored in these packs are lost. Repairing the index (dropping the "
+                "stale references) is tracked in https://github.com/borgbackup/borg/issues/8572."
+            )
         # corrupt_ids() is every pack recorded corrupt, including from earlier runs. with a corrupt
         # index the packs were not scanned, so report nothing.
         corrupt_ids = tracker.corrupt_ids() if index_errors == 0 else []

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -988,11 +988,11 @@ class Repository:
 
         It also reports missing packs (refs #9898): pack ids the chunk index references but that are
         absent from packs/. The index is read from its fragments only and its referenced pack ids are
-        compared with the packs present in the store. This cross-check is skipped, and the check still
+        compared with the packs present in the store. This cross-check runs before the pack loop, so
+        max_duration bounds it and it runs on partial runs too. It is skipped, and the check still
         passes, when the index cannot be read from its fragments (an invalid index is regenerated from
         the packs on next use, so it can never reference a missing pack; a pack that is truly gone then
-        surfaces as missing chunks in the archives check). It is also skipped on a partial run
-        (max_duration), which covers packs incrementally; the cross-check runs on the full check instead.
+        surfaces as missing chunks in the archives check).
 
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
         max_age, accepting a future timestamp up to MAX_CLOCK_SKEW (clock skew). Results are recorded
@@ -1070,6 +1070,38 @@ class Repository:
                     logger.error(f"Store object packs/{info.name} has an invalid name.")
                     pack_errors += 1
             pack_infos = valid_pack_infos
+            present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
+            # cross-check the chunk index against packs/ to find referenced-but-absent packs (refs #9898).
+            # run before the pack loop so max_duration bounds it and partial checks cover it too. read
+            # the index from its fragments only: a full rebuild reads every pack (too slow) and writes
+            # to the repo (a check must not).
+            if not index_invalid and not sig_int:
+                chunks = build_chunkindex_from_repo(self, fragments_only=True)
+                if chunks is None:
+                    logger.warning(
+                        "Cannot cross-check packs against the chunk index: the index could not be loaded "
+                        "from its fragments; skipping missing-pack detection."
+                    )
+                else:
+                    referenced_pack_ids = {
+                        entry.pack_id
+                        for _, entry in chunks.iteritems()
+                        # F_PENDING marks a chunk whose pack location is unresolved, so its pack_id
+                        # is a placeholder rather than a real pack; skip such entries.
+                        if not (entry.flags & ChunkIndex.F_PENDING)
+                    }
+                    # set the session chunk index (.chunks) so later reads reuse it; clear_new() has
+                    # run, so close() does not write it back.
+                    self.chunks = chunks
+                    # index entries pointing to a pack absent from packs/: data loss.
+                    missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
+                    # packs no index entry references: leftovers of an interrupted operation, not an error.
+                    orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
+                    if orphan_pack_ids:
+                        logger.info(
+                            f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
+                            f"(leftovers from an interrupted operation)."
+                        )
             if partial:
                 # a partial check stops after max_duration; verify the least-recently-checked packs
                 # first so repeated runs cover every pack. sort by recorded check time, unrecorded
@@ -1114,40 +1146,8 @@ class Repository:
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-            present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
             tracker.prune(present_pack_ids)
             pack_pi.finish()
-            # cross-check the chunk index against packs/ to find referenced-but-absent packs (refs #9898).
-            # read the index from its fragments only; if that fails, skip the cross-check (rebuilding from
-            # packs is too slow here, and a check must not write). also skip after Ctrl-C (sig_int) and on
-            # a partial run (--max-duration), which the full check's cross-check covers.
-            if not index_invalid and not sig_int and not partial:
-                chunks = build_chunkindex_from_repo(self, fragments_only=True)
-                if chunks is None:
-                    logger.warning(
-                        "Cannot cross-check packs against the chunk index: the index could not be loaded "
-                        "from its fragments; skipping missing-pack detection."
-                    )
-                else:
-                    try:
-                        referenced_pack_ids = {
-                            entry.pack_id
-                            for _, entry in chunks.iteritems()
-                            # F_PENDING marks a chunk whose pack location is unresolved, so its pack_id
-                            # is a placeholder rather than a real pack; skip such entries.
-                            if not (entry.flags & ChunkIndex.F_PENDING)
-                        }
-                    finally:
-                        chunks.clear()
-                    # index entries pointing to a pack absent from packs/: data loss.
-                    missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
-                    # packs no index entry references: leftovers of an interrupted operation, not an error.
-                    orphan_pack_ids = sorted(present_pack_ids - referenced_pack_ids)
-                    if orphan_pack_ids:
-                        logger.info(
-                            f"{len(orphan_pack_ids)} pack(s) in packs/ are not referenced by the index "
-                            f"(leftovers from an interrupted operation)."
-                        )
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
             logger.error("Repository index is corrupted and must be repaired; skipping the pack check.")

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -986,6 +986,11 @@ class Repository:
         it. The record clears at the check that finds the pack intact again or gone (removed by
         compact, or salvaged and dropped by repair; refs #8572); prune() does this from packs/.
 
+        It also reports missing packs (refs #9898): pack ids the chunk index references but that are
+        absent from packs/. The chunk index is loaded and its referenced pack ids are compared with the
+        packs present in the store. A corrupt or invalid index is rebuilt from the packs on next use, so
+        its references are not checked here.
+
         max_age (seconds, 0 = verify every pack): skip packs whose intact record is younger than
         max_age, accepting a future timestamp up to MAX_CLOCK_SKEW (clock skew). Results are recorded
         regardless of max_age.
@@ -1027,15 +1032,17 @@ class Repository:
         t_last_checkpoint = t_start
         index_files = index_errors = 0
         pack_files = pack_errors = pack_skipped = 0
+        missing_pack_ids = []  # packs referenced by the index but absent from packs/ (refs #9898)
         # index and packs get separate progress indicators, each running from 0% to 100%.
         # the index is checked first and in full, on partial checks too: it is small, and index errors
         # stop the pack check below.
         index_infos = store_list("index")
         # an invalid chunk index means an interrupted fragment deletion; it will be rebuilt on next
         # use, so warn rather than verify the leftover fragments.
-        from .cache import chunkindex_is_invalid
+        from .cache import chunkindex_is_invalid, build_chunkindex_from_repo
 
-        if chunkindex_is_invalid(self):
+        index_invalid = chunkindex_is_invalid(self)
+        if index_invalid:
             logger.warning("chunk index is invalid (interrupted operation); it will be rebuilt on next use.")
         index_pi = ProgressIndicatorPercent(total=len(index_infos), msg="Checking index %3.0f%%", msgid="check.index")
         for info in index_infos:
@@ -1104,19 +1111,40 @@ class Repository:
                 if pack_infos:
                     pack_pi.show(current=len(pack_infos))  # finish at 100%
                 logger.info("Finished checking packs.")
-            tracker.prune({hex_to_bin(info.name) for info in pack_infos})
+            present_pack_ids = {hex_to_bin(info.name) for info in pack_infos}
+            tracker.prune(present_pack_ids)
             pack_pi.finish()
+            # report packs the index references but that are absent from packs/ (refs #9898). an
+            # invalid index is rebuilt from the packs on next use, so its references are not checked.
+            if not index_invalid:
+                chunks = build_chunkindex_from_repo(self)
+                try:
+                    referenced_pack_ids = {
+                        entry.pack_id
+                        for _, entry in chunks.iteritems()
+                        if not (entry.flags & ChunkIndex.F_PENDING)  # pending: pack_id not resolved yet
+                    }
+                finally:
+                    chunks.clear()
+                missing_pack_ids = sorted(referenced_pack_ids - present_pack_ids)
         else:
             # TODO: --repair will rebuild the index from the packs here instead of stopping (refs #8572).
             logger.error("Repository index is corrupted and must be repaired; skipping the pack check.")
-        objs_errors = index_errors + pack_errors
+        objs_errors = index_errors + pack_errors + len(missing_pack_ids)
         summary = (
             f"Checked {index_files} index files ({index_errors} errors) "
             f"and {pack_files} packs ({pack_errors} errors)."
         )
+        if missing_pack_ids:
+            summary += f" {len(missing_pack_ids)} pack(s) referenced by the index are missing."
         if pack_skipped:
             summary += f" Reused {pack_skipped} recent pack check result(s)."
         logger.info(summary)
+        if missing_pack_ids:
+            # one id per line (the list can be long).
+            logger.error(f"Found {len(missing_pack_ids)} missing pack(s) referenced by the index:")
+            for pack_id in missing_pack_ids:
+                logger.error(f"Missing pack: {bin_to_hex(pack_id)}")
         # corrupt_ids() is every pack recorded corrupt, including from earlier runs. with a corrupt
         # index the packs were not scanned, so report nothing.
         corrupt_ids = tracker.corrupt_ids() if index_errors == 0 else []

--- a/src/borg/testsuite/cache_test.py
+++ b/src/borg/testsuite/cache_test.py
@@ -12,6 +12,7 @@ from .. import cache as cache_mod
 from ..cache import (
     AdHocWithFilesCache,
     ChunksMixin,
+    CorruptChunkIndexFragment,
     FileCacheEntry,
     build_chunkindex_from_repo,
     chunkindex_is_invalid,
@@ -144,6 +145,35 @@ def test_read_chunkindex_from_repo_missing(tmp_path):
         # Try to load a non-existent index entry — should return None, not raise.
         result = read_chunkindex_from_repo(repository, "f" * 64)
         assert result is None
+
+
+def test_read_chunkindex_from_repo_corrupt(tmp_path):
+    """A fragment whose name matches its content hash but does not deserialize raises."""
+    repository_location = os.fspath(tmp_path / "repository")
+    with Repository(repository_location, exclusive=True, create=True) as repository:
+        content = b"not a serialized chunk index"
+        name = hashlib.sha256(content).hexdigest()  # valid name, so the name check passes
+        repository.store_store(f"index/{name}", content)
+        with pytest.raises(CorruptChunkIndexFragment):
+            read_chunkindex_from_repo(repository, name)
+
+
+def test_build_chunkindex_rebuilds_on_corrupt_fragment(tmp_path):
+    """A corrupt fragment (valid name, unreadable content) triggers a rebuild from the packs, no retry."""
+    repository_location = os.fspath(tmp_path / "repository")
+    with Repository(repository_location, exclusive=True, create=True) as repository:
+        ci = ChunkIndex()
+        ci[H(1)] = ChunkIndexEntry(ChunkIndex.F_NEW, 0, H(1), 0, 4)
+        write_chunkindex_to_repo(repository, ci, incremental=False, force_write=True)
+        content = b"not a serialized chunk index"
+        name = hashlib.sha256(content).hexdigest()
+        repository.store_store(f"index/{name}", content)
+        chunks = build_chunkindex_from_repo(repository)
+        # the rebuild reads the (empty) packs namespace, so H(1) from the corrupt fragment is absent
+        assert H(1) not in chunks
+        assert len(chunks) == 0
+        # fragments_only returns None here rather than rebuilding from the packs
+        assert build_chunkindex_from_repo(repository, fragments_only=True) is None
 
 
 def test_build_chunkindex_retries_on_vanished_fragment(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1172,9 +1172,9 @@ def test_check_missing_pack_detection_skipped_when_index_unreadable(tmp_path, ca
         assert "Cannot cross-check packs against the chunk index" in caplog.text
 
 
-def test_check_partial_skips_missing_pack_cross_check(tmp_path, caplog):
-    # a partial check (max_duration) does not cross-check the index against packs/; missing-pack
-    # detection runs on the full check instead (refs #9898).
+def test_check_partial_still_detects_missing_pack(tmp_path, caplog):
+    # a partial check (max_duration) cross-checks the index against packs/ before the pack loop, so
+    # it detects a missing pack and fails just like a full check (refs #9898).
     location = os.fspath(tmp_path / "repo")
     with Repository(location, exclusive=True, create=True) as repository:
         for x in range(3):
@@ -1184,8 +1184,8 @@ def test_check_partial_skips_missing_pack_cross_check(tmp_path, caplog):
         pack_id = repository.chunks[H(0)].pack_id
         repository.store_delete("packs/" + bin_to_hex(pack_id))  # pack gone, index entry kept
         with caplog.at_level(logging.ERROR):
-            assert repository.check(repair=False, max_duration=3600) is True
-        assert "Missing pack" not in caplog.text
+            assert repository.check(repair=False, max_duration=3600) is False
+        assert f"Missing pack: {bin_to_hex(pack_id)}" in caplog.text
 
 
 def test_check_checked_packs_roundtrip(tmp_path):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1140,6 +1140,23 @@ def test_check_missing_pack_detection_skipped_when_index_invalid(tmp_path, caplo
         assert "chunk index is invalid" in caplog.text
 
 
+def test_check_reports_orphan_pack_not_referenced_by_index(tmp_path, caplog):
+    # a pack that no index entry references is reported at info level and does not fail check (refs #9898).
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        for x in range(3):
+            repository.put(H(x), fchunk(b"DATA-%02d" % x, chunk_id=H(x)))
+        repository.flush()  # flush before close persists the index
+    with Repository(location, exclusive=True) as repository:
+        # a validly-named pack (name == sha256(content)) that no index entry points into.
+        content = b"orphan pack content"
+        orphan_id = sha256(content).digest()
+        repository.store_store("packs/" + bin_to_hex(orphan_id), content)
+        with caplog.at_level(logging.INFO):
+            assert repository.check(repair=False) is True
+        assert "not referenced by the index" in caplog.text
+
+
 def test_check_checked_packs_roundtrip(tmp_path):
     # the set survives a store/load round-trip; a rotted blob loads as empty.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1152,6 +1152,42 @@ def test_check_reports_orphan_pack_not_referenced_by_index(tmp_path, caplog):
         assert "not referenced by the index" in caplog.text
 
 
+def test_check_missing_pack_detection_skipped_when_index_unreadable(tmp_path, caplog):
+    # an index/ fragment whose name matches its content hash but whose content does not deserialize
+    # into a ChunkIndex makes the fragment set unreadable; check skips the cross-check (and still
+    # passes) instead of crashing or rebuilding from the packs (refs #9898).
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        for x in range(3):
+            repository.put(H(x), fchunk(b"DATA-%02d" % x, chunk_id=H(x)))
+        repository.flush()
+    with Repository(location, exclusive=True) as repository:
+        pack_id = repository.chunks[H(0)].pack_id
+        repository.store_delete("packs/" + bin_to_hex(pack_id))  # pack gone, index entry kept
+        content = b"not a serialized chunk index"
+        repository.store_store("index/" + bin_to_hex(sha256(content).digest()), content)
+        with caplog.at_level(logging.WARNING):
+            assert repository.check(repair=False) is True
+        assert "Missing pack" not in caplog.text
+        assert "Cannot cross-check packs against the chunk index" in caplog.text
+
+
+def test_check_partial_skips_missing_pack_cross_check(tmp_path, caplog):
+    # a partial check (max_duration) does not cross-check the index against packs/; missing-pack
+    # detection runs on the full check instead (refs #9898).
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        for x in range(3):
+            repository.put(H(x), fchunk(b"DATA-%02d" % x, chunk_id=H(x)))
+        repository.flush()
+    with Repository(location, exclusive=True) as repository:
+        pack_id = repository.chunks[H(0)].pack_id
+        repository.store_delete("packs/" + bin_to_hex(pack_id))  # pack gone, index entry kept
+        with caplog.at_level(logging.ERROR):
+            assert repository.check(repair=False, max_duration=3600) is True
+        assert "Missing pack" not in caplog.text
+
+
 def test_check_checked_packs_roundtrip(tmp_path):
     # the set survives a store/load round-trip; a rotted blob loads as empty.
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 import pytest
 from borghash import HashTableNT
 
+from ..cache import write_chunkindex_invalid
 from ..constants import MAX_CLOCK_SKEW
 from ..helpers import IntegrityError, Location, bin_to_hex
 from ..hashindex import ChunkIndex
@@ -1024,12 +1025,11 @@ def test_flush_store_failure_drops_pending_entries(tmp_path):
         assert H(1) not in repository._chunks
 
 
-def _serialized_chunkindex(chunks=None):
-    # Serialize a ChunkIndex to bytes, as stored under index/<sha256(content)>. check() parses index
-    # fragments, so a fragment must be a real ChunkIndex serialization.
-    chunks = chunks if chunks is not None else ChunkIndex()
+def _serialized_chunkindex():
+    # Serialize an empty ChunkIndex to bytes, as stored under index/<sha256(content)>. check() parses
+    # index fragments, so a fragment must be a real ChunkIndex serialization.
     with io.BytesIO() as f:
-        chunks.write(f)
+        ChunkIndex().write(f)
         return f.getvalue()
 
 
@@ -1083,9 +1083,6 @@ def test_check_reports_invalid_pack_name(tmp_path, caplog):
 def test_check_warns_on_invalid_chunk_index(tmp_path, caplog):
     # check warns about an invalid chunk index but does not fail, since the index is not part of
     # the repository's object integrity.
-    import logging
-    from ..cache import write_chunkindex_invalid
-
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         write_chunkindex_invalid(repository)
         with caplog.at_level(logging.WARNING):
@@ -1123,8 +1120,6 @@ def test_check_detects_missing_pack_referenced_by_index(tmp_path, caplog):
 def test_check_missing_pack_detection_skipped_when_index_invalid(tmp_path, caplog):
     # an invalid index is rebuilt from the packs on next use, so check does not report missing packs
     # from it (refs #9898); it only warns about the invalid index.
-    from ..cache import write_chunkindex_invalid
-
     location = os.fspath(tmp_path / "repo")
     with Repository(location, exclusive=True, create=True) as repository:
         for x in range(3):

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1024,6 +1024,15 @@ def test_flush_store_failure_drops_pending_entries(tmp_path):
         assert H(1) not in repository._chunks
 
 
+def _serialized_chunkindex(chunks=None):
+    # Serialize a ChunkIndex to bytes, as stored under index/<sha256(content)>. check() parses index
+    # fragments, so a fragment must be a real ChunkIndex serialization.
+    chunks = chunks if chunks is not None else ChunkIndex()
+    with io.BytesIO() as f:
+        chunks.write(f)
+        return f.getvalue()
+
+
 def test_check_detects_corruption_in_later_object(tmp_path):
     # Corruption anywhere in a multi-object pack must be caught, not just in the first object: the pack
     # is named by sha256(content), so flipping any byte makes its stored hash differ from its name.
@@ -1044,7 +1053,7 @@ def test_check_detects_corruption_in_later_object(tmp_path):
 
 def test_check_detects_index_corruption(tmp_path):
     # index/ objects are named by sha256(content) like packs, so check verifies them the same way.
-    content = b"pretend this is a serialized chunk index"
+    content = _serialized_chunkindex()
     index_name = "index/" + bin_to_hex(sha256(content).digest())
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         repository.store_store(index_name, content)
@@ -1092,6 +1101,43 @@ def test_check_intact_multi_object_pack_passes(tmp_path):
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         repository.store_store(pack_name, pack)
         assert repository.check(repair=False) is True
+
+
+def test_check_detects_missing_pack_referenced_by_index(tmp_path, caplog):
+    # check must report a pack the chunk index references but that is absent from packs/ (refs #9898).
+    # put+flush+close persists the index; then delete the pack, keeping its index entry.
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        for x in range(3):
+            repository.put(H(x), fchunk(b"DATA-%02d" % x, chunk_id=H(x)))
+        repository.flush()  # flush before close persists the index
+    with Repository(location, exclusive=True) as repository:
+        assert repository.check(repair=False) is True  # index and pack both present
+        pack_id = repository.chunks[H(0)].pack_id
+        repository.store_delete("packs/" + bin_to_hex(pack_id))  # pack gone, index entry kept
+        with caplog.at_level(logging.ERROR):
+            assert repository.check(repair=False) is False
+        assert f"Missing pack: {bin_to_hex(pack_id)}" in caplog.text
+
+
+def test_check_missing_pack_detection_skipped_when_index_invalid(tmp_path, caplog):
+    # an invalid index is rebuilt from the packs on next use, so check does not report missing packs
+    # from it (refs #9898); it only warns about the invalid index.
+    from ..cache import write_chunkindex_invalid
+
+    location = os.fspath(tmp_path / "repo")
+    with Repository(location, exclusive=True, create=True) as repository:
+        for x in range(3):
+            repository.put(H(x), fchunk(b"DATA-%02d" % x, chunk_id=H(x)))
+        repository.flush()
+    with Repository(location, exclusive=True) as repository:
+        pack_id = repository.chunks[H(0)].pack_id
+        repository.store_delete("packs/" + bin_to_hex(pack_id))  # pack gone
+        write_chunkindex_invalid(repository)  # mark the index invalid
+        with caplog.at_level(logging.WARNING):
+            assert repository.check(repair=False) is True
+        assert "Missing pack" not in caplog.text
+        assert "chunk index is invalid" in caplog.text
 
 
 def test_check_checked_packs_roundtrip(tmp_path):
@@ -1574,7 +1620,7 @@ def test_check_progress_covers_packs_and_index(tmp_path, monkeypatch):
     monkeypatch.setattr("borg.repository.ProgressIndicatorPercent", FakePI)
     pack = fchunk(b"A", chunk_id=H(1))
     pack_name = "packs/" + bin_to_hex(sha256(pack).digest())
-    index_content = b"serialized chunk index"
+    index_content = _serialized_chunkindex()
     index_name = "index/" + bin_to_hex(sha256(index_content).digest())
     with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
         repository.store_store(pack_name, pack)


### PR DESCRIPTION
Fixes #9898.

A read-only check verified pack and index integrity separately but never compared them, so a pack that the chunk index still referenced while missing from packs/ passed clean. The loss only showed up later, on extract.

With an intact index, check now reads the chunk index from its stored fragments and cross-checks its pack ids against packs/:

- pack ids referenced by the index but absent from packs/ are reported as errors and fail the check (data loss).
- packs present in packs/ that no index entry references are reported at info level and do not fail the check; they are leftovers of an interrupted operation, not an error.

The cross-check reads the index from its fragments only, never rebuilding it from the packs (too slow for a routine check) and never writing to the repo. It is skipped, and the check still passes, when the index cannot be read that way: a corrupt or invalid index is rebuilt from the packs on next use (and so can never reference a missing pack), and a pack that is truly gone then surfaces as missing chunks in the archives check. It is also skipped on a partial run (--max-duration), which the full check's cross-check covers.

Tests cover the missing-pack detection, the clean case, the invalid-index skip, the unreadable-fragments skip, the partial-run skip, and the orphan-pack report.