### PR TITLE
CI: speed up OpenBSD testing VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             do_binaries: false
 
           - os: openbsd
-            version: '7.8'
+            version: '7.9'
             display_name: OpenBSD
             do_binaries: false
             # extra RAM for the mfs-backed TMPDIR, see the openbsd test step
@@ -556,7 +556,7 @@ jobs:
               sudo -E pkg_add lz4 git rust openssl%3.5 py3-pip py3-virtualenv py3-tox
 
               export BORG_OPENSSL_NAME=eopenssl35
-              tox -e py312-none
+              tox -e py313-none
               ;;
 
             omnios)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,8 @@ jobs:
             version: '7.8'
             display_name: OpenBSD
             do_binaries: false
+            # extra RAM for the mfs-backed TMPDIR, see the openbsd test step
+            memory: 12G
 
           - os: omnios
             version: 'r151056'
@@ -444,7 +446,7 @@ jobs:
           shell: bash
           # the default VM size (2 cpus) leaves half of the runner's 4 vcpus idle
           cpu_count: 4
-          memory: 8G
+          memory: ${{ matrix.memory || '8G' }}
 
       - name: Test on ${{ matrix.display_name }}
         shell: cpa.sh {0}
@@ -540,10 +542,18 @@ jobs:
               ;;
 
             openbsd)
-              sudo -E pkg_add lz4 git
-              sudo -E pkg_add rust
-              sudo -E pkg_add openssl%3.5
-              sudo -E pkg_add py3-pip py3-virtualenv py3-tox
+              # Put the temp tree (pip/cc build temps, pytest tmp dirs and the
+              # borg test repos in them) on a memory-backed filesystem instead
+              # of the slow FFS disk. Sized generously (the pytest tmp tree is
+              # only cleaned up after the run); the VM gets 12G RAM for this.
+              sudo mkdir -p /mfs
+              # -O2: FFS2 format - mfs defaults to FFS1, whose 32 bit
+              # timestamps silently wrap (breaks test_extract_y2261).
+              sudo mount_mfs -O2 -s 6g swap /mfs
+              sudo chmod 1777 /mfs
+              export TMPDIR=/mfs
+
+              sudo -E pkg_add lz4 git rust openssl%3.5 py3-pip py3-virtualenv py3-tox
 
               export BORG_OPENSSL_NAME=eopenssl35
               tox -e py312-none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # .pip-cache lives inside the workspace, which cross-platform-actions
+      # rsyncs into the VM and back, so wheels built from sdists in one run
+      # (most of the VM setup time) are reused by the next one.
+      - name: Cache pip-built wheels
+        uses: actions/cache@v6
+        with:
+          path: .pip-cache
+          key: ${{ matrix.os }}-${{ matrix.version }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.version }}-pip-
+
       - name: Start VM for ${{ matrix.display_name }}
         id: cross_os
         # a normal boot takes < 1 minute; since 1.4.0 the action bounds
@@ -458,6 +469,9 @@ jobs:
           # a hung test must fail instead of stalling the suite until the
           # job timeout (tox passes all env vars through to pytest).
           export PYTEST_TIMEOUT=300
+
+          # see the "Cache pip-built wheels" step
+          export PIP_CACHE_DIR="$PWD/.pip-cache"
 
           case "${{ matrix.os }}" in
             freebsd)


### PR DESCRIPTION
The OpenBSD job is the slowest one in the vm_tests matrix: ~51 min, vs. ~26 min FreeBSD / ~32 min OmniOS / ~38 min NetBSD in the same run (~1 min pkg_add, ~11 min tox env setup building all deps from source, ~38 min pytest).

Three commits:

1. **mfs-backed TMPDIR** — the pip/cc build temps, the pytest tmp tree and the borg test repos in it never touch the (slow) FFS VM disk. Sized 6g (pytest cleans its tmp tree only after the run), backed by 12G VM RAM via a new per-OS `matrix.memory` override. Created with `-O2` (FFS2): mount_mfs defaults to FFS1, whose 32 bit timestamps silently wrap instead of failing with EOVERFLOW, breaking `test_extract_y2261`. Also folds the four `pkg_add` calls into one. pytest 37:40 → 34:14.
   (An earlier attempt remounting the FFS `async,noatime` + `vm.malloc_conf=j` gave no measurable win — qemu's virtual disk absorbs the synchronous metadata writes in the host page cache anyway — and was dropped.)
2. **Upgrade to OpenBSD 7.9** (image in openbsd-builder v0.14.0). Default python3 is now 3.13, so the tox env moves to `py313-none`; openssl stays 3.5/`eopenssl35`. Surprisingly the biggest test-phase win: pytest 34:14 → 24:44.
3. **Wheel caching for all VM jobs** — `PIP_CACHE_DIR` points into `.pip-cache` in the workspace (rsynced into the VM and back by cross-platform-actions), persisted via `actions/cache`, keyed per OS/version + the locked requirements like the existing Linux pip cache. Kills most of the ~11 min setup phase on cache hits; each OS populates its cache on its first run.

Measured on this branch: cold cache **38:49** (the run that populates the cache), warm cache **27:02** — tox setup 673s → 98s, pytest 23:15, all tests green — down from ~51 min on master. That puts OpenBSD at FreeBSD's level; the other VM jobs gain the same setup savings once their caches are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
