### PR TITLE
illumos/Solaris: add xattr support, see #1337

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,12 @@ jobs:
               export TMPDIR=/var/tmp/borg-ci
               mkdir -p "$TMPDIR"
 
+              # show whether xattrs work on the ZFS-backed TMPDIR (they are files in a
+              # hidden per-file attribute directory there, listed via runat(1))
+              touch "$TMPDIR/testfile"
+              /usr/bin/runat "$TMPDIR/testfile" ls -a && echo "*** xattrs supported on $TMPDIR ***"
+              rm "$TMPDIR/testfile"
+
               python3 -m venv .venv
               . .venv/bin/activate
               python -V

--- a/docs/usage/general/file-metadata.rst.inc
+++ b/docs/usage/general/file-metadata.rst.inc
@@ -37,7 +37,7 @@ On some platforms additional features are supported:
 +-------------------------+----------+-----------+------------+
 | NetBSD                  | n/a      | Yes       | Yes (all)  |
 +-------------------------+----------+-----------+------------+
-| Solaris and derivatives | No [2]_  | No [2]_   | n/a        |
+| Solaris and derivatives | No [2]_  | Yes       | n/a        |
 +-------------------------+----------+-----------+------------+
 | Windows (cygwin)        | No [3]_  | No        | No         |
 +-------------------------+----------+-----------+------------+

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -6,7 +6,7 @@ Public APIs are documented in platform.base.
 
 from types import ModuleType
 
-from ..platformflags import is_win32, is_linux, is_freebsd, is_netbsd, is_darwin, is_cygwin, is_haiku
+from ..platformflags import is_win32, is_linux, is_freebsd, is_netbsd, is_darwin, is_cygwin, is_haiku, is_sunos
 
 from .base import ENOATTR
 from .base import SaveFile, sync_dir, fdatasync, safe_fadvise
@@ -54,6 +54,15 @@ elif is_darwin:  # pragma: darwin only
     from .darwin import set_flags
     from .darwin import fdatasync, sync_dir  # type: ignore[no-redef]
     from .base import get_flags
+    from .base import SyncFile
+    from .posix import process_alive, local_pid_alive
+    from .posix import get_errno
+    from .posix import getosusername
+    from . import posix_ug as platform_ug
+elif is_sunos:  # pragma: sunos only
+    from .solaris import listxattr, getxattr, setxattr
+    from .base import acl_get, acl_set
+    from .base import set_flags, get_flags
     from .base import SyncFile
     from .posix import process_alive, local_pid_alive
     from .posix import get_errno

