### PR TITLE
CI: force colored tox/pytest output in all jobs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force colored tox and pytest output even without a tty - the GitHub
+  # Actions log viewer renders ANSI colors. tox passes both vars through
+  # to pytest (pass_env = ["*"]).
+  PY_COLORS: "1"       # pytest
+  TOX_COLORED: "yes"   # tox's own output
+
 jobs:
   canary_tests:
     name: Canary (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.toxenv }})
@@ -107,7 +114,6 @@ jobs:
     timeout-minutes: 180
 
     env:
-      PY_COLORS: 1
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS2_ENV_CONV_EXCL: "*"
       # see the "Cache pip-built wheels" step. MSYS2_ENV_CONV_EXCL above keeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Force colored tox and pytest output even without a tty - the GitHub
+  # Actions log viewer renders ANSI colors. tox passes both vars through
+  # to pytest (pass_env = ["*"]).
+  PY_COLORS: "1"       # pytest
+  TOX_COLORED: "yes"   # tox's own output
+
 jobs:
   lint:
 
@@ -470,6 +477,11 @@ jobs:
           # job timeout (tox passes all env vars through to pytest).
           export PYTEST_TIMEOUT=300
 
+          # colored tox/pytest output - the workflow-level env vars do not
+          # reach into the VM, so export them here again.
+          export PY_COLORS=1
+          export TOX_COLORED=yes
+
           # see the "Cache pip-built wheels" step
           export PIP_CACHE_DIR="$PWD/.pip-cache"
 
@@ -668,7 +680,6 @@ jobs:
     needs: [lint]
 
     env:
-      PY_COLORS: 1
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS2_ENV_CONV_EXCL: "*"
       # see the "Cache pip-built wheels" step. MSYS2_ENV_CONV_EXCL above keeps


### PR DESCRIPTION
Previously only the Windows jobs had colored output (job-level `PY_COLORS`); all other jobs ran tox/pytest without a tty and thus without color.

- Set `PY_COLORS=1` (pytest) and `TOX_COLORED=yes` (tox 4's own output) at the workflow level in ci.yml and canary.yml. The GitHub Actions log viewer renders ANSI colors, and tox forwards both vars to pytest via `pass_env = ["*"]`.
- Remove the now-redundant job-level `PY_COLORS` from the two Windows jobs.
- The `vm_tests` job runs its script inside cross-platform-actions VMs, where the workflow-level env does not arrive — so both vars are exported inside the VM script, next to the existing `PYTEST_TIMEOUT` export. (NetBSD's `tox3` is pkgsrc's tox 4 with a python 3.13 interpreter suffix, so `TOX_COLORED` applies there too.)
- black.yaml runs neither tox nor pytest, so it is unchanged.

Verified locally with piped (non-tty) output: pytest 9.1.1 emits ANSI colors only with `PY_COLORS=1`, tox 4.59 only with `TOX_COLORED=yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)