### PR TITLE
list: add --sort-by=SPEC, fixes #9009

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -222,6 +222,7 @@ New features:
   - use --chunking / --hashing / --encrypting / --compressing / --msgpacking
     to run only a subset of the benchmarks, #10050
 - completion: generate fish and tcsh completions, #9989, #9503
+- list: --sort-by=field[,field,...], #9009
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041
 

--- a/docs/usage/completion.rst.inc
+++ b/docs/usage/completion.rst.inc
@@ -48,3 +48,9 @@ Please note that for some dynamic completions (like archive IDs), the shell
 completion script will call borg to query the repository. This will work best
 if that call can be made without prompting for user input, so you may want to
 set BORG_REPO and BORG_PASSPHRASE environment variables.
+
+In tcsh, completions for positional arguments are matched by word position, so
+e.g. an archive name is only completed if no options precede it - one more
+reason to use BORG_REPO there rather than --repo. Also, options are matched by
+name only, so --sort-by offers the union of the sort keys valid for list, diff
+and the commands filtering archives.

--- a/docs/usage/list.rst
+++ b/docs/usage/list.rst
@@ -36,3 +36,12 @@ Examples
     -rw-rw-r-- user   user    1416192 Sun, 2015-02-01 11:00:00 code/myproject/file.text
     ...
 
+    # Use --sort-by with a comma-separated list; sorts apply stably from last to first.
+    # Here: primary by size descending, tie-breaker by path ascending.
+    # Note the quoting - ">" would otherwise be a shell redirection.
+    $ borg list archiveA --sort-by='>size,path' --format='{size:8d} {path}{NL}'
+     1416192 code/myproject/file.ext
+     1416192 code/myproject/file.text
+           0 .
+    ...
+

--- a/docs/usage/list.rst.inc
+++ b/docs/usage/list.rst.inc
@@ -29,6 +29,8 @@ borg list
     +-------------------------------------------------------+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                       | ``--depth N``                         | only list files up to the specified directory depth                                                                                                                                   |
     +-------------------------------------------------------+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                       | ``--sort-by SPEC``                    | sort output by comma-separated fields (e.g. '>size,path'), see Sorting below                                                                                                          |
+    +-------------------------------------------------------+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     | .. class:: borg-common-opt-ref                                                                                                                                                                                                                                                        |
     |                                                                                                                                                                                                                                                                                       |
     | :ref:`common_options`                                                                                                                                                                                                                                                                 |
@@ -61,10 +63,11 @@ borg list
 
 
     options
-        --short     only print file/directory names, nothing else
+        --short            only print file/directory names, nothing else
         --format FORMAT    specify format for file listing (default: "{mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")
-        --json-lines    Format output as JSON Lines. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text.
-        --depth N    only list files up to the specified directory depth
+        --json-lines       Format output as JSON Lines. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text.
+        --depth N          only list files up to the specified directory depth
+        --sort-by SPEC     sort output by comma-separated fields (e.g. '>size,path'), see Sorting below
 
 
     :ref:`common_options`
@@ -157,3 +160,32 @@ Keys available only when listing files in an archive:
 - archiveid: internal ID of the archive
 - archivename: name of the archive
 - extra: prepends {target} with " -> " for soft links and " link to " for hard links
+
+
+Sorting
++++++++
+Use ``--sort-by SPEC`` where SPEC is a comma-separated list of fields.
+Sorts are applied stably from last to first in the given list, thus the first
+field is the primary sort criterion. Prepend ">" for descending, "<" (or no
+prefix) for ascending order, e.g. ``--sort-by='>size,path'`` (quote it, ">" is
+a shell redirection).
+
+Supported fields, sorting by the same value that ``--format`` would print:
+
+- path: the item path
+- type, mode: the file type character resp. the full file mode string
+- user, group: the owner/group name, or the numeric id if the name is not known
+- uid, gid: the numeric owner/group id
+- size: the file size (0 for hardlink slaves, same as {size})
+- mtime, ctime, atime: the timestamps (atime/ctime fall back to mtime if not stored)
+
+There is no ``birthtime`` field, as there is no {birthtime} format key either.
+
+The sort fields are independent of ``--format``, you may sort by a field you do
+not print.
+
+Note: ``--sort-by`` needs to read all (matching) items into memory before it can
+print anything, so listing a huge archive this way needs a lot of memory and
+delays the first output line. Without ``--sort-by``, items are streamed and their
+order is undefined. If memory usage is a problem, consider
+``borg list --format ... | sort`` instead.

--- a/src/borg/archiver/completion_cmd.py
+++ b/src/borg/archiver/completion_cmd.py
@@ -60,6 +60,8 @@ import re
 import shtab
 
 from ._common import process_epilog
+from .diff_cmd import DIFF_SORT_KEYS, diff_sort_spec
+from .list_cmd import ITEM_SORT_KEYS, item_sort_spec
 from ..constants import *  # NOQA
 from ..helpers import (
     archivename_validator,
@@ -236,52 +238,7 @@ _borg_complete_file_size() {
   compgen -W "${choices}" -- "$1"
 }
 
-# Complete comma-separated sort keys for any option with type=SortBySpec.
-# Keys are validated against Borg's AI_HUMAN_SORT_KEYS.
-_borg_complete_sortby() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-
-  # Extract value part for --opt=value forms; otherwise the value is the word itself
-  local val prefix_eq
-  if [[ "$cur" == *=* ]]; then
-    prefix_eq="${cur%%=*}="
-    val="${cur#*=}"
-  else
-    prefix_eq=""
-    val="$cur"
-  fi
-
-  # Split into head (selected keys + trailing comma if any) and fragment (last token being typed)
-  local head frag
-  if [[ "$val" == *,* ]]; then
-    head="${val%,*},"
-    frag="${val##*,}"
-  else
-    head=""
-    frag="$val"
-  fi
-
-  # Build a comma-delimited list for cheap membership testing
-  local headlist
-  if [[ -n "$head" ]]; then
-    headlist=",${head%,},"
-  else
-    headlist=","  # nothing selected yet
-  fi
-
-  # Valid keys (embedded at generation time)
-  local keys=({SORT_KEYS})
-
-  local k
-  for k in "${keys[@]}"; do
-    # skip already-selected keys
-    [[ "$headlist" == *",${k},"* ]] && continue
-    # match prefix of last fragment
-    [[ -n "$frag" && "$k" != "$frag"* ]] && continue
-    printf '%s\n' "${prefix_eq}${head}${k}"
-  done
-}
-
+{SORTBY_FUNCS}
 # Complete comma-separated files cache mode tokens for options with type=FilesCacheMode.
 _borg_complete_filescachemode() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -527,50 +484,7 @@ _borg_complete_file_size() {
   compadd -V 'file size' -Q -a choices
 }
 
