### PR TITLE
compression: support zstd negative ("fast") levels

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -198,6 +198,8 @@ New features:
     via OpenSSL, #9987, #10043
   - zero-copy fill and lazy buffer compaction optimizations
   - log the chunker and its scan kernel at debug level
+- compression: support zstd's negative ("fast") levels, ``zstd,-1`` .. ``zstd,-128``, #9950.
+  They trade compression ratio for speed. Compatible with existing repositories.
 - webdav: serve archives via WebDAV / HTTP, including PAX tar downloads - this is a nice
   replacement for `borg mount` in some use cases, #9942
 - mount: expose POSIX ACLs on Linux mounts (not enforced), #1042

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -115,7 +115,8 @@ Repo object metadata
 Metadata is a MessagePack-encoded (and encrypted/authenticated) dict with:
 
 - ctype (compression type 0..255)
-- clevel (compression level 0..255)
+- clevel (compression level, one byte, interpreted depending on ctype - see
+  :ref:`data-compression`)
 - csize (overall compressed (and maybe obfuscated) data size)
 - psize (only when obfuscated: payload size without the obfuscation trailer)
 - size (uncompressed size of the data)
@@ -1011,19 +1012,25 @@ Compression
 -----------
 
 Borg supports the following compression methods, each identified by a ctype value
-in the range between 0 and 255 (and augmented by a clevel 0..255 value for the
+in the range between 0 and 255 (and augmented by a one-byte clevel value for the
 compression level):
 
 - none (no compression, pass through data 1:1), identified by 0x00
 - lz4 (low compression, but super fast), identified by 0x01
-- zstd (level 1-22 offering a wide range: level 1 is lower compression and high
-  speed, level 22 is higher compression and lower speed) - identified by 0x03
+- zstd (level -128..22 offering a wide range: level 22 is higher compression and lower
+  speed, level 1 is lower compression and high speed, and the negative "fast" levels
+  trade still more compression for still more speed) - identified by 0x03
 - zlib (level 0-9, level 0 is no compression [but still adding zlib overhead],
   level 1 is low, level 9 is high compression), identified by 0x05
 - lzma (level 0-9, level 0 is low, level 9 is high compression), identified
   by 0x02.
 
-The type byte is followed by a byte indicating the compression level.
+The type byte is followed by a byte indicating the compression level. How that byte is
+interpreted depends on the compression type: for zstd it is an ``int8_t``, so that the
+negative levels fit (level -1 is stored as 255, -128 as 128). For all other types it is
+an unsigned byte, with 255 meaning "no level applies" (as for none and lz4). Levels 1..22
+occupy the same byte values either way, so zstd data written by older borg versions keeps
+its meaning.
 
 Speed:  none > lz4 > zlib > lzma, lz4 > zstd
 Compression: lzma > zlib > lz4 > none, zstd > lz4

--- a/src/borg/archiver/completion_cmd.py
+++ b/src/borg/archiver/completion_cmd.py
@@ -972,7 +972,16 @@ class CompletionMixIn:
         help_choices = " ".join(sorted(help_choices))
 
         # Compression spec choices (static list)
-        comp_spec_choices = ["lz4", "zstd,3", "auto,zstd,10", "zlib,6", "lzma,6", "obfuscate,250,lz4", "none"]
+        comp_spec_choices = [
+            "lz4",
+            "zstd,3",
+            "zstd,-4",
+            "auto,zstd,10",
+            "zlib,6",
+            "lzma,6",
+            "obfuscate,250,lz4",
+            "none",
+        ]
         comp_spec_choices_str = " ".join(comp_spec_choices)
 
         # Chunker params choices (static list)

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -480,8 +480,15 @@ class HelpMixIn:
 
         zstd[,L]
             Use zstd ("zstandard") compression, a modern wide-range algorithm.
-            If you do not explicitly give the compression level L (ranging from 1
+            If you do not explicitly give the compression level L (ranging from -128
             to 22), it will use level 3.
+            Negative levels are zstd's "fast" levels (level -N is what the zstd command
+            line tool calls --fast=N): they give up compression ratio for speed.
+            -1 to -10 is the useful range for general data; going lower only pays off for
+            data with long repeats (disk/VM images, database files), where it stays fast
+            while still finding the big matches.
+            Level 0 selects zstd's default level (3) - for zstd it does not mean
+            "no compression" (use "none" for that), unlike for zlib below.
 
         zlib[,L]
             Use zlib ("gz") compression. Medium speed, medium compression.

--- a/src/borg/archiver/repo_compress_cmd.py
+++ b/src/borg/archiver/repo_compress_cmd.py
@@ -19,14 +19,18 @@ logger = create_logger()
 
 
 def get_csettings(c):
-    """Return the (ctype, clevel, olevel) compression settings a compressor is configured for."""
+    """Return the (ctype, clevel, olevel) compression settings a compressor is configured for.
+
+    clevel is the *stored* level byte, so that it can be compared against the clevel of an
+    existing repo object as-is - see PackRecompressor.transform.
+    """
     if isinstance(c, Auto):
         return get_csettings(c.compressor)
     if isinstance(c, ObfuscateSize):
         ctype, clevel, _ = get_csettings(c.compressor)
         olevel = c.level
         return ctype, clevel, olevel
-    ctype, clevel, olevel = c.ID, c.level, -1
+    ctype, clevel, olevel = c.ID, c.encode_level(c.level), -1
     return ctype, clevel, olevel
 
 
@@ -37,7 +41,11 @@ def format_compression_spec(ctype, clevel, olevel):
             cname = f"{cname}"
             break
     else:
-        cname = f"{ctype}"
+        cname, cls = f"{ctype}", None
+    if cls is not None:
+        # decode before checking for 255 ("level not applicable"): for zstd the byte is an
+        # int8_t, so 255 there is level -1 and has to be shown.
+        clevel = cls.decode_level(clevel)
     clevel = f",{clevel}" if clevel != 255 else ""
     return obfuscation + cname + clevel
 
@@ -228,7 +236,7 @@ class RepoCompressMixIn:
             type=CompressionSpec,
             default=CompressionSpec("lz4"),
             action=Highlander,
-            help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
+            help='select compression algorithm, see the output of the "borg help compression" command for details.',
         )
 
         subparser.add_argument("-s", "--stats", dest="stats", action="store_true", help="print statistics")

