### PR TITLE
add ProgressIndicatorSpinner, for work of unknown duration

### DIFF
--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -95,6 +95,18 @@ General:
         ``BORG_PROGRESS_FPS=0.1`` limits it to one update every 10 seconds.
         Lower values are useful when the output goes into a logfile rather than
         to an interactive terminal.
+    BORG_SPINNER
+        Controls the spinner borg animates on a terminal while doing work of unknown
+        duration:
+
+        - unset (default): animate, using Unicode frames if the terminal can display them
+        - ``ascii``: animate, but only use ASCII frames (``|/-\``)
+        - ``off``: do not animate, only output the messages next to the spinner
+
+        The spinner is animated only on an interactive terminal anyway (and never
+        with ``--log-json``), and its colour follows the usual ``NO_COLOR`` and
+        ``COLORTERM`` conventions. See also ``BORG_PROGRESS_FPS``: it also gives
+        the spinner its frame rate.
     BORG_DEBUG_PROFILE
         When set to a filename, write an execution profile in Borg format into that file
         (see :ref:`debugging`). If the filename ends with ``.pyprof``, a Python-compatible

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -664,6 +664,18 @@ class HelpMixIn:
                 ``BORG_PROGRESS_FPS=0.1`` limits it to one update every 10 seconds.
                 Lower values are useful when the output goes into a logfile rather than
                 to an interactive terminal.
+            BORG_SPINNER
+                Controls the spinner borg animates on a terminal while doing work of unknown
+                duration:
+
+                - unset (default): animate, using Unicode frames if the terminal can display them
+                - ``ascii``: animate, but only use ASCII frames (``|/-\\``)
+                - ``off``: do not animate, only output the messages next to the spinner
+
+                The spinner is animated only on an interactive terminal anyway (and never
+                with ``--log-json``), and its colour follows the usual ``NO_COLOR`` and
+                ``COLORTERM`` conventions. See also ``BORG_PROGRESS_FPS``: it also gives
+                the spinner its frame rate.
             BORG_DEBUG_PROFILE
                 When set to a filename, write an execution profile in Borg format into that file
                 (see :ref:`debugging`). If the filename ends with ``.pyprof``, a Python-compatible

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -53,7 +53,7 @@ from .parseformat import Highlander, MakePathSafeAction
 from .process import daemonize, daemonizing, ThreadRunner
 from .process import signal_handler, raising_signal_handler, sig_int, ignore_sigint, SigHup, SigTerm
 from .process import popen_with_error_handling, is_terminal, prepare_subprocess_env, create_filter_process
-from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, get_progress_dt
+from .progress import ProgressIndicatorPercent, ProgressIndicatorMessage, ProgressIndicatorSpinner, get_progress_dt
 from .time import parse_timestamp, timestamp, safe_timestamp, safe_s, safe_ns, MAX_S, SUPPORT_32BIT_PLATFORMS
 from .time import format_time, format_timedelta, OutputTimestamp, archive_ts_now
 from .yes_no import yes, TRUISH, FALSISH, DEFAULTISH

--- a/src/borg/helpers/progress.py
+++ b/src/borg/helpers/progress.py
@@ -1,9 +1,12 @@
 import logging
 import json
 import os
+import sys
 import time
+from shutil import get_terminal_size
 
-from ..logger import create_logger
+from .parseformat import ellipsis_truncate
+from ..logger import create_logger, JSONProgressFormatter
 
 logger = create_logger()
 
@@ -109,3 +112,178 @@ class ProgressIndicatorPercent(ProgressIndicatorBase):
     def output(self, message, info=None):
         j = self.make_json(message=message, current=self.counter, total=self.total, info=info)
         self.logger.info(j)
