### PR TITLE
chunkers: release the GIL in the AES chunkers' scan kernels

### DIFF
--- a/src/borg/chunkers/goldilocks_aes.pyx
+++ b/src/borg/chunkers/goldilocks_aes.pyx
@@ -53,7 +53,7 @@ cdef extern from "goldilocks_aes_impl.h":
     void gl_free(GL_CTX *ctx)
     const char *gl_kind(const GL_CTX *ctx)
     uint64_t gl_digest64(const GL_CTX *ctx, const uint8_t *q)
-    int64_t gl_scan(GL_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
+    int64_t gl_scan(GL_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) nogil
 
 
 # --- Goldilocks field helpers (pure Python, used at chunker setup only) ---
@@ -165,7 +165,10 @@ cdef class ChunkerGoldilocksAES(ChunkerPHTE):
             self.ctx = NULL
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:
-        return gl_scan(self.ctx, p, n, digest, mask)
+        cdef int64_t r
+        with nogil:
+            r = gl_scan(self.ctx, p, n, digest, mask)
+        return r
 
     cdef uint64_t _digest64(self, const uint8_t *q) noexcept:
         return gl_digest64(self.ctx, q)

--- a/src/borg/chunkers/rabin_aes.pyx
+++ b/src/borg/chunkers/rabin_aes.pyx
@@ -64,7 +64,7 @@ cdef extern from "rabin_aes_impl.h":
     void ra_free(RA_CTX *ctx)
     const char *ra_kind(const RA_CTX *ctx)
     uint64_t ra_digest64(const RA_CTX *ctx, const uint8_t *q)
-    int64_t ra_scan(RA_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
+    int64_t ra_scan(RA_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) nogil
 
 
 # --- GF(2)[x] polynomial helpers (pure Python, used at chunker setup only) ---
@@ -234,7 +234,10 @@ cdef class ChunkerRabinAES(ChunkerPHTE):
             self.ctx = NULL
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:
-        return ra_scan(self.ctx, p, n, digest, mask)
+        cdef int64_t r
+        with nogil:
+            r = ra_scan(self.ctx, p, n, digest, mask)
+        return r
 
     cdef uint64_t _digest64(self, const uint8_t *q) noexcept:
         return ra_digest64(self.ctx, q)

--- a/src/borg/chunkers/toeplitz_aes.pyx
+++ b/src/borg/chunkers/toeplitz_aes.pyx
@@ -57,7 +57,7 @@ cdef extern from "toeplitz_aes_impl.h":
     void tp_free(TP_CTX *ctx)
     const char *tp_kind(const TP_CTX *ctx)
     uint64_t tp_digest64(const TP_CTX *ctx, const uint8_t *q)
-    int64_t tp_scan(TP_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask)
+    int64_t tp_scan(TP_CTX *ctx, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) nogil
 
 
 # --- GF(2)[x] helpers (pure Python, used at chunker setup only) ----------
@@ -166,7 +166,10 @@ cdef class ChunkerToeplitzAES(ChunkerPHTE):
             self.ctx = NULL
 
     cdef int64_t _scan(self, const uint8_t *p, size_t n, uint64_t *digest, uint64_t mask) noexcept:
-        return tp_scan(self.ctx, p, n, digest, mask)
+        cdef int64_t r
+        with nogil:
+            r = tp_scan(self.ctx, p, n, digest, mask)
+        return r
 
     cdef uint64_t _digest64(self, const uint8_t *q) noexcept:
         return tp_digest64(self.ctx, q)


### PR DESCRIPTION
The scan kernels of the three AES-based chunkers (`ra_scan`/`gl_scan`/`tp_scan`) are pure C (OpenSSL EVP or AES hardware intrinsics, no Python API calls), but were called with the GIL held. A scan span covers up to the 8 MiB maximum chunk size, so it could block all other threads for milliseconds at a time — e.g. the PackWriter store-thread between its GIL-releasing parts.

This wraps the kernel calls in `with nogil` (and declares the externs `nogil`), the same pattern the fastcdc/buzhash/buzhash64 chunkers already use since [#10014](https://github.com/borgbackup/borg/pull/10014). This brings all chunkers to parity and is groundwork for further incremental threading along the lines of [#37](https://github.com/borgbackup/borg/issues/37) / [#929](https://github.com/borgbackup/borg/issues/929).

Chunker output and single-thread performance are unchanged. Measured with two threads chunking 64 MiB each concurrently (rabin-aes, evp kernel, macOS arm64, py3.11): wall-clock ratio vs a single thread drops from 2.02x (fully serialized) to 1.13x (parallel); single-thread time is identical (0.146 s vs 0.147 s). Verified both kernel paths (`evp` and `aes-arm64`) chunk correctly; the existing chunker tests cover cut-point identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)