### PR TITLE
create --progress: show big sizes with more decimals, fixes #3559

### DIFF
--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -263,6 +263,11 @@ The ``--progress`` option shows (from left to right) Original and (uncompressed)
 deduplicated size (O and U respectively), then the Number of files (N) processed so far,
 followed by the currently processed path.
 
+Sizes of GB and above are shown with enough decimal places that even MB-sized progress
+stays visible. On a terminal, this needs a width of at least 110 columns - on narrower
+terminals, the compact format is used, so that the path stays readable. If the output
+does not go to a terminal (e.g. into a logfile), the precise format is always used.
+
 When using ``--stats``, you will get some statistics about how much data was
 added - the "This Archive" deduplicated size there is most interesting as that is
 how much your repository will grow. Please note that the "All archives" stats refer to

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -213,7 +213,10 @@ Files changed while reading: {files_changed_while_reading}
             elif not stream.isatty():
                 # Non-TTY output: use normal linefeeds and do not truncate the path.
                 if not final:
-                    msg = "{0.osize_fmt} O {0.usize_fmt} U {0.nfiles} N ".format(self)
+                    # no width limit here, so always show the sizes precisely, see #3559.
+                    osize_fmt = format_file_size(self.osize, fine=True)
+                    usize_fmt = format_file_size(self.usize, fine=True)
+                    msg = f"{osize_fmt} O {usize_fmt} U {self.nfiles} N "
                     msg += remove_surrogates(item.path) if item else ""
                 else:
                     msg = ""
@@ -221,7 +224,12 @@ Files changed while reading: {files_changed_while_reading}
             else:
                 columns, lines = get_terminal_size()
                 if not final:
-                    msg = "{0.osize_fmt} O {0.usize_fmt} U {0.nfiles} N ".format(self)
+                    # more decimals eat into the space left for the path, so only show them
+                    # if the terminal is clearly wider than the classic 80 columns, see #3559.
+                    fine = columns >= 110
+                    osize_fmt = format_file_size(self.osize, fine=fine)
+                    usize_fmt = format_file_size(self.usize, fine=fine)
+                    msg = f"{osize_fmt} O {usize_fmt} U {self.nfiles} N "
                     path = remove_surrogates(item.path) if item else ""
                     space = columns - swidth(msg)
                     if space < 12:

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -656,6 +656,11 @@ class CreateMixIn:
         deduplicated size (O and U respectively), then the Number of files (N) processed so far,
         followed by the currently processed path.
 
+        Sizes of GB and above are shown with enough decimal places that even MB-sized progress
+        stays visible. On a terminal, this needs a width of at least 110 columns - on narrower
+        terminals, the compact format is used, so that the path stays readable. If the output
+        does not go to a terminal (e.g. into a logfile), the precise format is always used.
+
         When using ``--stats``, you will get some statistics about how much data was
         added - the "This Archive" deduplicated size there is most interesting as that is
         how much your repository will grow. Please note that the "All archives" stats refer to

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -554,15 +554,18 @@ def get_size_units():
     return "si"
 
 
-def format_file_size(v, precision=2, sign=False):
-    """Format file size into a human friendly format, using the units requested via BORG_UNITS."""
+def format_file_size(v, precision=2, sign=False, fine=False):
+    """Format file size into a human friendly format, using the units requested via BORG_UNITS.
+
+    If fine is given, big sizes get more decimals, so that changes of ~1MB stay visible.
+    """
     units = get_size_units()
     if units == "raw":
-        # exact byte counts, so scripts can easily parse the output
+        # exact byte counts, so scripts can easily parse the output (fine does not apply)
         v = round(v)  # v might be a float, e.g. a throughput value
         return f"{v:{'+' if sign and v > 0 else ''}d} B"
     fn = sizeof_fmt_iec if units == "iec" else sizeof_fmt_decimal
-    return fn(v, suffix="B", sep=" ", precision=precision, sign=sign)
+    return fn(v, suffix="B", sep=" ", precision=precision, sign=sign, fine=fine)
 
 
 class FileSize(int):
@@ -587,39 +590,47 @@ def parse_file_size(s):
     return int(float(s) * factor)
 
 
-def sizeof_fmt(num, suffix="B", units=None, power=None, sep="", precision=2, sign=False):
+def sizeof_fmt(num, suffix="B", units=None, power=None, sep="", precision=2, sign=False, fine=False):
     sign = "+" if sign and num > 0 else ""
     fmt = "{0:{1}.{2}f}{3}{4}{5}"
     prec = 0