+
+
+# borg green, as on borgbackup.org: #22D045
+GREEN_TRUECOLOR = "\x1b[38;2;34;208;69m"
+# The nearest xterm-256 entry (41 == #00d75f) drops the red channel and reads cooler and more
+# acid than the brand green, so we rather use the bright green from the terminal's own palette:
+# it behaves better on light backgrounds and on other people's terminals.
+GREEN_16 = "\x1b[92m"
+ANSI_RESET = "\x1b[0m"
+ANSI_HIDE_CURSOR = "\x1b[?25l"
+ANSI_SHOW_CURSOR = "\x1b[?25h"
+ANSI_CLEAR_LINE = "\r\x1b[2K"  # carriage return, then erase the whole line
+
+# All frames have East Asian Width "Neutral", so they occupy exactly one cell each and the
+# message after the spinner never shifts column while the animation runs.
+SPINNER_FRAMES = {
+    "square": "▫▪◻◼",  # ▫ ▪ ◻ ◼ - pulsing: small to medium, hollow to solid
+    "cube": "◰◳◲◱",  # ◰ ◳ ◲ ◱ - quadrant rotating clockwise
+    "boxed": "⊞⊠⊟⊡",  # ⊞ ⊠ ⊟ ⊡ - squared plus/times/minus/dot
+    "ascii": "|/-\\",  # the classic, for terminals that can not encode the above
+}
+DEFAULT_SPINNER = "square"
+
+
+def _encodable(text, stream):
+    """Can <text> be represented in the encoding of <stream>?"""
+    try:
+        text.encode(getattr(stream, "encoding", None) or "ascii")
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+def _progress_output_is_json():
+    """Is progress output currently rendered as JSON (--log-json)?"""
+    progress_logger = logging.getLogger(ProgressIndicatorBase.LOGGER)
+    return any(isinstance(handler.formatter, JSONProgressFormatter) for handler in progress_logger.handlers)
+
+
+def spinner_colour(stream):
+    """The ANSI sequence for borg green, or "" if colour is unwanted on <stream>."""
+    if os.environ.get("NO_COLOR") is not None:
+        return ""
+    if os.environ.get("COLORTERM", "").lower() in ("truecolor", "24bit"):
+        return GREEN_TRUECOLOR
+    return GREEN_16
+
+
+class ProgressIndicatorSpinner(ProgressIndicatorBase):
+    """
+    Progress indicator for operations of unknown duration or unknown size.
+
+    Nothing is counted here, the spinner just shows that borg is still working (and, via the
+    message, at what). It is pull-based on purpose: no thread, no timer, nothing runs while the
+    caller is not calling. show() is rate limited to BORG_PROGRESS_FPS internally, so calling it
+    very often is cheap: it costs one time.monotonic() per call and repaints at most that often.
+
+    On a terminal, the spinner frame and the message are repainted in place, in borg green.
+    Without a terminal (or with --log-json), an animation is pointless, so nothing is repainted:
+    only message changes are logged, in the same way ProgressIndicatorMessage does it.
+
+    Usage:
+
+        with ProgressIndicatorSpinner("Deduplicating", msgid="create") as spinner:
+            for chunk in chunks:
+                process(chunk)
+                spinner.show()
+
+    Without the context manager, call finish() yourself - it clears the spinner line and
+    switches the terminal's cursor back on.
+
+    Set BORG_SPINNER=off to never animate, BORG_SPINNER=ascii to force the ASCII frames.
+    """
+
+    JSON_TYPE = "progress_message"  # same contract as ProgressIndicatorMessage, see frontends docs
+
+    def __init__(self, message="", *, frames=DEFAULT_SPINNER, msgid=None, stream=None, animate=None):
+        """
+        :param message: text shown next to the spinner, can be updated via show(message).
+        :param frames: name of a SPINNER_FRAMES set, or a string of frame characters.
+        :param msgid: see ProgressIndicatorBase.
+        :param stream: where to paint the animation [sys.stderr, looked up when writing].
+        :param animate: force the animation on or off [None: decide by looking at the output].
+        """
+        super().__init__(msgid=msgid)
+        self.message = message
+        self._stream = stream
+        mode = os.environ.get("BORG_SPINNER", "").lower()
+        frames = SPINNER_FRAMES.get(frames, frames)
+        self.frames = SPINNER_FRAMES["ascii"] if mode == "ascii" or not _encodable(frames, self.stream) else frames
+        self.animate = self._animation_wanted(mode) if animate is None else animate
+        self.colour = spinner_colour(self.stream) if self.animate else ""
+        self.reset = ANSI_RESET if self.colour else ""
+        self.index = 0  # index of the next frame to paint
+        self.next_update = 0.0  # time.monotonic() value from which on the next output is due
+        self.painted = False  # is there a spinner line on the terminal right now?
+        self.started = False  # did we output anything yet?
+
+    @property
+    def stream(self):
+        """Like logger.StderrHandler, use whatever sys.stderr is *now*, not at construction time."""
+        return sys.stderr if self._stream is None else self._stream
+
+    def _animation_wanted(self, mode):
+        if mode == "off":
+            return False
+        if os.environ.get("TERM", "") in ("", "dumb"):
+            return False
+        try:
+            if not self.stream.isatty():
+                return False
+        except (OSError, ValueError):  # closed or otherwise unusable stream
+            return False
+        return not _progress_output_is_json()
+
+    def show(self, message=None):
+        """Advance the spinner, optionally updating the message. Cheap to over-call."""
+        changed = message is not None and message != self.message
+        if message is not None:
+            self.message = message
+        now = time.monotonic()
+        if now < self.next_update:
+            return
+        if self.animate:
+            self.next_update = now + get_progress_dt()
+            self.paint()
+        elif changed or not self.started:
+            # no terminal to animate on: only say something if there is something new to say.
+            self.next_update = now + get_progress_dt()
+            self.started = True
+            self.output(self.message)
+
+    def paint(self):
+        """Repaint the spinner line in place."""
+        if not self.logger.isEnabledFor(logging.INFO):  # e.g. --quiet
+            return
+        frame = self.frames[self.index % len(self.frames)]
+        self.index += 1
+        # a wrapped line could not be repainted in place, thus the truncation.
+        # ellipsis_truncate pads short messages to the full width - we erase the line instead.
+        columns, lines = get_terminal_size()
+        message = ellipsis_truncate(self.message, columns - 2).rstrip(" ") if self.message else ""
+        text = f"{self.colour}{frame}{self.reset} {message}" if message else f"{self.colour}{frame}{self.reset}"
+        self.write(("" if self.painted else ANSI_HIDE_CURSOR) + ANSI_CLEAR_LINE + text)
+        self.painted = True
+        self.started = True
+
+    def write(self, text):
+        try:
+            self.stream.write(text)
+            self.stream.flush()
+        except (OSError, ValueError):  # the stream went away, e.g. a closed pipe
+            self.animate = False
+
+    def output(self, message):
+        j = self.make_json(message=message)
+        self.logger.info(j)
+
+    def finish(self):
+        """Remove the spinner line from the terminal / log that the operation is finished."""
+        if self.animate:
+            if self.painted:
+                self.write(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR)
+                self.painted = False
+            # no JSON "finished" record here: if we animate, nobody is parsing our output anyway
+            # and the empty line the text formatter would emit for it is just in the way.
+        else:
+            super().finish()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.finish()
+        return False