--- a/src/borg/compress.pyx
+++ b/src/borg/compress.pyx
@@ -128,8 +128,24 @@ cdef class CompressorBase:
     def detect(cls, data):
         return data and data[0] == cls.ID
 
+    @classmethod
+    def encode_level(cls, level):
+        """Compression level as the compressor uses it -> the single clevel byte we store.
+
+        Compressors that need a different byte encoding (see ZSTD) override this and
+        decode_level. Doing it per compressor rather than globally keeps the stored byte
+        of every other compressor exactly as it always was.
+        """
+        assert 0 <= level <= 255, f"invalid level: {level}"
+        return level
+
+    @classmethod
+    def decode_level(cls, clevel):
+        """The stored clevel byte -> compression level as the compressor uses it."""
+        return clevel
+
     def __init__(self, level=255, legacy_mode=False, **kwargs):
-        assert 0 <= level <= 255
+        self.encode_level(level)  # rejects levels this compressor cannot store
         self.level = level
         self.legacy_mode = legacy_mode  # True: support prefixed ctype/clevel bytes
 
@@ -152,10 +168,10 @@ cdef class CompressorBase:
         """
         if self.legacy_mode:
             # the ID/level prefix concatenation needs bytes (bytes() is a no-op for bytes input)
-            return None, bytes((self.ID, self.level)) + bytes(data)
+            return None, bytes((self.ID, self.encode_level(self.level))) + bytes(data)
         else:
             meta["ctype"] = self.ID
-            meta["clevel"] = self.level
+            meta["clevel"] = self.encode_level(self.level)
             meta["csize"] = len(data)
             return meta, data
 
@@ -384,9 +400,24 @@ class LZMA(DecidingCompressor):
 class ZSTD(DecidingCompressor):
     """
     zstd compression / decompression (python stdlib (python >= 3.14))