--- a/src/borg/platform/solaris.py
+++ b/src/borg/platform/solaris.py
@@ -1,0 +1,101 @@
+"""
+xattr support for illumos / Solaris and derivatives.
+
+On these platforms, the extended attributes of a file are regular files inside a hidden
+attribute directory attached to that file. The attribute directory is opened by giving
+O_XATTR to open(2)/openat(2), see fsattr(7) — xattr names/values map to the names/contents
+of the files in there. There are no xattr namespaces, so names are used verbatim.
+"""
+
+import errno
+import os
+
+from .base import ENOATTR
+
+# CPython exposes os.O_XATTR on Solaris-derived platforms; 0x4000 is its value on illumos
+# and Oracle Solaris (belt and braces in case the os module does not have it).
+O_XATTR = getattr(os, "O_XATTR", 0x4000)
+
+# "Extended system attributes" maintained by the OS inside every attribute directory
+# (e.g. on ZFS) — these are not user-set xattrs, so hide them from listing and refuse
+# to write them.
+SYSATTR_PREFIX = "SUNWattr_"
+
+# Attribute files can be arbitrarily large — refuse to read values bigger than this
+# (the other platforms' xattr support is limited alike, via their Buffer(limit=2**24)).
+XATTR_SIZE_LIMIT = 2**24
+
+
+def _open_attrdir(path, follow_symlinks):
+    # Open the hidden attribute directory of *path* (a bytes path or an open file descriptor).
+    # O_XATTR is only interpreted by openat() when looking up relative to a file descriptor
+    # referring to the file, so for a path, the file itself must be opened first.
+    if isinstance(path, int):
+        return os.open(".", os.O_RDONLY | O_XATTR, dir_fd=path)
+    flags = os.O_RDONLY | os.O_NONBLOCK  # O_NONBLOCK: do not hang on FIFOs
+    if not follow_symlinks:
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    try:
+        return os.open(".", os.O_RDONLY | O_XATTR, dir_fd=fd)
+    finally:
+        os.close(fd)
+
+
+def listxattr(path, *, follow_symlinks=False):
+    try:
+        dirfd = _open_attrdir(path, follow_symlinks)
+    except OSError as e:
+        if e.errno == errno.ELOOP:
+            # symlinks cannot have extended attributes on this platform
+            return []
+        if e.errno == errno.EINVAL:
+            # open(2): the filesystem does not support extended attributes
+            raise OSError(errno.ENOTSUP, os.strerror(errno.ENOTSUP), path) from None
+        raise
+    try:
+        names = os.listdir(dirfd)
+    finally:
+        os.close(dirfd)
+    return [os.fsencode(name) for name in names if not name.startswith(SYSATTR_PREFIX)]
+
+
+def getxattr(path, name, *, follow_symlinks=False):
+    dirfd = _open_attrdir(path, follow_symlinks)
+    try:
+        try:
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dirfd)
+        except FileNotFoundError:
+            # no attribute file with that name -> no such xattr
+            raise OSError(ENOATTR, os.strerror(ENOATTR), path) from None
+        try:
+            if os.fstat(fd).st_size > XATTR_SIZE_LIMIT:
+                raise OSError(errno.EFBIG, os.strerror(errno.EFBIG), path)
+            chunks = []
+            while chunk := os.read(fd, 2**20):
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            os.close(fd)
+    finally:
+        os.close(dirfd)
+
+
+def setxattr(path, name, value, *, follow_symlinks=False):
+    name_str = os.fsdecode(name)
+    if not name_str or "/" in name_str or "\0" in name_str or name_str in (".", ".."):
+        # such a name cannot be the name of an attribute file
+        raise OSError(errno.EINVAL, os.strerror(errno.EINVAL), path)
+    if name_str.startswith(SYSATTR_PREFIX):
+        raise OSError(errno.EPERM, os.strerror(errno.EPERM), path)
+    dirfd = _open_attrdir(path, follow_symlinks)
+    try:
+        fd = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, mode=0o644, dir_fd=dirfd)
+        try:
+            mv = memoryview(value)
+            while mv:
+                mv = mv[os.write(fd, mv) :]
+        finally:
+            os.close(fd)
+    finally:
+        os.close(dirfd)

--- a/src/borg/platformflags.py
+++ b/src/borg/platformflags.py
@@ -16,6 +16,7 @@ is_netbsd = sys.platform.startswith("netbsd")
 is_openbsd = sys.platform.startswith("openbsd")
 is_darwin = sys.platform.startswith("darwin")
 is_haiku = sys.platform.startswith("haiku")
+is_sunos = sys.platform.startswith("sunos")  # illumos and Solaris
 
 # MSYS2 (on Windows)
 is_msystem = is_win32 and "MSYSTEM" in os.environ

--- a/src/borg/testsuite/xattr_test.py
+++ b/src/borg/testsuite/xattr_test.py
@@ -4,7 +4,12 @@ import pytest
 
 from ..platform.xattr import buffer, split_lstring
 from ..xattr import is_enabled, getxattr, setxattr, listxattr, XATTR_FAKEROOT
-from ..platformflags import is_linux
+from ..platformflags import is_linux, is_sunos
+
+# Whether xattrs can be set on a symlink itself:
+# Linux does not allow setting user.* xattrs on symlinks; on illumos/Solaris,
+# symlinks cannot have extended attributes at all.
+symlink_xattrs = not is_linux and not is_sunos
 
 
 @pytest.fixture()
