### PR TITLE
create --encryption: new none-* and authenticated-* modes, #9104

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -167,6 +167,31 @@ Version 2.0.0b23 (not released yet)
 
 New features:
 
+- crypto: protect metadata and object header in the modes that do not encrypt, #9104.
+
+  The "none" and "authenticated" modes had a no-op repo object envelope: only the chunk
+  id over the plaintext was checked, so a repo object's metadata (which selects the
+  decompressor!) and its object header were not verified at all. They now use a tagged
+  envelope: every object slot carries a 32 byte tag over the payload, the object header,
+  the chunk id and the meta/data slot, verified before the payload is used.
+
+  - "authenticated-sha256" / "authenticated-blake3": the tag is a MAC (HMAC-SHA256 resp.
+    keyed BLAKE3, key derived from crypt_key), thus these modes now detect tampering with
+    metadata and object header, not just with the chunk content.
+  - "none-sha256" / "none-blake3": the tag is an unkeyed checksum, which detects accidental
+    corruption. It is no authentication - these modes have no key and make no such claim.
+  - The tag is deterministic (no nonce/session), so repositories with the same key material
+    store byte-identical objects for identical input.
+  - The unencrypted modes are named "<mode>-<hash>" now, because the hash *is* what protects
+    the data there: "none-sha256", "none-blake3", "authenticated-sha256",
+    "authenticated-blake3". Bare "--encryption none" / "--encryption authenticated" are
+    rejected, and "--id-hash" only applies to the encrypted modes now.
+  - "none-blake3" is new: the unencrypted mode was limited to sha256 before.
+
+  Breaking: borg 2 beta repositories using the old "none" or "authenticated" formats are not
+  supported any more - create a new repository, or transfer the archives with borg 2.0.0b23
+  or older first. Reading borg 1.x "none"/"authenticated" repositories for
+  "borg transfer --from-borg1" is not affected.
 - faster create:
 
   - use multi-threaded zstd compression for big chunks, #9961

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -920,6 +920,54 @@ need any special handling when reading, because the session id is part of every 
 header. Because the advantages of the individual session keys just add up, frequent
 session key changes also keep the total advantage low over the lifetime of a borg key.
 
+.. _tagged_envelope:
+
+Modes without encryption
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``authenticated-*`` and ``none-*`` modes do not encrypt: the payload of a repository
+object slot (the compressed chunk data resp. the packed metadata, see `Repository objects`_)
+is stored as-is. Every slot still carries a 32 byte tag::
+
+    TYPE(1) + reserved(1) + tag(32) + payload
+
+``TYPE`` is the key type byte (which identifies the mode, see ``KeyType``), ``reserved`` is
+zero. The tag is computed over the envelope header, the AAD and the payload::
+
+    aad_full = aad + chunk_id
+    tag = MAC(tag_key, TYPE || reserved || len16_be(aad_full) || aad_full || payload)
+
+``aad`` is what ``RepoObj`` authenticates alongside the payload: the object header prefix
+(magic, format version, chunk id) and the slot tag (``M`` for meta, ``D`` for data), see
+:ref:`pack-format`. Consequently, the tag detects modification of the payload, of the
+metadata, of the object header, a swap of the meta and the data slot, and an object slice
+taken from a different object. The length prefix keeps the boundary between the AAD and the
+payload unambiguous.
+
+There is no nonce, no session and no other state: the tag is deterministic. Two repositories
+with the same key material therefore store byte-identical objects for identical input, which
+allows deduplicating them on the filesystem level (e.g. with CoW/dedup tools).
+
+The modes differ in the tag algorithm and in whether they have a key at all:
+
+- ``authenticated-sha256`` / ``authenticated-blake3``: the tag is a **MAC** (HMAC-SHA256 resp.
+  keyed BLAKE3), so only somebody who has the borg key can compute it - this detects malicious
+  tampering, not just accidental corruption. The MAC key is derived from ``crypt_key``::
+
+      tag_key = sha256(crypt_key + b"borg-repoobj-mac-hmac-sha256")[:32]   # authenticated-sha256
+      tag_key = sha256(crypt_key + b"borg-repoobj-mac-blake3")[:32]        # authenticated-blake3
+
+  It is deliberately not derived from ``id_key``: chunk ids are public, and related repositories
+  share the id key (see ``borg repo-create --other-repo``), which must not enable them to forge
+  each other's objects. ``--copy-crypt-key`` shares ``crypt_key`` and thus opts into producing
+  byte-identical objects across the related repositories.
+- ``none-sha256`` / ``none-blake3``: there is no key at all, so the tag is an **unkeyed** hash
+  (plain SHA-256 resp. BLAKE3 over the same input), i.e. a checksum. It detects accidental
+  corruption and reads that returned the wrong bytes, but anybody who modifies an object can
+  recompute it - it is no protection against malicious tampering. For the same reason, the chunk
+  ids of these modes are unkeyed hashes of the plaintext, which makes all repositories of such a
+  mode dedup identically.
+
 Legacy modes
 ~~~~~~~~~~~~
 
@@ -929,8 +977,12 @@ Old repositories (which used AES-CTR mode) are supported read-only to be able to
 AES-CTR mode is not supported for new repositories and the related code will be
 removed in a future release.
 
-Both modes
-~~~~~~~~~~
+The same applies to the borg 1.x ``none`` and ``authenticated`` modes: their envelope is just
+the type byte followed by the payload, so nothing about an object is verified except the chunk
+id over the plaintext. They were replaced by the tagged modes described above.
+
+All modes
+~~~~~~~~~
 
 Encryption keys (and other secrets) are kept either in the keys directory on
 the client ('keyfile' mode) or under the keys/ namespace in the repository

--- a/docs/internals/packs.rst
+++ b/docs/internals/packs.rst
@@ -54,12 +54,14 @@ The fixed part of each blob header is 49 bytes (``REPOOBJ_HEADER_SIZE``):
 ``REPOOBJ_HEADER_SIZE = len(OBJ_MAGIC) + 1 + 32 + 4 + 4 = 49``
 
 Format version ``0x02`` (``OBJ_VERSION_HEADER_AAD``) binds the header's first 41 bytes (``OBJ_MAGIC``
-+ version + ``chunk_id`` -- ``REPOOBJ_HEADER_AAD_SIZE``) into the AEAD authentication of
++ version + ``chunk_id`` -- ``REPOOBJ_HEADER_AAD_SIZE``) into the authentication of
 ``encrypted_meta`` and ``encrypted_data`` as additional authenticated data (AAD: data that is
-authenticated together with the ciphertext, but not itself encrypted). This applies to the AEAD
-encryption modes (AES-256-OCB, ChaCha20-Poly1305). ``meta_size`` and ``data_size`` are excluded from
-the AAD; tampering with either still fails authentication, because it changes the length of the
-ciphertext slice being decrypted. A forged ``chunk_id``, version, or magic byte therefore fails AEAD
+authenticated together with the ciphertext, but not itself encrypted). This applies to all borg 2
+modes: the AEAD encryption modes (AES-256-OCB, ChaCha20-Poly1305) authenticate it with their AEAD
+tag, the ``authenticated-*`` modes with their MAC and the ``none-*`` modes with their (unkeyed)
+checksum, see :ref:`tagged_envelope`. ``meta_size`` and ``data_size`` are excluded from
+the AAD; tampering with either still fails the check, because it changes the length of the
+slice being read. A forged ``chunk_id``, version, or magic byte therefore fails
 authentication in ``RepoObj.parse()``/``parse_meta()``.
 
 ``encrypted_meta`` and ``encrypted_data`` each add a one-byte slot tag on top of the shared header
@@ -82,7 +84,7 @@ decrypting, so it does not check header AAD authentication.
 
     The fixed 49-byte blob header. ``meta_size`` and ``data_size`` drive
     traversal; integrity comes from the content-addressed pack name and the
-    per-blob AEAD, which authenticates magic/version/chunk_id as additional
+    per-blob tag, which authenticates magic/version/chunk_id as additional
     authenticated data.
 
 A reader locates the next blob by advancing::

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -75,10 +75,21 @@ object's metadata (like e.g.: manifest vs. archive vs. user file content data).
 When loading data from the repo, borg verifies that the type of object it got
 matches the type it wanted. borg 2 does not use TAMs any more.
 
-As both the object's metadata and data are AEAD encrypted and also bound to
+As both the object's metadata and data are authenticated and also bound to
 the object ID (via giving the ID as AAD), there is no way an attacker (without
 access to the borg key) could change the type of the object or move content
-to a different object ID.
+to a different object ID. This holds for the AEAD encryption modes (where the
+AEAD tag authenticates them) as well as for the ``authenticated-*`` modes
+(where a MAC does, see :ref:`tagged_envelope`).
+
+It does **not** hold for the ``none-*`` modes: they have no key, so their objects
+carry an unkeyed checksum rather than a MAC, and an attacker who modifies an
+object can simply recompute it. What still constrains an attacker there is the
+object ID being the (unkeyed) hash of the plaintext: the content of an existing
+object can not be replaced without the ID no longer matching. But the object's
+metadata, the archives list and the manifest are not anchored to anything secret,
+so a ``none-*`` repository provides no tamper protection - only detection of
+accidental corruption.
 
 This effectively 'anchors' each archive to the key, which is controlled by the
 client, thereby anchoring the DAG starting from the archives list entry,
@@ -201,10 +212,50 @@ Notable:
   recommended periodic audit for this).
 
 
+Authenticated modes
+~~~~~~~~~~~~~~~~~~~
+
+Modes: ``--encryption authenticated-(sha256|blake3)``
+
+Supported: borg 2.0+
+
+These modes do not encrypt: everything in the repository is readable by anybody who
+can read the repository. They do authenticate, though - like an AEAD mode minus the
+data encryption:
+
+- Every repository object slot (metadata and data) carries a MAC over the payload, the
+  object header and the slot, see :ref:`tagged_envelope`. Reading verifies it before the
+  payload is used for anything (in particular before decompressing it), so tampering with
+  any of them is detected, whether accidental or malicious.
+- The chunk IDs are MACs over the plaintext, as in the encrypted modes.
+- The MAC key lives in a borg key (repokey or keyfile, ``--key-location``), protected by a
+  passphrase like the keys of the encrypted modes. An attacker without that key can neither
+  forge objects nor chunk IDs.
+
+Different from the AEAD modes, the MAC is deterministic (a MAC needs no nonce): there is no
+session key, no IV and thus no usage limit to observe, and identical input produces identical
+objects.
+
+Unencrypted modes
+~~~~~~~~~~~~~~~~~
+
+Modes: ``--encryption none-(sha256|blake3)``
+
+Supported: borg 2.0+
+
+These modes have no key at all: they neither encrypt nor authenticate. Every repository
+object slot carries an *unkeyed* checksum (see :ref:`tagged_envelope`), which detects
+accidental corruption - bad storage hardware, a truncated write, a read that returned the
+wrong bytes - before the data is used. It is not a protection against an attacker: whoever
+modifies an object can recompute the checksum, and the chunk IDs are unkeyed hashes as well.
+
+You are advised not to use these modes. Use ``authenticated-*`` instead if you do not want
+your data encrypted but do want to detect tampering; it is the same thing plus a key.
+
 Legacy modes
 ~~~~~~~~~~~~
 
-Modes: ``--encryption (repokey|keyfile)[-blake2]``
+Modes: ``--encryption (repokey|keyfile)[-blake2]``, ``--encryption (none|authenticated)``
 
 Supported: borg < 2.0
 
@@ -212,6 +263,11 @@ These were the AES-CTR based modes in previous borg versions, with the chunk ID
 derived via HMAC-SHA256 or (in the ``-blake2`` variants) Blake2b. ``blake2b`` is
 only used by these legacy modes; new repositories use ``sha256`` or ``blake3``
 (see above).
+
+The borg 1.x ``none`` and ``authenticated`` modes belong here, too: their repository
+objects have no tag at all, so nothing about an object is verified except the chunk ID
+over the plaintext - not even the object's metadata. They were replaced by the modes
+described above, which cover metadata and object header as well.
 
 borg 2.0 does not support creating new repos using these modes,
 but ``borg transfer`` can still read such existing repos.

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -846,9 +846,15 @@ class HelpMixIn:
                     in WSL1 (Windows Subsystem for Linux 1).
 
                 authenticated_no_key
-                    Work around a lost passphrase or key for an ``authenticated`` mode repository
+                    Work around a lost passphrase or key for an ``authenticated-*`` mode repository
                     (these are only authenticated, but not encrypted).
                     If the key is missing in the repository config, add ``key = anything`` there.
+
+                    Without the key, borg can not verify anything that needs it: neither the
+                    authentication tag of the repository objects nor the chunk ids. It therefore
+                    reads the repository **unverified** - a corrupted or tampered repository will
+                    not be detected. (This only concerns the ``authenticated-*`` modes; the
+                    ``none-*`` modes need no key and keep verifying their checksums.)
 
                     This workaround is **only** for emergencies and **only** to extract data
                     from an affected repository (read-only access)::

--- a/src/borg/archiver/repo_create_cmd.py
+++ b/src/borg/archiver/repo_create_cmd.py
@@ -32,7 +32,7 @@ class RepoCreateMixIn:
         manifest.write()
         with Cache(repository, manifest, warn_if_unencrypted=False):
             pass
