### PR TITLE
compression: use zstd,-4 as the new default

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -879,7 +879,7 @@ and disk space on subsequent runs. Here what Borg does when you run ``borg creat
 - Then it checks whether this chunk is already in the repo (local hashtable lookup,
   fast). If so, the processing of the chunk is completed here. Otherwise it needs to
   process the chunk:
-- Compresses (the default lz4 is super fast)
+- Compresses (the default zstd,-4 is very fast)
 - Encrypts and authenticates (AES-OCB, usually fast if your CPU has AES acceleration as usual
   since about 10y, or chacha20-poly1305, fast pure-software crypto)
 - Transmits to repo. If the repo is remote, this usually involves an SSH connection
@@ -916,8 +916,8 @@ If you feel your Borg backup is too slow somehow, here is what you can do:
   files you have)
 - Use one of the blake2 modes for --encryption except if you positively know
   your CPU (and openssl) accelerates sha256 (then stay with hmac-sha256).
-- Don't use any expensive compression. The default is lz4 and super fast.
-  Uncompressed is often slower than lz4.
+- Don't use any expensive compression. The default is zstd,-4 and very fast.
+  Uncompressed is often slower than fast compression.
 - Just wait. You can also interrupt it and start it again as often as you like,
   it will converge against a valid "completed" state. It is starting
   from the beginning each time, but it is still faster then as it does not store

--- a/docs/man/borg-compression.1
+++ b/docs/man/borg-compression.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg-compression" "1" "2026-07-21" "" "borg backup tool"
+.TH "borg-compression" "1" "2026-08-14" "" "borg backup tool"
 .SH Name
 borg-compression \- Details regarding compression
 .SH DESCRIPTION
@@ -42,7 +42,7 @@ another backup that also uses this chunk will not change the stored chunk.
 So if you use different compression specs for the backups, whichever stores a
 chunk first determines its compression. See also \fBborg recreate\fP\&.
 .sp
-Compression is lz4 by default. If you want something else, you have to specify what you want.
+Compression is zstd,\-4 by default. If you want something else, you have to specify what you want.
 .sp
 Valid compression specifiers are:
 .INDENT 0.0
@@ -51,12 +51,19 @@ Valid compression specifiers are:
 Do not compress.
 .TP
 .B lz4
-Use lz4 compression. Very high speed, very low compression. (default)
+Use lz4 compression. Very high speed, very low compression.
 .TP
 .B zstd[,L]