-# Complete comma-separated sort keys for any option with type=SortBySpec.
-_borg_complete_sortby() {
-  local cur
-  cur="${words[$CURRENT]}"
-
-  local val prefix_eq
-  if [[ "$cur" == *"="* ]]; then
-    prefix_eq="${cur%%\=*}="
-    val="${cur#*=}"
-  else
-    prefix_eq=""
-    val="$cur"
-  fi
-
-  local head frag
-  if [[ "$val" == *","* ]]; then
-    head="${val%,*},"
-    frag="${val##*,}"
-  else
-    head=""
-    frag="$val"
-  fi
-
-  local headlist
-  if [[ -n "$head" ]]; then
-    headlist=",${head%,},"
-  else
-    headlist=","  # nothing selected yet
-  fi
-
-  # Valid keys (embedded at generation time)
-  local -a keys=({SORT_KEYS})
-
-  local -a candidates=()
-  local k
-  for k in ${keys[@]}; do
-    [[ "$headlist" == *",${k},"* ]] && continue
-    [[ -n "$frag" && "$k" != "$frag"* ]] && continue
-    candidates+=( "${prefix_eq}${head}${k}" )
-  done
-  compadd -Q -- $candidates
-  return 0
-}
-
+{SORTBY_FUNCS}
 # Complete comma-separated files cache mode tokens for options with type=FilesCacheMode.
 _borg_complete_filescachemode() {
   local cur
@@ -753,17 +667,7 @@ function _borg_csv_emit
     end
 end
 
-# Complete comma-separated sort keys for any option with type=SortBySpec.
-function _borg_complete_sortby
-    _borg_csv_scan
-    for k in {SORT_KEYS}
-        if contains -- $k $_borg_csv_selected
-            continue
-        end
-        _borg_csv_emit $k
-    end
-end
-
+{SORTBY_FUNCS}
 # Complete comma-separated files cache mode tokens for options with type=FilesCacheMode.
 function _borg_complete_filescachemode
     _borg_csv_scan
@@ -799,7 +703,7 @@ TCSH_PREAMBLE_TMPL = r"""
 alias _borg_complete_timestamp 'date +"%Y-%m-%dT%H:%M:%S"'
 
 
-alias _borg_complete_sortby "echo {SORT_KEYS}"
+{SORTBY_FUNCS}
 alias _borg_complete_filescachemode "echo {FCM_KEYS}"
 alias _borg_help_topics "echo {HELP_CHOICES}"
 alias _borg_complete_compression_spec "echo {COMP_SPEC_CHOICES}"
@@ -844,6 +748,149 @@ TCSH_SH_COMPLETE = (
     'borg repo-list "$@" --format "{archive}{NL}" 2>/dev/null </dev/null; '
     "fi"
 )
+
+
+# There is more than one kind of --sort-by (archives, items, item diffs), each with its own set of
+# valid sort keys. The completion code is the same for all of them - only the helper's name and the
+# key list differ - so it is generated from one template per shell, rendered once per key set, see
+# SORTBY_COMPLETERS and _sortby_functions.
+BASH_SORTBY_FN_TMPL = r"""
+# Complete comma-separated sort keys for the options using this set of keys.
+{FN_NAME}() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+
+  # Extract value part for --opt=value forms; otherwise the value is the word itself
+  local val prefix_eq
+  if [[ "$cur" == *=* ]]; then
+    prefix_eq="${cur%%=*}="
+    val="${cur#*=}"
+  else
+    prefix_eq=""
+    val="$cur"
+  fi
+
+  # Split into head (selected keys + trailing comma if any) and fragment (last token being typed)
+  local head frag
+  if [[ "$val" == *,* ]]; then
+    head="${val%,*},"
+    frag="${val##*,}"
+  else
+    head=""
+    frag="$val"
+  fi
+
+  # Build a comma-delimited list for cheap membership testing
+  local headlist
+  if [[ -n "$head" ]]; then
+    headlist=",${head%,},"
+  else
+    headlist=","  # nothing selected yet
+  fi
+
+  # Valid keys (embedded at generation time)
+  local keys=({KEYS})
+
+  local k
+  for k in "${keys[@]}"; do
+    # skip already-selected keys
+    [[ "$headlist" == *",${k},"* ]] && continue
+    # match prefix of last fragment
+    [[ -n "$frag" && "$k" != "$frag"* ]] && continue
+    printf '%s\n' "${prefix_eq}${head}${k}"
+  done
+}
+"""
+
+ZSH_SORTBY_FN_TMPL = r"""
+# Complete comma-separated sort keys for the options using this set of keys.
+{FN_NAME}() {
+  local cur
+  cur="${words[$CURRENT]}"
+
+  local val prefix_eq
+  if [[ "$cur" == *"="* ]]; then
+    prefix_eq="${cur%%\=*}="
+    val="${cur#*=}"
+  else
+    prefix_eq=""
+    val="$cur"
+  fi
+
+  local head frag
+  if [[ "$val" == *","* ]]; then
+    head="${val%,*},"
+    frag="${val##*,}"
+  else
+    head=""
+    frag="$val"
+  fi
+
+  local headlist
+  if [[ -n "$head" ]]; then
+    headlist=",${head%,},"
+  else
+    headlist=","  # nothing selected yet
+  fi
+
+  # Valid keys (embedded at generation time)
+  local -a keys=({KEYS})
+
+  local -a candidates=()
+  local k
+  for k in ${keys[@]}; do
+    [[ "$headlist" == *",${k},"* ]] && continue
+    [[ -n "$frag" && "$k" != "$frag"* ]] && continue
+    candidates+=( "${prefix_eq}${head}${k}" )
+  done
+  compadd -Q -- $candidates
+  return 0
+}
+"""
+
+FISH_SORTBY_FN_TMPL = r"""
+# Complete comma-separated sort keys for the options using this set of keys.
+function {FN_NAME}
+    _borg_csv_scan
+    for k in {KEYS}
+        if contains -- $k $_borg_csv_selected
+            continue
+        end
+        _borg_csv_emit $k
+    end
+end
+"""
+
+TCSH_SORTBY_FN_TMPL = 'alias {FN_NAME} "echo {KEYS}"\n'
+
+SORTBY_FN_TMPLS = {
+    "bash": BASH_SORTBY_FN_TMPL,
+    "zsh": ZSH_SORTBY_FN_TMPL,
+    "fish": FISH_SORTBY_FN_TMPL,
+    "tcsh": TCSH_SORTBY_FN_TMPL,
+}
+
+# tcsh matches completion rules by option name only, in one flat namespace for all subcommands,
+# so it can not tell `borg list --sort-by` from `borg repo-list --sort-by`. Thus, it gets a single
+# helper offering the union of all sort keys, see for_all_shells(tcsh_fn=...).
+TCSH_SORTBY_FN = "_borg_complete_sortby"
+
+# the --sort-by flavours: (argparse type, name of the shell helper completing it, valid sort keys)
+SORTBY_COMPLETERS = [
+    (SortBySpec, "_borg_complete_sortby", AI_HUMAN_SORT_KEYS),  # archives: repo-list, ...
+    (item_sort_spec, "_borg_complete_item_sortby", ITEM_SORT_KEYS),  # items: list
+    (diff_sort_spec, "_borg_complete_diff_sortby", DIFF_SORT_KEYS),  # item diffs: diff
+]
+
+
+def _sortby_functions(shell, completers):
+    """Render the --sort-by completion helpers for shell, one per set of sort keys."""
+    template = SORTBY_FN_TMPLS[shell]
+    if shell == "tcsh":
+        union = sorted({key for _, _, keys in completers for key in keys})
+        completers = [(None, TCSH_SORTBY_FN, union)]
+    return "".join(
+        partial_format(template, {"FN_NAME": fn_name, "KEYS": " ".join(keys)}) for _, fn_name, keys in completers
+    )
 
 
 # in a `p@N@`...`@` rule, one `if (...) <action>` clause, e.g.
@@ -938,13 +985,16 @@ class CompletionMixIn:
         finally:
             self.prog = prog
 
-        def for_all_shells(fn_name):
+        def for_all_shells(fn_name, tcsh_fn=None):
             # same-named completion helper in the bash, zsh, tcsh and fish preambles;
-            # fish needs a command substitution to call it, tcsh backquotes
-            return {"bash": fn_name, "zsh": fn_name, "tcsh": f"`{fn_name}`", "fish": f"({fn_name})"}
+            # fish needs a command substitution to call it, tcsh backquotes.
+            # tcsh matches rules by option name only, over all subcommands, so options needing
+            # different completions per subcommand have to share one tcsh helper.
+            return {"bash": fn_name, "zsh": fn_name, "tcsh": f"`{tcsh_fn or fn_name}`", "fish": f"({fn_name})"}
 
         _attach_completion(parser, archivename_validator, for_all_shells("_borg_complete_archive"))
-        _attach_completion(parser, SortBySpec, for_all_shells("_borg_complete_sortby"))
+        for sortby_type, sortby_fn, _ in SORTBY_COMPLETERS:
+            _attach_completion(parser, sortby_type, for_all_shells(sortby_fn, tcsh_fn=TCSH_SORTBY_FN))
         _attach_completion(parser, FilesCacheMode, for_all_shells("_borg_complete_filescachemode"))
         _attach_completion(parser, CompressionSpec, for_all_shells("_borg_complete_compression_spec"))
         _attach_completion(parser, PathSpec, shtab.DIRECTORY)
@@ -965,7 +1015,6 @@ class CompletionMixIn:
         _attach_help_completion(parser, for_all_shells("_borg_help_topics"))
 
         # Build preambles using partial_format to avoid escaping braces etc.
-        sort_keys = " ".join(AI_HUMAN_SORT_KEYS)
         fcm_keys = " ".join(["ctime", "mtime", "size", "inode", "rechunk", "disabled"])  # keep in sync with parser
 
         # Help completion templates
@@ -1006,7 +1055,6 @@ class CompletionMixIn:
         file_size_choices_str = " ".join(file_size_choices)
 
         mapping = {
-            "SORT_KEYS": sort_keys,
             "FCM_KEYS": fcm_keys,
             "COMP_SPEC_CHOICES": comp_spec_choices_str,
             "CHUNKER_PARAMS_CHOICES": chunker_params_choices_str,
@@ -1014,6 +1062,8 @@ class CompletionMixIn:
             "FILE_SIZE_CHOICES": file_size_choices_str,
             "HELP_CHOICES": help_choices,
             "SH_COMPLETE": TCSH_SH_COMPLETE,
+            # last, so that the rendered helpers are not scanned for the placeholders above
+            "SORTBY_FUNCS": _sortby_functions(args.shell, SORTBY_COMPLETERS) if args.shell in SORTBY_FN_TMPLS else "",
         }
         preamble_templates = {
             "bash": BASH_PREAMBLE_TMPL,
@@ -1043,7 +1093,9 @@ class CompletionMixIn:
 
         In tcsh, completions for positional arguments are matched by word position, so
         e.g. an archive name is only completed if no options precede it - one more
-        reason to use BORG_REPO there rather than --repo.
+        reason to use BORG_REPO there rather than --repo. Also, options are matched by
+        name only, so --sort-by offers the union of the sort keys valid for list, diff
+        and the commands filtering archives.
         """
         )
 

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -8,12 +8,31 @@ from ..archive import Archive
 from ..constants import *  # NOQA
 from ..helpers import BaseFormatter, DiffFormatter, archivename_validator, PathSpec, BorgJsonEncoder
 from ..helpers import IncludePatternNeverMatchedWarning, remove_surrogates