+
+    Levels range from -128 to 22. The negative ones are zstd's "fast" levels (level -N is
+    what the zstd cli calls --fast=N): they trade compression ratio for speed.
     """
     ID = 0x03
     name = 'zstd'
+
+    @classmethod
+    def encode_level(cls, level):
+        # We interpret the clevel byte as an int8_t, which is what makes the negative levels
+        # storable at all. Levels 1..22 encode to the very same byte value as before, so
+        # repos written by older borg versions keep their meaning.
+        assert -128 <= level <= 127, f"invalid level: {level}"
+        return level & 0xFF
+
+    @classmethod
+    def decode_level(cls, clevel):
+        return clevel - 256 if clevel >= 128 else clevel
 
     def __init__(self, level=3, legacy_mode=False, **kwargs):
         super().__init__(level=level, legacy_mode=legacy_mode, **kwargs)
@@ -715,9 +746,9 @@ class Compressor:
     @staticmethod
     def detect(data):
         hdr = bytes(data[:2])  # detect() does not work with memoryview
-        level = hdr[1]  # usually the level, but not for zlib_legacy
+        clevel = hdr[1]  # usually the level byte, but not for zlib_legacy
         for cls in COMPRESSOR_LIST:
             if cls.detect(hdr):
-                return cls, (255 if cls.name == 'zlib_legacy' else level)
+                return cls, (255 if cls.name == 'zlib_legacy' else cls.decode_level(clevel))
         else:
             raise ValueError('No decompressor for this data found: %r.', data[:2])

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -227,8 +227,10 @@ class CompressionSpec:
                     level = 3  # default compression level in zstd
                 elif count == 2:
                     level = int(values[1])
-                    if not 1 <= level <= 22:
-                        raise ArgumentTypeError("level must be >= 1 and <= 22")
+                    # negative levels are zstd's "fast" levels, -128 is what the clevel byte
+                    # can still store (it is interpreted as an int8_t for zstd).
+                    if not -128 <= level <= 22:
+                        raise ArgumentTypeError("level must be >= -128 and <= 22")
                 else:
                     raise ArgumentTypeError("too many arguments")
                 self.level = level

--- a/src/borg/testsuite/archiver/repo_compress_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_compress_cmd_test.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 
@@ -76,6 +77,47 @@ def test_repo_compress(archiver):
     check_compression(ctype, clevel, olevel)
 
     # data must survive all those recompressions unharmed
+    cmd(archiver, "check")
+
+
+def test_repo_compress_zstd_negative_level(archiver):
+    """zstd's negative ("fast") levels survive a repo-compress round trip.
+
+    The second run is the interesting part: it only reports everything as already-ok if the
+    level the compressor is configured with and the clevel byte stored in the repo are the
+    same representation. If they diverge, borg parses and recompresses every object again on
+    every run (see get_csettings).
+    """
+    create_regular_file(archiver.input_path, "file1", size=1024 * 10)
+    create_regular_file(archiver.input_path, "file2", contents=os.urandom(1024 * 10))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input", "-C", "lz4")
+
+    for level in (-1, -4):  # -1 is the level whose byte (255) is also the "no level" sentinel
+        cmd(archiver, "repo-compress", "-C", f"zstd,{level}")
+        repository = Repository(archiver.repository_path, exclusive=True)
+        with repository:
+            manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
+            for id, _ in repo_lister(repository, limit=LIST_SCAN_LIMIT):
+                chunk = repository.get(id, read_data=True)
+                meta, data = manifest.repo_objs.parse(id, chunk, ro_type=ROBJ_DONTCARE)
+                assert meta["ctype"] in (ZSTD.ID, LZ4.ID, CNONE.ID)
+                if meta["ctype"] == ZSTD.ID:
+                    assert meta["clevel"] == ZSTD.encode_level(level)
+
+        # Running it again must recognise the objects as already having the desired
+        # compression. Checking for "0 recompressed" alone would not catch anything: objects
+        # whose settings are misread get recompressed to the identical result and are then
+        # counted as "kept as-is", so the telling number is how many were recognised as ok.
+        output = cmd(archiver, "repo-compress", "-C", f"zstd,{level}", "--stats")
+        stats = re.search(
+            r"Objects: (\d+) total, (\d+) recompressed, (\d+) already had the desired compression", output
+        )
+        assert stats, output
+        total, recompressed, already_ok = (int(g) for g in stats.groups())
+        assert recompressed == 0
+        assert already_ok > 0, f"no object was recognised as already compressed with zstd,{level}"
+
     cmd(archiver, "check")
 
 

--- a/src/borg/testsuite/compress_test.py
+++ b/src/borg/testsuite/compress_test.py
@@ -232,7 +232,8 @@ def test_default_compression_level(c_type, c_name):
 
 
 @pytest.mark.parametrize(
-    "c_type, c_name, c_levels", [(ZLIB, "zlib", [0, 9]), (LZMA, "lzma", [0, 9]), (ZSTD, "zstd", [1, 22])]
+    "c_type, c_name, c_levels",
+    [(ZLIB, "zlib", [0, 9]), (LZMA, "lzma", [0, 9]), (ZSTD, "zstd", [-128, -22, -4, -1, 1, 22])],
 )
 def test_specified_compression_level(c_type, c_name, c_levels):
     for level in c_levels:
@@ -241,10 +242,51 @@ def test_specified_compression_level(c_type, c_name, c_levels):
         assert cs.level == level
 
 
-@pytest.mark.parametrize("invalid_spec", ["", "lzma,9,invalid", "invalid"])
+@pytest.mark.parametrize("invalid_spec", ["", "lzma,9,invalid", "invalid", "zstd,-129", "zstd,23"])
 def test_invalid_compression_level(invalid_spec):
     with pytest.raises(ArgumentTypeError):
         CompressionSpec(invalid_spec)
+
+
+@pytest.mark.parametrize("level, clevel", [(22, 22), (3, 3), (1, 1), (-1, 255), (-4, 252), (-22, 234), (-128, 128)])
+def test_zstd_level_encoding(level, clevel):
+    """The clevel byte is an int8_t for zstd, and levels 1..22 keep the byte they always had."""
+    assert ZSTD.encode_level(level) == clevel
+    assert ZSTD.decode_level(clevel) == level
+    # the autodetection has to hand back the decoded (possibly negative) level
+    assert Compressor.detect(bytes((ZSTD.ID, clevel))) == (ZSTD, level)
+
+
+@pytest.mark.parametrize("level", [-128, -22, -4, -1, 1, 3, 22])
+def test_zstd_level_roundtrip(level):
+    data = bytes(bytearray(range(256))) * 400
+    compressor = CompressionSpec(f"zstd,{level}").compressor
+    meta, compressed = compressor.compress({}, data)
+    assert meta["clevel"] == ZSTD.encode_level(level)
+    # decompress via the autodetecting Compressor, i.e. the way a repo object is read back
+    meta, decompressed = Compressor("zstd").decompress(dict(meta), compressed)
+    assert decompressed == data
+
+
+@pytest.mark.parametrize("level", [-128, -4, -1, 3])
+def test_zstd_level_roundtrip_legacy_mode(level):
+    data = bytes(bytearray(range(256))) * 400
+    compressor = ZSTD(level=level, legacy_mode=True)
+    # legacy mode returns meta None, but compress() still needs a dict to put "size" into
+    meta, compressed = compressor.compress({}, data)
+    assert compressed[:2] == bytes((ZSTD.ID, ZSTD.encode_level(level)))
+    meta, decompressed = Compressor("zstd", legacy_mode=True).decompress(None, compressed)
+    assert decompressed == data
+
+
+def test_other_compressors_keep_their_level_byte():
+    """Only zstd reinterprets the byte - everything else must store exactly what it did before."""
+    for cls in (CNONE, LZ4, ZLIB, LZMA):
+        assert cls.encode_level(255) == 255
+        assert cls.decode_level(255) == 255
+        for level in (0, 6, 9):
+            assert cls.encode_level(level) == level
+            assert cls.decode_level(level) == level
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds support for zstd's negative ("fast") levels: `zstd,-128` .. `zstd,22`. Fixes #9950.

### Why

Negative levels trade compression ratio for speed. How much they are worth depends strongly on the data, which is why the full range the level byte can hold is accepted rather than cutting it off somewhere (benchmarks in #9950):

- on data with **short** matches, everything below about -10 is dominated by lz4 / `none`
- on data with **long** repeats (disk/VM images, database files), `zstd,-50` reached **2.2x lz4's ratio at 2.2x lz4's speed**, and even `-128` beat lz4 on both axes

borg cannot know the user's data, so it does not impose a cutoff libzstd does not have.

### Compatible with existing repositories

The clevel byte is now interpreted per compressor: an `int8_t` for zstd, unsigned as before for everything else. Levels 1..22 encode to the byte value they always had, and `CompressionSpec` never allowed anything outside 1..22 for zstd, so byte values 128..255 have never been written for `ctype=0x03` by borg 1.x or 2.x. No repo format change.

Verified by building unmodified borg, writing a repo with it (`zstd,3`, `zstd,22`, `lz4`), then reading that repo with this branch: all archives extract byte-identical and `check --verify-data` passes.

### Implementation

`CompressorBase.encode_level` / `decode_level` classmethods (identity by default, overridden by `ZSTD`). Doing it per compressor rather than globally means only zstd changes meaning and every other compressor keeps storing exactly the byte it did before. A global signed interpretation was considered and rejected: `ObfuscateSize` uses levels 110..123 and 250, which do not fit in an `int8_t`, and it would have changed the byte written for lz4/none.

Two spots in `repo-compress` needed fixing, as they compare or display the byte without knowing the type:

- `get_csettings` returned the compressor object's level while `transform` compares it against the stored byte. With them diverging, every object gets parsed and recompressed on every run, only to then keep the old bytes - wasteful and silent. It now returns the stored byte.
- `format_compression_spec` hid the level when the byte was 255 ("level not applicable"), which would print `zstd,-1` as `zstd`. It now decodes before that check.

### Tests

Level encoding, data round trips (normal and legacy mode), a guard that no other compressor's byte changed, and a `repo-compress` test that a second run recognises the objects as already compressed - the regression guard for the `get_csettings` fix (checking only "0 recompressed" would not catch it, since misread objects get recompressed to an identical result and are then counted as "kept as-is").

Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UowHQDcnmow3JnYBmaGDpN