--- a/src/borg/testsuite/helpers/progress_test.py
+++ b/src/borg/testsuite/helpers/progress_test.py
@@ -1,7 +1,12 @@
+import io
+import logging
+
 import pytest
 
 from ...helpers import progress
-from ...helpers.progress import ProgressIndicatorPercent, get_progress_dt
+from ...helpers.progress import ProgressIndicatorBase, ProgressIndicatorPercent, ProgressIndicatorSpinner
+from ...helpers.progress import get_progress_dt
+from ...helpers.progress import ANSI_CLEAR_LINE, ANSI_HIDE_CURSOR, ANSI_SHOW_CURSOR, GREEN_16, GREEN_TRUECOLOR
 
 
 @pytest.mark.parametrize(
@@ -74,3 +79,197 @@ def test_progress_percentage_quiet(capfd):
     pi.finish()
     out, err = capfd.readouterr()
     assert err == ""
+
+
+class FakeStream(io.StringIO):
+    """A stream that has an encoding, like the real stderr has."""
+
+    encoding = "utf-8"
+
+
+class FakeTTY(FakeStream):
+    """A stream that claims to be a terminal, so the spinner animates into it."""
+
+    def isatty(self):
+        return True
+
+
+@pytest.fixture
+def progress_logger():
+    """The progress logger at the level setup_logging() gives it, restored afterwards."""
+    logger = logging.getLogger(ProgressIndicatorBase.LOGGER)
+    level = logger.level
+    logger.setLevel(logging.INFO)  # setLevel (not .level = ...): it also invalidates the isEnabledFor cache
+    yield logger
+    logger.setLevel(level)
+
+
+@pytest.fixture
+def tty(monkeypatch, progress_logger):
+    monkeypatch.setenv("TERM", "xterm")
+    monkeypatch.setenv("COLUMNS", "80")  # make the terminal width deterministic
+    monkeypatch.setenv("NO_COLOR", "1")  # ... and the escape sequences short
+    monkeypatch.delenv("BORG_SPINNER", raising=False)
+    return FakeTTY()
+
+
+def show_force(spinner, message=None):
+    # bypass the BORG_PROGRESS_FPS rate limiting, so every call produces output
+    spinner.next_update = 0.0
+    spinner.show(message)
+
+
+def test_spinner_animates(tty):
+    spinner = ProgressIndicatorSpinner("Deduplicating", stream=tty)
+    assert spinner.animate
+    show_force(spinner)
+    assert tty.getvalue() == ANSI_HIDE_CURSOR + ANSI_CLEAR_LINE + "▫ Deduplicating"
+    tty.truncate(0), tty.seek(0)
+    show_force(spinner, "Compacting")
+    show_force(spinner)
+    show_force(spinner)
+    show_force(spinner)  # frames wrap around to the first one
+    assert tty.getvalue() == "".join(ANSI_CLEAR_LINE + f"{frame} Compacting" for frame in "▪◻◼▫")
+    tty.truncate(0), tty.seek(0)
+    spinner.finish()
+    assert tty.getvalue() == ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR
+
+
+def test_spinner_rate_limited(tty, monkeypatch):
+    monkeypatch.setenv("BORG_PROGRESS_FPS", "0.1")  # one update per 10s
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    spinner.show()  # the first update is always shown
+    assert tty.getvalue() != ""
+    tty.truncate(0), tty.seek(0)
+    spinner.show()  # immediately after: suppressed by the rate limit
+    spinner.show("even a new message has to wait")
+    assert tty.getvalue() == ""
+
+
+def test_spinner_context_manager(tty):
+    with ProgressIndicatorSpinner("Working", stream=tty) as spinner:
+        show_force(spinner)
+    assert tty.getvalue().startswith(ANSI_HIDE_CURSOR)
+    assert tty.getvalue().endswith(ANSI_CLEAR_LINE + ANSI_SHOW_CURSOR)
+
+
+def test_spinner_nothing_painted_nothing_to_clean_up(tty):
+    with ProgressIndicatorSpinner("Working", stream=tty):
+        pass  # no show() call, so we never hid the cursor and must not paint anything either
+    assert tty.getvalue() == ""
+
+
+def test_spinner_no_message(tty):
+    spinner = ProgressIndicatorSpinner(stream=tty)
+    show_force(spinner)
+    assert tty.getvalue() == ANSI_HIDE_CURSOR + ANSI_CLEAR_LINE + "▫"  # no trailing blank
+
+
+def test_spinner_long_message_truncated(tty):
+    spinner = ProgressIndicatorSpinner(stream=tty)
+    show_force(spinner, "x" * 200)
+    line = tty.getvalue().rsplit(ANSI_CLEAR_LINE, 1)[1]
+    assert len(line) <= 80
+    assert line.startswith("▫ xxx") and line.endswith("xxx")
+
+
+@pytest.mark.parametrize("frames,expected", [("cube", "◰"), ("square", "▫"), ("boxed", "⊞"), ("+x", "+")])
+def test_spinner_frame_sets(tty, frames, expected):
+    spinner = ProgressIndicatorSpinner(frames=frames, stream=tty)
+    show_force(spinner)
+    assert tty.getvalue().endswith(expected)
+
+
+def test_spinner_ascii_forced(tty, monkeypatch):
+    monkeypatch.setenv("BORG_SPINNER", "ascii")
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    show_force(spinner)
+    assert tty.getvalue().endswith("| Working")
+
+
+def test_spinner_ascii_fallback_for_unencodable_frames(tty):
+    tty.encoding = "ascii"  # a terminal that can not represent the fancy frames
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    show_force(spinner)
+    assert tty.getvalue().endswith("| Working")
+
+
+@pytest.mark.parametrize(
+    "env,colour",
+    [
+        ({}, GREEN_16),
+        ({"COLORTERM": "truecolor"}, GREEN_TRUECOLOR),
+        ({"COLORTERM": "24bit"}, GREEN_TRUECOLOR),
+        ({"COLORTERM": "8bit"}, GREEN_16),
+        ({"NO_COLOR": "1"}, ""),
+        ({"NO_COLOR": "1", "COLORTERM": "truecolor"}, ""),
+    ],
+)
+def test_spinner_colour(tty, monkeypatch, env, colour):
+    monkeypatch.delenv("NO_COLOR", raising=False)  # the tty fixture sets it
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    show_force(spinner)
+    assert tty.getvalue().endswith(f"{colour}▫{progress.ANSI_RESET if colour else ''} Working")
+
+
+def test_spinner_quiet(tty, progress_logger):
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    progress_logger.setLevel("WARN")  # e.g. --quiet
+    show_force(spinner)
+    assert tty.getvalue() == ""
+
+
+def test_spinner_broken_stream(tty):
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    tty.close()  # e.g. the terminal went away
+    show_force(spinner)
+    assert not spinner.animate  # we gave up on it, no exception
+
+
+@pytest.mark.parametrize("env", [{"BORG_SPINNER": "off"}, {"TERM": "dumb"}, {"TERM": ""}])
+def test_spinner_animation_disabled(tty, monkeypatch, env):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    spinner = ProgressIndicatorSpinner("Working", stream=tty)
+    assert not spinner.animate
+    show_force(spinner)
+    assert tty.getvalue() == ""  # nothing painted, it goes to the log instead
+
+
+def test_spinner_no_tty(capfd, monkeypatch, progress_logger):
+    monkeypatch.delenv("BORG_SPINNER", raising=False)
+    spinner = ProgressIndicatorSpinner("Saving files cache")  # stderr is not a tty here
+    assert not spinner.animate
+    show_force(spinner)
+    out, err = capfd.readouterr()
+    assert err == "Saving files cache\n"
+    show_force(spinner)  # the message did not change: an animation frame is all we could add
+    show_force(spinner)
+    out, err = capfd.readouterr()
+    assert err == ""
+    show_force(spinner, "Saving chunks cache")
+    out, err = capfd.readouterr()
+    assert err == "Saving chunks cache\n"
+    spinner.finish()
+    out, err = capfd.readouterr()
+    assert err == "\n"  # the "finished" record, like the other progress indicators emit it
+
+
+def test_spinner_no_tty_quiet(capfd, progress_logger):
+    spinner = ProgressIndicatorSpinner("Saving files cache")
+    progress_logger.setLevel("WARN")  # e.g. --quiet
+    show_force(spinner)
+    spinner.finish()
+    out, err = capfd.readouterr()
+    assert err == ""
+
+
+def test_spinner_animate_forced(monkeypatch, progress_logger):
+    stream = FakeStream()  # not a tty at all
+    monkeypatch.setenv("COLUMNS", "80")
+    monkeypatch.setenv("NO_COLOR", "1")
+    spinner = ProgressIndicatorSpinner("Working", stream=stream, animate=True)
+    show_force(spinner)
+    assert stream.getvalue().endswith("▫ Working")


### PR DESCRIPTION
The other progress indicators either count (`ProgressIndicatorPercent`) or just emit a message (`ProgressIndicatorMessage`). For work whose duration or size is not known in advance, neither fits: what we want to show is *"borg is still working, at this"* — and that is a spinner.

```python
with ProgressIndicatorSpinner("Deduplicating", msgid="create") as spinner:
    for chunk in chunks:
        process(chunk)
        spinner.show()
```

### How it behaves

- **Pull-based on purpose**: no thread, no timer, nothing runs while the caller is not calling. `show()` is rate limited by `BORG_PROGRESS_FPS` internally, so calling it a million times a second costs one `time.monotonic()` per call.
- **On a terminal**: the frame and the message are repainted in place, in borg green (`#22D045` on truecolor terminals, else the terminal's own bright green — the nearest xterm-256 entry drops the red channel and reads too acid). The message is truncated to the terminal width, because a wrapped line could not be repainted in place. The cursor is hidden at the first paint and switched back on in `finish()`.
- **Without a terminal, or with `--log-json`**: an animation would be pointless, so nothing is repainted — only message *changes* are logged, as `progress_message`, exactly like `ProgressIndicatorMessage` does it. So a logfile gets one line per phase rather than one per frame, and frontends need no changes.
- `--quiet` silences it, like the other indicators.

### Frames

All frames are East Asian Width "Neutral", so they occupy exactly one cell and the message after the spinner never shifts column:

| name | frames | |
|---|---|---|
| `square` (default) | ▫ ▪ ◻ ◼ | pulsing: small to medium, hollow to solid |
| `cube` | ◰ ◳ ◲ ◱ | quadrant rotating clockwise |
| `boxed` | ⊞ ⊠ ⊟ ⊡ | squared plus/times/minus/dot |
| `ascii` | \| / - \\ | the classic |

If the output encoding can not represent the fancy frames, the ASCII ones are used automatically.

### New environment variable

`BORG_SPINNER=off` never animates, `BORG_SPINNER=ascii` forces the ASCII frames. Documented in the `environment` help topic (and thus in the docs). Colour follows the usual `NO_COLOR` / `COLORTERM` conventions.

### Notes

- No caller yet — this adds the indicator only. The existing indefinite-duration spots (e.g. `Cache.close()`) are single-call phases where nothing would animate; wiring it up where there is a real loop is a separate change.
- Tests cover animation, frame sets and fallbacks, colour, rate limiting, truncation, `--quiet`, non-tty logging, and a stream that goes away mid-run.