### PR TITLE
check --repair: flush pack writer in ArchiveChecker.finish() before dropping the index

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2392,6 +2392,9 @@ class ArchiveChecker:
 
     def finish(self):
         if self.repair:
+            # store packs still buffered from chunks re-added during repair, so their index entries
+            # are set before the index is dropped below and no chunk is left buffered at close().
+            self.repository.flush()
             # we may have deleted chunks. delete_chunkindex_from_repo() removes the on-disk index and
             # drops the stale in-memory index, so the next repository access rebuilds it from the repo.
             logger.info("Deleting chunk indexes in repository - next repository access will cause a rebuild.")

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -556,6 +556,34 @@ def test_extra_chunks(archivers, request):
     cmd(archiver, "check", "-v", exit_code=0)  # check does not deal with orphans anymore
 
 
+def test_repair_finish_flushes_pack_writer(archivers, request):
+    """finish() stores chunks re-added during --repair before it drops the index (#10055).
+
+    close() asserts an empty pack writer buffer, so a chunk left buffered by finish() would
+    trip it.
+    """
+    archiver = request.getfixturevalue(archivers)
+    if archiver.get_kind() != "local":
+        pytest.skip("inspects in-process repository internals")
+    check_cmd_setup(archiver)
+    cmd(archiver, "check", exit_code=0)
+
+    with Repository(archiver.repository_location, exclusive=True) as repository:
+        checker = ArchiveChecker()
+        checker.repair = True
+        checker.repository = repository
+        checker.key = checker.make_key(repository)
+        checker.manifest = Manifest.load(repository, (Manifest.Operation.CHECK,), key=checker.key)
+
+        # a chunk re-added during repair, buffered in the pack writer:
+        key = b"01234567890123456789012345678901"
+        repository.put(key, fchunk(b"repaired", chunk_id=key))
+        assert repository._pack_writer._pieces
+
+        checker.finish()
+        assert not repository._pack_writer._pieces  # finish() stored it
+
+
 @pytest.mark.parametrize("init_args", [["--encryption=aes256-ocb"], ["--encryption", "none"]])
 def test_verify_data(archivers, request, init_args):
     archiver = request.getfixturevalue(archivers)


### PR DESCRIPTION
Closes #10055.

During `check --repair`, `add_reference()` re-adds chunks via `repository.put()`, which only buffers them in the pack writer. `ArchiveChecker.finish()` then deleted the chunk index without flushing, so a buffered chunk could survive to `repository.close()`, which asserts an empty buffer.

This flushes the pack writer in `finish()` before deleting the index. The test buffers a chunk in a repair-mode checker and checks that `finish()` stores it.