-    for unit in units[:-1]:
+    for i, unit in enumerate(units[:-1]):
         if abs(round(num, precision)) < power:
             break
         num /= float(power)
         prec = precision
     else:
+        i = len(units) - 1
         unit = units[-1]
+    if fine:
+        # scale dependent precision, so ~1 M<unit> stays visible at any scale: M: 2 (default),
+        # G: 3, T: 6, P: 9 decimals. capped at 9 - a float can not resolve more anyway and it
+        # bounds the output width. see #3559.
+        prec = max(prec, min((i - 2) * 3, 9))
     return fmt.format(num, sign, prec, sep, unit, suffix)
 
 
-def sizeof_fmt_iec(num, suffix="B", sep="", precision=2, sign=False):
+def sizeof_fmt_iec(num, suffix="B", sep="", precision=2, sign=False, fine=False):
     return sizeof_fmt(
         num,
         suffix=suffix,
         sep=sep,
         precision=precision,
         sign=sign,
+        fine=fine,
         units=["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"],
         power=1024,
     )
 
 
-def sizeof_fmt_decimal(num, suffix="B", sep="", precision=2, sign=False):
+def sizeof_fmt_decimal(num, suffix="B", sep="", precision=2, sign=False, fine=False):
     return sizeof_fmt(
         num,
         suffix=suffix,
         sep=sep,
         precision=precision,
         sign=sign,
+        fine=fine,
         units=["", "k", "M", "G", "T", "P", "E", "Z", "Y"],
         power=1000,
     )

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -35,6 +35,11 @@ def show_progress_force(stats, **kwargs):
     stats.show_progress(**kwargs)
 
 
+class TTYStringIO(StringIO):
+    def isatty(self):
+        return True
+
+
 def test_stats_basic(stats):
     assert stats.osize == 20
     assert stats.usize == 20
@@ -44,10 +49,6 @@ def test_stats_basic(stats):
 
 
 def test_stats_progress_tty(stats, monkeypatch, columns=80):
-    class TTYStringIO(StringIO):
-        def isatty(self):
-            return True
-
     monkeypatch.setenv("COLUMNS", str(columns))
     out = TTYStringIO()
     show_progress_force(stats, stream=out)
@@ -69,6 +70,23 @@ def test_stats_progress_tty(stats, monkeypatch, columns=80):
     assert out.getvalue() == s + buf + "\r"
 
 
+@pytest.mark.parametrize(
+    "columns, s",
+    [
+        (80, "1.00 TB O 20 B U 1 N foo"),  # narrow terminal: compact format, so the path stays visible
+        (109, "1.00 TB O 20 B U 1 N foo"),  # still too narrow
+        (110, "1.000000 TB O 20 B U 1 N foo"),  # wide terminal: more decimals, see #3559
+    ],
+)
+def test_stats_progress_tty_fine(stats, monkeypatch, columns, s):
+    monkeypatch.setenv("COLUMNS", str(columns))
+    stats.update(10**12, unique=False)
+    out = TTYStringIO()
+    show_progress_force(stats, item=Item(path="foo"), final=False, stream=out)
+    buf = " " * (columns - len(s))
+    assert out.getvalue() == s + buf + "\r"
+
+
 def test_stats_progress_file(stats, monkeypatch):
     out = StringIO()
     show_progress_force(stats, stream=out)
@@ -86,6 +104,13 @@ def test_stats_progress_file(stats, monkeypatch):
     path = "foo" * 40
     show_progress_force(stats, item=Item(path=path), final=False, stream=out)
     s = f"1.02 kB O 20 B U 1 N {path}"
