### PR TITLE
docs: add generated man page borg-environment.1

### DIFF
--- a/docs/man/borg-environment.1
+++ b/docs/man/borg-environment.1
@@ -1,0 +1,612 @@
+.\" Man page generated from reStructuredText
+.\" by the Docutils 0.22.4 manpage writer.
+.
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.TH "borg-environment" "1" "2026-08-14" "" "borg backup tool"
+.SH Name
+borg-environment \- Details regarding environment
+.SH DESCRIPTION
+.sp
+Borg uses some environment variables for automation:
+.INDENT 0.0
+.TP
+.B General:
+.INDENT 7.0
+.TP
+.B BORG_REPO
+When set, use the value to give the default repository location.
+Use this so you do not need to type \fB\-\-repo /path/to/my/repo\fP all the time.
+.TP
+.B BORG_OTHER_REPO
+Similar to BORG_REPO, but gives the default for \fB\-\-other\-repo\fP\&.
+.TP
+.B BORG_PASSPHRASE (and BORG_OTHER_PASSPHRASE)
+When set, use the value to answer the passphrase question for encrypted repositories.
+It is used when a passphrase is needed to access an encrypted repo as well as when a new
+passphrase should be initially set when initializing an encrypted repo.
+See also BORG_NEW_PASSPHRASE.
+.TP
+.B BORG_PASSCOMMAND (and BORG_OTHER_PASSCOMMAND)
+When set, use the standard output of the command (trailing newlines are stripped) to answer the
+passphrase question for encrypted repositories.
+It is used when a passphrase is needed to access an encrypted repo as well as when a new
+passphrase should be initially set when initializing an encrypted repo. Note that the command
+is executed without a shell. So variables, like \fB$HOME\fP will work, but \fB~\fP won\(aqt.
+If BORG_PASSPHRASE is also set, it takes precedence.
+See also BORG_NEW_PASSPHRASE.
+.TP
+.B BORG_PASSPHRASE_FD (and BORG_OTHER_PASSPHRASE_FD)
+When set, specifies a file descriptor to read a passphrase
+from. Programs starting borg may choose to open an anonymous pipe
+and use it to pass a passphrase. This is safer than passing via
+BORG_PASSPHRASE, because on some systems (e.g. Linux) environment
+can be examined by other processes.
+If BORG_PASSPHRASE or BORG_PASSCOMMAND are also set, they take precedence.
+.TP
+.B BORG_NEW_PASSPHRASE
+When set, use the value to answer the passphrase question when a \fBnew\fP passphrase is asked for.
+This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will also
+be checked.
+Main use case for this is to fully automate \fBborg key change\-passphrase\fP\&.
+.TP
+.B BORG_DISPLAY_PASSPHRASE
+When set, use the value to answer the \(dqdisplay the passphrase for verification\(dq question when defining a new passphrase for encrypted repositories.
+.TP
+.B BORG_DEBUG_PASSPHRASE
+When set to YES, display debugging information that includes passphrases used and passphrase related env vars set.
+.TP
+.B BORG_EXIT_CODES
+When set to \(dqmodern\(dq, the borg process will return more specific exit codes (rc).
+When set to \(dqlegacy\(dq, the borg process will return rc 2 for all errors, 1 for all warnings, 0 for success.
+Default is \(dqmodern\(dq.
+.TP
+.B BORG_HOST_ID
+Borg usually computes a host id from the FQDN plus the results of \fBuuid.getnode()\fP (which usually returns
+a unique id based on the MAC address of the network interface. Except if that MAC happens to be all\-zero \- in
+that case it returns a random value, which is not what we want (because it kills automatic stale lock removal).
+So, if you have an all\-zero MAC address or other reasons to better control the host id externally, just set this
+environment variable to a unique value. If all your FQDNs are unique, you can just use the FQDN. If not,
+use \%<FQDN@\:uniqueid>\&.
+.TP
+.B BORG_HOSTNAME
+When set, use this value as the hostname (instead of the auto\-detected one), e.g. to run borg
+on one host, but impersonate another host. This affects the hostname stored in newly created
+archives as well as the \fB{hostname}\fP placeholder.
+.TP
+.B BORG_USERNAME
+When set, use this value as the username (instead of the auto\-detected one), e.g. to run borg
+as one user, but impersonate another user. This affects the username stored in newly created
+archives as well as the \fB{user}\fP placeholder.
+.TP
+.B BORG_LOCK_WAIT
+You can set the default value for the \fB\-\-lock\-wait\fP option with this, so
+you do not need to give it as a command line option.
+.TP
+.B BORG_LOGGING_CONF
+When set, use the given filename as INI\-style logging configuration (see
+\%<https://\:docs\:.python\:.org/\:3/\:library/\:logging\:.config\:.html#\:configuration-file-format>).
+A basic example conf can be found at \fBdocs/misc/logging.conf\fP\&.
+.TP
+.B BORG_RSH
+When set, use this command instead of \fBssh\fP\&. This can be used to specify ssh options, such as
+a custom identity file \fBssh \-i /path/to/private/key\fP\&. See \fBman ssh\fP for other options.
+This is the replacement for the removed \fB\-\-rsh CMD\fP command line option.
+borg also gives this to borgstore as \fBBORGSTORE_RSH\fP, except if that is already set.
+.TP
+.B BORG_REMOTE_PATH
+When set, use the given path as borg executable on the remote (defaults to \(dqborg\(dq if unset).
+This is the replacement for the removed \fB\-\-remote\-path PATH\fP command line option.
+.TP
+.B BORG_UNITS
+Determines how borg formats sizes in its human\-readable output:
+.INDENT 7.0
+.IP \(bu 2
+\fBsi\fP (default): decimal units, e.g. \fB1.23 MB\fP (1kB = 1000B)
+.IP \(bu 2
+\fBiec\fP: binary units, e.g. \fB1.18 MiB\fP (1KiB = 1024B)
+.IP \(bu 2
+\fBraw\fP: exact byte counts, e.g. \fB1234567 B\fP
+.UNINDENT
+.sp
+Use \fBraw\fP if you want to parse sizes with scripts (e.g. for monitoring),
+so you do not have to deal with scaled values and different units.
+Alternatively, use a command\(aqs \fB\-\-json\fP output or, for the commands
+supporting \fB\-\-format\fP, the size related format keys \- sizes are given
+as byte counts there anyway.
+.sp
+\fBBORG_UNITS=iec\fP is the replacement for the removed \fBBORG_IEC\fP environment
+variable (and for the \fB\-\-iec\fP command line option removed before that).
+.TP
+.B BORG_PROGRESS_FPS
+How often the \fB\-\-progress\fP output is updated at most, in updates per
+second (default: 5). Fractional values are allowed, e.g.
+\fBBORG_PROGRESS_FPS=0.1\fP limits it to one update every 10 seconds.
+Lower values are useful when the output goes into a logfile rather than
+to an interactive terminal.
+.TP
+.B BORG_SPINNER
+Controls the spinner borg animates on a terminal while doing work of unknown
+duration:
+.INDENT 7.0
+.IP \(bu 2
+unset (default): animate, using Unicode frames if the terminal can display them
+.IP \(bu 2
+\fBascii\fP: animate, but only use ASCII frames (\fB|/\-\e\fP)
+.IP \(bu 2
+\fBoff\fP: do not animate, only output the messages next to the spinner
+.UNINDENT
+.sp
+The spinner is animated only on an interactive terminal anyway (and never
+with \fB\-\-log\-json\fP), and its colour follows the usual \fBNO_COLOR\fP and
+\fBCOLORTERM\fP conventions. See also \fBBORG_PROGRESS_FPS\fP: it also gives
+the spinner its frame rate.
+.TP
+.B BORG_DEBUG_PROFILE
+When set to a filename, write an execution profile in Borg format into that file
+(see \fIdebugging\fP). If the filename ends with \fB\&.pyprof\fP, a Python\-compatible
+profile is written instead.
+This is the replacement for the removed \fB\-\-debug\-profile\fP command line option.
+Note: every borg invocation writes the profile, so unset it again when you are done.
+.TP
+.B BORG_REPO_PERMISSIONS
+Set repository permissions, see also: \fIborg_serve\fP
+.TP
+.B BORG_FILES_CACHE_SUFFIX
+When set to a value at least one character long, instructs borg to use a specifically named
+(based on the suffix) alternative files cache. This can be used to avoid loading and saving
+cache entries for backup sources other than the current sources.
+.TP
+.B BORG_FILES_CACHE_TTL
+When set to a numeric value, this determines the maximum \(dqtime to live\(dq for the files cache
+entries (default: 2). The files cache is used to determine quickly whether a file is unchanged.
+.TP
+.B BORG_ASSERT_ID
+Comma\-separated list of the places where borg shall verify that a chunk\(aqs content matches
+its chunk id (\fBchunkid == id_hash(content)\fP) after decrypting and decompressing it.
+Verifying costs a full hash pass over everything that is read at such a place.
+.sp
+Default (variable not set):
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_ASSERT_ID=repair,transfer,rechunk
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+These are the place names that can be listed:
+.INDENT 7.0
+.TP
+.B read
+Every read that decompresses a chunk: \fBborg extract\fP, \fBborg mount\fP,
+\fBborg export\-tar\fP, \fBborg diff\fP, ... This is by far the most data borg reads, so
+this place is \fBnot\fP in the default, see the explanation below.
+.TP
+.B repair
+\fBborg check \-\-repair\fP\&. It rebuilds archives from the item metadata stream it reads,
+re\-packing it into new chunks with freshly computed ids, and it recreates manifest and
+archives directory entries from what it reads.
+.TP
+.B transfer
+\fBborg transfer\fP, for everything it reads from the source repository. Transferring
+re\-anchors the content in another repository, which is a trust boundary.
+.TP
+.B rechunk
+\fBborg recreate \-\-chunker\-params ...\fP, i.e. re\-chunking reads. Re\-chunking computes
+new chunk ids from the content it reads, so a violation would not be noticeable any
+more afterwards. (Re\-chunking in \fBborg transfer\fP is covered by \fBtransfer\fP\&.)
+.UNINDENT
+.sp
+An unknown place name is an error. An empty value (\fBBORG_ASSERT_ID=\fP) verifies at none of
+these places, but still where borg always verifies (see below).
+.sp
+Why \fBread\fP is not in the default: for encrypted repositories (all the AEAD ciphersuites),
+the chunk id is part of the AEAD additional authenticated data, so a successful decryption
+already proves that a holder of the repository key deliberately stored exactly this
+ciphertext for exactly this chunk id. A malicious or buggy \fBrepository\fP can therefore not
+swap, splice or substitute objects, whether the id is verified on read or not. What the id
+check adds is the detection of chunks whose content does not match their id, which only a
+malicious or compromised \fBborg client that had your borg key\fP could have written (e.g. to
+poison future deduplication). If that is in your threat model \- e.g. because some machines
+writing into the repository are not fully trusted \- add \fBread\fP to the list:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_ASSERT_ID=read,repair,transfer,rechunk
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+Otherwise, running \fBborg check \-\-verify\-data\fP periodically is recommended: it is the
+audit that re\-certifies the invariant for all chunks in the background, instead of on
+every read.
+.sp
+Independent of this variable, borg always verifies the chunk id:
+.INDENT 7.0
+.IP \(bu 2
+in \fBborg check \-\-verify\-data\fP\&. That audit is what makes not verifying elsewhere
+defensible, so it is not configurable (there is no \fBverify_data\fP place name).
+.IP \(bu 2
+for \fBauthenticated\fP and \fBnone\fP mode repositories: there is no AEAD there, so the id
+check \fIis\fP the read path\(aqs integrity check and switching it off would remove it
+completely. Same for reading borg 1.x repositories (\fBborg transfer\fP).
+.UNINDENT
+.TP
+.B BORG_BLAKE3_MT_THRESHOLD
+When set to a numeric value, chunks of at least that many KiB get their id computed by
+multi\-threaded BLAKE3, smaller ones single\-threaded (default: 256, i.e. 256KiB).
+Only relevant for repositories using \fB\-\-id\-hash blake3\fP\&.
+Multi\-threading only pays off for big enough chunks and the break\-even point depends on
+the machine\(aqs core count, so the default is deliberately conservative.
+Run \fBscripts/blake3\-optimize\-mt\-threshold.py\fP to measure the best value for your
+machine \- it sweeps input sizes, prints the recommended threshold and the command to
+set it, and can optionally show a chart of the measurements in your browser
+(\fB\-\-html \-\-open\fP).
+0 means \(dqalways multi\-threaded\(dq, a very large value effectively disables multi\-threading.
+.TP
+.B BORG_ZSTD_MT_WORKERS
+When set to a numeric value, use that many threads to zstd\-compress a single chunk
+(default: the cpu count). 0 or 1 means single\-threaded compression.
+Only relevant when compressing with \fBzstd\fP\&.
+Chunks below 768KiB are always compressed single\-threaded: libzstd will not use a
+compression job smaller than 512KiB, so a small chunk gets split very unevenly and
+multi\-threading it would be slower than not doing it at all.
+Multi\-threading trades a little compression ratio for speed (measured at \fBzstd,3\fP:
++0.05% archive size for 1MiB chunks, +0.64% for 8MiB ones, more at higher levels), and
+it uses more cpu time in total to reduce the wallclock time. Set it to 1 if you would
+rather have the smaller archive, or if borg has to share the cpu with other work.
+.TP
+.B BORG_FASTCDC_KERNEL / BORG_BUZHASH64_KERNEL
+Select the scan kernel the \fBfastcdc\fP / \fBbuzhash64\fP chunker uses (default:
+\fBscalar\fP, the plain sequential loop). Accepted values are \fBavx512\fP, \fBavx2\fP,
+\fBneon\fP, \fBblockwise\fP and \fBscalar\fP\&.
+All kernels chunk identically \- same cut points, same chunk ids \- and differ only in
+speed, so this is safe to change at any time, also for an existing repository.
+Which kernel is fastest is not predictable from the instruction set: it depends on the
+cpu and on the compiler that built borg, and the sequential loop wins on some machines.
+Nothing is selected automatically, so measure on your own hardware with
+\fBborg benchmark cpu \-\-chunking\fP before setting these.
+\fBavx512\fP and \fBavx2\fP exist only on x86\-64, \fBneon\fP only on aarch64, and only if the
+compiler that built borg supported them; \fBscalar\fP and \fBblockwise\fP are portable C
+and always available.
+Requesting a kernel that this build or this cpu cannot run is an error rather than a
+silent fallback, so a benchmark can not accidentally measure a different kernel.
+\fBborg create \-\-debug\fP logs the chunker and the kernel it was created with.
+.TP
+.B BORG_AES_CHUNKER_KERNEL
+Select the scan kernel used by the AES based chunkers \- one variable for all three of
+\fBtoeplitz\-aes\fP, \fBrabin\-aes\fP and \fBgoldilocks\-aes\fP (default: \fBevp\fP, the portable
+OpenSSL path). Accepted values are \fBvaes\fP, \fBaes\-ni\fP, \fBaes\-arm64\fP and \fBevp\fP\&.
+As with the chunker kernels above, all of them chunk identically and differ only in
+speed, nothing is selected automatically, and a kernel that can not run here is an
+error rather than a silent fallback.
+\fBvaes\fP and \fBaes\-ni\fP exist only on x86\-64, \fBaes\-arm64\fP only on aarch64.
+\fBvaes\fP additionally needs a compiler that knows it (gcc >= 11 / clang >= 14), so a
+cpu supporting VAES is not by itself enough to have that kernel available.
+.TP
+.B BORG_SHOW_SYSINFO
+When set to no (default: yes), system information (like OS, Python version, ...) in
+exceptions is not shown.
+Please only use for good reasons as it makes issues harder to analyze.
+.TP
+.B BORG_MSGPACK_VERSION_CHECK
+Controls whether Borg checks the \fBmsgpack\fP version.
+The default is \fByes\fP (strict check). Set to \fBno\fP to disable the version check and
+allow any installed \fBmsgpack\fP version. Use this at your own risk; malfunctioning or
+incompatible \fBmsgpack\fP versions may cause subtle bugs or repository data corruption.
+.TP
+.B BORG_FUSE_IMPL
+Choose the low\-level FUSE implementation borg shall use for \fBborg mount\fP\&.
+This is a comma\-separated list of implementation names, they are tried in the
+given order, e.g.:
+.INDENT 7.0
+.IP \(bu 2
+\fBmfusepy,pyfuse3,llfuse\fP: default, first try to load mfusepy, then pyfuse3, then llfuse.
+.IP \(bu 2
+\fBllfuse,pyfuse3\fP: first try to load llfuse, then try to load pyfuse3.
+.IP \(bu 2
+\fBmfusepy\fP: only try to load mfusepy
+.IP \(bu 2
+\fBpyfuse3\fP: only try to load pyfuse3
+.IP \(bu 2
+\fBllfuse\fP: only try to load llfuse
+.IP \(bu 2
+\fBnone\fP: do not try to load an implementation
+.UNINDENT
+.TP
+.B BORG_SELFTEST
+This can be used to influence borg\(aqs built\-in self\-tests. The default is to execute the tests
+at the beginning of each borg command invocation.
+.sp
+BORG_SELFTEST=disabled can be used to switch off the tests and rather save some time.
+Disabling is not recommended for normal borg users, but large scale borg storage providers can
+use this to optimize production servers after at least doing a one\-time test borg (with
+self\-tests not disabled) when installing or upgrading machines/OS/Borg.
+.TP
+.B BORG_WORKAROUNDS
+A list of comma\-separated strings that trigger workarounds in borg,
+e.g. to work around bugs in other software.
+.sp
+Currently known strings are:
+.INDENT 7.0
+.TP
+.B basesyncfile
+Use the more simple BaseSyncFile code to avoid issues with sync_file_range.
+You might need this to run borg on WSL (Windows Subsystem for Linux) or
+in systemd.nspawn containers on some architectures (e.g. ARM).
+Using this does not affect data safety, but might result in a more bursty
+write\-to\-disk behavior (not continuously streaming to disk).
+.TP
+.B retry_erofs
+Retry opening a file without O_NOATIME if opening a file with O_NOATIME
+caused EROFS. You will need this to make archives from volume shadow copies
+in WSL1 (Windows Subsystem for Linux 1).
+.TP
+.B authenticated_no_key
+Work around a lost passphrase or key for an \fBauthenticated\-*\fP mode repository
+(these are only authenticated, but not encrypted).
+If the key is missing in the repository config, add \fBkey = anything\fP there.
+.sp
+Without the key, borg can not verify anything that needs it: neither the
+authentication tag of the repository objects nor the chunk ids. It therefore
+reads the repository \fBunverified\fP \- a corrupted or tampered repository will
+not be detected. (This only concerns the \fBauthenticated\-*\fP modes; the
+\fBnone\-*\fP modes need no key and keep verifying their checksums.)
+.sp
+This workaround is \fBonly\fP for emergencies and \fBonly\fP to extract data
+from an affected repository (read\-only access):
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_WORKAROUNDS=authenticated_no_key borg extract \-\-repo repo archive
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+After you have extracted all data you need, you MUST delete the repository:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_WORKAROUNDS=authenticated_no_key borg delete repo
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+Now you can init a fresh repo. Make sure you do not use the workaround any more.
+.UNINDENT
+.UNINDENT
+.TP
+.B Output formatting:
+.INDENT 7.0
+.TP
+.B BORG_CHECK_FORMAT
+Giving the default value for \fBborg check \-\-format=X\fP\&.
+.TP
+.B BORG_LIST_FORMAT
+Giving the default value for \fBborg list \-\-format=X\fP\&.
+.TP
+.B BORG_REPO_LIST_FORMAT
+Giving the default value for \fBborg repo\-list \-\-format=X\fP\&.
+.TP
+.B BORG_PRUNE_FORMAT
+Giving the default value for \fBborg prune \-\-format=X\fP\&.
+.UNINDENT
+.TP
+.B Some automatic \(dqanswerers\(dq (if set, they automatically answer confirmation questions):
+.INDENT 7.0
+.TP
+.B BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)
+For \(dqWarning: Attempting to access a previously unknown unencrypted repository\(dq
+.TP
+.B BORG_RELOCATED_REPO_ACCESS_IS_OK=no (or =yes)
+For \(dqWarning: The repository at location ... was previously located at ...\(dq
+.TP
+.B BORG_CHECK_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
+For \(dqThis is a potentially dangerous function...\(dq (check \-\-repair)
+.TP
+.B BORG_DELETE_I_KNOW_WHAT_I_AM_DOING=NO (or =YES)
+For \(dqYou requested to DELETE the repository completely \fIincluding\fP all archives it contains:\(dq
+.UNINDENT
+.sp
+Note: answers are case sensitive. setting an invalid answer value might either give the default
+answer or ask you interactively, depending on whether retries are allowed (they by default are
+allowed). So please test your scripts interactively before making them a non\-interactive script.
+.TP
+.B Directories and files:
+Borg 2 uses the platformdirs library (\%<https://\:pypi\:.org/\:project/\:platformdirs/>) to determine
+default directory locations. This means that default paths are \fBplatform\-specific\fP:
+.INDENT 7.0
+.IP \(bu 2
+Linux: XDG Base Directory Specification paths are used (e.g. \fB~/.config/borg\fP,
+\fB~/.cache/borg\fP, \fB~/.local/share/borg\fP). \fBXDG_*\fP environment variables are
+honoured (see \%<https://\:specifications\:.freedesktop\:.org/\:basedir-spec/\:0\:.6/\:ar01s03\:.html>).
+.IP \(bu 2
+macOS: native macOS directories are used by default (e.g. \fB~/Library/Application Support/borg\fP,
+\fB~/Library/Caches/borg\fP). \fBXDG_*\fP environment variables are honoured if set.
+.IP \(bu 2
+Windows: Windows AppData directories are used (e.g. \fBC:\eUsers\e<user>\eAppData\eRoaming\eborg\fP,
+\fBC:\eUsers\e<user>\eAppData\eLocal\eborg\fP). \fBXDG_*\fP environment variables are \fBnot\fP honoured.
+.UNINDENT
+.sp
+On all platforms, you can override each directory individually using the specific environment
+variables described below. You can also set \fBBORG_BASE_DIR\fP to force borg to use
+\fBBORG_BASE_DIR/.config/borg\fP, \fBBORG_BASE_DIR/.cache/borg\fP, etc., regardless of the platform.
+.sp
+Default directory locations by platform (when no \fBBORG_*\fP environment variables are set):
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+Directory  Linux                 macOS                                 Windows
+Config     ~/.config/borg        ~/Library/Application Support/borg    %APPDATA%\eborg
+Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\eborg\eCache
+Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\eborg
+Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %TEMP%\eborg
+Keys       <config_dir>/keys     <config_dir>/keys                     <config_dir>\ekeys
+Security   <data_dir>/security   <data_dir>/security                   <data_dir>\esecurity
+.EE
+.UNINDENT
+.UNINDENT
+.INDENT 7.0
+.TP
+.B BORG_BASE_DIR
+Defaults to \fB$HOME\fP or \fB~$USER\fP or \fB~\fP (in that order).
+If you want to move all borg\-specific folders to a custom path at once, all you need to do is
+to modify \fBBORG_BASE_DIR\fP: the other paths for cache, config etc. will adapt accordingly
+(assuming you didn\(aqt set them to a different custom value).
+.TP
+.B BORG_CACHE_DIR
+Defaults to the platform\-specific cache directory (see table above).
+If \fBBORG_BASE_DIR\fP is set, defaults to \fB$BORG_BASE_DIR/.cache/borg\fP\&.
+On Linux and macOS, \fBXDG_CACHE_HOME\fP is also honoured if \fBBORG_BASE_DIR\fP is not set.
+This directory contains the local cache and might need a lot
+of space for dealing with big repositories. Make sure you\(aqre aware of the associated
+security aspects of the cache location: \fIcache_security\fP
+.TP
+.B BORG_CONFIG_DIR
+Defaults to the platform\-specific config directory (see table above).
+If \fBBORG_BASE_DIR\fP is set, defaults to \fB$BORG_BASE_DIR/.config/borg\fP\&.
+On Linux and macOS, \fBXDG_CONFIG_HOME\fP is also honoured if \fBBORG_BASE_DIR\fP is not set.
+This directory contains all borg configuration directories, see the FAQ
+for a security advisory about the data in this directory: \fIhome_config_borg\fP
+.TP
+.B BORG_DATA_DIR
+Defaults to the platform\-specific data directory (see table above).
+If \fBBORG_BASE_DIR\fP is set, defaults to \fB$BORG_BASE_DIR/.local/share/borg\fP\&.
+On Linux and macOS, \fBXDG_DATA_HOME\fP is also honoured if \fBBORG_BASE_DIR\fP is not set.
+This directory contains all borg data directories, see the FAQ
+for a security advisory about the data in this directory: \fIhome_data_borg\fP
+.TP
+.B BORG_RUNTIME_DIR
+Defaults to the platform\-specific runtime directory (see table above).
+If \fBBORG_BASE_DIR\fP is set, defaults to \fB$BORG_BASE_DIR/.cache/borg\fP\&.
+On Linux and macOS, \fBXDG_RUNTIME_DIR\fP is also honoured if \fBBORG_BASE_DIR\fP is not set.
+This directory contains borg runtime files, like e.g. the socket file.
+.TP
+.B BORG_SECURITY_DIR
+Defaults to \fB$BORG_DATA_DIR/security\fP\&.
+This directory contains security relevant data.
+.TP
+.B BORG_KEYS_DIR
+Defaults to \fB$BORG_CONFIG_DIR/keys\fP\&.
+This directory contains keys for encrypted repositories.
+.TP
+.B BORG_KEY_FILE
+When set, use the given path as repository key file. Please note that this is only
+for rather special applications that externally fully manage the key files:
+.INDENT 7.0
+.IP \(bu 2
+this setting only applies to the keyfile modes (not to the repokey modes).
+.IP \(bu 2
+using a full, absolute path to the key file is recommended.
+.IP \(bu 2
+all directories in the given path must exist.
+.IP \(bu 2
+this setting forces borg to use the key file at the given location.
+.IP \(bu 2
+the key file must either exist (for most commands) or will be created (\fBborg repo\-create\fP).
+.IP \(bu 2
+you need to give a different path for different repositories.
+.IP \(bu 2
+you need to point to the correct key file matching the repository the command will operate on.
+.UNINDENT
+.TP
+.B TMPDIR
+This is where temporary files are stored (might need a lot of temporary space for some
+operations), see \%<https://\:docs\:.python\:.org/\:3/\:library/\:tempfile\:.html#\:tempfile\:.gettempdir>
+for details.
+.UNINDENT
+.TP
+.B Building:
+.INDENT 7.0
+.TP
+.B BORG_OPENSSL_NAME
+Defines the subdirectory name for OpenSSL (setup.py).
+.TP
+.B BORG_OPENSSL_PREFIX
+Adds given OpenSSL header file directory to the default locations (setup.py).
+.TP
+.B BORG_LIBACL_PREFIX
+Adds given prefix directory to the default locations. If an \(aqinclude/acl/libacl.h\(aq is found
+Borg will be linked against the system libacl instead of a bundled implementation. (setup.py)
+.TP
+.B BORG_LIBLZ4_PREFIX
+Adds given prefix directory to the default locations. If a \(aqinclude/lz4.h\(aq is found Borg
+will be linked against the system liblz4 instead of a bundled implementation. (setup.py)
+.UNINDENT
+.TP
+.B Automatic option environment variables:
+Borg uses jsonargparse (\%<https://\:jsonargparse\:.readthedocs\:.io/>) with \fBdefault_env=True\fP,
+which means that every command\-line option can also be set via an environment variable.
+.sp
+The environment variable name is derived from the program name (\fBborg\fP),
+the subcommand (if any), and the option name, all converted to uppercase
+with dashes replaced by underscores.
+.sp
+For \fBtop\-level options\fP (not specific to a subcommand), the pattern is:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_<OPTION>
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+For example, \fB\-\-lock\-wait\fP can be set via \fBBORG_LOCK_WAIT\fP\&.
+.sp
+For \fBsubcommand options\fP, the subcommand and option are separated by a
+double underscore:
+.INDENT 7.0
+.INDENT 3.5
+.sp
+.EX
+BORG_<SUBCOMMAND>__<OPTION>
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+For example, \fBborg create \-\-comment\fP can be set via \fBBORG_CREATE__COMMENT\fP\&.
+.UNINDENT
+.sp
+Please note:
+.INDENT 0.0
+.IP \(bu 2
+Be very careful when using the \(dqyes\(dq sayers, the warnings with prompt exist for your / your data\(aqs security/safety.
+.IP \(bu 2
+Also be very careful when putting your passphrase into a script, make sure it has appropriate file permissions (e.g.
+mode 600, root:root).
+.UNINDENT
+.SH Author
+The Borg Collective
+.\" End of generated man page.


### PR DESCRIPTION
PR #10063 added the `borg help environment` topic, and `scripts/make.py build_man` generates `docs/man/borg-environment.1` since then — but the generated man page was never committed, so it was missing from the repo (and thus from releases).

Add the generated page (built via `scripts/make.py build_man` on current master; all other pages' regeneration churn reverted, this PR only adds the new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)