### PR TITLE
find: search files across archives

### DIFF
--- a/docs/man/borg-find.1
+++ b/docs/man/borg-find.1
@@ -1,0 +1,259 @@
+.\" Man page generated from reStructuredText
+.\" by the Docutils 0.22.4 manpage writer.
+.
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.TH "borg-find" "1" "2026-08-14" "" "borg backup tool"
+.SH Name
+borg-find \- Find files across archives.
+.SH SYNOPSIS
+.sp
+borg [common options] find [options] [PATH...]
+.SH DESCRIPTION
+.sp
+This command finds files matching the given paths or patterns in the archives
+selected by the usual archive filter options (all archives, if no filters are
+given). It iterates over the matching archives from newest to oldest, over all
+items of each archive, and outputs one line per match, like \fBborg list\fP, but
+prefixed with a short archive ID and the archive name. As the archives of a
+series all share the same name, only the archive ID uniquely identifies the
+archive.
+.sp
+This makes it easy to answer questions like \(dqwhich archives contain this file?\(dq
+or \(dqwhere did that file end up?\(dq:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+$ borg find home/user/file.txt          # in which archives is this file?
+$ borg find \(aqsh:**/*.jpg\(aq \-\-last 3      # all jpg files in the last 3 archives
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+The given PATHs match like in \fBborg list\fP or \fBborg extract\fP: a plain path
+matches the item with that path as well as everything below it, and the pattern
+styles (\fBfm:\fP, \fBsh:\fP, \fBre:\fP, \fBpp:\fP, \fBpf:\fP) are supported as well.
+For more help on include/exclude patterns, see the output of \fIborg_patterns\fP\&.
+.sp
+Note: there is no extra index for the file paths, so this command reads the
+metadata of all selected archives, which may take a while for many/big archives.
+.SH OPTIONS
+.sp
+See \fIborg\-common(1)\fP for common options of Borg commands.
+.SS arguments
+.INDENT 0.0
+.TP
+.B PATH
+paths to find; patterns are supported
+.UNINDENT
+.SS options
+.INDENT 0.0
+.TP
+.BI \-\-format \ FORMAT
+specify format for file listing (default: \(dq{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}\(dq)
+.TP
+.B  \-\-json\-lines
+Format output as JSON Lines. The form of \fB\-\-format\fP is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text.
+.UNINDENT
+.SS Archive filters
+.INDENT 0.0
+.TP
+.BI \-a \ PATTERN\fR,\fB \ \-\-match\-archives \ PATTERN
+only consider archives matching all patterns. See \(dqborg help match\-archives\(dq.
+.TP
+.BI \-\-sort\-by \ KEYS
+Comma\-separated list of sorting keys; valid keys are: timestamp, archive, name, id, tags, host, user; default is: timestamp
+.TP
+.BI \-\-first \ N
+consider the first N archives after other filters are applied
+.TP
+.BI \-\-last \ N
+consider the last N archives after other filters are applied
+.TP
+.BI \-\-oldest \ TIMESPAN
+consider archives between the oldest archive\(aqs timestamp and (oldest + TIMESPAN), e.g., 7d or 12m.
+.TP
+.BI \-\-newest \ TIMESPAN
+consider archives between the newest archive\(aqs timestamp and (newest \- TIMESPAN), e.g., 7d or 12m.
+.TP
+.BI \-\-older \ TIMESPAN
+consider archives older than (now \- TIMESPAN), e.g., 7d or 12m.
+.TP
+.BI \-\-newer \ TIMESPAN
+consider archives newer than (now \- TIMESPAN), e.g., 7d or 12m.
+.UNINDENT
+.SS Include/Exclude options
+.INDENT 0.0
+.TP
+.BI \-e \ PATTERN\fR,\fB \ \-\-exclude \ PATTERN
+exclude paths matching PATTERN
+.TP
+.BI \-\-exclude\-from \ EXCLUDEFILE
+read exclude patterns from EXCLUDEFILE, one per line
+.TP
+.BI \-\-pattern \ PATTERN
+include/exclude paths matching PATTERN
+.TP
+.BI \-\-patterns\-from \ PATTERNFILE
+read include/exclude patterns from PATTERNFILE, one per line
+.UNINDENT
+.SH EXAMPLES
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+# In which archives is this file? Searched / printed from newest to oldest archive.
+$ borg find home/user/file.txt
+41a2ed21 docs \-rw\-rw\-r\-\- user   user       1522 Sun, 2022\-02\-06 21:02:18 home/user/file.txt
+20e70e3a docs \-rw\-rw\-r\-\- user   user       1440 Sun, 2022\-01\-30 20:47:32 home/user/file.txt
+
+# Find all jpg files in the last 3 archives.
+$ borg find \(aqsh:**/*.jpg\(aq \-\-last 3
+39c8956e photos \-rw\-rw\-r\-\- user   user     919337 Sat, 2022\-01\-01 14:20:21 photos/paris/eiffel.jpg
+39c8956e photos \-rw\-rw\-r\-\- user   user    1023881 Sun, 2022\-02\-06 09:12:44 photos/rome/colosseum.jpg
+04061a53 photos \-rw\-rw\-r\-\- user   user     919337 Sat, 2022\-01\-01 14:20:21 photos/paris/eiffel.jpg
+
+# Only print the archive and the path, nothing else.
+$ borg find \-\-format \(aq{archiveid:.8} {archivename} {path}{NL}\(aq home/user/file.txt
+41a2ed21 docs home/user/file.txt
+20e70e3a docs home/user/file.txt
+.EE
+.UNINDENT
+.UNINDENT
+.SH NOTES
+.SS The FORMAT specifier syntax
+.sp
+The \fB\-\-format\fP option uses Python\(aqs format string syntax \%<https://\:docs\:.python\:.org/\:3\:.11/\:library/\:string\:.html#\:formatstrings>\&.
+.sp
+Examples:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+# only print the archive and the path, nothing else
+$ borg find \-\-format \(aq{archiveid:.8} {archivename} {path}{NL}\(aq \(aqsh:**/*.jpg\(aq
+20e70e3a photos photos/paris/eiffel.jpg
+\&...
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+{archiveid:.8} prints a short archive ID (use {archiveid} for the full ID),
+{archivename} the archive name (the archives of a series all share the name).
+.sp
+The following keys are always available:
+\- NEWLINE: OS dependent line separator
+\- NL: alias of NEWLINE
+\- NUL: NUL character for creating print0 / xargs \-0 like output
+\- SPACE: space character
+\- TAB: tab character
+\- CR: carriage return character
+\- LF: line feed character
+.sp
+Keys available only when finding files in an archive:
+.INDENT 0.0
+.IP \(bu 2
+type: file type (file, dir, symlink, ...)
+.IP \(bu 2
+mode: file mode (as in stat)
+.IP \(bu 2
+uid: user id of file owner
+.IP \(bu 2
+gid: group id of file owner
+.IP \(bu 2
+user: user name of file owner
+.IP \(bu 2
+group: group name of file owner
+.IP \(bu 2
+path: file path
+.IP \(bu 2
+target: link target for symlinks
+.IP \(bu 2
+hlid: hard link identity (same if hardlinking same fs object)
+.IP \(bu 2
+inode: inode number
+.IP \(bu 2
+flags: file flags
+.IP \(bu 2
+size: file size
+.IP \(bu 2
+num_chunks: number of chunks in this file
+.IP \(bu 2
+mtime: file modification time
+.IP \(bu 2
+ctime: file change time
+.IP \(bu 2
+atime: file access time
+.IP \(bu 2
+isomtime: file modification time (ISO 8601 format)
+.IP \(bu 2
+isoctime: file change time (ISO 8601 format)
+.IP \(bu 2
+isoatime: file access time (ISO 8601 format)
+.IP \(bu 2
+fingerprint: Fingerprint of the file content (may have false negatives), format: H(conditions)\-H(chunk_ids)
+.IP \(bu 2
+blake2b
+.IP \(bu 2
+blake2s
+.IP \(bu 2
+blake3
+.IP \(bu 2
+md5
+.IP \(bu 2
+sha1
+.IP \(bu 2
+sha224
+.IP \(bu 2
+sha256
+.IP \(bu 2
+sha384
+.IP \(bu 2
+sha3_224
+.IP \(bu 2
+sha3_256
+.IP \(bu 2
+sha3_384
+.IP \(bu 2
+sha3_512
+.IP \(bu 2
+sha512
+.IP \(bu 2
+archiveid: internal ID of the archive
+.IP \(bu 2
+archivename: name of the archive
+.IP \(bu 2
+extra: prepends {target} with \(dq \-> \(dq for soft links and \(dq link to \(dq for hard links
+.UNINDENT
+.SH SEE ALSO
+.sp
+\fIborg\-common(1)\fP
+.SH Author
+The Borg Collective
+.\" End of generated man page.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,7 @@ Usage
    usage/extract
    usage/check
    usage/list
+   usage/find
    usage/tag
    usage/rename
    usage/diff

--- a/docs/usage/find.rst
+++ b/docs/usage/find.rst
@@ -1,0 +1,21 @@
+.. include:: find.rst.inc
+
+Examples
+~~~~~~~~
+::
+
+    # In which archives is this file? Searched / printed from newest to oldest archive.
+    $ borg find home/user/file.txt
+    41a2ed21 docs -rw-rw-r-- user   user       1522 Sun, 2022-02-06 21:02:18 home/user/file.txt
+    20e70e3a docs -rw-rw-r-- user   user       1440 Sun, 2022-01-30 20:47:32 home/user/file.txt
+
+    # Find all jpg files in the last 3 archives.
+    $ borg find 'sh:**/*.jpg' --last 3
+    39c8956e photos -rw-rw-r-- user   user     919337 Sat, 2022-01-01 14:20:21 photos/paris/eiffel.jpg
+    39c8956e photos -rw-rw-r-- user   user    1023881 Sun, 2022-02-06 09:12:44 photos/rome/colosseum.jpg
+    04061a53 photos -rw-rw-r-- user   user     919337 Sat, 2022-01-01 14:20:21 photos/paris/eiffel.jpg
+
+    # Only print the archive and the path, nothing else.
+    $ borg find --format '{archiveid:.8} {archivename} {path}{NL}' home/user/file.txt
+    41a2ed21 docs home/user/file.txt
+    20e70e3a docs home/user/file.txt

--- a/docs/usage/find.rst.inc
+++ b/docs/usage/find.rst.inc
@@ -1,0 +1,194 @@
+.. IMPORTANT: this file is auto-generated from borg's built-in help, do not edit!
+
+.. _borg_find:
+
+borg find
+---------
+.. code-block:: none
+
+    borg [common options] find [options] [PATH...]
+
+.. only:: html
+
+    .. class:: borg-options-table
+
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | **positional arguments**                                                                                                                                                                                                                                                                                           |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``PATH``                                     | paths to find; patterns are supported                                                                                                                                                 |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | **options**                                                                                                                                                                                                                                                                                                        |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--format FORMAT``                          | specify format for file listing (default: "{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")                                                |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--json-lines``                             | Format output as JSON Lines. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text. |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | .. class:: borg-common-opt-ref                                                                                                                                                                                                                                                                                     |
+    |                                                                                                                                                                                                                                                                                                                    |
+    | :ref:`common_options`                                                                                                                                                                                                                                                                                              |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | **Archive filters** — Archive filters can be applied to repository targets.                                                                                                                                                                                                                                        |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``-a PATTERN``, ``--match-archives PATTERN`` | only consider archives matching all patterns. See "borg help match-archives".                                                                                                         |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--sort-by KEYS``                           | Comma-separated list of sorting keys; valid keys are: timestamp, archive, name, id, tags, host, user; default is: timestamp                                                           |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--first N``                                | consider the first N archives after other filters are applied                                                                                                                         |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--last N``                                 | consider the last N archives after other filters are applied                                                                                                                          |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--oldest TIMESPAN``                        | consider archives between the oldest archive's timestamp and (oldest + TIMESPAN), e.g., 7d or 12m.                                                                                    |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--newest TIMESPAN``                        | consider archives between the newest archive's timestamp and (newest - TIMESPAN), e.g., 7d or 12m.                                                                                    |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--older TIMESPAN``                         | consider archives older than (now - TIMESPAN), e.g., 7d or 12m.                                                                                                                       |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--newer TIMESPAN``                         | consider archives newer than (now - TIMESPAN), e.g., 7d or 12m.                                                                                                                       |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | **Include/Exclude options**                                                                                                                                                                                                                                                                                        |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``-e PATTERN``, ``--exclude PATTERN``        | exclude paths matching PATTERN                                                                                                                                                        |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--exclude-from EXCLUDEFILE``               | read exclude patterns from EXCLUDEFILE, one per line                                                                                                                                  |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--pattern PATTERN``                        | include/exclude paths matching PATTERN                                                                                                                                                |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                             | ``--patterns-from PATTERNFILE``              | read include/exclude patterns from PATTERNFILE, one per line                                                                                                                          |
+    +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+    .. raw:: html
+
+        <script type='text/javascript'>
+        $(document).ready(function () {
+            $('.borg-options-table colgroup').remove();
+        })
+        </script>
+
+.. only:: latex
+
+    PATH
+        paths to find; patterns are supported
+
+
+    options
+        --format FORMAT    specify format for file listing (default: "{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")
+        --json-lines     Format output as JSON Lines. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text.
+
+
+    :ref:`common_options`
+        |
+
+    Archive filters
+        -a PATTERN, --match-archives PATTERN     only consider archives matching all patterns. See "borg help match-archives".
+        --sort-by KEYS                           Comma-separated list of sorting keys; valid keys are: timestamp, archive, name, id, tags, host, user; default is: timestamp
+        --first N                                consider the first N archives after other filters are applied
+        --last N                                 consider the last N archives after other filters are applied
+        --oldest TIMESPAN                        consider archives between the oldest archive's timestamp and (oldest + TIMESPAN), e.g., 7d or 12m.
+        --newest TIMESPAN                        consider archives between the newest archive's timestamp and (newest - TIMESPAN), e.g., 7d or 12m.
+        --older TIMESPAN                         consider archives older than (now - TIMESPAN), e.g., 7d or 12m.
+        --newer TIMESPAN                         consider archives newer than (now - TIMESPAN), e.g., 7d or 12m.
+
+
+    Include/Exclude options
+        -e PATTERN, --exclude PATTERN     exclude paths matching PATTERN
+        --exclude-from EXCLUDEFILE        read exclude patterns from EXCLUDEFILE, one per line
+        --pattern PATTERN                 include/exclude paths matching PATTERN
+        --patterns-from PATTERNFILE       read include/exclude patterns from PATTERNFILE, one per line
+
+
+Description
+~~~~~~~~~~~
+
+This command finds files matching the given paths or patterns in the archives
+selected by the usual archive filter options (all archives, if no filters are
+given). It iterates over the matching archives from newest to oldest, over all
+items of each archive, and outputs one line per match, like ``borg list``, but
+prefixed with a short archive ID and the archive name. As the archives of a
+series all share the same name, only the archive ID uniquely identifies the
+archive.
+
+This makes it easy to answer questions like "which archives contain this file?"
+or "where did that file end up?"::
+
+    $ borg find home/user/file.txt          # in which archives is this file?
+    $ borg find 'sh:**/*.jpg' --last 3      # all jpg files in the last 3 archives
+
+The given PATHs match like in ``borg list`` or ``borg extract``: a plain path
+matches the item with that path as well as everything below it, and the pattern
+styles (``fm:``, ``sh:``, ``re:``, ``pp:``, ``pf:``) are supported as well.
+For more help on include/exclude patterns, see the output of :ref:`borg_patterns`.
+
+Note: there is no extra index for the file paths, so this command reads the
+metadata of all selected archives, which may take a while for many/big archives.
+
+.. man NOTES
+
+The FORMAT specifier syntax
++++++++++++++++++++++++++++
+
+The ``--format`` option uses Python's `format string syntax
+<https://docs.python.org/3.11/library/string.html#formatstrings>`_.
+
+Examples:
+::
+
+    # only print the archive and the path, nothing else
+    $ borg find --format '{archiveid:.8} {archivename} {path}{NL}' 'sh:**/*.jpg'
+    20e70e3a photos photos/paris/eiffel.jpg
+    ...
+
+{archiveid:.8} prints a short archive ID (use {archiveid} for the full ID),
+{archivename} the archive name (the archives of a series all share the name).
+
+The following keys are always available:
+- NEWLINE: OS dependent line separator
+- NL: alias of NEWLINE
+- NUL: NUL character for creating print0 / xargs -0 like output
+- SPACE: space character
+- TAB: tab character
+- CR: carriage return character
+- LF: line feed character
+
+
+Keys available only when finding files in an archive:
+
+- type: file type (file, dir, symlink, ...)
+- mode: file mode (as in stat)
+- uid: user id of file owner
+- gid: group id of file owner
+- user: user name of file owner
+- group: group name of file owner
+- path: file path
+- target: link target for symlinks
+- hlid: hard link identity (same if hardlinking same fs object)
+- inode: inode number
+- flags: file flags
+
+- size: file size
+- num_chunks: number of chunks in this file
+
+- mtime: file modification time
+- ctime: file change time
+- atime: file access time
+- isomtime: file modification time (ISO 8601 format)
+- isoctime: file change time (ISO 8601 format)
+- isoatime: file access time (ISO 8601 format)
+
+- fingerprint: Fingerprint of the file content (may have false negatives), format: H(conditions)-H(chunk_ids)
+- blake2b
+- blake2s
+- blake3
+- md5
+- sha1
+- sha224
+- sha256
+- sha384
+- sha3_224
+- sha3_256
+- sha3_384
+- sha3_512
+- sha512
+
+- archiveid: internal ID of the archive
+- archivename: name of the archive
+- extra: prepends {target} with " -> " for soft links and " link to " for hard links

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -288,6 +288,8 @@ General:
 Output formatting:
     BORG_CHECK_FORMAT
         Giving the default value for ``borg check --format=X``.
+    BORG_FIND_FORMAT
+        Giving the default value for ``borg find --format=X``.
     BORG_LIST_FORMAT
         Giving the default value for ``borg list --format=X``.
     BORG_REPO_LIST_FORMAT

--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -74,6 +74,7 @@ from .debug_cmd import DebugMixIn
 from .delete_cmd import DeleteMixIn
 from .diff_cmd import DiffMixIn
 from .extract_cmd import ExtractMixIn
+from .find_cmd import FindMixIn
 from .help_cmd import HelpMixIn
 from .info_cmd import InfoMixIn
 from .key_cmds import KeysMixIn
@@ -109,6 +110,7 @@ class Archiver(
     DeleteMixIn,
     DiffMixIn,
     ExtractMixIn,
+    FindMixIn,
     HelpMixIn,
     InfoMixIn,
     KeysMixIn,
@@ -301,6 +303,7 @@ class Archiver(
         self.build_parser_delete(subparsers, common_parser, mid_common_parser)
         self.build_parser_diff(subparsers, common_parser, mid_common_parser)
         self.build_parser_extract(subparsers, common_parser, mid_common_parser)
+        self.build_parser_find(subparsers, common_parser, mid_common_parser)
         self.build_parser_help(subparsers, common_parser, mid_common_parser, parser)
         self.build_parser_info(subparsers, common_parser, mid_common_parser)
         self.build_parser_keys(subparsers, common_parser, mid_common_parser)

--- a/src/borg/archiver/find_cmd.py
+++ b/src/borg/archiver/find_cmd.py
@@ -1,0 +1,134 @@
+import os
+import textwrap
+import sys
+
+from ._common import with_repository, build_matcher, define_archive_filters_group, Highlander
+from ..archive import Archive
+from ..cache import Cache
+from ..constants import *  # NOQA
+from ..helpers import ItemFormatter, BaseFormatter, PathSpec
+from ..helpers.argparsing import ArgumentParser
+from ..manifest import Manifest
+
+from ..logger import create_logger
+
+logger = create_logger()
+
+
+class FindMixIn:
+    @with_repository(compatibility=(Manifest.Operation.READ,))
+    def do_find(self, args, repository, manifest):
+        """Find files across archives."""
+        matcher = build_matcher(args.patterns, args.paths)
+        if args.format is not None:
+            format = args.format
+        else:
+            format = os.environ.get(
+                "BORG_FIND_FORMAT",
+                "{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}",
+            )
+        # check the format before doing any work with it (also: the ItemFormatter is only built later)
+        ItemFormatter.validate_format(format)
+
+        archive_infos = manifest.archives.list_considering(args, reverse=True)
+        num_archives = len(archive_infos)
+
+        def _find_inner(cache):
+            for i, info in enumerate(archive_infos):
+                logger.info(f"Searching archive {info.name} {info.ts.astimezone()} ({i + 1}/{num_archives})")
+                archive = Archive(manifest, info.id, cache=cache)
+                formatter = ItemFormatter(archive, format)
+                for item in archive.iter_items(lambda item: matcher.match(item.path)):
+                    sys.stdout.write(formatter.format_item(item, args.json_lines, sort=True))
+
+        # Only load the cache if it will be used
+        if ItemFormatter.format_needs_cache(format):
+            with Cache(repository, manifest) as cache:
+                _find_inner(cache)
+        else:
+            _find_inner(cache=None)
+
+    def build_parser_find(self, subparsers, common_parser, mid_common_parser):
+        from ._common import process_epilog, define_exclusion_group
+
+        find_epilog = (
+            process_epilog(
+                """
+        This command finds files matching the given paths or patterns in the archives
+        selected by the usual archive filter options (all archives, if no filters are
+        given). It iterates over the matching archives from newest to oldest, over all
+        items of each archive, and outputs one line per match, like ``borg list``, but
+        prefixed with a short archive ID and the archive name. As the archives of a
+        series all share the same name, only the archive ID uniquely identifies the
+        archive.
+
+        This makes it easy to answer questions like "which archives contain this file?"
+        or "where did that file end up?"::
+
+            $ borg find home/user/file.txt          # in which archives is this file?
+            $ borg find 'sh:**/*.jpg' --last 3      # all jpg files in the last 3 archives
+
+        The given PATHs match like in ``borg list`` or ``borg extract``: a plain path
+        matches the item with that path as well as everything below it, and the pattern
+        styles (``fm:``, ``sh:``, ``re:``, ``pp:``, ``pf:``) are supported as well.
+        For more help on include/exclude patterns, see the output of :ref:`borg_patterns`.
+
+        Note: there is no extra index for the file paths, so this command reads the
+        metadata of all selected archives, which may take a while for many/big archives.
+
+        .. man NOTES
+
+        The FORMAT specifier syntax
+        +++++++++++++++++++++++++++
+
+        The ``--format`` option uses Python's `format string syntax
+        <https://docs.python.org/3.11/library/string.html#formatstrings>`_.
+
+        Examples:
+        ::
+
+            # only print the archive and the path, nothing else
+            $ borg find --format '{archiveid:.8} {archivename} {path}{NL}' 'sh:**/*.jpg'
+            20e70e3a photos photos/paris/eiffel.jpg
+            ...
+
+        {archiveid:.8} prints a short archive ID (use {archiveid} for the full ID),
+        {archivename} the archive name (the archives of a series all share the name).
+
+        The following keys are always available:
+
+        """
+            )
+            + BaseFormatter.keys_help()
+            + textwrap.dedent(
+                """
+
+        Keys available only when finding files in an archive:
+
+        """
+            )
+            + ItemFormatter.keys_help()
+        )
+        subparser = ArgumentParser(parents=[common_parser], description=self.do_find.__doc__, epilog=find_epilog)
+        subparsers.add_subcommand("find", subparser, help="find files across archives")
+        subparser.add_argument(
+            "--format",
+            metavar="FORMAT",
+            dest="format",
+            action=Highlander,
+            help="specify format for file listing (default: "
+            '"{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}")',
+        )
+        subparser.add_argument(
+            "--json-lines",
+            action="store_true",
+            help="Format output as JSON Lines. "
+            "The form of ``--format`` is ignored, "
+            "but keys used in it are added to the JSON output. "
+            "Some keys are always present. Note: JSON can only represent text.",
+        )
+        subparser.add_argument(
+            "paths", metavar="PATH", nargs="*", type=PathSpec, help="paths to find; patterns are supported"
+        )
+        define_archive_filters_group(subparser)
+        define_exclusion_group(subparser)

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -870,6 +870,8 @@ class HelpMixIn:
         Output formatting:
             BORG_CHECK_FORMAT
                 Giving the default value for ``borg check --format=X``.
+            BORG_FIND_FORMAT
+                Giving the default value for ``borg find --format=X``.
             BORG_LIST_FORMAT
                 Giving the default value for ``borg list --format=X``.
             BORG_REPO_LIST_FORMAT

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -120,7 +120,7 @@ class ArchivesInterface(Protocol):  # pragma: no cover
         newest=None,
         deleted=False,
     ): ...
-    def list_considering(self, args): ...
+    def list_considering(self, args, *, reverse=False): ...
     def get_one(self, match, *, match_end=r"\Z", deleted=False): ...
 
 
@@ -413,7 +413,7 @@ class Archives:
             archive_infos.reverse()
         return archive_infos
 
-    def list_considering(self, args):
+    def list_considering(self, args, *, reverse=False):
         """
         get a list of archives, considering --first/last/prefix/match-archives/sort cmdline args
         """
@@ -424,6 +424,7 @@ class Archives:
             )
         return self.list(
             sort_by=args.sort_by.split(","),
+            reverse=reverse,
             match=args.match_archives,
             first=getattr(args, "first", None),
             last=getattr(args, "last", None),

--- a/src/borg/testsuite/archiver/find_cmd_test.py
+++ b/src/borg/testsuite/archiver/find_cmd_test.py
@@ -1,0 +1,132 @@
+import json
+
+from ...constants import *  # NOQA
+from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
+
+pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
+
+# terse format for tests that only care about which archives/items matched
+FMT = "{archiveid:.8} {archivename} {path}{NL}"
+
+
+def short_ids(archiver):
+    """map archive name -> short (8 hex digits) archive id, as printed by the default find output"""
+    output = cmd(archiver, "repo-list", "--json")
+    return {archive["name"]: archive["id"][:8] for archive in json.loads(output)["archives"]}
+
+
+def test_find_basic(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "archive1", "input")
+    create_regular_file(archiver.input_path, "file2", size=1024)
+    cmd(archiver, "create", "archive2", "input")
+    ids = short_ids(archiver)
+
+    # file1 is in both archives, output ordered from newest to oldest archive.
+    output = cmd(archiver, "find", "input/file1", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive2']} archive2 input/file1", f"{ids['archive1']} archive1 input/file1"]
+
+    # file2 is only in the second archive.
+    output = cmd(archiver, "find", "input/file2", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive2']} archive2 input/file2"]
+
+    # a path matches itself and everything below it.
+    output = cmd(archiver, "find", "input", "--format", FMT)
+    lines = output.splitlines()
+    # ordered by archive; within one archive, the items come in the order stored in the archive.
+    assert lines[0] == f"{ids['archive2']} archive2 input"
+    assert set(lines[1:3]) == {f"{ids['archive2']} archive2 input/file1", f"{ids['archive2']} archive2 input/file2"}
+    assert lines[3:] == [f"{ids['archive1']} archive1 input", f"{ids['archive1']} archive1 input/file1"]
+
+    # without any PATH, all items of all archives match.
+    assert cmd(archiver, "find", "--format", FMT) == output
+
+    # no match: no output.
+    output = cmd(archiver, "find", "input/does-not-exist", "--format", FMT)
+    assert output == ""
+
+
+def test_find_patterns(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "dir1/file.jpg", size=1)
+    create_regular_file(archiver.input_path, "dir2/file.txt", size=1)
+    cmd(archiver, "create", "archive1", "input")
+    ids = short_ids(archiver)
+
+    output = cmd(archiver, "find", "sh:**/*.jpg", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive1']} archive1 input/dir1/file.jpg"]
+
+    output = cmd(archiver, "find", "fm:*.txt", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive1']} archive1 input/dir2/file.txt"]
+
+    output = cmd(archiver, "find", "input", "--exclude", "sh:**/*.jpg", "--format", FMT)
+    assert "file.jpg" not in output
+    assert f"{ids['archive1']} archive1 input/dir2/file.txt" in output
+
+    output = cmd(archiver, "find", "--pattern", "+ re:\\.jpg$", "--pattern", "- re:^.*$", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive1']} archive1 input/dir1/file.jpg"]
+
+
+def test_find_archive_filters(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "archive1", "input")
+    cmd(archiver, "create", "archive2", "input")
+    ids = short_ids(archiver)
+
+    output = cmd(archiver, "find", "input/file1", "--last", "1", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive2']} archive2 input/file1"]
+
+    output = cmd(archiver, "find", "input/file1", "--first", "1", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive1']} archive1 input/file1"]
+
+    output = cmd(archiver, "find", "input/file1", "-a", "archive1", "--format", FMT)
+    assert output.splitlines() == [f"{ids['archive1']} archive1 input/file1"]
+
+
+def test_find_default_format(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "archive1", "input")
+    cmd(archiver, "create", "archive2", "input")
+    ids = short_ids(archiver)
+
+    # the default format is the borg list default format with "{archiveid:.8} {archivename} " prepended.
+    find_output = cmd(archiver, "find", "input/file1")
+    expected = []
+    for name in ("archive2", "archive1"):  # newest to oldest
+        for line in cmd(archiver, "list", name, "input/file1").splitlines():
+            expected.append(f"{ids[name]} {name} {line}")
+    assert find_output.splitlines() == expected
+
+
+def test_find_format(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "archive1", "input")
+
+    output = cmd(archiver, "find", "input/file1", "--format", "{size} {path}{NL}")
+    assert output.splitlines() == ["1024 input/file1"]
+
+
+def test_find_json_lines(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "archive1", "input")
+    cmd(archiver, "create", "archive2", "input")
+    ids = short_ids(archiver)
+
+    output = cmd(archiver, "find", "input/file1", "--json-lines")
+    rows = [json.loads(line) for line in output.splitlines()]
+    # the default format contains {archiveid} and {archivename}, so they are present in the JSON output.
+    assert [(row["archiveid"][:8], row["archivename"], row["path"]) for row in rows] == [
+        (ids["archive2"], "archive2", "input/file1"),
+        (ids["archive1"], "archive1", "input/file1"),
+    ]


### PR DESCRIPTION
Implements #9974: a `borg find` command that iterates over the archives selected by the usual archive filter options (`-a`, `--first/--last`, `--oldest/--newest`, `--older/--newer`; all archives by default) from newest to oldest, over all items of each archive, and outputs one line per match.

Output lines are formatted like `borg list` default output, but prefixed with a short archive ID and the archive name. As the archives of a series all share the same name, only the archive ID uniquely identifies the archive:

```
$ borg find home/user/file.txt          # in which archives is this file?
41a2ed21 docs -rw-rw-r-- user   user       1522 Sun, 2022-02-06 21:02:18 home/user/file.txt
20e70e3a docs -rw-rw-r-- user   user       1440 Sun, 2022-01-30 20:47:32 home/user/file.txt

$ borg find 'sh:**/*.jpg' --last 3      # all jpg files in the last 3 archives
```

Details:

- The PATH arguments match like in `borg list` / `borg extract`: a plain path matches itself and everything below it, and all pattern styles (`fm:`, `sh:`, `re:`, `pp:`, `pf:`) are supported, as are `--pattern` / `--exclude` etc.
- Output is customizable with `--format` (ItemFormatter keys; default `"{archiveid:.8} {archivename} {mode} {user:6} {group:6} {size:8} {mtime} {path}{extra}{NL}"`, overridable via `BORG_FIND_FORMAT`) and `--json-lines`.
- A progress line per archive is logged at info level.
- `Archives.list_considering()` grew a `reverse` keyword (passing through to `Archives.list()`) for the newest-to-oldest iteration.
- As discussed in the ticket, there is no extra index for file paths (keeping one up to date would cost considerable runtime and space), so the command reads the metadata of all selected archives.