@@ -35,22 +40,22 @@ def test(tempfile_symlink):
     setxattr(tmp_fn, b"user.foo", b"bar")
     setxattr(tmp_fd, b"user.bar", b"foo")
     setxattr(tmp_fn, b"user.empty", b"")
-    if not is_linux:
-        # Linux does not allow setting user.* xattrs on symlinks.
+    if symlink_xattrs:
         setxattr(tmp_lfn, b"user.linkxattr", b"baz")
     assert_equal_se(listxattr(tmp_fn), [b"user.foo", b"user.bar", b"user.empty"])
     assert_equal_se(listxattr(tmp_fd), [b"user.foo", b"user.bar", b"user.empty"])
     assert_equal_se(listxattr(tmp_lfn, follow_symlinks=True), [b"user.foo", b"user.bar", b"user.empty"])
-    if not is_linux:
+    if symlink_xattrs:
         assert_equal_se(listxattr(tmp_lfn), [b"user.linkxattr"])
     assert getxattr(tmp_fn, b"user.foo") == b"bar"
     assert getxattr(tmp_fd, b"user.foo") == b"bar"
     assert getxattr(tmp_lfn, b"user.foo", follow_symlinks=True) == b"bar"
-    if not is_linux:
+    if symlink_xattrs:
         assert getxattr(tmp_lfn, b"user.linkxattr") == b"baz"
     assert getxattr(tmp_fn, b"user.empty") == b""
 
 
+@pytest.mark.skipif(is_sunos, reason="the illumos/Solaris xattr backend does not use the shared buffer")
 def test_listxattr_buffer_growth(tempfile_symlink):
     temp_file, symlink = tempfile_symlink
     tmp_fn = os.fsencode(temp_file.name)
@@ -65,6 +70,7 @@ def test_listxattr_buffer_growth(tempfile_symlink):
     assert len(buffer) > 64
 
 
+@pytest.mark.skipif(is_sunos, reason="the illumos/Solaris xattr backend does not use the shared buffer")
 def test_getxattr_buffer_growth(tempfile_symlink):
     temp_file, symlink = tempfile_symlink
     tmp_fn = os.fsencode(temp_file.name)

--- a/src/borg/xattr.py
+++ b/src/borg/xattr.py
@@ -1,4 +1,4 @@
-"""A basic extended attributes (xattr) implementation for Linux, FreeBSD and macOS."""
+"""A basic extended attributes (xattr) implementation for Linux, FreeBSD, macOS, NetBSD and illumos/Solaris."""
 
 import errno
 import os


### PR DESCRIPTION
Add xattr support for illumos / Solaris derivatives, see #1337.

On these platforms, the extended attributes of a file are regular files inside a hidden attribute directory attached to that file, accessed by giving O_XATTR to open(2)/openat(2), see fsattr(7). Thus this can be implemented in pure Python (new `src/borg/platform/solaris.py`, no C extension): xattr names/values map to the names/contents of the files in the attribute directory.

- `listxattr`: list the attribute directory, hiding the `SUNWattr_*` "extended system attributes" the OS maintains in there.
- `getxattr`: read the attribute file (missing attribute file → ENOATTR); values are limited to 16 MiB, like on the other platforms.
- `setxattr`: create/overwrite the attribute file (refusing names unusable as file names, and `SUNWattr_*`).
- symlinks cannot have extended attributes on these platforms: `listxattr` returns an empty result for them, and the set-xattr-on-symlink parts of the xattr tests are now gated accordingly.
- filesystems without xattr support (e.g. tmpfs): ENOTSUP.

With this, `xattr.is_enabled()` returns True on ZFS, so the xattr tests and the archiver tests' xattr comparisons now actually run in the omniOS CI job (its TMPDIR is ZFS-backed). The job now also probes/logs xattr support on TMPDIR via runat(1). Docs: platform support matrix updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)