-from ..helpers.argparsing import ArgumentParser, ArgumentTypeError
+from ..helpers.argparsing import ArgumentParser
+from ..helpers.sorting import sort_spec_validator, sorted_by_spec
 from ..item import ItemDiff
 from ..manifest import Manifest
 from ..logger import create_logger
 
 logger = create_logger()
+
+# item diff fields "borg diff --sort-by" can sort by
+DIFF_SORT_KEYS = (
+    "path",
+    "size_added",
+    "size_removed",
+    "size_diff",
+    "size",
+    "user",
+    "group",
+    "uid",
+    "gid",
+    "ctime",
+    "mtime",
+    "ctime_diff",
+    "mtime_diff",
+)
+diff_sort_spec = sort_spec_validator(DIFF_SORT_KEYS, name="diff_sort_spec")
 
 
 class DiffMixIn:
@@ -93,19 +112,9 @@ class DiffMixIn:
         # Filter out equal items early (keep as generator; listify only if sorting)
         diffs = (diff for diff in diffs_iter if not diff.equal(args.content_only))
 
-        sort_specs = []
-        if args.sort_by:
-            for spec in args.sort_by.split(","):
-                spec = spec.strip()
-                if spec:
-                    sort_specs.append(spec)
-
         def key_for(field: str, d: "ItemDiff"):
-            # strip direction markers if present
-            if field and field[0] in ("<", ">"):
-                field = field[1:]
             # path
-            if field in (None, "", "path"):
+            if field == "path":
                 return remove_surrogates(d.path)
             # compute size_* from changes
             if field in ("size_diff", "size_added", "size_removed"):
@@ -150,15 +159,7 @@ class DiffMixIn:
                 return it.get(field, attr_defaults[field])
             raise ValueError(f"Invalid field name: {field}")
 