-Use zstd (\(dqzstandard\(dq) compression, a modern wide\-range algorithm.
-If you do not explicitly give the compression level L (ranging from 1
+Use zstd (\(dqzstandard\(dq) compression, a modern wide\-range algorithm. (default: zstd,\-4)
+If you do not explicitly give the compression level L (ranging from \-128
 to 22), it will use level 3.
+Negative levels are zstd\(aqs \(dqfast\(dq levels (level \-N is what the zstd command
+line tool calls \-\-fast=N): they give up compression ratio for speed.
+\-1 to \-10 is the useful range for general data; going lower only pays off for
+data with long repeats (disk/VM images, database files), where it stays fast
+while still finding the big matches.
+Level 0 selects zstd\(aqs default level (3) \- for zstd it does not mean
+\(dqno compression\(dq (use \(dqnone\(dq for that), unlike for zlib below.
 .TP
 .B zlib[,L]
 Use zlib (\(dqgz\(dq) compression. Medium speed, medium compression.

--- a/docs/man/borg-create.1
+++ b/docs/man/borg-create.1
@@ -407,8 +407,11 @@ $ borg create \-\-sparse \-\-chunker\-params fixed,4194304 my\-disk my\-disk.raw
 # No compression (none)
 $ borg create \-\-compression none arch ~
 
-# Super fast, low compression (lz4, default)
+# Fast, moderate compression (zstd,\-4, default)
 $ borg create arch ~
+
+# Super fast, low compression (lz4)
+$ borg create \-\-compression lz4 arch ~
 
 # Less fast, higher compression (zlib, N = 0..9)
 $ borg create \-\-compression zlib,N arch ~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -292,12 +292,12 @@ E.g. if your crypto device supports GPG and borg calls ``gpg`` via
 Backup compression
 ------------------
 
-The default is lz4 (very fast, but low compression ratio), but other methods are
+The default is zstd,-4 (very fast, moderate compression ratio), but other methods are
 supported for different situations. Compression not only helps you save disk space,
 but will especially speed up remote backups since less data needs to be transferred.
 
 zstd is a modern compression algorithm which can be parametrized to anything between
-N=1 for highest speed (and relatively low compression) to N=22 for highest compression
+N=-128 for highest speed (and low compression) to N=22 for highest compression
 (and lower speed)::
 
     $ borg create --compression zstd,N arch ~

--- a/docs/usage/benchmark_cpu.rst.inc
+++ b/docs/usage/benchmark_cpu.rst.inc
@@ -12,15 +12,25 @@ borg benchmark cpu
 
     .. class:: borg-options-table
 
-    +-------------------------------------------------------+------------+-----------------------+
-    | **options**                                                                                |
-    +-------------------------------------------------------+------------+-----------------------+
-    |                                                       | ``--json`` | format output as JSON |
-    +-------------------------------------------------------+------------+-----------------------+
-    | .. class:: borg-common-opt-ref                                                             |
-    |                                                                                            |
-    | :ref:`common_options`                                                                      |
-    +-------------------------------------------------------+------------+-----------------------+
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    | **options**                                                                                                |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--json``        | format output as JSON          |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--chunking``    | benchmark the chunkers         |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--hashing``     | benchmark the hashes / MACs    |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--encrypting``  | benchmark the encryption modes |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--compressing`` | benchmark the compressors      |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    |                                                       | ``--msgpacking``  | benchmark msgpack item packing |
+    +-------------------------------------------------------+-------------------+--------------------------------+
+    | .. class:: borg-common-opt-ref                                                                             |
+    |                                                                                                            |
+    | :ref:`common_options`                                                                                      |
+    +-------------------------------------------------------+-------------------+--------------------------------+
 
     .. raw:: html
 
@@ -35,7 +45,12 @@ borg benchmark cpu
 
 
     options
-        --json     format output as JSON
+        --json           format output as JSON
+        --chunking       benchmark the chunkers
+        --hashing        benchmark the hashes / MACs
+        --encrypting     benchmark the encryption modes
+        --compressing    benchmark the compressors
+        --msgpacking     benchmark msgpack item packing
 
 
     :ref:`common_options`
@@ -51,3 +66,19 @@ To reduce outside influence on the timings, please make sure to run this with:
 
 - an otherwise as idle as possible machine
 - enough free memory so there will be no slow down due to paging activity
+
+By default all benchmarks run. Give one or more of --chunking, --hashing,
+--encrypting, --compressing, --msgpacking to run only those.
+
+Some algorithms use multiple threads only above a size threshold, so the
+hashes and the compressors are measured at more than one buffer size: the
+hashes at 64MiB (a borg pack) and 2MiB (a typical borg chunk), both above
+blake3's threshold, the compressors at 2MiB and 128kiB, which is below
+zstd's. Within a section every row processes the same total number of
+bytes - 1 GiB, or 10 MiB for the compressors - so the throughput column is
+comparable between rows.
+
+The compressors work on synthetic text-like data that compresses about 4x
+at zstd,3. Random data would be the worst possible input: no codec can
+compress it, so all of them would take their incompressible fast path and
+the levels would barely differ.

--- a/docs/usage/create.rst
+++ b/docs/usage/create.rst
@@ -64,8 +64,11 @@ Examples
     # No compression (none)
     $ borg create --compression none arch ~
 
-    # Super fast, low compression (lz4, default)
+    # Fast, moderate compression (zstd,-4, default)
     $ borg create arch ~
+
+    # Super fast, low compression (lz4)
+    $ borg create --compression lz4 arch ~
 
     # Less fast, higher compression (zlib, N = 0..9)
     $ borg create --compression zlib,N arch ~

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -476,7 +476,7 @@ another backup that also uses this chunk will not change the stored chunk.
 So if you use different compression specs for the backups, whichever stores a
 chunk first determines its compression. See also ``borg recreate``.
 
-Compression is lz4 by default. If you want something else, you have to specify what you want.
+Compression is zstd,-4 by default. If you want something else, you have to specify what you want.
 
 Valid compression specifiers are:
 
@@ -484,12 +484,19 @@ none
     Do not compress.
 
 lz4
-    Use lz4 compression. Very high speed, very low compression. (default)
+    Use lz4 compression. Very high speed, very low compression.
 
 zstd[,L]
-    Use zstd ("zstandard") compression, a modern wide-range algorithm.
-    If you do not explicitly give the compression level L (ranging from 1
+    Use zstd ("zstandard") compression, a modern wide-range algorithm. (default: zstd,-4)
+    If you do not explicitly give the compression level L (ranging from -128
     to 22), it will use level 3.
+    Negative levels are zstd's "fast" levels (level -N is what the zstd command
+    line tool calls --fast=N): they give up compression ratio for speed.
+    -1 to -10 is the useful range for general data; going lower only pays off for
+    data with long repeats (disk/VM images, database files), where it stays fast
+    while still finding the big matches.
+    Level 0 selects zstd's default level (3) - for zstd it does not mean
+    "no compression" (use "none" for that), unlike for zlib below.
 
 zlib[,L]
     Use zlib ("gz") compression. Medium speed, medium compression.

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -399,6 +399,7 @@ class BenchmarkMixIn:
                 number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
                 for spec in [
                     "lz4",
+                    "zstd,-4",
                     "zstd,1",
                     "zstd,3",
                     "zstd,5",

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -1183,7 +1183,7 @@ class CreateMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -483,7 +483,7 @@ class DebugMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -468,7 +468,7 @@ class HelpMixIn:
         So if you use different compression specs for the backups, whichever stores a
         chunk first determines its compression. See also ``borg recreate``.
 
-        Compression is lz4 by default. If you want something else, you have to specify what you want.
+        Compression is zstd,-4 by default. If you want something else, you have to specify what you want.
 
         Valid compression specifiers are:
 
@@ -476,10 +476,10 @@ class HelpMixIn:
             Do not compress.
 
         lz4
-            Use lz4 compression. Very high speed, very low compression. (default)
+            Use lz4 compression. Very high speed, very low compression.
 
         zstd[,L]
-            Use zstd ("zstandard") compression, a modern wide-range algorithm.
+            Use zstd ("zstandard") compression, a modern wide-range algorithm. (default: zstd,-4)
             If you do not explicitly give the compression level L (ranging from -128
             to 22), it will use level 3.
             Negative levels are zstd's "fast" levels (level -N is what the zstd command

--- a/src/borg/archiver/recreate_cmd.py
+++ b/src/borg/archiver/recreate_cmd.py
@@ -154,7 +154,7 @@ class RecreateMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )

--- a/src/borg/archiver/repo_compress_cmd.py
+++ b/src/borg/archiver/repo_compress_cmd.py
@@ -237,7 +237,7 @@ class RepoCompressMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help='select compression algorithm, see the output of the "borg help compression" command for details.',
         )

--- a/src/borg/archiver/tar_cmds.py
+++ b/src/borg/archiver/tar_cmds.py
@@ -830,7 +830,7 @@ class TarMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -373,7 +373,7 @@ class TransferMixIn:
             metavar="COMPRESSION",
             dest="compression",
             type=CompressionSpec,
-            default=CompressionSpec("lz4"),
+            default=CompressionSpec("zstd,-4"),
             action=Highlander,
             help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
         )

--- a/src/borg/testsuite/archiver/restricted_permissions_test.py
+++ b/src/borg/testsuite/archiver/restricted_permissions_test.py
@@ -83,7 +83,7 @@ def test_repository_permissions_no_delete(archivers, request, monkeypatch):
     # A dry run only reads and reports, so it is allowed even without write/delete access.
     cmd(archiver, "compact", "--dry-run")
 
-    # Try to repo-compress (and change compression from lz4 to zstd), which should fail up front:
+    # Try to repo-compress (and change compression to zstd,3), which should fail up front:
     # it rewrites (and deletes) pack files, which is disallowed by no-delete.
     with pytest.raises(Repository.PermissionDenied):
         cmd(archiver, "repo-compress", "-C", "zstd")


### PR DESCRIPTION
Makes `zstd,-4` the default compression for `create`, `recreate`, `import-tar`, `transfer`, `repo-compress` and `debug put-obj` (previously `lz4`). Fixes #10085.

### Why zstd,-4

Benchmarked on ~45 GB of real data on an M3 Pro (12 cores), with the default chunker (fastcdc, ~2 MiB target) and the current default of 4 zstd MT workers per chunk. Measured both at the compressor level (chunks fed to the compressor exactly as borg produces them) and end-to-end via `borg create` / `borg extract`. Corpora:

- **code**: four dev trees incl. their `.git` (7.6 GB, 250k chunks, 44% of bytes in small chunks < 768 KiB, i.e. no MT)
- **binaries**: a homebrew installation (11.0 GB, 219k chunks, 26% small-chunk bytes)
- **vm**: a Windows 11 qcow2 disk image (26.7 GB logical, ~17 GB allocated)
- **entropy**: synthetic 4-bit-per-byte data - no repeats, compressible only by entropy coding (5.4 GB)

Compressor level, byte-weighted (size = % of lz4's compressed size, lower is better):

| corpus | spec | speed vs lz4 | size vs lz4 |
|---|---|---|---|
| code | zstd,-4 | 1.26x | 100.2% |
| | zstd,-2 | 1.19x | 93.7% |
| | zstd,-1 | 1.13x | 91.0% |
| binaries | zstd,-4 | 1.41x | 98.6% |
| | zstd,-2 | 1.30x | 92.6% |
| | zstd,-1 | 1.27x | 90.1% |
| entropy | zstd,-4 | >= 1.2x | 100% |
| vm | zstd,-4 | 0.72x | 99.6% |

On small chunks alone (single-threaded) lz4 keeps a slight edge; big chunks flip it, as libzstd's threads engage from 768 KiB up. On the VM image lz4 stays ahead at every negative level: that image is dominated by long, easy repeats which lz4 races through at ~8 GB/s, and no zstd level changes this (they all land within 0.70x..0.74x) because the level only steers match search, which is not the limit there.

End-to-end, median of 3 interleaved iterations, fresh repo per run, `-e none-blake3`:

| corpus | spec | create | extract | repo size |
|---|---|---|---|---|
| code, 7.7 GB | lz4 | 57.3s | 86.2s | 3348 MB |
| | **zstd,-4** | **56.3s** | 91.2s | 3365 MB |
| | zstd,-2 | 56.3s | 87.4s | 3177 MB |
| | zstd,3 | 59.4s | 85.7s | 2718 MB |
| binaries, 19.0 GB | lz4 | 87.3s | 93.3s | 9539 MB |
| | **zstd,-4** | **83.5s** | 96.6s | 9402 MB |
| | zstd,-2 | 83.7s | 101.4s | 8827 MB |
| | zstd,3 | 92.7s | 101.2s | 7542 MB |
| vm, 26.7 GB | lz4 | **37.2s** | 27.0s | 17263 MB |
| | zstd,-4 | 41.2s | **25.5s** | 17196 MB |
| | zstd,3 | 43.8s | 26.1s | 17190 MB |
| entropy, 5.4 GB | lz4 | 9.3s | 5.8s | 5370 MB |
| | zstd,-4 | 9.5s | 5.8s | 5370 MB |
| | zstd,3 | 14.7s | 9.0s | 2785 MB |

`create` with zstd,-4 is faster than lz4 on both file-tree corpora (2% on code, 5% on binaries), a tie on incompressible data, and 11% slower on the VM image - at the same or smaller repo size everywhere. `extract` is 5-6% slower on the tree corpora (lz4 decompresses faster in isolation, though restore is not decompression-bound) and 6% faster on the VM image.

That matches the goal in #10085: as fast as or faster than lz4 in the common cases, MT for large chunks, good small-chunk speed, and slightly better compression thrown in. Users who back up mostly hard-to-compress images can keep lz4's edge there with `-C lz4`, `-C auto,zstd,-4` or `-C none`.

Why this level: levels below -4 buy no end-to-end speed at all (create is flat from -10 to -1, within ~2%) and only cost repo size - zstd,-10 stores 12% more than lz4 on code. Levels above -4 shrink repos further at unchanged create time, and positive levels cost real time (zstd,3: +4% create on code, +6% on binaries, +58% on entropy). `zstd,-4` is the speed-first choice, as suspected in #10085; `zstd,-2` is the ratio-leaning alternative at the same create time (repos 5-6% smaller) if that trade is preferred.

The entropy corpus also shows what the negative levels give up: they skip literal entropy coding, so data that only an entropy coder can shrink stays uncompressed for them (as for lz4), while zstd,3 halves it.

Verified functionally: after `borg create` without `-C`, a `borg repo-compress -C zstd,-4 --stats` run reports all compressible objects as "already had the desired compression".

### Changes

- all six `-C` argparse defaults: `lz4` -> `zstd,-4`
- `borg help compression`: default moved from the lz4 entry to zstd
- docs: quickstart, FAQ, create examples updated; usage/man pages regenerated
- `borg benchmark cpu`: `zstd,-4` added to the compressor list
- lz4 itself is unchanged and stays available; nothing about the repo format changes (per-chunk ctype/clevel as before)

### Tests

No test asserted the default spec; the one stale comment mentioning it was updated. CI is green; locally 2505 tests pass and the failures that remain reproduce identically on unmodified master in the same environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
