### PR TITLE
validate object headers when walking a pack (PackReader.iter_headers)

### DIFF
--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -361,12 +361,28 @@ class PackReader:
             return memoryview(self.pack_contents)[offset : offset + size]
         return self.store.load(self.key, offset=offset, size=size)
 
+    def size(self):
+        """Return the pack size in bytes; for a store-backed pack this is one metadata lookup."""
+        if self.pack_contents is not None:
+            return len(self.pack_contents)
+        return self.store.info(self.key).size
+
     def iter_headers(self):
         """Yield (chunk_id, offset, size) for each object by walking the fixed object headers.
 
         Only the headers are read, not the payloads, so locating every object costs one short
-        range read per object (or just a slice, when the pack is already in memory).
+        range read per object (or just a slice, when the pack is already in memory), plus one
+        store metadata lookup for the pack size.
+
+        Each full header must have OBJ_MAGIC and describe an object that fits into the pack,
+        otherwise the pack is corrupt and IntegrityError is raised. Ending the walk instead
+        would be worse than raising: the chunks index rebuilt from these headers would just be
+        missing the rest of the pack, and borg check --repair would then "fix" the archives by
+        dropping chunks that are there.
+        A trailing partial header is the clean end of the pack, not corruption.
         """
+        pack_hex = bin_to_hex(self.pack_id) if self.pack_id is not None else "<no id>"
+        pack_size = self.size()
         hdr_size = RepoObj.obj_header.size
         offset = 0
         while True:
@@ -374,7 +390,16 @@ class PackReader:
             if len(hdr_data) < hdr_size:
                 break  # clean EOF, or trailing partial bytes
             hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(hdr_data))
+            if hdr.magic != OBJ_MAGIC:
+                raise IntegrityError(
+                    f'pack {pack_hex}: no object header at offset {offset} (pack corruption), run "borg check"'
+                )
             obj_size = hdr_size + hdr.meta_size + hdr.data_size
+            if offset + obj_size > pack_size:
+                raise IntegrityError(
+                    f"pack {pack_hex}: object extends past end of file at offset {offset} "
+                    f'(pack corruption), run "borg check"'
+                )
             yield hdr.chunk_id, offset, obj_size
             offset += obj_size
 

--- a/src/borg/testsuite/repository_test.py
+++ b/src/borg/testsuite/repository_test.py
@@ -1635,6 +1635,55 @@ def test_pack_reader_iter_headers_reads_through_store(tmp_path):
         assert list(reader.iter_headers()) == [(H(47), 0, len(obj1)), (H(48), len(obj1), len(obj2))]
 
 
+def test_pack_reader_raises_on_bad_magic():
+    # a header without OBJ_MAGIC means the walk desynced onto payload bytes: corruption, not EOF.
+    obj1 = fchunk(b"payload-one", meta=b"meta1", chunk_id=H(1))
+    obj2 = bytearray(fchunk(b"d2", meta=b"m2", chunk_id=H(2)))
+    obj2[0] ^= 0xFF  # break the magic of the second object's header
+    reader = PackReader(pack_contents=obj1 + bytes(obj2))
+    with pytest.raises(IntegrityError):
+        list(reader.iter_headers())
+
+
+def test_pack_reader_raises_on_bad_magic_through_store(tmp_path):
+    obj = bytearray(fchunk(b"FIRST", chunk_id=H(47)))
+    obj[0] ^= 0xFF
+    pack_id = H(44)
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        repository.store_store("packs/" + bin_to_hex(pack_id), bytes(obj))
+        reader = PackReader(repository.store, pack_id)
+        with pytest.raises(IntegrityError):
+            list(reader.iter_headers())
+
+
+def test_pack_reader_raises_on_object_past_end_of_pack():
+    # a valid header whose declared sizes overrun the pack: the object cannot be there.
+    obj = fchunk(b"data", meta=b"meta", chunk_id=H(5))
+    pack = obj[:-1]  # drop a byte, so the header's data_size no longer fits
+    reader = PackReader(pack_contents=pack)
+    with pytest.raises(IntegrityError):
+        list(reader.iter_headers())
+
+
+def test_pack_reader_raises_on_object_past_end_of_pack_through_store(tmp_path):
+    obj = fchunk(b"FIRST", chunk_id=H(49))
+    pack_id = H(45)
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        repository.store_store("packs/" + bin_to_hex(pack_id), obj[:-1])
+        reader = PackReader(repository.store, pack_id)
+        with pytest.raises(IntegrityError):
+            list(reader.iter_headers())
+
+
+def test_pack_reader_size(tmp_path):
+    obj = fchunk(b"data", meta=b"meta", chunk_id=H(6))
+    assert PackReader(pack_contents=obj).size() == len(obj)
+    pack_id = H(46)
+    with Repository(str(tmp_path / "repo"), exclusive=True, create=True) as repository:
+        repository.store_store("packs/" + bin_to_hex(pack_id), obj)
+        assert PackReader(repository.store, pack_id).size() == len(obj)
+
+
 def test_pack_reader_in_memory_read_returns_view():
     # read() over an in-memory pack returns a memoryview into pack_contents.
     obj1 = fchunk(b"payload-one", meta=b"meta1", chunk_id=H(1))