-        if sort_specs:
-            diffs = list(diffs)
-            # Apply stable sorts from last to first
-            for spec in reversed(sort_specs):
-                desc = False
-                field = spec
-                if field and field[0] in ("<", ">"):
-                    desc = field[0] == ">"
-                diffs.sort(key=lambda di: key_for(field, di), reverse=desc)
+        diffs = sorted_by_spec(diffs, args.sort_by, key_for)
 
         formatter = DiffFormatter(format, args.content_only)
         for diff in diffs:
@@ -266,33 +267,6 @@ class DiffMixIn:
             )
         )
 
-        def diff_sort_spec_validator(s):
-            if not isinstance(s, str):
-                raise ArgumentTypeError("unsupported sort field (not a string)")
-            allowed = {
-                "path",
-                "size_added",
-                "size_removed",
-                "size_diff",
-                "size",
-                "user",
-                "group",
-                "uid",
-                "gid",
-                "ctime",
-                "mtime",
-                "ctime_diff",
-                "mtime_diff",
-            }
-            parts = [p.strip() for p in s.split(",") if p.strip()]
-            if not parts:
-                raise ArgumentTypeError("unsupported sort field: empty spec")
-            for spec in parts:
-                field = spec[1:] if spec and spec[0] in (">", "<") else spec
-                if field not in allowed:
-                    raise ArgumentTypeError(f"unsupported sort field: {field}")
-            return ",".join(parts)
-
         subparser = ArgumentParser(parents=[common_parser], description=self.do_diff.__doc__, epilog=diff_epilog)
         subparsers.add_subcommand("diff", subparser, help="find differences in archive contents")
         subparser.add_argument(
@@ -318,7 +292,7 @@ class DiffMixIn:
         subparser.add_argument(
             "--sort-by",
             dest="sort_by",
-            type=diff_sort_spec_validator,
+            type=diff_sort_spec,
             help="Sort output by comma-separated fields (e.g., '>size_added,path').",
         )
         subparser.add_argument(

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -293,6 +293,7 @@ class DiffMixIn:
             "--sort-by",
             dest="sort_by",
             type=diff_sort_spec,
+            action=Highlander,
             help="Sort output by comma-separated fields (e.g., '>size_added,path').",
         )
         subparser.add_argument(

--- a/src/borg/archiver/list_cmd.py
+++ b/src/borg/archiver/list_cmd.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import textwrap
 import sys
 
@@ -8,11 +9,38 @@ from ..cache import Cache
 from ..constants import *  # NOQA
 from ..helpers import ItemFormatter, BaseFormatter, archivename_validator, PathSpec
 from ..helpers.argparsing import ArgumentParser
+from ..helpers.sorting import sort_spec_validator, sorted_by_spec
 from ..manifest import Manifest
 
 from ..logger import create_logger
 
 logger = create_logger()
+
+# item fields "borg list --sort-by" can sort by
+ITEM_SORT_KEYS = ("path", "type", "mode", "user", "uid", "group", "gid", "size", "mtime", "ctime", "atime")
+item_sort_spec = sort_spec_validator(ITEM_SORT_KEYS, name="item_sort_spec")
+
+
+def item_sort_key(field, item):
+    """Compute the sort key of item for field, mirroring what ItemFormatter displays."""
+    if field == "path":
+        return item.path
+    if field in ("type", "mode"):
+        mode = stat.filemode(item.get("mode", 0))
+        return mode[0] if field == "type" else mode
+    if field == "size":
+        return item.get_size()
+    if field in ("uid", "gid"):
+        value = item.get(field)
+        return -1 if value is None else value
+    if field in ("user", "group"):
+        value = item.get(field)
+        # if the name is not known, ItemFormatter displays the numeric id, so sort by that.
+        return str(item.get("uid" if field == "user" else "gid")) if value is None else value
+    if field in ("mtime", "ctime", "atime"):
+        # raw ns timestamps. ItemFormatter falls back to mtime for a missing atime/ctime, mirror that.
+        return item.get(field) or item.get("mtime") or 0
+    raise ValueError(f"Invalid sort field name: {field}")
 
 
 class ListMixIn:
@@ -49,7 +77,8 @@ class ListMixIn:
                         return False
                 return True
 
-            for item in archive.iter_items(item_filter):
+            items = sorted_by_spec(archive.iter_items(item_filter), args.sort_by, item_sort_key)
+            for item in items:
                 sys.stdout.write(formatter.format_item(item, args.json_lines, sort=True))
 
         # Only load the cache if it will be used
@@ -103,6 +132,38 @@ class ListMixIn:
         """
             )
             + ItemFormatter.keys_help()
+            + textwrap.dedent(
+                """
+
+        Sorting
+        +++++++
+        Use ``--sort-by SPEC`` where SPEC is a comma-separated list of fields.
+        Sorts are applied stably from last to first in the given list, thus the first
+        field is the primary sort criterion. Prepend ">" for descending, "<" (or no
+        prefix) for ascending order, e.g. ``--sort-by='>size,path'`` (quote it, ">" is
+        a shell redirection).
+
+        Supported fields, sorting by the same value that ``--format`` would print:
+
+        - path: the item path
+        - type, mode: the file type character resp. the full file mode string
+        - user, group: the owner/group name, or the numeric id if the name is not known
+        - uid, gid: the numeric owner/group id
+        - size: the file size (0 for hardlink slaves, same as {size})
+        - mtime, ctime, atime: the timestamps (atime/ctime fall back to mtime if not stored)
+
+        There is no ``birthtime`` field, as there is no {birthtime} format key either.
+
+        The sort fields are independent of ``--format``, you may sort by a field you do
+        not print.
+
+        Note: ``--sort-by`` needs to read all (matching) items into memory before it can
+        print anything, so listing a huge archive this way needs a lot of memory and
+        delays the first output line. Without ``--sort-by``, items are streamed and their
+        order is undefined. If memory usage is a problem, consider
+        ``borg list --format ... | sort`` instead.
+        """
+            )
         )
         subparser = ArgumentParser(parents=[common_parser], description=self.do_list.__doc__, epilog=list_epilog)
         subparsers.add_subcommand("list", subparser, help="list archive contents")
@@ -127,6 +188,14 @@ class ListMixIn:
         )
         subparser.add_argument(
             "--depth", metavar="N", dest="depth", type=int, help="only list files up to the specified directory depth"
+        )
+        subparser.add_argument(
+            "--sort-by",
+            metavar="SPEC",
+            dest="sort_by",
+            type=item_sort_spec,
+            action=Highlander,
+            help="sort output by comma-separated fields (e.g. '>size,path'), see Sorting below",
         )
         subparser.add_argument("name", metavar="NAME", type=archivename_validator, help="specify the archive name")
         subparser.add_argument(

--- a/src/borg/helpers/sorting.py
+++ b/src/borg/helpers/sorting.py
@@ -1,0 +1,68 @@
+"""
+Multi-field, direction-aware, stable sorting of command output.
+
+Used by commands offering a ``--sort-by SPEC`` option that sorts archive contents
+(``borg list``, ``borg diff``), where SPEC is a comma-separated list of field names,
+each optionally prefixed with "<" (ascending, the default) or ">" (descending).
+
+Not to be confused with helpers.parseformat.SortBySpec, which is the simpler
+archive-level sort spec of ``borg repo-list`` (no direction prefixes).
+"""
+
+from .argparsing import ArgumentTypeError
+
+ASCENDING, DESCENDING = "<", ">"
+
+
+def parse_sort_spec(spec):
+    """Split SPEC into [(field, descending), ...]. None / empty / blank gives []."""
+    result = []
+    for part in (spec or "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if part[0] in (ASCENDING, DESCENDING):
+            result.append((part[1:], part[0] == DESCENDING))
+        else:
+            result.append((part, False))
+    return result
+
+
+def sort_spec_validator(allowed_keys, *, name="sort_spec"):
+    """Build an argparse type= callable validating a --sort-by SPEC.
+
+    The returned function has the allowed keys as .sort_keys, so shell completion
+    can be generated from it, see archiver/completion_cmd.py.
+    """
+    allowed = tuple(allowed_keys)
+
+    def validator(text):
+        parsed = parse_sort_spec(text)
+        if not parsed:
+            raise ArgumentTypeError("unsupported sort field: empty spec")
+        for field, _ in parsed:
+            if field not in allowed:
+                raise ArgumentTypeError(f"unsupported sort field: {field}, supported: {', '.join(allowed)}")
+        return ",".join((DESCENDING if descending else "") + field for field, descending in parsed)
+
+    validator.__name__ = name
+    validator.sort_keys = allowed
+    return validator
+
+
+def sorted_by_spec(seq, spec, key_for):
+    """Sort seq as requested by spec, using key_for(field, element) to compute sort keys.
+
+    Sorting is stable and applied from the last field of the spec to the first, so the
+    first field is the primary sort criterion.
+
+    If spec does not select any field, seq is returned as is (and not consumed), so
+    callers can keep streaming.
+    """
+    parsed = parse_sort_spec(spec)
+    if not parsed:
+        return seq
+    result = list(seq)
+    for field, descending in reversed(parsed):
+        result.sort(key=lambda element, field=field: key_for(field, element), reverse=descending)
+    return result

--- a/src/borg/testsuite/archiver/completion_cmd_test.py
+++ b/src/borg/testsuite/archiver/completion_cmd_test.py
@@ -8,6 +8,7 @@ import tempfile
 import pytest
 
 import borg
+from ...archiver.completion_cmd import TCSH_SORTBY_FN
 from . import cmd, generate_archiver_tests, RK_ENCRYPTION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local")  # NOQA
@@ -56,6 +57,28 @@ def _run_bash_completion_fn(completion_script, setup_code):
     finally:
         os.unlink(script_path)
     return result
+
+
+def _run_zsh_completion_fn(completion_script, setup_code):
+    """Run a preamble helper of the completion script in zsh, return subprocess result.
+
+    The generated script can not just be sourced: its tail calls _shtab_borg when it is not
+    sourced from a completion context. So we only take the preamble (shtab wraps it into
+    markers) and stub compadd, which is how the helpers report their candidates.
+    """
+    preamble = completion_script.split("# Custom Preamble\n", 1)[1].split("\n# End Custom Preamble", 1)[0]
+    code = (
+        preamble + "\n"
+        'compadd() { local a; for a in "$@"; do [[ $a == -* ]] && continue; print -r -- $a; done }\n' + setup_code
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".zsh", delete=False) as f:
+        f.write(code)
+        script_path = f.name
+    try:
+        # -f: do not read the startup files
+        return subprocess.run(["zsh", "-f", script_path], capture_output=True, text=True, timeout=120)
+    finally:
+        os.unlink(script_path)
 
 
 def _fish_quote(text):
@@ -217,27 +240,110 @@ def test_tcsh_completion_syntax(archivers, request):
     assert result.returncode == 0, f"Generated Tcsh completion has errors: {result.stderr.decode()}"
 
 
-# -- borg-specific preamble function behavior (bash) --------------------------
+# -- --sort-by completion (one helper per set of sort keys) -------------------
+
+# (command, name of the shell helper completing its --sort-by)
+SORTBY_WIRING = [
+    ("repo-list", "_borg_complete_sortby"),
+    ("list", "_borg_complete_item_sortby"),
+    ("diff", "_borg_complete_diff_sortby"),
+]
+
+# (helper, already typed value, keys it must offer, keys it must not offer)
+SORTBY_BEHAVIOR = [
+    # archive sort keys, must not re-offer an already selected key
+    ("_borg_complete_sortby", "timestamp,", ["timestamp,archive"], ["timestamp,timestamp"]),
+    # item sort keys, not the archive or item diff ones
+    ("_borg_complete_item_sortby", "", ["path", "size", "atime"], ["timestamp", "archive", "size_added"]),
+    ("_borg_complete_item_sortby", "size,", ["size,path"], ["size,size"]),
+    # item diff sort keys: "size" is a valid key, but does not match the "size_" fragment
+    ("_borg_complete_diff_sortby", "size_", ["size_added", "size_removed", "size_diff"], ["size"]),
+    ("_borg_complete_diff_sortby", "path,", ["path,size_added"], ["path,path", "path,atime"]),
+]
+
+
+@pytest.mark.parametrize("command,fn", SORTBY_WIRING)
+def test_bash_sortby_wiring(archivers, request, command, fn):
+    output = cmd(request.getfixturevalue(archivers), "completion", "bash")
+    assert f"_shtab_borg_{command.replace('-', '_')}___sort_by_COMPGEN={fn}\n" in output
+    assert f"\n{fn}() {{\n" in output
+
+
+@pytest.mark.parametrize("command,fn", SORTBY_WIRING)
+def test_zsh_sortby_wiring(archivers, request, command, fn):
+    output = cmd(request.getfixturevalue(archivers), "completion", "zsh")
+    block = output.split(f"\n_shtab_borg_{command.replace('-', '_')}_options=(\n", 1)[1].split("\n)\n", 1)[0]
+    assert f':sort_by:{fn}"' in block
+    assert f"\n{fn}() {{\n" in output
+
+
+@pytest.mark.parametrize("command,fn", SORTBY_WIRING)
+def test_fish_sortby_wiring(archivers, request, command, fn):
+    output = cmd(request.getfixturevalue(archivers), "completion", "fish")
+    assert any(
+        f"_shtab_borg_using {command}'" in line and " -l sort-by " in line and f'"({fn})"' in line
+        for line in output.splitlines()
+    )
+    assert f"\nfunction {fn}\n" in output
+
+
+def test_tcsh_sortby_single_rule(archivers, request):
+    """tcsh matches by option name only, so all --sort-by options share one helper."""
+    output = cmd(request.getfixturevalue(archivers), "completion", "tcsh")
+    assert output.count("'n/--sort-by/") == 1
+    assert f"'n/--sort-by/`{TCSH_SORTBY_FN}`/'" in output
+    alias = next(line for line in output.splitlines() if line.startswith(f"alias {TCSH_SORTBY_FN} "))
+    for key in ("timestamp", "atime", "size_added"):  # the union of all the sort keys
+        assert f" {key}" in alias
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish", "tcsh"])
+def test_completion_helpers_are_defined(archivers, request, shell):
+    """Every _borg_* helper the generated script refers to must also be defined by it."""
+    output = cmd(request.getfixturevalue(archivers), "completion", shell)
+    defined = set(re.findall(r"^(?:function |alias )?(_borg_\w+)\s*(?:\(\)|\(|\s|$)", output, re.M))
+    referenced = set(re.findall(r"_borg_complete_\w+|_borg_help_topics", output))
+    assert referenced <= defined, f"undefined: {sorted(referenced - defined)}"
 
 
 @needs_bash
-def test_bash_sortby_dedup(archivers, request):
-    """_borg_complete_sortby should not re-offer already-selected sort keys."""
+@pytest.mark.parametrize("fn,typed,expected,not_expected", SORTBY_BEHAVIOR)
+def test_bash_sortby_keysets(archivers, request, fn, typed, expected, not_expected):
     archiver = request.getfixturevalue(archivers)
     script = cmd(archiver, "completion", "bash")
 
-    # Simulate: user typed "borg repo-list --sort-by timestamp,"
-    # The function should offer remaining keys but NOT "timestamp" again.
-    result = _run_bash_completion_fn(
-        script, 'COMP_WORDS=(borg repo-list --sort-by "timestamp,")\n' "COMP_CWORD=3\n" "_borg_complete_sortby\n"
-    )
+    result = _run_bash_completion_fn(script, f'COMP_WORDS=(borg cmd --sort-by "{typed}")\nCOMP_CWORD=3\n{fn}\n')
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    lines = [line for line in result.stdout.strip().splitlines() if line.strip()]
-    # "timestamp" must not appear as a standalone completion candidate
-    bare_keys = [line.rsplit(",", 1)[-1] for line in lines]
-    assert "timestamp" not in bare_keys, f"timestamp was re-offered: {lines}"
-    # Other keys like "archive" should be offered
-    assert any("archive" in line for line in lines), f"expected 'archive' in completions: {lines}"
+    candidates = result.stdout.split()
+    assert set(expected) <= set(candidates), f"missing from {candidates}"
+    assert not set(not_expected) & set(candidates), f"unexpected in {candidates}"
+
+
+@needs_zsh
+@pytest.mark.parametrize("fn,typed,expected,not_expected", SORTBY_BEHAVIOR)
+def test_zsh_sortby_keysets(archivers, request, fn, typed, expected, not_expected):
+    archiver = request.getfixturevalue(archivers)
+    script = cmd(archiver, "completion", "zsh")
+
+    result = _run_zsh_completion_fn(script, f"words=(borg cmd --sort-by '{typed}')\nCURRENT=4\n{fn}\n")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    candidates = result.stdout.split()
+    assert set(expected) <= set(candidates), f"missing from {candidates}"
+    assert not set(not_expected) & set(candidates), f"unexpected in {candidates}"
+
+
+@needs_fish
+def test_fish_sortby_keysets(archivers, request):
+    """Each command's --sort-by completes its own sort keys."""
+    archiver = request.getfixturevalue(archivers)
+    script = cmd(archiver, "completion", "fish")
+
+    items = _fish_complete_candidates(script, "borg list --sort-by ")
+    assert "atime" in items and "timestamp" not in items and "size_added" not in items
+    diffs = _fish_complete_candidates(script, "borg diff --sort-by size_added,")
+    assert "size_added,path" in diffs and "size_added,size_added" not in diffs
+    archives = _fish_complete_candidates(script, "borg repo-list --sort-by ")
+    assert "timestamp" in archives and "atime" not in archives
 
 
 @needs_bash

--- a/src/borg/testsuite/archiver/completion_cmd_test.py
+++ b/src/borg/testsuite/archiver/completion_cmd_test.py
@@ -66,7 +66,7 @@ def _run_zsh_completion_fn(completion_script, setup_code):
     sourced from a completion context. So we only take the preamble (shtab wraps it into
     markers) and stub compadd, which is how the helpers report their candidates.
     """
-    preamble = completion_script.split("# Custom Preamble\n", 1)[1].split("\n# End Custom Preamble", 1)[0]
+    preamble = completion_script.split("# Custom Preamble", 1)[1].split("# End Custom Preamble", 1)[0]
     code = (
         preamble + "\n"
         'compadd() { local a; for a in "$@"; do [[ $a == -* ]] && continue; print -r -- $a; done }\n' + setup_code
@@ -262,37 +262,42 @@ SORTBY_BEHAVIOR = [
 ]
 
 
+def completion_lines(archivers, request, shell):
+    """The generated completion script as a list of lines (on Windows it has CRLF line endings)."""
+    return cmd(request.getfixturevalue(archivers), "completion", shell).splitlines()
+
+
 @pytest.mark.parametrize("command,fn", SORTBY_WIRING)
 def test_bash_sortby_wiring(archivers, request, command, fn):
-    output = cmd(request.getfixturevalue(archivers), "completion", "bash")
-    assert f"_shtab_borg_{command.replace('-', '_')}___sort_by_COMPGEN={fn}\n" in output
-    assert f"\n{fn}() {{\n" in output
+    lines = completion_lines(archivers, request, "bash")
+    assert f"_shtab_borg_{command.replace('-', '_')}___sort_by_COMPGEN={fn}" in lines
+    assert f"{fn}() {{" in lines
 
 
 @pytest.mark.parametrize("command,fn", SORTBY_WIRING)
 def test_zsh_sortby_wiring(archivers, request, command, fn):
-    output = cmd(request.getfixturevalue(archivers), "completion", "zsh")
-    block = output.split(f"\n_shtab_borg_{command.replace('-', '_')}_options=(\n", 1)[1].split("\n)\n", 1)[0]
-    assert f':sort_by:{fn}"' in block
-    assert f"\n{fn}() {{\n" in output
+    lines = completion_lines(archivers, request, "zsh")
+    block = lines[lines.index(f"_shtab_borg_{command.replace('-', '_')}_options=(") :]
+    block = block[: block.index(")")]
+    assert any(f':sort_by:{fn}"' in line for line in block)
+    assert f"{fn}() {{" in lines
 
 
 @pytest.mark.parametrize("command,fn", SORTBY_WIRING)
 def test_fish_sortby_wiring(archivers, request, command, fn):
-    output = cmd(request.getfixturevalue(archivers), "completion", "fish")
+    lines = completion_lines(archivers, request, "fish")
     assert any(
-        f"_shtab_borg_using {command}'" in line and " -l sort-by " in line and f'"({fn})"' in line
-        for line in output.splitlines()
+        f"_shtab_borg_using {command}'" in line and " -l sort-by " in line and f'"({fn})"' in line for line in lines
     )
-    assert f"\nfunction {fn}\n" in output
+    assert f"function {fn}" in lines
 
 
 def test_tcsh_sortby_single_rule(archivers, request):
     """tcsh matches by option name only, so all --sort-by options share one helper."""
-    output = cmd(request.getfixturevalue(archivers), "completion", "tcsh")
-    assert output.count("'n/--sort-by/") == 1
-    assert f"'n/--sort-by/`{TCSH_SORTBY_FN}`/'" in output
-    alias = next(line for line in output.splitlines() if line.startswith(f"alias {TCSH_SORTBY_FN} "))
+    lines = completion_lines(archivers, request, "tcsh")
+    assert sum(line.count("'n/--sort-by/") for line in lines) == 1
+    assert any(f"'n/--sort-by/`{TCSH_SORTBY_FN}`/'" in line for line in lines)
+    alias = next(line for line in lines if line.startswith(f"alias {TCSH_SORTBY_FN} "))
     for key in ("timestamp", "atime", "size_added"):  # the union of all the sort keys
         assert f" {key}" in alias
 
@@ -300,7 +305,7 @@ def test_tcsh_sortby_single_rule(archivers, request):
 @pytest.mark.parametrize("shell", ["bash", "zsh", "fish", "tcsh"])
 def test_completion_helpers_are_defined(archivers, request, shell):
     """Every _borg_* helper the generated script refers to must also be defined by it."""
-    output = cmd(request.getfixturevalue(archivers), "completion", shell)
+    output = "\n".join(completion_lines(archivers, request, shell))
     defined = set(re.findall(r"^(?:function |alias )?(_borg_\w+)\s*(?:\(\)|\(|\s|$)", output, re.M))
     referenced = set(re.findall(r"_borg_complete_\w+|_borg_help_topics", output))
     assert referenced <= defined, f"undefined: {sorted(referenced - defined)}"

--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -330,6 +330,17 @@ def test_sort_by_invalid_field_is_rejected(archivers, request):
     cmd(archiver, "diff", "a1", "a2", "--sort-by=not_a_field", exit_code=EXIT_ERROR)
 
 
+def test_sort_by_twice_is_rejected(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+
+    create_regular_file(archiver.input_path, "file", size=1)
+    cmd(archiver, "create", "a1", "input")
+    cmd(archiver, "create", "a2", "input")
+
+    cmd(archiver, "diff", "a1", "a2", "--sort-by=path", "--sort-by=size", exit_code=EXIT_ERROR)
+
+
 def test_sort_by_size_added_then_path(archivers, request):
     archiver = request.getfixturevalue(archivers)
     cmd(archiver, "repo-create", RK_ENCRYPTION)

--- a/src/borg/testsuite/archiver/list_cmd_test.py
+++ b/src/borg/testsuite/archiver/list_cmd_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from ...constants import *  # NOQA
 from ...helpers import CommandError
+from .. import granularity_sleep
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION, requires_hardlinks
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
@@ -299,3 +300,118 @@ def test_fingerprint(archivers, request):
 
     # Even unmodified files should have different fingerprints because conditions_hash changed
     assert fingerprints1["input/file2"] != fingerprints5["input/file2"]
+
+
+def test_list_sort_by_path(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "c_file", size=1)
+    create_regular_file(archiver.input_path, "a_file", size=1)
+    create_regular_file(archiver.input_path, "b_file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    expected = ["input", "input/a_file", "input/b_file", "input/c_file"]
+    assert cmd(archiver, "list", "test", "--short", "--sort-by=path").splitlines() == expected
+    assert cmd(archiver, "list", "test", "--short", "--sort-by=>path").splitlines() == list(reversed(expected))
+
+
+def test_list_sort_by_size_then_path(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "a_file", size=30)
+    create_regular_file(archiver.input_path, "b_file", size=10)
+    create_regular_file(archiver.input_path, "c_file", size=20)
+    cmd(archiver, "create", "test", "input")
+
+    output = cmd(archiver, "list", "test", "--sort-by=>size,path", "--format={size} {path}{NL}")
+    assert output.splitlines() == ["30 input/a_file", "20 input/c_file", "10 input/b_file", "0 input"]
+
+
+def test_list_sort_by_type(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "dir/file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    output = cmd(archiver, "list", "test", "--sort-by=type,path", "--format={type} {path}{NL}")
+    # regular files ("-") sort before directories ("d")
+    assert output.splitlines() == ["- input/dir/file", "d input", "d input/dir"]
+
+
+def test_list_sort_by_is_stable(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "a_file", size=10)
+    create_regular_file(archiver.input_path, "b_file", size=10)
+    cmd(archiver, "create", "test", "input")
+
+    # equal sizes, so the last sort field decides the order of these 2 items
+    output = cmd(archiver, "list", "test", "--short", "--sort-by=size,>path")
+    assert output.splitlines() == ["input", "input/b_file", "input/a_file"]
+
+
+@pytest.mark.parametrize("sort_spec", ["not_a_field", "path,not_a_field", "", ",", ">", "birthtime"])
+def test_list_sort_by_invalid_spec_is_rejected(archivers, request, sort_spec):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    cmd(archiver, "list", "test", f"--sort-by={sort_spec}", exit_code=EXIT_ERROR)
+
+
+def test_list_sort_by_twice_is_rejected(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    cmd(archiver, "list", "test", "--sort-by=path", "--sort-by=size", exit_code=EXIT_ERROR)
+
+
+@pytest.mark.parametrize(
+    "sort_key", ["path", "type", "mode", "user", "uid", "group", "gid", "size", "mtime", "ctime", "atime"]
+)
+def test_list_sort_by_all_keys_with_directions(archivers, request, sort_key):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "a_file", size=11)
+    create_regular_file(archiver.input_path, "b_file", size=22)
+    granularity_sleep()  # the files created below shall have newer timestamps
+    create_regular_file(archiver.input_path, "c_file", size=33)
+    create_regular_file(archiver.input_path, "dir/d_file", size=44)
+    cmd(archiver, "create", "test", "input")
+
+    expected_paths = {"input", "input/a_file", "input/b_file", "input/c_file", "input/dir", "input/dir/d_file"}
+    # We do not check the order here, this is mostly for coverage of all the sort keys.
+    for direction in ("<", ">"):
+        output = cmd(archiver, "list", "test", "--short", f"--sort-by={direction}{sort_key},path")
+        assert set(output.splitlines()) == expected_paths
+
+
+def test_list_sort_by_json_lines(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "a_file", size=1)
+    create_regular_file(archiver.input_path, "b_file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    output = cmd(archiver, "list", "test", "--json-lines", "--sort-by=>path")
+    paths = [json.loads(line)["path"] for line in output.splitlines()]
+    assert paths == ["input/b_file", "input/a_file", "input"]
+
+
+def test_list_sort_by_with_depth_and_pattern(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "b_file", size=1)
+    create_regular_file(archiver.input_path, "a_file", size=1)
+    create_regular_file(archiver.input_path, "dir/c_file", size=1)
+    cmd(archiver, "create", "test", "input")
+
+    # filtering happens before sorting
+    output = cmd(archiver, "list", "test", "--short", "--depth=1", "--sort-by=path")
+    assert output.splitlines() == ["input", "input/a_file", "input/b_file", "input/dir"]
+
+    output = cmd(archiver, "list", "test", "--short", "--sort-by=>path", "--pattern=+ re:_file$", "--pattern=- re:^.*$")
+    assert output.splitlines() == ["input/dir/c_file", "input/b_file", "input/a_file"]

--- a/src/borg/testsuite/helpers/sorting_test.py
+++ b/src/borg/testsuite/helpers/sorting_test.py
@@ -1,0 +1,74 @@
+import pytest
+
+from ...helpers.argparsing import ArgumentTypeError
+from ...helpers.sorting import parse_sort_spec, sort_spec_validator, sorted_by_spec
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        (None, []),
+        ("", []),
+        ("   ", []),
+        (",", []),
+        ("path", [("path", False)]),
+        ("<path", [("path", False)]),
+        (">path", [("path", True)]),
+        (" >size , path ", [("size", True), ("path", False)]),
+        ("size,,path", [("size", False), ("path", False)]),
+    ],
+)
+def test_parse_sort_spec(spec, expected):
+    assert parse_sort_spec(spec) == expected
+
+
+def test_validator_accepts_and_normalizes():
+    validator = sort_spec_validator(("path", "size"))
+    assert validator("path") == "path"
+    assert validator("<path") == "path"  # "<" is the default and thus dropped
+    assert validator(" >size , path ") == ">size,path"
+
+
+def test_validator_rejects():
+    validator = sort_spec_validator(("path", "size"))
+    for spec in ("", "  ", ",", "nosuchfield", "path,nosuchfield", ">", "<"):
+        with pytest.raises(ArgumentTypeError):
+            validator(spec)
+
+
+def test_validator_has_sort_keys():
+    validator = sort_spec_validator(["path", "size"], name="test_sort_spec")
+    assert validator.sort_keys == ("path", "size")
+    assert validator.__name__ == "test_sort_spec"
+
+
+def key_for(field, element):
+    return element[field]
+
+
+def test_sorted_by_spec_keeps_unsorted_seq_as_is():
+    # important: without a sort spec, callers shall be able to keep streaming
+    seq = iter([{"path": "b"}, {"path": "a"}])
+    assert sorted_by_spec(seq, None, key_for) is seq
+    assert sorted_by_spec(seq, "", key_for) is seq
+
+
+def test_sorted_by_spec_single_field():
+    seq = [{"path": "b"}, {"path": "c"}, {"path": "a"}]
+    assert [e["path"] for e in sorted_by_spec(seq, "path", key_for)] == ["a", "b", "c"]
+    assert [e["path"] for e in sorted_by_spec(seq, ">path", key_for)] == ["c", "b", "a"]
+
+
+def test_sorted_by_spec_multiple_fields():
+    seq = [{"size": 1, "path": "b"}, {"size": 2, "path": "c"}, {"size": 1, "path": "a"}, {"size": 2, "path": "a"}]
+    # first field is the primary criterion, following fields break ties
+    result = [(e["size"], e["path"]) for e in sorted_by_spec(seq, ">size,path", key_for)]
+    assert result == [(2, "a"), (2, "c"), (1, "a"), (1, "b")]
+    result = [(e["size"], e["path"]) for e in sorted_by_spec(seq, "size,>path", key_for)]
+    assert result == [(1, "b"), (1, "a"), (2, "c"), (2, "a")]
+
+
+def test_sorted_by_spec_is_stable():
+    # equal sort keys must not change the relative order of the elements
+    seq = [{"size": 1, "path": "b"}, {"size": 1, "path": "a"}, {"size": 1, "path": "c"}]
+    assert [e["path"] for e in sorted_by_spec(seq, "size", key_for)] == ["b", "a", "c"]


### PR DESCRIPTION
Adds `borg list --sort-by=SPEC` for archive contents, as requested in #9009.

SPEC is a comma-separated list of fields, each optionally prefixed with `>` for descending or `<` for ascending (the default) order. The sorts are applied stably from the last field to the first, so the first field is the primary criterion:

```
$ borg list --sort-by='>size,path' --format='{size:8d} {path}{NL}' ARCHIVE
```

Supported fields: `path`, `type`, `mode`, `user`, `uid`, `group`, `gid`, `size`, `mtime`, `ctime`, `atime`.

Without `--sort-by`, items are streamed as before and their order stays undefined (no tie-breaker is applied).

### Notes on the implementation

- The sort keys are the same values `--format` would print, so the order always matches the visible column: `type` / `mode` sort by the rendered `stat.filemode()` values, `atime` / `ctime` fall back to `mtime` if not stored, `user` / `group` fall back to the numeric id if the name is unknown.
- No `birthtime` field, as there is no `{birthtime}` format key either. Could be added later, together with the format key.
- Sorting needs all (matching) items in memory. That is documented in the epilog, including the hint to use `borg list --format ... | sort` if that is a problem. Note that the patterns and `--depth` filter *before* sorting, so only matching items are buffered.
- Spec parsing/validation and the stable multi-field sort now live in a small new leaf module `helpers/sorting.py`. `borg diff --sort-by` was converted to it, with no change to its accepted fields, error messages or resulting order (its existing tests pass unchanged).
- `list --sort-by` and `diff --sort-by` now have shell completion for their fields (`diff --sort-by` had none so far). As there are 3 different sets of sort keys now (archives / items / item diffs), the completion helper is generated once per key set from one template per shell. In tcsh, completion rules match by option name only, over all subcommands, so there one helper offers the union of all sort keys - noted in the `borg completion` docs.
- Completion of the `<` / `>` prefix is not implemented: both characters are in bash's default `COMP_WORDBREAKS`, so the fragment never reaches the completion helper intact, and changing `COMP_WORDBREAKS` for them would break redirection completion for all other commands.

The last commit ("diff: --sort-by can only be given once") is the only behaviour change to `diff`: it adds `action=Highlander`, like `list --sort-by`, `repo-list --sort-by` and `diff --format` have. Easy to drop if unwanted.