+    assert out.getvalue() == s + "\n"
+
+    out = StringIO()
+    stats.update(10**12, unique=False)
+    path = "foo"
+    show_progress_force(stats, item=Item(path=path), final=False, stream=out)
+    s = f"1.000000 TB O 20 B U 1 N {path}"  # no width limit here, so always more decimals, see #3559
     assert out.getvalue() == s + "\n"
 
 

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -679,6 +679,57 @@ def test_file_size_sign(size, fmt):
 
 
 @pytest.mark.parametrize(
+    "size, fmt",
+    [
+        (0, "0 B"),  # bytes and kB are formatted like with fine=False
+        (999, "999 B"),
+        (1234, "1.23 kB"),
+        (10**6, "1.00 MB"),  # MB: 2 decimals, like with fine=False
+        (1234567, "1.23 MB"),
+        (10**9, "1.000 GB"),  # GB: 3 decimals
+        (1234567890, "1.235 GB"),
+        (999995000, "1.000 GB"),  # rounded up to the next unit, like with fine=False
+        (999994999999, "999.995 GB"),  # almost 1 TB, but still shown as GB
+        (999999000000, "0.999999 TB"),  # unit like with fine=False ("1.00 TB"), but exact value
+        (10**12, "1.000000 TB"),  # TB: 6 decimals
+        (5000001000000, "5.000001 TB"),  # 1 MB more is visible now, that is the point of #3559
+        (10**15, "1.000000000 PB"),  # PB: 9 decimals
+        (5 * 10**15 + 10**6, "5.000000001 PB"),
+        (10**18, "1.000000000 EB"),  # decimals are capped at 9
+        (-(10**12), "-1.000000 TB"),
+    ],
+)
+def test_file_size_fine(size, fmt):
+    """fine=True shows big sizes with more decimals, so that changes of ~1MB stay visible"""
+    assert format_file_size(size, fine=True) == fmt
+
+
+@pytest.mark.parametrize(
+    "size, fmt",
+    [
+        (2**20, "1.00 MiB"),
+        (2**30, "1.000 GiB"),
+        (2**40, "1.000000 TiB"),
+        (2**40 + 2**20, "1.000001 TiB"),
+        (2**50 + 2**20, "1.000000001 PiB"),
+    ],
+)
+def test_file_size_fine_iec(monkeypatch, size, fmt):
+    monkeypatch.setenv("BORG_UNITS", "iec")
+    assert format_file_size(size, fine=True) == fmt
+
+
+def test_file_size_fine_raw(monkeypatch):
+    """BORG_UNITS=raw is exact anyway, so fine does not change anything"""
+    monkeypatch.setenv("BORG_UNITS", "raw")
+    assert format_file_size(10**12, fine=True) == "1000000000000 B"
+
+
+def test_file_size_fine_sign():
+    assert format_file_size(10**12, sign=True, fine=True) == "+1.000000 TB"
+
+
+@pytest.mark.parametrize(
     "string, value", [("1", 1), ("20", 20), ("5K", 5000), ("1.75M", 1750000), ("1e+9", 1e9), ("-1T", -1e12)]
 )
 def test_parse_file_size(string, value):


### PR DESCRIPTION
Fixes #3559.

At TB scale, the sizes in the `borg create --progress` status line only changed every 10GB, so
one could not tell whether it was still making progress (the more so when running from cron and
not seeing the beginning of the run).

### Formatting

`format_file_size` (and the `sizeof_fmt*` helpers) got a `fine=False` option that gives big sizes
a scale dependent precision, so that changes of ~1MB stay visible:

| size | default | `fine=True` |
| --- | --- | --- |
| 1234567 | `1.23 MB` | `1.23 MB` |
| 10\*\*9 | `1.00 GB` | `1.000 GB` |
| 5000001000000 | `5.00 TB` | `5.000001 TB` |
| 5\*10\*\*15 + 10\*\*6 | `5.00 PB` | `5.000000001 PB` |

Decimals are capped at 9 - a float can not resolve more anyway, and it bounds the output width.

Unit *selection* is deliberately unchanged (the rounding guard still uses the base precision), so
a size is never shown with a different unit than before. As a consequence, `999999000000` shows
as `0.999999 TB` where the default format rounds to `1.00 TB` - the value is exact, the unit is
the same. There is a test for it.

### Status line

@ThomasWaldmann noted in the issue that more digits shrink the space left for the path, which is
a problem at 80 columns, and that increasing the digits only for much wider terminals would be
the way to go. So:

- on a terminal, the precise format is only used at >= 110 columns. `fine` adds at most 7 chars
  per size field, i.e. 14 for both, so even in the worst case the path still gets more room than
  it had at 80 columns with the compact format. It is re-evaluated on every refresh, so resizing
  the terminal degrades gracefully.
- if the output does not go to a terminal (e.g. into a logfile), the precise format is always
  used - there is no width limit there.
- the JSON progress output is unchanged (it has raw byte values anyway).

At 80 columns nothing changes:
```
5.00 TB O 1.57 TB U 362508 N mnt/to_backup/oct/some...her_long_filename_here.bin
```
At 110 columns, 1MB steps become visible:
```
5.000000 TB O 1.570000 TB U 362508 N mnt/to_backup/oct/some_rather_long_filename_here.bin
5.000001 TB O 1.570000 TB U 362508 N mnt/to_backup/oct/some_rather_long_filename_here.bin
5.000002 TB O 1.570000 TB U 362508 N mnt/to_backup/oct/some_rather_long_filename_here.bin
```

`--stats` / `borg info` / all other size output keep the default 2 decimals (`fine` defaults to
`False`, and `Statistics.osize_fmt`/`usize_fmt` are untouched).