-        if key.ENC_NAME != "none":  # any key-bearing suite (everything except plaintext "none")
+        if key.has_secret_key:  # any key-bearing suite (everything except the "none-*" modes)
             logger.warning(
                 "\n"
                 "IMPORTANT: you will need both KEY AND PASSPHRASE to access this repository!\n"
@@ -125,21 +125,23 @@ class RepoCreateMixIn:
         Depending on your hardware, hashing and crypto performance may vary widely.
         The easiest way to find out what is fastest is to run ``borg benchmark cpu``.
 
-        A crypto suite is selected by three orthogonal options:
-
-        ``--encryption`` (**required**) selects the cipher / authenticated-encryption algorithm:
+        ``--encryption`` (**required**) selects the mode:
 
         - ``aes256-ocb``: AES256 in OCB mode (encryption + authentication).
         - ``chacha20-poly1305``: ChaCha20 + Poly1305 (encryption + authentication).
-        - ``authenticated``: no encryption, but still authenticates your data (tamper detection).
-        - ``none``: no encryption and no authentication (see the warning below).
+        - ``authenticated-sha256`` / ``authenticated-blake3``: no encryption, but authentication
+          (tamper detection) using HMAC-SHA-256 resp. keyed BLAKE3.
+        - ``none-sha256`` / ``none-blake3``: neither encryption nor authentication, only
+          SHA-256 resp. BLAKE3 checksums (see below).
 
-        ``--id-hash`` selects the id hash function (used for chunk ids and authentication):
+        ``--id-hash`` selects the id hash function of the **encrypted** modes:
 
-        - ``sha256`` (default): HMAC-SHA-256 (or plain SHA-256 for the ``none`` encryption).
+        - ``sha256`` (default): HMAC-SHA-256.
         - ``blake3``: BLAKE3. Often faster on CPUs without SHA hardware acceleration.
 
-        The ``none`` encryption has no key, so it only supports the ``sha256`` id hash.
+        For the modes that do not encrypt, the hash is not just used for the chunk ids, it also is
+        what protects your data - therefore it is part of the mode name there and ``--id-hash``
+        does not apply to them.
 
         ``--key-location`` selects where the key is stored (orthogonal to the crypto suite):
 
@@ -149,20 +151,23 @@ class RepoCreateMixIn:
           this if you want "passphrase and having-the-key" security.
 
         You can move the key between these locations later with ``borg key change-location``.
-        This also applies to the ``authenticated`` encryption: it does not encrypt your data, but it
-        still has a key (used for the id hash and authentication), so ``--key-location`` selects
-        where that key is stored, just like for the encrypted suites.
-        ``--key-location`` is only ignored for the ``none`` encryption, which has no key at all.
+        This also applies to the ``authenticated-*`` modes: they do not encrypt your data, but they
+        still have a key (used for the id hash and the authentication), so ``--key-location``
+        selects where that key is stored, just like for the encrypted modes.
+        ``--key-location`` is only ignored for the ``none-*`` modes, which have no key at all.
 
-        `none` encryption uses no encryption and no authentication. You are advised NOT to use this
-        as it would expose you to a Denial-of-Service risk (due to how the :ref:`internals_hashindex`
-        works) and other issues (confidentiality, tampering, ...) in case of malicious activity
-        in the repository.
+        The ``none-*`` modes use neither encryption nor authentication: everything in the
+        repository is readable by anybody, and while every repository object carries a checksum
+        (which detects accidental corruption, e.g. bad storage hardware), anybody who modifies an
+        object can just recompute that checksum. You are advised NOT to use these modes: in case
+        of malicious activity in the repository, they expose you to a Denial-of-Service risk (due
+        to how the :ref:`internals_hashindex` works) and other issues (confidentiality,
+        tampering, ...).
 
         If you do **not** want to encrypt the contents of your backups, but still want to detect
-        malicious tampering, use ``--encryption authenticated``. It is like an encrypted suite
-        minus the data encryption.
-        To normally work with ``authenticated`` repositories, you will need the passphrase, but
+        malicious tampering, use ``--encryption authenticated-sha256`` (or ``-blake3``). These
+        modes are like an encrypted mode minus the data encryption.
+        To normally work with ``authenticated-*`` repositories, you will need the passphrase, but
         there is an emergency workaround; see ``BORG_WORKAROUNDS=authenticated_no_key`` docs.
 
         Creating a related repository
@@ -213,8 +218,8 @@ class RepoCreateMixIn:
             required=True,
             choices=encryption_argument_names(),
             action=Highlander,
-            help="select cipher / AE algorithm: 'none', 'authenticated', 'aes256-ocb' or "
-            "'chacha20-poly1305' **(required)**",
+            help="select the mode: 'aes256-ocb', 'chacha20-poly1305', 'authenticated-sha256', "
+            "'authenticated-blake3', 'none-sha256' or 'none-blake3' **(required)**",
         )
         subparser.add_argument(
             "-i",
@@ -222,10 +227,10 @@ class RepoCreateMixIn:
             metavar="HASH",
             dest="id_hash",
             choices=id_hash_argument_names(),
-            default="sha256",
+            default=None,  # None: not given. Do not default to sha256 here, see key_creator.
             action=Highlander,
-            help="select the id hash function: 'sha256' (default) or 'blake3'. "
-            "The 'none' encryption only supports 'sha256'.",
+            help="select the id hash function of the encrypted modes: 'sha256' or 'blake3'. "
+            "The 'none-*' and 'authenticated-*' modes name their hash themselves.",
         )
         subparser.add_argument(
             "--key-location",

--- a/src/borg/archiver/repo_info_cmd.py
+++ b/src/borg/archiver/repo_info_cmd.py
@@ -26,12 +26,12 @@ class RepoInfoMixIn:
             # the two dimensions: cipher / AE algorithm (ENC_NAME) and id hash function (IDHASH_NAME).
             storage = getattr(key, "storage", None)
             mode = {KeyBlobStorage.KEYFILE: "keyfile", KeyBlobStorage.REPO: "repokey"}.get(storage)
-            suite = "%s, %s" % (key.ENC_NAME, key.IDHASH_NAME)
-            if key.ENC_NAME in ("none", "authenticated"):
-                # the "none" and "authenticated" encryptions do not encrypt data; "authenticated"
-                # (unlike "none"/plaintext) still has a key stored as a keyfile or repokey, so show
-                # that location when there is one.
-                encryption += "No (%s, %s)" % (mode, suite) if mode else "No"
+            # the "none-*" and "authenticated-*" modes name their id hash in ENC_NAME already.
+            suite = key.ENC_NAME if key.IDHASH_IN_ENC_NAME else "%s, %s" % (key.ENC_NAME, key.IDHASH_NAME)
+            if not key.encrypts:
+                # these modes do not encrypt data; the "authenticated-*" ones (unlike "none-*")
+                # still have a key stored as a keyfile or repokey, so show that location if there is one.
+                encryption += "No (%s, %s)" % (mode, suite) if mode else "No (%s)" % suite
             else:
                 encryption += "Yes (%s, %s)" % (mode, suite) if mode else "Yes (%s)" % suite
             if storage == KeyBlobStorage.KEYFILE:

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -254,7 +254,15 @@ class KeyType:
     CHPO = 0x20
     BLAKE3AESOCB = 0x30
     BLAKE3CHPO = 0x40
-    BLAKE3AUTHENTICATED = 0x50
+    # 0x50 was a borg2 beta format ("authenticated" with blake3 ids and a no-op envelope). It was
+    # dropped before the 2.0 release, see #9104 - the byte stays reserved so it is not reused.
+    DROPPED_BLAKE3AUTHENTICATED = 0x50
+    # the "authenticated-*" and "none-*" modes: not encrypted, but every repo object slot carries
+    # a tag (a MAC resp. an unkeyed checksum), see MACKeyBase.
+    SHA256AUTHENTICATED = 0x60
+    BLAKE3AUTHENTICATED = 0x70
+    SHA256NONE = 0x80
+    BLAKE3NONE = 0x90
 
 
 CACHE_TAG_NAME = "CACHEDIR.TAG"

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -5,7 +5,7 @@ import textwrap
 from hashlib import sha256
 from math import ceil
 from pathlib import Path
-from typing import Literal, ClassVar, Optional
+from typing import Any, Literal, ClassVar, Optional
 from collections.abc import Callable
 
 from ..logger import create_logger
@@ -27,7 +27,7 @@ from ..helpers import workarounds
 from ..item import Key, EncryptedKey
 from ..manifest import Manifest
 from ..platform import SaveFile
-from ..repoobj import RepoObj
+from ..repoobj import RepoObj, RepoObj1
 
 
 from .low_level import bytes_to_int, num_cipher_blocks, hmac_sha256
@@ -170,18 +170,27 @@ KEY_LOCATIONS = {"keyfile": KeyBlobStorage.KEYFILE, "repokey": KeyBlobStorage.RE
 
 
 def key_creator(repository, args, *, other_key=None):
-    # the crypto suite is selected by two orthogonal dimensions: the cipher / AE algorithm
-    # (--encryption) and the id hash function (--id-hash). id-hash is always significant, so e.g.
-    # "--encryption none --id-hash blake3" finds no match and is rejected (none only supports sha256).
+    # For the encrypted modes, the crypto suite is selected by two orthogonal dimensions: the
+    # cipher / AE algorithm ("--encryption") and the id hash function ("--id-hash", defaulting to
+    # sha256). For the modes that do not encrypt, the hash is not a tuning knob but *is* the
+    # mechanism (it authenticates resp. checksums the data), so it is part of the mode name:
+    # "none-sha256", "none-blake3", "authenticated-sha256", "authenticated-blake3". Giving
+    # "--id-hash" in addition to one of those names is only accepted if both agree.
     enc = args.encryption
-    id_hash = getattr(args, "id_hash", "sha256")
+    id_hash = getattr(args, "id_hash", None)  # None: not given, see the --id-hash argparse default
     for key in AVAILABLE_KEY_TYPES:
-        if key.ENC_NAME == enc and key.IDHASH_NAME == id_hash:
+        if key.ENC_NAME != enc:
+            continue
+        if key.IDHASH_IN_ENC_NAME:
+            if id_hash is not None and id_hash != key.IDHASH_NAME:
+                raise Error(
+                    f'The "{enc}" encryption mode always uses the "{key.IDHASH_NAME}" id-hash, '
+                    f'thus --id-hash "{id_hash}" can not be used with it.'
+                )
             return key.create(repository, args, other_key=other_key)
-    raise Error(
-        f'Unsupported --encryption "{enc}" / --id-hash "{id_hash}" combination '
-        f'(the "none" encryption only supports the "sha256" id-hash).'
-    )
+        if key.IDHASH_NAME == (id_hash or "sha256"):
+            return key.create(repository, args, other_key=other_key)
+    raise Error(f'Unsupported --encryption "{enc}" / --id-hash "{id_hash}" combination.')
 
 
 def encryption_argument_names():
@@ -217,7 +226,14 @@ def identify_key(manifest_data):
 def key_factory(repository, manifest_chunk, *, other=False, ro_cls=RepoObj):
     manifest_data = ro_cls.extract_crypted_data(manifest_chunk)
     assert manifest_data, "manifest data must not be zero bytes long"
-    return identify_key(manifest_data).detect(repository, manifest_data, other=other)
+    key_cls = identify_key(manifest_data)
+    if key_cls in LEGACY_KEY_TYPES and ro_cls is not RepoObj1:
+        # A borg 2 repository using a borg 1.x key type: that can only be a repository created by
+        # a borg 2 beta in the old "none" or "authenticated" mode, which have been replaced by the
+        # tagged envelope modes (see MACKeyBase). The legacy key classes only exist to read borg
+        # 1.x repositories (ro_cls is RepoObj1 then), e.g. for "borg transfer --from-borg1".
+        raise UnsupportedPayloadError(manifest_data[0])
+    return key_cls.detect(repository, manifest_data, other=other)
 
 
 def uses_same_chunker_secret(other_key, key):
@@ -230,12 +246,13 @@ def uses_same_chunker_secret(other_key, key):
 def uses_same_id_hash(other_key, key):
     """other_key -> key upgrade: is the id hash the same?"""
     # avoid breaking the deduplication by changing the id hash
-    old_sha256_ids = (PlaintextKey,)
-    new_sha256_ids = (PlaintextKey,)
-    old_hmac_sha256_ids = (AESCTRKey, AuthenticatedKey)
+    old_sha256_ids = (LegacyPlaintextKey,)  # unkeyed sha256 over the plaintext
+    new_sha256_ids = (ChecksumKey,)
+    old_hmac_sha256_ids = (AESCTRKey, LegacyAuthenticatedKey)
     new_hmac_sha256_ids = (AESOCBKey, CHPOKey, AuthenticatedKey)
     # note: we do not support blake2b for new repos, see #8867
     new_blake3_ids = (Blake3AESOCBKey, Blake3CHPOKey, Blake3AuthenticatedKey)
+    new_unkeyed_blake3_ids = (Blake3ChecksumKey,)  # unkeyed blake3 over the plaintext
     same_ids = (
         isinstance(other_key, old_hmac_sha256_ids + new_hmac_sha256_ids)
         and isinstance(key, new_hmac_sha256_ids)
@@ -243,6 +260,8 @@ def uses_same_id_hash(other_key, key):
         and isinstance(key, new_blake3_ids)
         or isinstance(other_key, old_sha256_ids + new_sha256_ids)
         and isinstance(key, new_sha256_ids)
+        or isinstance(other_key, new_unkeyed_blake3_ids)
+        and isinstance(key, new_unkeyed_blake3_ids)
     )
     return same_ids
 
@@ -260,10 +279,20 @@ class KeyBase:
     # None means "not creatable this way" (e.g. legacy read-only classes).
     ENC_NAME: ClassVar[str] = None  # override in creatable subclasses
     IDHASH_NAME: ClassVar[str] = None  # override in creatable subclasses (or via id-hash mix-in)
+    # Is the id hash part of the ENC_NAME (e.g. "none-blake3") instead of being selectable via
+    # "--id-hash"? True for the modes that do not encrypt: there, the hash is not a tuning knob,
+    # it is what protects the data, so it belongs to the mode. See key_creator.
+    IDHASH_IN_ENC_NAME: ClassVar[bool] = False
 
     # Storage type (no key blob storage / keyfile / repo). This is only a default seed for the
     # per-instance self.storage; keyfile vs repokey is a property of an individual key, not the class.
     STORAGE: ClassVar[str] = KeyBlobStorage.NO_STORAGE
+
+    # per-instance key location, set in __init__ (see also FlexiKey, which shares these with us
+    # in the classes inheriting from both): declared here so that a subclass in another module
+    # does not have to infer their types across the module import cycle.
+    storage: str  # where this key is/will be stored, one of the KeyBlobStorage values
+    target: Any  # key location: keyfile path or repository object
 
     # Whether a key of this class may be stored as a keyfile or as a repokey (configurable at
     # repo creation via --key-location and changeable later via "borg key change-location").
@@ -286,6 +315,18 @@ class KeyBase:
     # False (the AEAD key classes): every read is authenticated by the AEAD tag, with the chunk id in the AAD,
     # independently of assert_id() - see AEADKeyBase.assert_id for what assert_id adds on top of that.
     id_check_is_authentication: ClassVar[bool] = True
+
+    # Does this mode encrypt the data at all? False for the modes that only tag it ("none-*",
+    # "authenticated-*" and their borg 1.x predecessors). Different from logically_encrypted,
+    # which is a per-instance property (an encrypted repo with an empty passphrase is not
+    # "logically" encrypted, but it does encrypt).
+    encrypts: ClassVar[bool] = True
+
+    # Does this key class have secret key material?
+    # False for the "none-*" modes: their chunk ids and their envelope checksums are unkeyed, thus
+    # they work without any key - and the authenticated_no_key workaround (which fakes the key
+    # material of a key it can not unlock) must not switch off checks that need no key at all.
+    has_secret_key: ClassVar[bool] = True
 
     # Whether this *particular instance* is encrypted from a practical point of view,
     # i.e. when it's using encryption with a empty passphrase, then
@@ -367,38 +408,6 @@ class KeyBase:
         return unpacked
 
 
-class PlaintextKey(KeyBase):
-    TYPE = KeyType.PLAINTEXT
-    TYPES_ACCEPTABLE = {TYPE}
-    ENC_NAME = "none"
-    IDHASH_NAME = "sha256"  # plain sha256(data), no key; blake3 is not supported for "none"
-
-    chunk_seed = 0
-    crypt_key = b""  # makes .derive_key() work, nothing secret here
-    id_key = b""  # makes .derive_key() work, nothing secret here
-
-    logically_encrypted = False
-
-    @classmethod
-    def create(cls, repository, args, **kw):
-        logger.info('Encryption NOT enabled.\nUse the "--encryption=repokey|keyfile" to enable encryption.')
-        return cls(repository)
-
-    @classmethod
-    def detect(cls, repository, manifest_data, *, other=False):
-        return cls(repository)
-
-    def id_hash(self, data):
-        return sha256(data).digest()
-
-    def encrypt(self, id, data, aad=b""):
-        return b"".join([self.TYPE_STR, data])
-
-    def decrypt(self, id, data, aad=b""):
-        self.assert_type(data[0], id)
-        return memoryview(data)[1:]
-
-
 class ID_HMAC_SHA_256:
     """
     Key mix-in class for using HMAC-SHA-256 for the id key.
@@ -476,6 +485,15 @@ class AESKeyBase(KeyBase):
 class FlexiKey:
     FILE_ID = KEYFILE_ID
     STORAGE: ClassVar[str] = KeyBlobStorage.NO_STORAGE  # override in subclass
+
+    # this is a mix-in for KeyBase subclasses: it only uses these, KeyBase defines them.
+    # they are declared here (same types as there) so that a subclass in another module does not
+    # have to infer their types across the module import cycle.
+    chunk_seed: int
+    crypt_key: bytes
+    id_key: bytes
+    storage: str
+    target: Any
 
     # multiple-borg-keys state (a repository may have multiple borg keys, one per passphrase):
     _encrypted_key_label = None  # label read from the EncryptedKey envelope on decrypt
@@ -640,7 +658,9 @@ class FlexiKey:
             # choose initial storage (keyfile or repokey) from --key-location (default: repokey).
             key.storage = KEY_LOCATIONS.get(getattr(args, "key_location", None), cls.STORAGE)
         if other_key is not None:
-            if isinstance(other_key, PlaintextKey):
+            if not other_key.has_secret_key:
+                # the "none-*" modes (and borg 1.x "none") have no key material to copy - and they
+                # need none: their chunk ids are unkeyed, so they all dedup identically anyway.
                 raise Error("Copying key material from an unencrypted repository is not possible.")
             if isinstance(key, AESKeyBase):
                 # user must use an AEADKeyBase subclass (AEAD modes with session keys)
@@ -988,10 +1008,176 @@ class FlexiKey:
         return victim
 
 
-class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
+# ------------ not encrypted, but tagged: the "authenticated-*" and "none-*" modes ------------
+
+
+class MACKeyBase(KeyBase):
+    """
+    Base class of the modes that do not encrypt, but tag every repo object slot.
+
+    Envelope layout: TYPE(1) + reserved(1) + tag(32) + payload
+
+    The payload (the compressed chunk data resp. the packed metadata) is stored as-is, so anyone
+    can read it. The tag is computed over the envelope header, the AAD and the payload, so a read
+    detects any modification of them. RepoObj puts the object header (magic, format version, chunk
+    id), the meta/data slot tag and the chunk id into the AAD, thus the tag also binds a payload to
+    the specific object and slot it was written for: swapping the meta and data slot, moving a slot
+    to another object or changing the object header all fail verification.
+
+    The tag is deterministic - there is no nonce, no session and no other state to keep (a MAC does
+    not need any). Two repositories with the same key material therefore store byte-identical
+    objects for identical input, which allows deduplicating them on the filesystem level.
+
+    Subclasses supply the tag algorithm (mac()) and, if they are keyed, the tag key (tag_key).
+    """
+
+    encrypts = False  # these modes only tag the data, they do not encrypt it
+    IDHASH_IN_ENC_NAME = True  # the hash is what protects the data here, see key_creator
+
+    # TYPE + reserved + tag. reserved is currently always zero; it is authenticated by the tag,
+    # so it can carry a format flag later without changing the envelope size.
+    TAG_SIZE = 32
+    HEADER_SIZE = 2
+    PAYLOAD_OVERHEAD = HEADER_SIZE + TAG_SIZE
+
+    def mac(self, prefix: bytes, payload) -> bytes:
+        """Compute the authentication tag over prefix + payload, returning TAG_SIZE bytes."""
+        raise NotImplementedError
+
+    @property
+    def tag_key(self) -> bytes:
+        """The key the tag is computed with (unkeyed modes do not have one)."""
+        raise NotImplementedError
+
+    def init_ciphers(self, manifest_data=None):
+        # there is no cipher and no session state here (the tag is deterministic), we only check
+        # the type byte of the manifest object.
+        if manifest_data is not None:
+            self.assert_type(manifest_data[0])
+
+    def _tag_prefix(self, header: bytes, aad: bytes, id: bytes) -> bytes:
+        # everything the tag covers except the payload. The AAD is length-prefixed, so the
+        # boundary between it and the payload is unambiguous (the AAD has a fixed length today,
+        # but the tag must not depend on that staying true).
+        aad_full = aad + id
+        assert len(aad_full) <= 0xFFFF, "aad too long to be length-prefixed"
+        return b"".join([header, len(aad_full).to_bytes(2, "big"), aad_full])
+
+    def encrypt(self, id, data, aad=b""):
+        header = self.TYPE_STR + b"\0"  # TYPE + reserved
+        tag = self.mac(self._tag_prefix(header, aad, id), data)
+        return b"".join([header, tag, data])
+
+    def decrypt(self, id, data, aad=b""):
+        if len(data) < self.PAYLOAD_OVERHEAD:
+            raise IntegrityError(f"Chunk {bin_to_hex(id)}: truncated envelope")
+        self.assert_type(data[0], id)
+        obj = memoryview(data)
+        payload = obj[self.PAYLOAD_OVERHEAD :]
+        if self.has_secret_key and AUTHENTICATED_NO_KEY:
+            # we do not have the key material, so we can not verify the tag, see the
+            # BORG_WORKAROUNDS docs. Unkeyed modes verify even then - they need no key.
+            return payload
+        header = bytes(obj[: self.HEADER_SIZE])
+        tag = bytes(obj[self.HEADER_SIZE : self.PAYLOAD_OVERHEAD])
+        computed_tag = self.mac(self._tag_prefix(header, aad, id), payload)
+        if not hmac.compare_digest(computed_tag, tag):
+            raise IntegrityError(f"Chunk {bin_to_hex(id)}: envelope tag verification failed")
+        return payload
+
+
+class ChecksumKeyBase(MACKeyBase):
+    """
+    Base class of the "none-*" modes: no encryption, no key, no authentication.
+
+    The tag is an **unkeyed** hash, i.e. a checksum: it detects accidental corruption of the
+    payload, the metadata or the object header (including a read that returned the wrong bytes),
+    but it is no protection against malicious tampering - whoever changes the object can just
+    recompute the checksum. Detecting that requires a secret, see the "authenticated-*" modes.
+
+    Because there is no key, the chunk id is an unkeyed hash of the plaintext, too. Thus, all
+    repositories of this mode dedup identically and store byte-identical objects for identical
+    input, no key sharing needed.
+    """
+
+    STORAGE = KeyBlobStorage.NO_STORAGE
+    LOCATION_CONFIGURABLE = False
+
+    chunk_seed = 0
+    crypt_key = b""  # makes .derive_key() work, nothing secret here
+    id_key = b""  # makes .derive_key() work, nothing secret here
+
+    logically_encrypted = False
+    has_secret_key = False
+
+    # The checksum can be recomputed by anybody, so it is not an authentication and thus can not
+    # take over the read path authentication the id hash does. Different from the keyed classes
+    # below, verifying the chunk id must therefore never be skipped, see RepoObj.parse.
+    id_check_is_authentication = True
+
+    @classmethod
+    def create(cls, repository, args, **kw):
+        logger.info(
+            "Encryption NOT enabled.\n"
+            'Use "--encryption=repokey-aes-ocb" (or another encrypted mode) to enable encryption.'
+        )
+        return cls(repository)
+
+    @classmethod
+    def detect(cls, repository, manifest_data, *, other=False):
+        return cls(repository)
+
+
+class ChecksumKey(ChecksumKeyBase):
+    TYPE = KeyType.SHA256NONE
+    TYPES_ACCEPTABLE = {TYPE}
+    ENC_NAME = "none-sha256"
+    IDHASH_NAME = "sha256"
+
+    def id_hash(self, data):
+        return sha256(data).digest()
+
+    def mac(self, prefix, payload):
+        h = sha256(prefix)
+        h.update(payload)
+        return h.digest()
+
+
+class Blake3ChecksumKey(ChecksumKeyBase):
+    TYPE = KeyType.BLAKE3NONE
+    TYPES_ACCEPTABLE = {TYPE}
+    ENC_NAME = "none-blake3"
+    IDHASH_NAME = "blake3"
+
+    def id_hash(self, data):
+        # see ID_BLAKE3_256.id_hash about max_threads
+        max_threads = blake3.AUTO if len(data) >= get_blake3_mt_threshold() else 1
+        return blake3(data, max_threads=max_threads).digest(length=32)
+
+    def mac(self, prefix, payload):
+        max_threads = blake3.AUTO if len(payload) >= get_blake3_mt_threshold() else 1
+        h = blake3(prefix, max_threads=max_threads)
+        h.update(payload)
+        return h.digest(length=32)
+
+
+class AuthenticatedKeyBase(MACKeyBase, FlexiKey):
+    """
+    Base class of the "authenticated-*" modes: no encryption, but real authentication.
+
+    These modes have key material (in a borg key, like the encrypted modes have), so their tag is
+    a MAC: only somebody who has the borg key can compute it. Thus, a read detects tampering with
+    the payload, the metadata and the object header, no matter whether it was accidental or
+    malicious. The chunk ids are keyed hashes for the same reason.
+
+    The MAC key is derived from crypt_key (not from id_key: chunk ids are public, and related
+    repositories share the id key - see FlexiKey.create - which must not give them the ability to
+    forge each other's objects; "repo-create --other-repo --copy-crypt-key" opts into sharing it).
+    """
+
     # default storage; an individual key's actual storage is tracked per-instance in self.storage.
     STORAGE = KeyBlobStorage.REPO
-    # an authenticated-mode key has real key material (id/auth key) and a key blob, just no data
+    # an authenticated-mode key has real key material (id/MAC key) and a key blob, just no data
     # encryption. The blob may live as a keyfile or inside the repository, like the encrypted modes
     # (configurable via --key-location, changeable later via "borg key change-location").
     LOCATION_CONFIGURABLE = True
@@ -999,14 +1185,33 @@ class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
     # It's only authenticated, not encrypted.
     logically_encrypted = False
 
+    # every read is authenticated by the envelope tag (which covers the chunk id via the AAD),
+    # independently of assert_id() - the same reasoning as for the AEAD keys, see
+    # AEADKeyBase.assert_id about what verifying the chunk id adds on top of that.
+    id_check_is_authentication = False
+
+    # domain for deriving the envelope MAC key from crypt_key, see tag_key. It is per MAC
+    # algorithm, so the classes below do not use the same key for different algorithms.
+    MAC_KEY_DOMAIN: ClassVar[bytes] = None  # override in subclass
+
+    _tag_key: bytes | None = None  # cache for the tag_key property
+
+    @property
+    def tag_key(self):
+        # derived lazily (and cached): a key instance may also be built by copying the key
+        # material onto a fresh instance, see "borg key change-location".
+        if self._tag_key is None:
+            self._tag_key = self.derive_key(salt=b"", domain=self.MAC_KEY_DOMAIN, size=32)
+        return self._tag_key
+
     def _load(self, key_data, passphrase):
         if AUTHENTICATED_NO_KEY:
-            # fake _load if we have no key or passphrase
-            NOPE = bytes(32)  # 256 bit all-zero
-            self.repository_id = NOPE
-            self.enc_key = NOPE
-            self.enc_hmac_key = NOPE
-            self.id_key = NOPE
+            # fake _load if we have no key or passphrase. The key material is all-zero and thus
+            # worthless, but these modes do not encrypt, so reading still works - decrypt() skips
+            # the tag verification and RepoObj.parse skips the chunk id check.
+            self.repository_id = bytes(32)
+            self.crypt_key = bytes(64)
+            self.id_key = bytes(32)
             self.chunk_seed = 0
             return True
         return super()._load(key_data, passphrase)
@@ -1025,30 +1230,44 @@ class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
         super().save(target, passphrase, algorithm, create=create, label=label, replace=replace)
         self.logically_encrypted = False
 
-    def init_ciphers(self, manifest_data=None):
-        if manifest_data is not None:
-            self.assert_type(manifest_data[0])
+    def init_from_given_data(self, *, crypt_key, id_key, chunk_seed):
+        assert len(crypt_key) == 32 + 32
+        assert len(id_key) == 32
+        assert isinstance(chunk_seed, int)
+        self.crypt_key = crypt_key
+        self.id_key = id_key
+        self.chunk_seed = chunk_seed
+        self._tag_key = None  # invalidate: it is derived from crypt_key
 
-    def encrypt(self, id, data, aad=b""):
-        return b"".join([self.TYPE_STR, data])
-
-    def decrypt(self, id, data, aad=b""):
-        self.assert_type(data[0], id)
-        return memoryview(data)[1:]
-
-
-# legacy imports placed after FlexiKey/AESKeyBase/KeyBase/AuthenticatedKeyBase so those names are already
-# in the partial module when legacy/crypto/key.py imports them back during circular load
-from ..legacy.crypto.key import AESCTRKey, Blake2AESCTRKey  # noqa: F401
-from ..legacy.crypto.key import Blake2AuthenticatedKey  # noqa: F401
-from ..legacy.crypto.key import LEGACY_KEY_TYPES  # noqa: E402
-from ..legacy.crypto.key import ID_BLAKE2b_256  # noqa: F401
+    def init_from_random_data(self):
+        data = os.urandom(100)
+        chunk_seed = bytes_to_int(data[96:100])
+        # Convert to signed int32
+        if chunk_seed & 0x80000000:
+            chunk_seed = chunk_seed - 0xFFFFFFFF - 1
+        self.init_from_given_data(crypt_key=data[0:64], id_key=data[64:96], chunk_seed=chunk_seed)
 
 
 class AuthenticatedKey(ID_HMAC_SHA_256, AuthenticatedKeyBase):
-    TYPE = KeyType.AUTHENTICATED
+    TYPE = KeyType.SHA256AUTHENTICATED
     TYPES_ACCEPTABLE = {TYPE}
-    ENC_NAME = "authenticated"  # IDHASH_NAME = "sha256" via ID_HMAC_SHA_256 mix-in
+    ENC_NAME = "authenticated-sha256"  # IDHASH_NAME = "sha256" via ID_HMAC_SHA_256 mix-in
+    MAC_KEY_DOMAIN = b"borg-repoobj-mac-hmac-sha256"
+
+    def mac(self, prefix, payload):
+        h = hmac.new(self.tag_key, prefix, sha256)
+        h.update(payload)
+        return h.digest()
+
+
+# legacy imports placed after FlexiKey/AESKeyBase/KeyBase so those names are already
+# in the partial module when legacy/crypto/key.py imports them back during circular load
+from ..legacy.crypto.key import AESCTRKey, Blake2AESCTRKey  # noqa: F401
+from ..legacy.crypto.key import Blake2AuthenticatedKey  # noqa: F401
+from ..legacy.crypto.key import AuthenticatedKey as LegacyAuthenticatedKey  # noqa: E402
+from ..legacy.crypto.key import PlaintextKey as LegacyPlaintextKey  # noqa: E402
+from ..legacy.crypto.key import LEGACY_KEY_TYPES  # noqa: E402
+from ..legacy.crypto.key import ID_BLAKE2b_256  # noqa: F401
 
 
 # ------------ new crypto ------------
@@ -1073,7 +1292,15 @@ class ID_BLAKE3_256:
 class Blake3AuthenticatedKey(ID_BLAKE3_256, AuthenticatedKeyBase):
     TYPE = KeyType.BLAKE3AUTHENTICATED
     TYPES_ACCEPTABLE = {TYPE}
-    ENC_NAME = "authenticated"  # IDHASH_NAME = "blake3" via ID_BLAKE3_256 mix-in
+    ENC_NAME = "authenticated-blake3"  # IDHASH_NAME = "blake3" via ID_BLAKE3_256 mix-in
+    MAC_KEY_DOMAIN = b"borg-repoobj-mac-blake3"
+
+    def mac(self, prefix, payload):
+        # see ID_BLAKE3_256.id_hash about max_threads
+        max_threads = blake3.AUTO if len(payload) >= get_blake3_mt_threshold() else 1
+        h = blake3(prefix, key=self.tag_key, max_threads=max_threads)
+        h.update(payload)
+        return h.digest(length=32)
 
 
 class AEADKeyBase(KeyBase):
@@ -1277,14 +1504,15 @@ class Blake3CHPOKey(ID_BLAKE3_256, AEADKeyBase, FlexiKey):
 
 
 AVAILABLE_KEY_TYPES = (
-    # these are available encryption modes for new repositories
-    # not encrypted modes
-    PlaintextKey,
-    AuthenticatedKey,
-    # new crypto
-    Blake3AuthenticatedKey,
+    # these are available encryption modes for new repositories, ordered by descending security
+    # encrypted modes (the id hash is selected via --id-hash)
     AESOCBKey,
     CHPOKey,
     Blake3AESOCBKey,
     Blake3CHPOKey,
+    # not encrypted modes (the id hash is part of the mode name, see key_creator)
+    AuthenticatedKey,
+    Blake3AuthenticatedKey,
+    ChecksumKey,
+    Blake3ChecksumKey,
 )

--- a/src/borg/legacy/crypto/key.py
+++ b/src/borg/legacy/crypto/key.py
@@ -1,10 +1,11 @@
 import hmac
 import os
-from hashlib import pbkdf2_hmac
+from hashlib import pbkdf2_hmac, sha256
 
 from ...constants import *  # NOQA
 from ...crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b, hmac_sha256, blake2b_256
-from ...crypto.key import ID_HMAC_SHA_256, AESKeyBase, FlexiKey, AuthenticatedKeyBase, UnsupportedKeyFormatError
+from ...crypto.key import ID_HMAC_SHA_256, KeyBase, AESKeyBase, FlexiKey, UnsupportedKeyFormatError
+from ...crypto.key import AUTHENTICATED_NO_KEY
 from ...helpers import get_limited_unpacker, msgpack
 from ...item import EncryptedKey
 from .low_level import AES
@@ -87,6 +88,102 @@ class ID_BLAKE2b_256:
         self.id_key = random_blake2b_256_key()
 
 
+# borg 1.x unencrypted modes ("none" and "authenticated"). Their repo object envelope is just the
+# type byte followed by the payload: nothing is authenticated by it, the only integrity check a read
+# has is the chunk id hash over the plaintext. borg 2 replaced them with the tagged envelope modes
+# (see MACKeyBase in borg.crypto.key), so these classes are read-only: they exist to read borg 1.x
+# repos, e.g. for "borg transfer --from-borg1". borg 2 never creates them (they are not in
+# AVAILABLE_KEY_TYPES) and refuses to use them for borg 2 repos (see key_factory).
+
+
+class PlaintextKey(KeyBase):
+    TYPE = KeyType.PLAINTEXT
+    TYPES_ACCEPTABLE = {TYPE}
+    ENC_NAME = "none"  # borg 1.x name of this mode; read-only (borg 1.x)
+    IDHASH_NAME = "sha256"
+
+    chunk_seed = 0
+    crypt_key = b""  # makes .derive_key() work, nothing secret here
+    id_key = b""  # makes .derive_key() work, nothing secret here
+
+    logically_encrypted = False
+    encrypts = False
+    has_secret_key = False  # unkeyed sha256 chunk ids, no key material at all
+
+    @classmethod
+    def create(cls, repository, args, **kw):
+        raise NotImplementedError("borg 2 does not create borg 1.x repositories.")
+
+    @classmethod
+    def detect(cls, repository, manifest_data, *, other=False):
+        return cls(repository)
+
+    def id_hash(self, data):
+        return sha256(data).digest()
+
+    def encrypt(self, id, data, aad=b""):
+        return b"".join([self.TYPE_STR, data])
+
+    def decrypt(self, id, data, aad=b""):
+        self.assert_type(data[0], id)
+        return memoryview(data)[1:]
+
+
+class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
+    # default storage; an individual key's actual storage is tracked per-instance in self.storage.
+    STORAGE = KeyBlobStorage.REPO
+    # an authenticated-mode key has real key material (id/auth key) and a key blob, just no data
+    # encryption. The blob may live as a keyfile or inside the repository, like the encrypted modes.
+    LOCATION_CONFIGURABLE = True
+
+    # It's only authenticated, not encrypted.
+    logically_encrypted = False
+    encrypts = False
+
+    def _load(self, key_data, passphrase):
+        if AUTHENTICATED_NO_KEY:
+            # fake _load if we have no key or passphrase
+            NOPE = bytes(32)  # 256 bit all-zero
+            self.repository_id = NOPE
+            self.enc_key = NOPE
+            self.enc_hmac_key = NOPE
+            self.id_key = NOPE
+            self.chunk_seed = 0
+            return True
+        return super()._load(key_data, passphrase)
+
+    def load(self, target, passphrase):
+        success = super().load(target, passphrase)
+        self.logically_encrypted = False
+        return success
+
+    def load_any(self, passphrase):
+        success = super().load_any(passphrase)
+        self.logically_encrypted = False
+        return success
+
+    def save(self, target, passphrase, algorithm, create=False, label=None, replace=True):
+        super().save(target, passphrase, algorithm, create=create, label=label, replace=replace)
+        self.logically_encrypted = False
+
+    def init_ciphers(self, manifest_data=None):
+        if manifest_data is not None:
+            self.assert_type(manifest_data[0])
+
+    def encrypt(self, id, data, aad=b""):
+        return b"".join([self.TYPE_STR, data])
+
+    def decrypt(self, id, data, aad=b""):
+        self.assert_type(data[0], id)
+        return memoryview(data)[1:]
+
+
+class AuthenticatedKey(ID_HMAC_SHA_256, AuthenticatedKeyBase):  # type: ignore[misc]
+    TYPE = KeyType.AUTHENTICATED
+    TYPES_ACCEPTABLE = {TYPE}
+    ENC_NAME = "authenticated"  # IDHASH_NAME = "sha256" via ID_HMAC_SHA_256 mix-in; read-only (borg 1.x)
+
+
 class Blake2AuthenticatedKey(ID_BLAKE2b_256, AuthenticatedKeyBase):  # type: ignore[misc]
     TYPE = KeyType.BLAKE2AUTHENTICATED
     TYPES_ACCEPTABLE = {TYPE}
@@ -117,4 +214,4 @@ class Blake2AESCTRKey(Pbkdf2FileMixin, ID_BLAKE2b_256, AESKeyBase, FlexiKey):  #
     CIPHERSUITE = AES256_CTR_BLAKE2b
 
 
-LEGACY_KEY_TYPES = (AESCTRKey, Blake2AESCTRKey, Blake2AuthenticatedKey)
+LEGACY_KEY_TYPES = (AESCTRKey, Blake2AESCTRKey, PlaintextKey, AuthenticatedKey, Blake2AuthenticatedKey)

--- a/src/borg/repoobj.py
+++ b/src/borg/repoobj.py
@@ -7,7 +7,7 @@ from .helpers import msgpack, workarounds
 from .helpers.errors import Error, IntegrityError
 from .compress import Compressor, LZ4_COMPRESSOR
 
-# Workaround for lost passphrase or key in "authenticated" or "authenticated-blake2" mode
+# Workaround for lost passphrase or key in the "authenticated-*" modes
 AUTHENTICATED_NO_KEY = "authenticated_no_key" in workarounds
 
 # The places where parse() verifies chunkid == id_hash(content) only if the user asks for it.
@@ -23,8 +23,9 @@ ASSERT_ID_PLACES = (
 # not verifying elsewhere defensible, so it must not be switchable.
 ASSERT_ID_PLACES_MANDATORY = ("verify_data",)  # borg check --verify-data
 # Default value of the BORG_ASSERT_ID env var: verify everywhere except on the (hot) general read
-# path - there, the AEAD authentication already covers what a repository could do to us, see
-# AEADKeyBase.assert_id.
+# path - there, the envelope authentication of the keyed modes already covers what a repository
+# could do to us, see AEADKeyBase.assert_id. (For the modes whose id check *is* the read path
+# authentication, this setting does not apply, see below.)
 BORG_ASSERT_ID_DEFAULT = ("repair", "transfer", "rechunk")
 # Reads through a RepoObj are attributed to this place unless a command sets another one.
 ASSERT_ID_PLACE_DEFAULT = "read"
@@ -34,8 +35,9 @@ def get_assert_id_places():
     """Determine the configurable places that shall verify the chunk id, see the BORG_ASSERT_ID docs.
 
     Note: this only decides for keys that authenticate reads independently of the id hash (the AEAD
-    ciphersuites, see KeyBase.id_check_is_authentication) - for all other keys, the id check is the
-    read path authentication itself and thus always happens, no matter what is configured here.
+    ciphersuites and the "authenticated-*" modes, see KeyBase.id_check_is_authentication) - for all
+    other keys, the id check is the read path authentication itself and thus always happens, no
+    matter what is configured here.
     The same is true for ASSERT_ID_PLACES_MANDATORY.
     """
     value = os.environ.get("BORG_ASSERT_ID")
@@ -252,19 +254,23 @@ class RepoObj:
             compressor_cls, compression_level = Compressor.detect(compr_hdr)
             compressor = compressor_cls(level=compression_level)
             meta, data = compressor.decompress(dict(meta_compressed), data_compressed[:psize])
-            # For keys where the id check is the read-path authentication ("authenticated" and "none" mode),
-            # it always has to happen - skipping it would remove all integrity checking from reads.
-            # For the AEAD keys, the ciphertext is already authenticated for this specific chunk id (the id is
-            # in the AAD), so the id check only adds detection of chunks whose plaintext does not match their id
-            # - which only an evil/broken borg client that had the repo key could have written. Whether that
-            # extra full-plaintext hash pass is worth it depends on the place we read at, see BORG_ASSERT_ID.
+            # For keys where the id check is the read-path authentication (the "none-*" modes, whose
+            # envelope checksum is unkeyed and thus no authentication), it always has to happen -
+            # skipping it would remove all integrity checking from reads.
+            # For the keys that authenticate the envelope (the AEAD and the "authenticated-*" modes), the
+            # payload is already authenticated for this specific chunk id (the id is in the AAD), so the id
+            # check only adds detection of chunks whose plaintext does not match their id - which only an
+            # evil/broken borg client that had the repo key could have written. Whether that extra
+            # full-plaintext hash pass is worth it depends on the place we read at, see BORG_ASSERT_ID.
             place = assert_id_place if assert_id_place is not None else self.assert_id_place
             assert_id = (
                 self.key.id_check_is_authentication
                 or place in ASSERT_ID_PLACES_MANDATORY
                 or place in self.assert_id_places
             )
-            if assert_id and not AUTHENTICATED_NO_KEY:
+            # the authenticated_no_key workaround fakes key material it could not unlock, so checks that
+            # need that key material can not work. The unkeyed modes need none, so they keep checking.
+            if assert_id and not (AUTHENTICATED_NO_KEY and self.key.has_secret_key):
                 self.key.assert_id(id, data)
         else:
             meta, data = None, None

--- a/src/borg/security.py
+++ b/src/borg/security.py
@@ -150,7 +150,6 @@ class SecurityManager:
                 fd.write(repository_location)
 
     def assert_no_manifest_replay(self, manifest, key):
-        from .crypto.key import PlaintextKey
 
         try:
             with self.manifest_ts_file.open() as fd:
@@ -165,7 +164,9 @@ class SecurityManager:
         logger.debug("security: determined newest manifest timestamp as %s", timestamp)
         # If repository is older than the cache or security dir something fishy is going on
         if timestamp and timestamp > manifest.timestamp:
-            if isinstance(key, PlaintextKey):
+            if not key.has_secret_key:
+                # unkeyed modes ("none-*", and borg 1.x "none"): the repository id is not derived
+                # from any secret, so two repositories can legitimately have the same id.
                 raise RepositoryIDNotUnique()
             else:
                 raise RepositoryReplay()

--- a/src/borg/testsuite/archive_test.py
+++ b/src/borg/testsuite/archive_test.py
@@ -10,7 +10,7 @@ import pytest
 from . import rejected_dotdot_paths
 from ..cache import ChunkListEntry
 from ..constants import ROBJ_FILE_STREAM, zeros
-from ..crypto.key import PlaintextKey
+from ..crypto.key import ChecksumKey
 from ..archive import Archive, CacheChunkBuffer, DownloadPipeline, RobustUnpacker, valid_msgpacked_dict
 from ..archive import ITEM_KEYS, Statistics
 from ..archive import BackupOSError, backup_io, backup_io_iter, get_item_uid_gid
@@ -181,7 +181,7 @@ def test_stats_progress_json(stats):
 )
 def test_timestamp_parsing(monkeypatch, isoformat, expected):
     repository = Mock()
-    key = PlaintextKey(repository)
+    key = ChecksumKey(repository)
     manifest = Manifest(key, repository)
     a = Archive(manifest, "test", create=True)
     a.metadata = ArchiveItem(time=isoformat)
@@ -205,7 +205,7 @@ class MockCache:
 def test_cache_chunk_buffer():
     data = [Item(path="p1"), Item(path="p2")]
     cache = MockCache()
-    key = PlaintextKey(None)
+    key = ChecksumKey(None)
     chunks = CacheChunkBuffer(cache, key, None)
     for d in data:
         chunks.add(d)
@@ -222,7 +222,7 @@ def test_partial_cache_chunk_buffer():
     big = "0123456789abcdefghijklmnopqrstuvwxyz" * 25000
     data = [Item(path="full", target=big), Item(path="partial", target=big)]
     cache = MockCache()
-    key = PlaintextKey(None)
+    key = ChecksumKey(None)
     chunks = CacheChunkBuffer(cache, key, None)
     for d in data:
         chunks.add(d)
@@ -257,7 +257,7 @@ def test_download_pipeline_parsed_cache():
     # a content data stream may reference the same chunk many times (e.g. the all-zero
     # chunks of a sparse file): repeated chunks shall be parsed (decrypted, authenticated,
     # decompressed) only once, see issue #1678.
-    key = PlaintextKey(None)
+    key = ChecksumKey(None)
     repo_objs = RepoObj(key)
     # note: repeated, but not all-zero data, so it is not served via the zeros shortcut
     chunks_data = [b"foobar" * 100, b"idletone" * 125, b"barbaz" * 100]
@@ -290,7 +290,7 @@ def test_download_pipeline_parsed_cache():
 def test_download_pipeline_missing_chunk(replacement_chunk):
     # a chunk missing in the repository is either replaced by all-zero data of the
     # correct size, or reported as None - and never blows up on the size check.
-    key = PlaintextKey(None)
+    key = ChecksumKey(None)
     repo_objs = RepoObj(key)
     data = b"foobar" * 100
     id = repo_objs.id_hash(data)
@@ -304,7 +304,7 @@ def test_download_pipeline_missing_chunk(replacement_chunk):
 def test_download_pipeline_zero_chunks_served_locally():
     # repeated all-zero chunks (e.g. from the holes of a sparse file) shall be served
     # directly from the zeros constant, without repository access, see issue #1678.
-    key = PlaintextKey(None)
+    key = ChecksumKey(None)
     repo_objs = RepoObj(key)
     data = b"foobar" * 100
     data_id = repo_objs.id_hash(data)

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -716,7 +716,7 @@ def test_repair_finish_flushes_pack_writer(archivers, request):
         assert not repository._pack_writer._pieces  # finish() stored it
 
 
-@pytest.mark.parametrize("init_args", [["--encryption=aes256-ocb"], ["--encryption", "none"]])
+@pytest.mark.parametrize("init_args", [["--encryption=aes256-ocb"], ["--encryption", "none-sha256"]])
 def test_verify_data(archivers, request, init_args):
     archiver = request.getfixturevalue(archivers)
     if archiver.get_kind() != "local":
@@ -809,7 +809,7 @@ def test_repair_wrong_item_metadata_chunk_content(archivers, request, monkeypatc
     assert "id verification failed" in output
 
 
-@pytest.mark.parametrize("init_args", [["--encryption=aes256-ocb"], ["--encryption", "none"]])
+@pytest.mark.parametrize("init_args", [["--encryption=aes256-ocb"], ["--encryption", "none-sha256"]])
 def test_corrupted_file_chunk(archivers, request, init_args):
     ## like test_verify_data, but also checks a repository-only check passes after repair and a plain
     ## archives check reports the missing chunk.

--- a/src/borg/testsuite/archiver/checks_test.py
+++ b/src/borg/testsuite/archiver/checks_test.py
@@ -46,7 +46,7 @@ def test_repository_swap_detection(archivers, request):
     repository_id = _extract_repository_id(archiver.repository_path)
     cmd(archiver, "create", "test", "input")
     shutil.rmtree(archiver.repository_path)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     _set_repository_id(archiver.repository_path, repository_id)
     assert repository_id == _extract_repository_id(archiver.repository_path)
     if archiver.FORK_DEFAULT:
@@ -61,7 +61,7 @@ def test_repository_swap_detection2(archivers, request):
     create_test_files(archiver.input_path)
     original_location = archiver.repository_location
     archiver.repository_location = original_location + "_unencrypted"
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     os.environ["BORG_PASSPHRASE"] = "passphrase"
     archiver.repository_location = original_location + "_encrypted"
     cmd(archiver, "repo-create", RK_ENCRYPTION)
@@ -83,7 +83,7 @@ def test_repository_swap_detection_no_cache(archivers, request):
     repository_id = _extract_repository_id(archiver.repository_path)
     cmd(archiver, "create", "test", "input")
     shutil.rmtree(archiver.repository_path)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     _set_repository_id(archiver.repository_path, repository_id)
     assert repository_id == _extract_repository_id(archiver.repository_path)
     cmd(archiver, "repo-delete", "--cache-only")
@@ -99,7 +99,7 @@ def test_repository_swap_detection2_no_cache(archivers, request):
     original_location = archiver.repository_location
     create_test_files(archiver.input_path)
     archiver.repository_location = original_location + "_unencrypted"
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     os.environ["BORG_PASSPHRASE"] = "passphrase"
     archiver.repository_location = original_location + "_encrypted"
     cmd(archiver, "repo-create", RK_ENCRYPTION)
@@ -175,7 +175,7 @@ def test_repository_move(archivers, request, monkeypatch):
 
 def test_unknown_unencrypted(archivers, request, monkeypatch):
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     # Ok: repository is known
     cmd(archiver, "repo-info")
 

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -136,7 +136,7 @@ def test_archived_paths(archivers, request):
     # no leading slash in borg archives:
     archived_path = posix_path.lstrip("/")
     create_regular_file(archiver.input_path, "test")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "test", "input", posix_path)
     # "input" directory is recursed into, "input/test" is discovered and joined by borg's recursion.
     # posix_path was directly given as a cli argument and should end up as archive_path in the borg archive.
@@ -202,7 +202,7 @@ def test_create_duplicate_root(archivers, request):
     hl_b = os.path.join(path_b, "hardlink")
     create_regular_file(archiver.input_path, hl_a, contents=b"123456")
     os.link(hl_a, hl_b)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "test", "input", "input")  # give input twice!
     # test if created archive has 'input' contents twice:
     archive_list = cmd(archiver, "list", "test", "--json-lines")
@@ -218,7 +218,7 @@ def test_create_unreadable_parent(archiver):
     os.mkdir(root_dir)
     os.chmod(parent_dir, 0o111)  # --x--x--x == parent dir traversable, but not readable
     try:
-        cmd(archiver, "repo-create", "--encryption=none")
+        cmd(archiver, "repo-create", "--encryption=none-sha256")
         # issue #7746: we *can* read root_dir and we *can* traverse parent_dir, so this should work:
         cmd(archiver, "create", "test", root_dir)
     finally:

--- a/src/borg/testsuite/archiver/disk_full_test.py
+++ b/src/borg/testsuite/archiver/disk_full_test.py
@@ -51,7 +51,7 @@ def test_disk_full(test_pass, cmd_fixture, monkeypatch):
     input = os.path.join(DF_MOUNT, "input")
     shutil.rmtree(repo, ignore_errors=True)
     shutil.rmtree(input, ignore_errors=True)
-    rc, out = cmd_fixture(f"--repo={repo}", "repo-create", "--encryption=none")
+    rc, out = cmd_fixture(f"--repo={repo}", "repo-create", "--encryption=none-sha256")
     if rc != EXIT_SUCCESS:
         print("repo-create", rc, out)
     assert rc == EXIT_SUCCESS

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -462,7 +462,7 @@ def test_extract_hardlinks_twice(archivers, request):
     hl_b = os.path.join(path_b, "hardlink")
     create_regular_file(archiver.input_path, hl_a, contents=b"123456")
     os.link(hl_a, hl_b)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "test", "input", "input")  # give input twice!
     # now test extraction
     with changedir("output"):
@@ -703,7 +703,7 @@ def test_extract_xattrs_errors(archivers, request):
 
     create_regular_file(archiver.input_path, "file")
     xattr.setxattr(b"input/file", b"user.attribute", b"value")
-    cmd(archiver, "repo-create", "-e", "none")
+    cmd(archiver, "repo-create", "-e", "none-sha256")
     cmd(archiver, "create", "test", "input")
     with changedir("output"):
         input_abspath = os.path.abspath("input/file")
@@ -731,7 +731,7 @@ def test_extract_xattrs_errors(archivers, request):
 def test_extract_xattrs_resourcefork(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file")
-    cmd(archiver, "repo-create", "-e", "none")
+    cmd(archiver, "repo-create", "-e", "none-sha256")
     input_path = os.path.abspath("input/file")
     xa_key, xa_value = b"com.apple.ResourceFork", b"whatshouldbehere"  # issue #7234
     xattr.setxattr(input_path.encode(), xa_key, xa_value)
@@ -770,7 +770,7 @@ def test_extract_restores_append_flag(archivers, request):
     if (platform.get_flags(src_path, st) & stat.UF_APPEND) == 0:
         pytest.skip("UF_APPEND not settable on this filesystem")
     # archive and extract
-    cmd(archiver, "repo-create", "-e", "none")
+    cmd(archiver, "repo-create", "-e", "none-sha256")
     cmd(archiver, "create", "test", "input")
     with changedir("output"):
         cmd(archiver, "extract", "test")
@@ -821,7 +821,7 @@ def test_do_not_fail_when_percent_is_in_xattr_name(archivers, request):
 
     create_regular_file(archiver.input_path, "file")
     xattr.setxattr(b"input/file", b"user.attribute%p", b"value")
-    cmd(archiver, "repo-create", "-e", "none")
+    cmd(archiver, "repo-create", "-e", "none-sha256")
     cmd(archiver, "create", "test", "input")
     with changedir("output"):
         with patch.object(xattr, "setxattr", patched_setxattr_EACCES):
@@ -841,7 +841,7 @@ def test_do_not_fail_when_percent_is_in_file_name(archivers, request):
 
     os.makedirs(os.path.join(archiver.input_path, "dir%p"))
     xattr.setxattr(b"input/dir%p", b"user.attribute", b"value")
-    cmd(archiver, "repo-create", "-e", "none")
+    cmd(archiver, "repo-create", "-e", "none-sha256")
     cmd(archiver, "create", "test", "input")
     with changedir("output"):
         with patch.object(xattr, "setxattr", patched_setxattr_EACCES):

--- a/src/borg/testsuite/archiver/key_cmds_test.py
+++ b/src/borg/testsuite/archiver/key_cmds_test.py
@@ -7,7 +7,7 @@ import pytest
 from ...constants import *  # NOQA
 from ...constants import KeyBlobStorage
 from ...crypto.key import AESOCBKey, CHPOKey, Passphrase, is_keyfile, keyfile_parse
-from ...crypto.keymanager import RepoIdMismatch, NotABorgKeyFile
+from ...crypto.keymanager import RepoIdMismatch, NotABorgKeyFile, UnencryptedRepo
 from ...helpers import CommandError
 from ...helpers import bin_to_hex, hex_to_bin
 from ...helpers import msgpack
@@ -79,26 +79,26 @@ def test_change_location_to_b3repokey(archivers, request):
 def test_change_location_authenticated_to_keyfile(archivers, request):
     # authenticated mode does not encrypt, but it still has a key whose location is configurable.
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, "repo-create", "--encryption=authenticated")
+    cmd(archiver, "repo-create", "--encryption=authenticated-sha256")
     log = cmd(archiver, "repo-info")
-    assert "(repokey, authenticated, sha256)" in log
+    assert "(repokey, authenticated-sha256)" in log
     cmd(archiver, "key", "change-location", "keyfile")
     [key_filename] = os.listdir(archiver.keys_path)
     assert key_filename  # key blob now lives as a keyfile
     log = cmd(archiver, "repo-info")
-    assert "(keyfile, authenticated, sha256)" in log
+    assert "(keyfile, authenticated-sha256)" in log
 
 
 def test_change_location_authenticated_to_repokey(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, "repo-create", "--encryption=authenticated", KF_LOCATION)
+    cmd(archiver, "repo-create", "--encryption=authenticated-sha256", KF_LOCATION)
     assert os.listdir(archiver.keys_path)  # key blob created as a keyfile
     log = cmd(archiver, "repo-info")
-    assert "(keyfile, authenticated, sha256)" in log
+    assert "(keyfile, authenticated-sha256)" in log
     cmd(archiver, "key", "change-location", "repokey")
     assert os.listdir(archiver.keys_path) == []  # keyfile removed after moving into the repo
     log = cmd(archiver, "repo-info")
-    assert "(repokey, authenticated, sha256)" in log
+    assert "(repokey, authenticated-sha256)" in log
 
 
 def test_keyfile_name_is_content_sha256(archivers, request):
@@ -136,6 +136,24 @@ def test_borg_key_file_env_keeps_explicit_path(archivers, request, monkeypatch):
     cmd(archiver, "repo-create", KF_ENCRYPTION, KF_LOCATION)
     assert os.path.isfile(explicit_key_path)
     assert os.listdir(archiver.keys_path) == []
+
+
+@pytest.mark.parametrize("mode", ["none-sha256", "none-blake3"])
+def test_key_management_unavailable_for_keyless_repo(archivers, request, mode):
+    # the "none-*" modes have no key at all, so there is nothing to export/import.
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", f"--encryption={mode}")
+    export_file = archiver.output_path + "/exported"
+    if archiver.FORK_DEFAULT:
+        # a forked/binary run returns the exit code, not the exception (BORG_EXIT_CODES defaults
+        # to "modern", so that is the specific mcode of UnencryptedRepo, not the generic EXIT_ERROR).
+        cmd(archiver, "key", "export", export_file, exit_code=UnencryptedRepo.exit_mcode)
+        cmd(archiver, "key", "import", export_file, exit_code=UnencryptedRepo.exit_mcode)
+    else:
+        with pytest.raises(UnencryptedRepo):
+            cmd(archiver, "key", "export", export_file)
+        with pytest.raises(UnencryptedRepo):
+            cmd(archiver, "key", "import", export_file)
 
 
 def test_key_export_keyfile(archivers, request):

--- a/src/borg/testsuite/archiver/lock_cmds_test.py
+++ b/src/borg/testsuite/archiver/lock_cmds_test.py
@@ -28,7 +28,7 @@ def test_with_lock(tmp_path):
     print("sys.path: %r" % sys.path)
     print("PYTHONPATH: %s" % env.get("PYTHONPATH", ""))
     print("PATH: %s" % env.get("PATH", ""))
-    command0 = "python3", "-m", "borg", "repo-create", "--encryption=none"
+    command0 = "python3", "-m", "borg", "repo-create", "--encryption=none-sha256"
     # Timings must be adjusted so that command1 keeps running while command2 tries to get the lock,
     # so that lock acquisition for command2 fails as the test expects it.
     lock_wait = 2

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -392,7 +392,7 @@ def test_migrate_lock_alive(archivers, request):
     # Decorate
     Lock.migrate_lock = write_assert_data(Lock.migrate_lock)
     try:
-        cmd(archiver, "repo-create", "--encryption=none")
+        cmd(archiver, "repo-create", "--encryption=none-sha256")
         create_src_archive(archiver, "arch")
         mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
         # In order that the decoration is kept for the borg mount process, we must not spawn, but actually fork;

--- a/src/borg/testsuite/archiver/recreate_cmd_test.py
+++ b/src/borg/testsuite/archiver/recreate_cmd_test.py
@@ -66,7 +66,7 @@ def test_recreate_exclude_keep_tagged(archivers, request):
 @pytest.mark.skipif(not are_hardlinks_supported(), reason="hard links not supported")
 def test_recreate_hardlinked_tags(archivers, request):  # test for issue #4911
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     create_regular_file(
         archiver.input_path, "file1", contents=CACHE_TAG_CONTENTS
     )  # "wrong" filename, but correct tag contents

--- a/src/borg/testsuite/archiver/repo_create_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_create_cmd_test.py
@@ -6,7 +6,7 @@ import pytest
 from ...helpers.errors import Error, CancelledByUser
 from ...constants import *  # NOQA
 from ...crypto.key import FlexiKey
-from . import cmd, generate_archiver_tests, RK_ENCRYPTION, KF_ENCRYPTION, KF_LOCATION
+from . import cmd, create_src_archive, generate_archiver_tests, RK_ENCRYPTION, KF_ENCRYPTION, KF_LOCATION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
@@ -43,9 +43,13 @@ def test_repo_create_requires_encryption_option(archivers, request):
         (["--encryption=aes256-ocb", "--id-hash=blake3"], "Yes (repokey, aes256-ocb, blake3)"),
         (["--encryption=chacha20-poly1305"], "Yes (repokey, chacha20-poly1305, sha256)"),
         (["--encryption=chacha20-poly1305", "--id-hash=blake3"], "Yes (repokey, chacha20-poly1305, blake3)"),
-        (["--encryption=authenticated"], "No (repokey, authenticated, sha256)"),
-        (["--encryption=authenticated", "--id-hash=blake3"], "No (repokey, authenticated, blake3)"),
-        (["--encryption=none"], "No"),
+        # the modes that do not encrypt name their id hash themselves, --id-hash does not apply
+        (["--encryption=authenticated-sha256"], "No (repokey, authenticated-sha256)"),
+        (["--encryption=authenticated-blake3"], "No (repokey, authenticated-blake3)"),
+        (["--encryption=none-sha256"], "No (none-sha256)"),
+        (["--encryption=none-blake3"], "No (none-blake3)"),
+        # giving the matching --id-hash in addition is accepted
+        (["--encryption=none-blake3", "--id-hash=blake3"], "No (none-blake3)"),
     ],
 )
 def test_repo_create_encryption_id_hash_combinations(archivers, request, extra_args, expected):
@@ -55,10 +59,19 @@ def test_repo_create_encryption_id_hash_combinations(archivers, request, extra_a
     assert expected in info
 
 
-def test_repo_create_none_rejects_blake3(archivers, request):
-    # "none" (plaintext) has no key, so it only supports the sha256 id-hash.
+@pytest.mark.parametrize("mode", ["none", "authenticated"])
+def test_repo_create_rejects_bare_unencrypted_mode_names(archivers, request, mode):
+    # these modes always name their id hash now, e.g. "none-sha256", see #9104.
     archiver = request.getfixturevalue(archivers)
-    arg = ("repo-create", "--encryption=none", "--id-hash=blake3")
+    cmd(archiver, "repo-create", f"--encryption={mode}", exit_code=2)
+
+
+@pytest.mark.parametrize("mode", ["none-sha256", "authenticated-blake3"])
+def test_repo_create_rejects_conflicting_id_hash(archivers, request, mode):
+    # the id hash of these modes is part of the mode name, so a contradicting --id-hash is an error.
+    archiver = request.getfixturevalue(archivers)
+    conflicting = "blake3" if mode.endswith("sha256") else "sha256"
+    arg = ("repo-create", f"--encryption={mode}", f"--id-hash={conflicting}")
     if archiver.FORK_DEFAULT:
         cmd(archiver, *arg, exit_code=2)
     else:
@@ -70,6 +83,35 @@ def test_repo_create_rejects_legacy_combined_mode(archivers, request):
     # clean break: the old combined "--encryption" names are no longer accepted (argparse choices).
     archiver = request.getfixturevalue(archivers)
     cmd(archiver, "repo-create", "--encryption=blake3-aes-ocb", exit_code=2)
+
+
+def test_repo_create_related_authenticated_repos_store_identical_objects(archivers, request, monkeypatch):
+    # The envelope MAC key of the "authenticated-*" modes is derived from crypt_key, and the tag is
+    # deterministic, so two related repositories created with --copy-crypt-key store byte-identical
+    # objects for identical input (which allows deduplicating them on the filesystem level).
+    # Without --copy-crypt-key, crypt_key is a fresh random key and the objects differ.
+    archiver = request.getfixturevalue(archivers)
+    src_location = archiver.repository_location
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_src_archive(archiver, "arch")
+    monkeypatch.setenv("BORG_OTHER_PASSPHRASE", os.environ["BORG_PASSPHRASE"])
+
+    def transferred_objects(suffix, *extra_args):
+        archiver.repository_location = archiver.repository_path = src_location + suffix
+        cmd(archiver, "repo-create", "--encryption=authenticated-sha256", f"--other-repo={src_location}", *extra_args)
+        cmd(archiver, "transfer", f"--other-repo={src_location}")
+        objects = []
+        for dirpath, _, filenames in os.walk(os.path.join(archiver.repository_path, "packs")):
+            for filename in sorted(filenames):
+                with open(os.path.join(dirpath, filename), "rb") as fd:
+                    objects.append(fd.read())
+        assert objects  # we did transfer something
+        return sorted(objects)
+
+    same_key = transferred_objects("dst1", "--copy-crypt-key")
+    same_key_again = transferred_objects("dst2", "--copy-crypt-key")
+    assert same_key == same_key_again
+    assert transferred_objects("dst3") != same_key  # a fresh crypt_key gives different tags
 
 
 def test_repo_create_refuse_to_overwrite_keyfile(archivers, request, monkeypatch):

--- a/src/borg/testsuite/archiver/return_codes_test.py
+++ b/src/borg/testsuite/archiver/return_codes_test.py
@@ -10,7 +10,7 @@ pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds
 
 def test_return_codes(archivers, request):
     archiver = request.getfixturevalue(archivers)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "archive", "input")
     with changedir("output"):
         cmd(archiver, "extract", "archive")

--- a/src/borg/testsuite/archiver/tar_cmds_test.py
+++ b/src/borg/testsuite/archiver/tar_cmds_test.py
@@ -110,7 +110,7 @@ def test_import_tar(archivers, request, tar_format="PAX"):
     archiver = request.getfixturevalue(archivers)
     create_test_files(archiver.input_path, create_hardlinks=False)  # hard links become separate files
     os.unlink("input/flagfile")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "simple.tar", f"--tar-format={tar_format}")
     cmd(archiver, "import-tar", "dst", "simple.tar")
@@ -129,7 +129,7 @@ def test_import_unusual_tar(archivers, request):
     # ./foo//bar
     # ./
     tar_archive = os.path.join(os.path.dirname(__file__), "unusual_paths.tar")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "import-tar", "dst", tar_archive)
     files = cmd(archiver, "list", "dst", "--format", "{path}{NL}").splitlines()
     assert set(files) == {"foobar", "bar", "foo2", "foo/bar", "."}
@@ -143,7 +143,7 @@ def test_import_tar_with_dotdot(archivers, request):
     # Contains this file:
     # ../../../../etc/shadow
     tar_archive = os.path.join(os.path.dirname(__file__), "dotdot_path.tar")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     with pytest.raises(ValueError, match="unexpected '..' element in path '../../../../etc/shadow'"):
         cmd(archiver, "import-tar", "dst", tar_archive, exit_code=2)
 
@@ -153,7 +153,7 @@ def test_import_tar_gz(archivers, request, tar_format="GNU"):
     archiver = request.getfixturevalue(archivers)
     create_test_files(archiver.input_path, create_hardlinks=False)  # hard links become separate files
     os.unlink("input/flagfile")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "simple.tgz", f"--tar-format={tar_format}")
     cmd(archiver, "import-tar", "dst", "simple.tgz")
@@ -168,7 +168,7 @@ def test_export_import_tar_zst(archivers, request, suffix):
     archiver = request.getfixturevalue(archivers)
     create_test_files(archiver.input_path, create_hardlinks=False)  # hard links become separate files
     os.unlink("input/flagfile")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", f"simple.{suffix}")
     with open(f"simple.{suffix}", "rb") as fd:
@@ -186,7 +186,7 @@ def test_export_import_tar_zst_mt(archivers, request, monkeypatch):
     monkeypatch.setattr("borg.compress._zstd_mt_workers", None)  # drop the cache
     create_test_files(archiver.input_path, create_hardlinks=False)  # hard links become separate files
     os.unlink("input/flagfile")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "simple.tar.zst")
     cmd(archiver, "import-tar", "dst", "simple.tar.zst")
@@ -217,7 +217,7 @@ def test_tar_filter_zstd_external(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_test_files(archiver.input_path, create_hardlinks=False)  # hard links become separate files
     os.unlink("input/flagfile")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "simple.tar.zst", "--tar-filter=zstd")
     with open("simple.tar.zst", "rb") as fd:
@@ -247,7 +247,7 @@ def test_import_concatenated_tar_with_ignore_zeros(archivers, request):
             # Clean up for assert_dirs_equal.
             os.unlink("the_rest.tar")
 
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "import-tar", "--ignore-zeros", "dst", "input/concatenated.tar")
     # Clean up for assert_dirs_equal.
     os.unlink("input/concatenated.tar")
@@ -272,7 +272,7 @@ def test_import_concatenated_tar_without_ignore_zeros(archivers, request):
             with open("the_rest.tar", "rb") as the_rest:
                 concatenated.write(the_rest.read())
             os.unlink("the_rest.tar")
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "import-tar", "dst", "input/concatenated.tar")
 
     with changedir(archiver.output_path):
@@ -300,7 +300,7 @@ def test_import_tar_with_dotslash_paths(archivers, request):
         assert "./dir/file" in tar_content
 
     # Import the tar file into a Borg repository
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "import-tar", "dotslash", "input/dotslash.tar")
 
     # List the archive contents and verify no paths start with './'
@@ -314,7 +314,7 @@ def test_roundtrip_pax_borg(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_test_files(archiver.input_path)
     os.remove("input/flagfile")  # this would be automagically excluded due to NODUMP
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "simple.tar", "--tar-format=BORG")
     cmd(archiver, "import-tar", "dst", "simple.tar")
@@ -331,7 +331,7 @@ def test_roundtrip_pax_xattrs(archivers, request):
     original_path = os.path.join(archiver.input_path, "file")
     xa_key, xa_value = b"user.xattrtest", b"not valid utf-8: \xff"
     xattr.setxattr(original_path.encode(), xa_key, xa_value)
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "src", "input")
     cmd(archiver, "export-tar", "src", "xattrs.tar", "--tar-format=PAX")
     cmd(archiver, "import-tar", "dst", "xattrs.tar")
@@ -393,7 +393,7 @@ def test_acl_roundtrip(archivers, request):
         pytest.skip("ACLs not supported or not working correctly")
 
     # 2. Create a Borg archive
-    cmd(archiver, "repo-create", "--encryption=none")
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
     cmd(archiver, "create", "original", "input")
 
     # 3. export-tar this archive to a tar file

--- a/src/borg/testsuite/benchmark_test.py
+++ b/src/borg/testsuite/benchmark_test.py
@@ -27,7 +27,7 @@ def repo_url(request, tmpdir, monkeypatch):
     tmpdir.remove(rec=1)
 
 
-@pytest.fixture(params=["none", "aes256-ocb"])
+@pytest.fixture(params=["none-sha256", "aes256-ocb"])
 def repo(request, cmd_fixture, repo_url):
     cmd_fixture(f"--repo={repo_url}", "repo-create", "--encryption", request.param)
     return repo_url

--- a/src/borg/testsuite/cockpit_test.py
+++ b/src/borg/testsuite/cockpit_test.py
@@ -24,7 +24,7 @@ def test_cockpit_app_create_archive(tmp_path):
     for i in range(5000):
         (input_path / f"test{i}.txt").write_text(f"content {i}")
 
-    subprocess.run(["borg", "-r", str(repo_path), "repo-create", "--encryption", "none"], check=True)
+    subprocess.run(["borg", "-r", str(repo_path), "repo-create", "--encryption", "none-sha256"], check=True)
 
     async def run():
         app = BorgCockpitApp()

--- a/src/borg/testsuite/crypto/crypto_test.py
+++ b/src/borg/testsuite/crypto/crypto_test.py
@@ -9,7 +9,7 @@ from ...crypto.low_level import bytes_to_long, bytes_to_int, long_to_bytes
 from ...crypto.low_level import hmac_sha256
 from ...legacy.crypto.low_level import AES
 from hashlib import sha256
-from ...crypto.key import CHPOKey, AESOCBKey, KeyBase, PlaintextKey
+from ...crypto.key import CHPOKey, AESOCBKey, KeyBase, ChecksumKey
 from ...legacy.crypto.key import AESCTRKey as LegacyAESCTRKey
 from ...helpers import msgpack, bin_to_hex
 
@@ -320,11 +320,11 @@ class TestDeriveKey(BaseTestCase):
             self.id_key = id_key
 
     def test_derive_key_with_plaintext_key(self):
-        """Test derive_key with PlaintextKey (empty crypt_key)"""
-        key = PlaintextKey(None)
+        """Test derive_key with ChecksumKey (empty crypt_key)"""
+        key = ChecksumKey(None)
         salt, domain, size = b"salt", b"domain", 16
 
-        # PlaintextKey has an empty crypt_key, so the derived key should be based on salt and domain only
+        # ChecksumKey has an empty crypt_key, so the derived key should be based on salt and domain only
         derived_key = key.derive_key(salt=salt, domain=domain, size=size)
         expected = sha256(b"" + salt + domain).digest()[:size]
         self.assert_equal(derived_key, expected)

--- a/src/borg/testsuite/crypto/key_test.py
+++ b/src/borg/testsuite/crypto/key_test.py
@@ -6,21 +6,22 @@ from unittest.mock import MagicMock
 import pytest
 
 from ...crypto.key import BLAKE3_MT_THRESHOLD_KIB, get_blake3_mt_threshold
-from ...crypto.key import PlaintextKey, AuthenticatedKey, Blake2AuthenticatedKey, keyfile_parse
-from ...crypto.key import AESCTRKey, Blake2AESCTRKey
+from ...crypto.key import ChecksumKey, Blake3ChecksumKey, keyfile_parse
+from ...crypto.key import AuthenticatedKey, Blake3AuthenticatedKey
+from ...crypto.key import AESCTRKey, Blake2AESCTRKey, Blake2AuthenticatedKey
+from ...crypto.key import LegacyPlaintextKey, LegacyAuthenticatedKey
 from ...crypto.key import AEADKeyBase
 from ...crypto.key import AESOCBKey, CHPOKey, Blake3AESOCBKey, Blake3CHPOKey
 from ...crypto.key import AES_OCB_MAX_SESSION_BLOCKS
-from ...crypto.key import Blake3AuthenticatedKey
 from ...crypto.key import ID_HMAC_SHA_256, ID_BLAKE2b_256, ID_BLAKE3_256
-from ...crypto.key import UnsupportedManifestError, UnsupportedKeyFormatError
+from ...crypto.key import UnsupportedManifestError, UnsupportedKeyFormatError, UnsupportedPayloadError
 from ...crypto.key import identify_key
 from ...crypto.low_level import IntegrityError as IntegrityErrorBase
 from ...helpers import Error
 from ...helpers import IntegrityError
 from ...helpers import Location
 from ...helpers import msgpack
-from ...constants import KEY_ALGORITHMS
+from ...constants import KEY_ALGORITHMS, KeyBlobStorage, KeyType, ROBJ_MANIFEST
 from ...helpers import hex_to_bin, bin_to_hex
 
 
@@ -87,11 +88,12 @@ class TestKey:
         params=(
             # keyfile and repokey are no longer separate classes (storage is a per-key property),
             # so each crypto suite appears once here.
-            # not encrypted
-            PlaintextKey,
+            # not encrypted, but tagged
+            ChecksumKey,
+            Blake3ChecksumKey,
             AuthenticatedKey,
             Blake3AuthenticatedKey,
-            # legacy crypto
+            # legacy crypto (read-only, borg 1.x)
             AESCTRKey,
             Blake2AESCTRKey,
             Blake2AuthenticatedKey,
@@ -128,11 +130,19 @@ class TestKey:
             # is storage-agnostic now and always probes repo candidates, even for keyfile keys.
             return getattr(self, "key_data", b"")
 
-    def test_plaintext(self):
-        key = PlaintextKey.create(None, None)
+    def test_none_sha256(self):
+        key = ChecksumKey.create(None, None)
         chunk = b"foo"
         id = key.id_hash(chunk)
+        # the chunk id of the "none-*" modes is the plain (unkeyed) hash of the chunk
         assert bin_to_hex(id) == "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+        assert chunk == key.decrypt(id, key.encrypt(id, chunk))
+
+    def test_none_blake3(self):
+        key = Blake3ChecksumKey.create(None, None)
+        chunk = b"foo"
+        id = key.id_hash(chunk)
+        assert bin_to_hex(id) == "04e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9"
         assert chunk == key.decrypt(id, key.encrypt(id, chunk))
 
     def test_keyfile(self, monkeypatch, keys_dir):
@@ -292,10 +302,13 @@ class TestKey:
         plaintext = b"123456789"
         id = key.id_hash(plaintext)
         authenticated = key.encrypt(id, plaintext)
-        # 0x07 is the key TYPE.
-        assert authenticated == b"\x07" + plaintext
+        # TYPE(1) + reserved(1) + tag(32) + payload, see MACKeyBase
+        assert authenticated[0:2] == b"\x60\x00"
+        assert authenticated[34:] == plaintext
+        assert key.decrypt(id, authenticated) == plaintext
 
     def test_blake2_authenticated_encrypt(self, monkeypatch):
+        # borg 1.x mode, read-only: its envelope is just the type byte plus the payload.
         monkeypatch.setenv("BORG_PASSPHRASE", "test")
         key = Blake2AuthenticatedKey.create(self.MockRepository(), self.MockArgs())
         assert Blake2AuthenticatedKey.id_hash is ID_BLAKE2b_256.id_hash
@@ -314,8 +327,9 @@ class TestKey:
         plaintext = b"123456789"
         id = key.id_hash(plaintext)
         authenticated = key.encrypt(id, plaintext)
-        # 0x50 is the key TYPE.
-        assert authenticated == b"\x50" + plaintext
+        assert authenticated[0:2] == b"\x70\x00"
+        assert authenticated[34:] == plaintext
+        assert key.decrypt(id, authenticated) == plaintext
 
     def test_blake3_mt_threshold_from_env(self, monkeypatch):
         # the env var gives the threshold in KiB, get_blake3_mt_threshold() returns bytes
@@ -363,6 +377,190 @@ class TestTAM:
         unpacked = key.unpack_archive(blob)
         assert unpacked["foo"] == "bar"
         assert "tam" not in unpacked  # legacy
+
+
+class TestMACEnvelope:
+    """The tagged envelope of the modes that do not encrypt, see MACKeyBase."""
+
+    # fixed key material, so the tests can check exact envelope bytes
+    CRYPT_KEY = bytes(range(64))
+    ID_KEY = bytes(range(100, 132))
+
+    ALL_CLASSES = (ChecksumKey, Blake3ChecksumKey, AuthenticatedKey, Blake3AuthenticatedKey)
+    KEYED_CLASSES = (AuthenticatedKey, Blake3AuthenticatedKey)
+    UNKEYED_CLASSES = (ChecksumKey, Blake3ChecksumKey)
+
+    class MockRepository:
+        id = bytes(32)
+        version = 2
+
+    def make_key(self, cls, crypt_key=None):
+        key = cls(self.MockRepository())
+        if cls.has_secret_key:
+            key.init_from_given_data(crypt_key=crypt_key or self.CRYPT_KEY, id_key=self.ID_KEY, chunk_seed=0)
+        return key
+
+    @pytest.fixture(params=ALL_CLASSES)
+    def key(self, request):
+        return self.make_key(request.param)
+
+    def test_envelope_layout(self, key):
+        payload = b"payload"
+        id = key.id_hash(payload)
+        envelope = key.encrypt(id, payload, aad=b"aad")
+        assert envelope[0] == key.TYPE
+        assert envelope[1] == 0  # reserved
+        assert len(envelope) == key.PAYLOAD_OVERHEAD + len(payload) == 34 + len(payload)
+        assert envelope[34:] == payload  # the payload is stored as-is, these modes do not encrypt
+        assert key.decrypt(id, envelope, aad=b"aad") == payload
+
+    def test_envelope_is_deterministic(self, key):
+        # no nonce, no session: same input -> same bytes (see MACKeyBase)
+        payload = b"payload"
+        id = key.id_hash(payload)
+        assert key.encrypt(id, payload, aad=b"aad") == key.encrypt(id, payload, aad=b"aad")
+
+    @pytest.mark.parametrize("cls", ALL_CLASSES)
+    def test_format_is_stable(self, cls):
+        # golden vectors: these bytes must not change silently, they are an on-disk format.
+        expected = {
+            ChecksumKey: "80001ab01692fad0f0b89f27983cbf51b1bd20ab73de736aea83363b749ee6ba314f",
+            Blake3ChecksumKey: "90008dec559eda6de95536f198f6b54b3b2728678c94ca1b3f0b77cf37e5b11c9b7c",
+            AuthenticatedKey: "600033ecaaf8c34d4142fa502278986c8f49efbcbf879de16d3c2767e1252bfb1994",
+            Blake3AuthenticatedKey: "70006de48e2139f8995790ec81b256e87f40ef5810d140d28396a8d07734ab05a358",
+        }[cls]
+        key = self.make_key(cls)
+        plaintext = b"123456789"
+        envelope = key.encrypt(key.id_hash(plaintext), plaintext, aad=b"")
+        assert bin_to_hex(envelope) == expected + bin_to_hex(plaintext)
+
+    @pytest.mark.parametrize("cls", UNKEYED_CLASSES)
+    def test_unkeyed_modes_are_repo_independent(self, cls):
+        # no key material at all, so any two repositories of such a mode store identical objects
+        # for identical input - that is what allows deduplicating them on the filesystem level.
+        key1, key2 = self.make_key(cls), self.make_key(cls)
+        payload = b"payload"
+        id = key1.id_hash(payload)
+        assert key1.id_hash(payload) == key2.id_hash(payload)
+        assert key1.encrypt(id, payload, aad=b"aad") == key2.encrypt(id, payload, aad=b"aad")
+
+    @pytest.mark.parametrize("cls", KEYED_CLASSES)
+    def test_keyed_modes_depend_on_crypt_key(self, cls):
+        # the tag key is derived from crypt_key: same crypt_key -> same objects (that is what
+        # "repo-create --other-repo --copy-crypt-key" gives), different crypt_key -> different tag.
+        payload = b"payload"
+        same = [self.make_key(cls), self.make_key(cls)]
+        other = self.make_key(cls, crypt_key=bytes(range(1, 65)))
+        id = same[0].id_hash(payload)
+        assert same[0].encrypt(id, payload, aad=b"aad") == same[1].encrypt(id, payload, aad=b"aad")
+        assert same[0].encrypt(id, payload, aad=b"aad") != other.encrypt(id, payload, aad=b"aad")
+        # a key that can not verify the tag must not be able to read
+        with pytest.raises(IntegrityError):
+            other.decrypt(id, same[0].encrypt(id, payload, aad=b"aad"), aad=b"aad")
+
+    def test_tampered_envelope_detected(self, key):
+        # every single byte of the envelope is covered by the tag
+        payload = b"0123456789"
+        id = key.id_hash(payload)
+        envelope = key.encrypt(id, payload, aad=b"aad")
+        for offset in range(len(envelope)):
+            tampered = bytearray(envelope)
+            tampered[offset] ^= 64  # stays within TYPES_ACCEPTABLE if it hits the type byte
+            with pytest.raises(IntegrityError):
+                key.decrypt(id, bytes(tampered), aad=b"aad")
+
+    def test_tampered_aad_detected(self, key):
+        # the AAD carries the object header, the meta/data slot tag and the chunk id, see RepoObj
+        payload = b"payload"
+        id = key.id_hash(payload)
+        envelope = key.encrypt(id, payload, aad=b"aadM")
+        with pytest.raises(IntegrityError):
+            key.decrypt(id, envelope, aad=b"aadD")  # e.g. meta and data slot swapped
+        other_id = key.id_hash(b"other payload")
+        with pytest.raises(IntegrityError):
+            key.decrypt(other_id, envelope, aad=b"aadM")  # chunk taken from another object
+
+    def test_truncated_envelope_detected(self, key):
+        payload = b"payload"
+        id = key.id_hash(payload)
+        envelope = key.encrypt(id, payload, aad=b"aad")
+        for length in range(key.PAYLOAD_OVERHEAD):  # cut into the header/tag
+            with pytest.raises(IntegrityError):
+                key.decrypt(id, envelope[:length], aad=b"aad")
+        with pytest.raises(IntegrityError):  # cut into the payload
+            key.decrypt(id, envelope[:-1], aad=b"aad")
+
+    @pytest.mark.parametrize("cls", ALL_CLASSES)
+    def test_flags(self, cls):
+        key = self.make_key(cls)
+        assert not key.encrypts
+        assert not key.logically_encrypted
+        assert key.IDHASH_IN_ENC_NAME
+        assert key.ENC_NAME.endswith("-" + key.IDHASH_NAME)
+        if cls in self.KEYED_CLASSES:
+            assert key.has_secret_key
+            # the envelope tag authenticates every read, so verifying the chunk id on top of that
+            # is optional (see BORG_ASSERT_ID), like for the AEAD modes.
+            assert not key.id_check_is_authentication
+            assert key.STORAGE == KeyBlobStorage.REPO
+            assert key.LOCATION_CONFIGURABLE
+        else:
+            assert not key.has_secret_key
+            # the checksum can be recomputed by anybody, thus it is no authentication: the chunk id
+            # check is the only one left and must never be skipped.
+            assert key.id_check_is_authentication
+            assert key.STORAGE == KeyBlobStorage.NO_STORAGE
+            assert not key.LOCATION_CONFIGURABLE
+
+    @pytest.mark.parametrize("cls", ALL_CLASSES)
+    def test_type_bytes_are_distinct(self, cls):
+        # identify_key must be able to tell the modes apart by the first envelope byte
+        key = self.make_key(cls)
+        envelope = key.encrypt(key.id_hash(b"x"), b"x")
+        assert identify_key(envelope) is cls
+
+    def test_authenticated_no_key_workaround(self, monkeypatch):
+        # without the key material, the keyed modes can not verify the tag - but they can still
+        # read the data (that is the point of the workaround, see BORG_WORKAROUNDS).
+        key = self.make_key(AuthenticatedKey)
+        payload = b"payload"
+        id = key.id_hash(payload)
+        envelope = bytearray(key.encrypt(id, payload, aad=b"aad"))
+        envelope[5] ^= 1  # corrupt the tag
+        monkeypatch.setattr("borg.crypto.key.AUTHENTICATED_NO_KEY", True)
+        assert key.decrypt(id, bytes(envelope), aad=b"aad") == payload
+
+    def test_unkeyed_modes_verify_despite_workaround(self, monkeypatch):
+        # the unkeyed modes need no key material, so the workaround must not switch their
+        # checksum verification off.
+        monkeypatch.setattr("borg.crypto.key.AUTHENTICATED_NO_KEY", True)
+        key = self.make_key(ChecksumKey)
+        payload = b"payload"
+        id = key.id_hash(payload)
+        envelope = bytearray(key.encrypt(id, payload, aad=b"aad"))
+        envelope[5] ^= 1
+        with pytest.raises(IntegrityError):
+            key.decrypt(id, bytes(envelope), aad=b"aad")
+
+
+def test_dropped_borg2_beta_key_types(tmpdir):
+    # the borg2 beta "none"/"authenticated" formats were dropped, see #9104. A borg2 repository
+    # using them must be refused instead of being read with the legacy classes.
+    from ...repoobj import RepoObj
+    from ...crypto.key import key_factory
+
+    for legacy_cls in (LegacyPlaintextKey, LegacyAuthenticatedKey):
+        key = legacy_cls(MagicMock(id=bytes(32)))
+        if legacy_cls is LegacyAuthenticatedKey:
+            key.id_key = bytes(32)
+        manifest_chunk = RepoObj(key).format(bytes(32), {}, b"manifest", ro_type=ROBJ_MANIFEST)
+        with pytest.raises(UnsupportedPayloadError):
+            key_factory(MagicMock(id=bytes(32)), manifest_chunk, ro_cls=RepoObj)
+
+
+def test_dropped_blake3_authenticated_type_byte():
+    with pytest.raises(UnsupportedPayloadError):
+        identify_key(bytes([KeyType.DROPPED_BLAKE3AUTHENTICATED]) + b"payload")
 
 
 def test_decrypt_key_file_unsupported_algorithm():

--- a/src/borg/testsuite/legacy_archives_test.py
+++ b/src/borg/testsuite/legacy_archives_test.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ..crypto.key import PlaintextKey
+from ..legacy.crypto.key import PlaintextKey
 from ..helpers.errors import CommandError, Error
 from ..legacy.archives import LegacyArchives
 from ..legacy.repository import LegacyRepository

--- a/src/borg/testsuite/repoobj_test.py
+++ b/src/borg/testsuite/repoobj_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..constants import ROBJ_FILE_STREAM, ROBJ_MANIFEST, ROBJ_ARCHIVE_META
-from ..crypto.key import PlaintextKey, AuthenticatedKey, CHPOKey
+from ..crypto.key import ChecksumKey, AuthenticatedKey, CHPOKey, LegacyPlaintextKey
 from ..helpers import msgpack
 from ..helpers.errors import Error, IntegrityError
 from ..repository import Repository
@@ -26,12 +26,19 @@ def repository(tmpdir):
 
 @pytest.fixture
 def key(repository):
-    return PlaintextKey(repository)
+    # "none-sha256" mode: not encrypted and not authenticated, but checksummed.
+    return ChecksumKey(repository)
+
+
+@pytest.fixture
+def legacy_key(repository):
+    # borg 1.x "none" mode: no envelope protection at all (read-only in borg 2).
+    return LegacyPlaintextKey(repository)
 
 
 @pytest.fixture
 def authenticated_key(repository):
-    # "authenticated" mode: not encrypted, the id check is the only read path authentication.
+    # "authenticated-sha256" mode: not encrypted, but the envelope is MAC-authenticated.
     key = AuthenticatedKey(repository)
     key.init_from_random_data()
     key.init_ciphers()
@@ -40,7 +47,6 @@ def authenticated_key(repository):
 
 @pytest.fixture
 def aead_key(repository):
-    # AEAD key, needed to test header_aad authentication; PlaintextKey is unauthenticated.
     key = CHPOKey(repository)
     key.init_from_random_data()
     key.init_ciphers()
@@ -70,8 +76,8 @@ def test_format_parse_roundtrip(key):
     assert edata.startswith(bytes((key.TYPE,)))
 
 
-def test_format_parse_roundtrip_borg1(key):  # legacy
-    repo_objs = RepoObj1(key)
+def test_format_parse_roundtrip_borg1(legacy_key):  # legacy
+    repo_objs = RepoObj1(legacy_key)
     data = b"foobar" * 10
     id = repo_objs.id_hash(data)
     meta = {}  # borg1 does not support this kind of metadata
@@ -90,13 +96,14 @@ def test_format_parse_roundtrip_borg1(key):  # legacy
     assert edata.startswith(bytes((key.TYPE, compressor.ID, compressor.level)))
 
 
-def test_borg1_borg2_transition(key):
+def test_borg1_borg2_transition(legacy_key, key):
     # Borg transfer reads Borg 1.x repository objects (without decompressing them),
     # and writes Borg 2 repository objects (providing already-compressed data to avoid recompression).
+    # The borg 1.x "none" and the borg 2 "none-sha256" mode use the same (unkeyed sha256) chunk ids.
     meta = {}  # borg1 does not support this kind of metadata
     data = b"foobar" * 10
     len_data = len(data)
-    repo_objs1 = RepoObj1(key)
+    repo_objs1 = RepoObj1(legacy_key)
     id = repo_objs1.id_hash(data)
     borg1_cdata = repo_objs1.format(id, meta, data, ro_type=ROBJ_FILE_STREAM)
     meta1, compr_data1 = repo_objs1.parse(
@@ -196,16 +203,23 @@ def _tamper(cdata, offset):
     return bytes(tampered)
 
 
-def test_tampered_header_chunk_id_detected(aead_key):
-    # chunk_id is part of header_aad, so tampering with it fails AEAD authentication in
+@pytest.fixture(params=["key", "authenticated_key", "aead_key"])
+def protected_key(request):
+    # every borg 2 mode protects the object with a tag over the payload and the AAD - an unkeyed
+    # checksum for "none-*", a MAC for "authenticated-*", the AEAD tag for the encrypted modes.
+    return request.getfixturevalue(request.param)
+
+
+def test_tampered_header_chunk_id_detected(protected_key):
+    # chunk_id is part of header_aad, so tampering with it fails the tag verification in
     # parse()/parse_meta().
-    repo_objs = RepoObj(aead_key)
+    repo_objs = RepoObj(protected_key)
     data = b"foobar" * 10
     id = repo_objs.id_hash(data)
     cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
 
     # chunk_id is at header offset 9..41 (after 8-byte magic + 1-byte version). It has no structural
-    # check, so tampering is detected only through AEAD authentication.
+    # check, so tampering is detected only through the tag.
     tampered = _tamper(cdata, offset=9)
     with pytest.raises(IntegrityError):
         repo_objs.parse_meta(id, tampered, ro_type=ROBJ_FILE_STREAM)
@@ -213,11 +227,11 @@ def test_tampered_header_chunk_id_detected(aead_key):
         repo_objs.parse(id, tampered, ro_type=ROBJ_FILE_STREAM)
 
 
-def test_tampered_header_magic_detected(aead_key):
+def test_tampered_header_magic_detected(protected_key):
     # A tampered magic byte is rejected by the structural check (`hdr.magic != OBJ_MAGIC`) before
-    # key.decrypt() runs, so this does not test AEAD authentication of header_aad - see
+    # key.decrypt() runs, so this does not test the authentication of header_aad - see
     # test_header_aad_tamper_detected_at_key_layer for that.
-    repo_objs = RepoObj(aead_key)
+    repo_objs = RepoObj(protected_key)
     data = b"foobar" * 10
     id = repo_objs.id_hash(data)
     cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
@@ -230,34 +244,90 @@ def test_tampered_header_magic_detected(aead_key):
         repo_objs.parse(id, tampered, ro_type=ROBJ_FILE_STREAM)
 
 
-def test_header_aad_tamper_detected_at_key_layer(aead_key):
+def test_tampered_meta_detected(protected_key):
+    # The metadata (which selects the decompressor and the payload size!) is covered by the tag in
+    # every mode, so it can not be modified without the read failing - and the check happens before
+    # the metadata is used for anything, see RepoObj.parse.
+    repo_objs = RepoObj(protected_key)
+    data = b"foobar" * 10
+    id = repo_objs.id_hash(data)
+    cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
+
+    hdr_size = RepoObj.obj_header.size
+    hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(cdata[:hdr_size]))
+    for offset in range(hdr_size, hdr_size + hdr.meta_size):  # every byte of the meta slot
+        tampered = _tamper(cdata, offset=offset)
+        with pytest.raises(IntegrityError):
+            repo_objs.parse_meta(id, tampered, ro_type=ROBJ_FILE_STREAM)
+        with pytest.raises(IntegrityError):
+            repo_objs.parse(id, tampered, ro_type=ROBJ_FILE_STREAM)
+
+
+def test_tampered_data_detected(protected_key):
+    repo_objs = RepoObj(protected_key)
+    data = b"foobar" * 10
+    id = repo_objs.id_hash(data)
+    cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
+
+    hdr_size = RepoObj.obj_header.size
+    hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(cdata[:hdr_size]))
+    for offset in range(hdr_size + hdr.meta_size, len(cdata)):  # every byte of the data slot
+        tampered = _tamper(cdata, offset=offset)
+        with pytest.raises(IntegrityError):
+            repo_objs.parse(id, tampered, ro_type=ROBJ_FILE_STREAM)
+
+
+def test_checksum_mode_does_not_authenticate(key):
+    # The honest limit of the "none-*" modes: their tag is an unkeyed checksum, so somebody who
+    # modifies an object can just recompute it. Detecting that needs a secret - the
+    # "authenticated-*" and the encrypted modes have one, this mode does not.
+    repo_objs = RepoObj(key)
+    data = b"foobar" * 10
+    id = repo_objs.id_hash(data)
+    cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
+
+    hdr_size = RepoObj.obj_header.size
+    hdr = RepoObj.ObjHeader(*RepoObj.obj_header.unpack(cdata[:hdr_size]))
+    header_aad = OBJ_MAGIC + bytes([OBJ_VERSION]) + id
+    # rewrite the meta slot with attacker-chosen content and a recomputed checksum
+    forged_meta = dict(repo_objs.parse_meta(id, cdata, ro_type=ROBJ_FILE_STREAM), custom="forged")
+    forged_meta_slot = key.encrypt(id, msgpack.packb(forged_meta), aad=header_aad + b"M")
+    forged = (
+        RepoObj.obj_header.pack(hdr.magic, hdr.version, hdr.chunk_id, len(forged_meta_slot), hdr.data_size)
+        + forged_meta_slot
+        + cdata[hdr_size + hdr.meta_size :]
+    )
+    assert repo_objs.parse_meta(id, forged, ro_type=ROBJ_FILE_STREAM)["custom"] == "forged"
+
+
+def test_header_aad_tamper_detected_at_key_layer(protected_key):
     # Calls key.encrypt()/key.decrypt() directly with header_aad, to check that every byte of
     # header_aad (magic, version, chunk_id) is authenticated, not just chunk_id.
     data = b"foobar" * 10
-    id = aead_key.id_hash(data)
+    id = protected_key.id_hash(data)
     header_aad = OBJ_MAGIC + bytes([OBJ_VERSION]) + id
-    encrypted = aead_key.encrypt(id, data, aad=header_aad)
+    encrypted = protected_key.encrypt(id, data, aad=header_aad)
 
-    assert aead_key.decrypt(id, encrypted, aad=header_aad) == data
+    assert protected_key.decrypt(id, encrypted, aad=header_aad) == data
 
     # tamper the magic byte (offset 0) after encryption; decrypt gets a different header_aad than encrypt did.
     tampered_header_aad = bytearray(header_aad)
     tampered_header_aad[0] ^= 0x01
     with pytest.raises(IntegrityError):
-        aead_key.decrypt(id, encrypted, aad=bytes(tampered_header_aad))
+        protected_key.decrypt(id, encrypted, aad=bytes(tampered_header_aad))
 
     # tamper the version byte (offset 8) after encryption.
     tampered_header_aad = bytearray(header_aad)
     tampered_header_aad[8] ^= 0x01
     with pytest.raises(IntegrityError):
-        aead_key.decrypt(id, encrypted, aad=bytes(tampered_header_aad))
+        protected_key.decrypt(id, encrypted, aad=bytes(tampered_header_aad))
 
 
-def test_meta_data_slot_swap_detected(aead_key):
-    # meta_encrypted and data_encrypted carry different slot tags in their AAD, so splicing one
+def test_meta_data_slot_swap_detected(protected_key):
+    # the meta and the data slot carry different slot tags in their AAD, so splicing one
     # into the other's position (fixing up meta_size/data_size to match the swapped lengths) must
-    # fail authentication instead of silently decrypting under the wrong slot.
-    repo_objs = RepoObj(aead_key)
+    # fail the tag verification instead of silently being read under the wrong slot.
+    repo_objs = RepoObj(protected_key)
     data = b"foobar" * 10
     id = repo_objs.id_hash(data)
     cdata = repo_objs.format(id, {"custom": "something"}, data, ro_type=ROBJ_FILE_STREAM)
@@ -378,11 +448,10 @@ def test_assert_id_places_env_var_mandatory_place(aead_key, monkeypatch):
     assert "verify_data: always verifies, can not be configured" in str(exc_info.value)
 
 
-@pytest.mark.parametrize("key_fixture", ["key", "authenticated_key"])
-def test_assert_id_never_skipped_for_non_aead_key(key_fixture, request, monkeypatch):
-    # PlaintextKey ("none" mode) and AuthenticatedKey ("authenticated" mode): there is no AEAD, so the id
-    # check is the only integrity check reads have and thus must happen no matter what the user configured.
-    key = request.getfixturevalue(key_fixture)
+def test_assert_id_never_skipped_for_unauthenticated_key(key, monkeypatch):
+    # ChecksumKey ("none-sha256" mode): the envelope checksum is unkeyed and thus no authentication,
+    # so the id check is the only integrity check reads have and must happen no matter what the
+    # user configured.
     monkeypatch.setenv("BORG_ASSERT_ID", "")  # verify nowhere - but this is not switchable off
     assert key.id_check_is_authentication
     repo_objs = RepoObj(key)
@@ -390,6 +459,22 @@ def test_assert_id_never_skipped_for_non_aead_key(key_fixture, request, monkeypa
     cdata = wrong_content_object(repo_objs, id)
 
     for place in ASSERT_ID_PLACES:
+        with pytest.raises(IntegrityError):
+            repo_objs.parse(id, cdata, ro_type=ROBJ_FILE_STREAM, assert_id_place=place)
+
+
+def test_assert_id_configurable_for_authenticated_key(authenticated_key, monkeypatch):
+    # AuthenticatedKey ("authenticated-sha256"): the envelope MAC authenticates every read (the
+    # chunk id is in the AAD), so verifying the id on top of that is configurable, like for AEAD.
+    monkeypatch.setenv("BORG_ASSERT_ID", "")  # verify at none of the configurable places
+    assert not authenticated_key.id_check_is_authentication
+    repo_objs = RepoObj(authenticated_key)
+    id = repo_objs.id_hash(b"foobar" * 10)
+    cdata = wrong_content_object(repo_objs, id)
+
+    for place in ASSERT_ID_PLACES:
+        repo_objs.parse(id, cdata, ro_type=ROBJ_FILE_STREAM, assert_id_place=place)
+    for place in ASSERT_ID_PLACES_MANDATORY:  # ... but check --verify-data always verifies
         with pytest.raises(IntegrityError):
             repo_objs.parse(id, cdata, ro_type=ROBJ_FILE_STREAM, assert_id_place=place)
 


### PR DESCRIPTION
Related to #9104.

The old `none` and `authenticated` modes had a no-op repo object envelope: just the key type byte followed by the payload, ignoring the aad the RepoObj layer passes. Only the chunk id over the plaintext was ever checked, so a repo object's metadata and its object header were not verified at all — and the metadata selects the decompressor and the payload size, i.e. it was used before anything about the object had been checked.

The new modes use a tagged envelope instead:

```
TYPE(1) + reserved(1) + tag(32) + payload
```

The tag covers the envelope header, the aad (object header, chunk id and the meta/data slot tag) and the payload, so tampering with any of them, swapping the meta and the data slot, or taking an object slice from a different object fails verification — and it does so before the metadata is used for anything. This also makes the existing header-aad and pack-header binding effective for these modes, which so far only worked for the AEAD modes.

The tag is deterministic: a MAC needs no nonce, so there is no session state to manage, and repositories with the same key material store byte-identical objects for identical input (which allows deduplicating them on the filesystem level).

- `authenticated-sha256` / `authenticated-blake3` (0x60 / 0x70): the tag is a MAC (HMAC-SHA256 resp. keyed BLAKE3), so these modes now detect malicious tampering with metadata and object header, not just with the chunk content. The MAC key is derived from `crypt_key`, deliberately not from `id_key`: chunk ids are public and related repositories share the id key, which must not let them forge each other's objects. `--copy-crypt-key` opts into sharing it.
- `none-sha256` / `none-blake3` (0x80 / 0x90): there is no key, so the tag is an unkeyed checksum. It detects accidental corruption (and a ranged read that returned the wrong bytes), but anybody can recompute it — these modes make no authenticity claim, so their chunk id check stays mandatory.

The unencrypted modes name their id hash now, because the hash is what protects the data there: bare `none` / `authenticated` are rejected and `--id-hash` only applies to the encrypted modes.

The borg 2 beta formats 0x02, 0x07 and 0x50 are dropped; 0x02/0x06/0x07 live on as read-only legacy classes so `borg transfer --from-borg1` keeps working, and `key_factory` refuses them for borg 2 repositories.

Docs updated for the new modes. Also corrects the packs docs, which said the header aad binding applies to the AEAD modes only — it applies to all borg 2 modes now.

**Compatibility:** this is a flag day for borg 2 beta repos created with `none` / `authenticated` (and the dropped 0x50 beta format) — they cannot be read by this code; borg 1.x repos are unaffected (legacy read path kept for `transfer --from-borg1`).

Tested locally on macOS/arm64, Python 3.11: `2509 passed, 360 skipped` (`-k "not remote and not binary"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