### PR DESCRIPTION
Noticed this while looking at #8476, which wants the chunks index rebuilt by iterating only over the object headers of the packs. That walk is `PackReader.iter_headers` (used by `build_chunkindex_from_repo`) and it did not check the headers at all.

It unpacks each fixed header and takes the next offset from the sizes in it:

```python
hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(hdr_data))
obj_size = hdr_size + hdr.meta_size + hdr.data_size
yield hdr.chunk_id, offset, obj_size
offset += obj_size
```

So on a corrupt header `obj_size` is wrong and the walk either keeps going on payload bytes and yields garbage `(chunk_id, offset, size)` tuples, or skips past the end of the pack, where the short read hits the `len(hdr_data) < hdr_size` branch and looks like a clean EOF. The index rebuilt from that is wrong either way, and nothing says so.

**This PR is now just the check.** Each header must have OBJ_MAGIC, a supported version and sizes that keep the object inside the pack, otherwise IntegrityError naming the pack, like `check_pack_objects` does. `superseded_gap_ranges` already does the same check when it walks headers in the gaps. The bounds check needs the pack size, which PackReader did not have, so there is now `PackReader.size()`: `len(pack_contents)` in memory, `store.info(key).size` otherwise, one metadata lookup per iter_headers call. No per-object roundtrip.

### Tests

Corrupt magic, unsupported version, and an object declared past the end of the pack all raise, in memory and through the store.

### Split off: repair-time resync

The two resync commits that were here (scan forward to the next object header, accept a candidate only if it authenticates) have been dropped from this PR and kept for a follow-up, because they depend on questions about the pack format itself rather than on this check:

- The scan hands each candidate's full bytes to the validator. Authenticating only the encrypted metadata is enough (the AAD covers magic, version and chunk_id) and turns up to MAX_DATA_SIZE per candidate into ~130 bytes. But then `data_size` is authenticated by nothing, and `parse_meta()` does no id check, so `none`/`authenticated` lose the one check that rejects a decoy object stored verbatim inside a file's content.
- Independently of corruption, `iter_headers` costs one store range read per object. Rebuilding an index over ssh/rest is that many roundtrips per pack.

Both go away if a pack carries an authenticated directory of its objects, or if the header itself is authenticated. Happy to work on either; the follow-up is easier to judge once that is decided.

### What this does not fix

The pack stays damaged. `check --repair` drops the index in `finish()`, so the next command rebuilds from the packs and raises on the same header again. Before this PR that rebuild would have silently produced a wrong index instead, so this is not a regression, but a repo is only really usable again once the pack itself is repaired (#10026).
