### PR TITLE
testsuite: make forked "python -m borg" run the code under test

### DIFF
--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -46,17 +46,33 @@ src_file = "archiver/__init__.py"  # relative path of one file in src_dir
 
 requires_hardlinks = pytest.mark.skipif(not are_hardlinks_supported(), reason="hard links not supported")
 
+# Parent directory of the borg package this testsuite belongs to. Forked ``python -m borg``
+# subprocesses get this prepended to PYTHONPATH so they run the same code as the testsuite,
+# not whatever borg happens to be installed in the environment (e.g. an editable install
+# pointing at another checkout would silently get tested instead of this source tree).
+borg_source_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def borg_subprocess_env():
+    # environment for spawning ``python -m borg``, see borg_source_root above.
+    env = dict(os.environ)
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = borg_source_root if not pythonpath else borg_source_root + os.pathsep + pythonpath
+    return env
+
 
 def exec_cmd(*args, archiver=None, fork=False, exe=None, input=b"", binary_output=False, **kw):
     if fork:
         try:
+            env = None
             if exe is None:
                 borg = (sys.executable, "-m", "borg")
+                env = borg_subprocess_env()
             elif isinstance(exe, str):
                 borg = (exe,)
             elif not isinstance(exe, tuple):
                 raise ValueError("exe must be None, a tuple or a str")
-            output = subprocess.check_output(borg + args, stderr=subprocess.STDOUT, input=input)
+            output = subprocess.check_output(borg + args, stderr=subprocess.STDOUT, input=input, env=env)
             ret = 0
         except subprocess.CalledProcessError as e:
             output = e.output

--- a/src/borg/testsuite/archiver/lock_cmds_test.py
+++ b/src/borg/testsuite/archiver/lock_cmds_test.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -6,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from ...constants import *  # NOQA
-from . import cmd, generate_archiver_tests, RK_ENCRYPTION
+from . import cmd, generate_archiver_tests, RK_ENCRYPTION, borg_subprocess_env
 from ...helpers import CommandError
 from ...platformflags import is_haiku, is_win32
 
@@ -22,7 +21,7 @@ def test_break_lock(archivers, request):
 @pytest.mark.skipif(is_haiku or is_win32, reason="does not find borg python module on Haiku OS and Windows")
 def test_with_lock(tmp_path):
     repo_path = tmp_path / "repo"
-    env = os.environ.copy()
+    env = borg_subprocess_env()
     env["BORG_REPO"] = Path(repo_path).as_uri()
     # test debug output:
     print("sys.path: %r" % sys.path)

--- a/src/borg/testsuite/benchmark_test.py
+++ b/src/borg/testsuite/benchmark_test.py
@@ -29,7 +29,8 @@ def repo_url(request, tmpdir, monkeypatch):
 
 @pytest.fixture(params=["none-sha256", "aes256-ocb"])
 def repo(request, cmd_fixture, repo_url):
-    cmd_fixture(f"--repo={repo_url}", "repo-create", "--encryption", request.param)
+    ret, out = cmd_fixture(f"--repo={repo_url}", "repo-create", "--encryption", request.param)
+    assert ret == 0, out
     return repo_url
 
 
@@ -61,7 +62,8 @@ def testdata(request, tmpdir_factory):
 @pytest.fixture(params=["none", "lz4"])
 def repo_archive(request, cmd_fixture, repo, testdata):
     archive = "test"
-    cmd_fixture(f"--repo={repo}", "create", "--compression", request.param, archive, testdata)
+    ret, out = cmd_fixture(f"--repo={repo}", "create", "--compression", request.param, archive, testdata)
+    assert ret == 0, out
     return repo, archive
 
 


### PR DESCRIPTION
Forked `python -m borg` subprocesses (`exec_cmd(fork=True)` and `test_with_lock`) inherited the environment unchanged, so they imported whatever borg the environment provides - e.g. an editable install pointing at another checkout - instead of the borg package the testsuite belongs to.

With a stale installed borg this made `benchmark_test.py` fail for all `none-sha256` variants after [#10095](https://github.com/borgbackup/borg/pull/10095): the `repo` fixture's `repo-create` was rejected with `invalid choice: 'none-sha256'` (rc 2, silently ignored by the fixture), and every subsequent command then failed with `Repository.DoesNotExist` (rc 13). CI does not catch this because every CI pytest invocation uses `--benchmark-skip` (and in tox runs the installed borg and the testsuite are the same code anyway).

Changes:
- `exec_cmd(fork=True)` with `exe=None` and `test_with_lock` now run the subprocess with the testsuite's own source root prepended to `PYTHONPATH` (new `borg_subprocess_env()` helper), so forked borg always runs the same code the testsuite was collected from.
- The benchmark `repo`/`repo_archive` fixtures now assert rc 0, so a failing setup command fails loudly at the source instead of cascading into confusing `DoesNotExist` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)