### PR TITLE
CI: cache pip-built wheels for the Windows jobs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -110,6 +110,9 @@ jobs:
       PY_COLORS: 1
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS2_ENV_CONV_EXCL: "*"
+      # see the "Cache pip-built wheels" step. MSYS2_ENV_CONV_EXCL above keeps
+      # this a Windows path when it enters the msys2 shell.
+      PIP_CACHE_DIR: ${{ github.workspace }}\.pip-cache
 
     defaults:
       run:
@@ -119,6 +122,18 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      # Same as the "Cache pip-built wheels" step in ci.yml (MSYS2's mingw
+      # Python cannot use PyPI's win_amd64 wheels). Own key, because the
+      # unlocked requirements may resolve to different versions; falls back
+      # to (and gets picked up by) the ci.yml cache via the shared prefix.
+      - name: Cache pip-built wheels
+        uses: actions/cache@v6
+        with:
+          path: .pip-cache
+          key: windows-msys2-pip-canary-${{ hashFiles('pyproject.toml', 'requirements.d/pyinstaller.txt') }}
+          restore-keys: |
+            windows-msys2-pip-
 
       - uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,6 +671,9 @@ jobs:
       PY_COLORS: 1
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS2_ENV_CONV_EXCL: "*"
+      # see the "Cache pip-built wheels" step. MSYS2_ENV_CONV_EXCL above keeps
+      # this a Windows path when it enters the msys2 shell.
+      PIP_CACHE_DIR: ${{ github.workspace }}\.pip-cache
 
     defaults:
       run:
@@ -680,6 +683,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      # MSYS2's mingw Python cannot use PyPI's win_amd64 wheels, so pip builds
+      # all compiled deps from source - incl. building maturin via cargo, just
+      # to build the blake3 wheel. Persist the wheels pip builds.
+      - name: Cache pip-built wheels
+        uses: actions/cache@v6
+        with:
+          path: .pip-cache
+          key: windows-msys2-pip-${{ hashFiles('pyproject.toml', 'requirements.d/pyinstaller.txt') }}
+          restore-keys: |
+            windows-msys2-pip-
 
       - uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
Same situation as the BSD/OmniOS/Haiku VMs in #10075, just on Windows: MSYS2's mingw (UCRT64) Python cannot use PyPI's win_amd64 wheels (its wheel tag is `mingw_x86_64_ucrt_gnu`), so pip builds every compiled dep from sdist on every run. The worst single item is blake3: pip's build isolation ignores the system `python-maturin` package and first compiles maturin itself with cargo — 4m13s of "Installing build dependencies" — before spending 16s on the blake3 wheel. PyYAML, borghash, borgstore and pyinstaller add ~15s more.

So, like the VM jobs: point `PIP_CACHE_DIR` into `.pip-cache` in the workspace and persist it with `actions/cache`. The already-set `MSYS2_ENV_CONV_EXCL: "*"` passes the Windows path into the msys2 shell unconverted. The cache key hashes `pyproject.toml` + `requirements.d/pyinstaller.txt` (this job does not use the lock file), with a prefix restore-key.

On cache hits pip resolves the same versions straight to cached wheels — no sdist downloads, no build-dep installs, no compiles — cutting the ~8.7 min Build step by ~5 min (windows_tests ~27 min → ~22 min; the rest is pytest). The first run populates the cache.

Also applied to the daily `windows_canary` job, under its own `-canary-` key (unlocked requirements may resolve differently) that falls back to the ci.yml cache via the shared prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
