### PR TITLE
docs: NetBSD xattr support is implemented, update platform feature table

### DIFF
--- a/docs/usage/general/file-metadata.rst.inc
+++ b/docs/usage/general/file-metadata.rst.inc
@@ -35,11 +35,11 @@ On some platforms additional features are supported:
 +-------------------------+----------+-----------+------------+
 | OpenBSD                 | n/a      | n/a       | Yes (all)  |
 +-------------------------+----------+-----------+------------+
-| NetBSD                  | n/a      | No [2]_   | Yes (all)  |
+| NetBSD                  | n/a      | Yes       | Yes (all)  |
 +-------------------------+----------+-----------+------------+
-| Solaris and derivatives | No [3]_  | No [3]_   | n/a        |
+| Solaris and derivatives | No [2]_  | No [2]_   | n/a        |
 +-------------------------+----------+-----------+------------+
-| Windows (cygwin)        | No [4]_  | No        | No         |
+| Windows (cygwin)        | No [3]_  | No        | No         |
 +-------------------------+----------+-----------+------------+
 
 Other Unix-like operating systems may work as well, but have not been tested yet.
@@ -49,9 +49,8 @@ For example, ntfs-3g on Linux is not able to convey NTFS ACLs.
 
 .. [1] Only "nodump", "immutable", "compressed" and "append" are supported.
     Feature request :issue:`618` for more flags.
-.. [2] Feature request :issue:`1332`
-.. [3] Feature request :issue:`1337`
-.. [4] Cygwin tries to map NTFS ACLs to permissions with varying degrees of success.
+.. [2] Feature request :issue:`1337`
+.. [3] Cygwin tries to map NTFS ACLs to permissions with varying degrees of success.
 
 .. [#acls] The native access control list mechanism of the OS. This normally limits access to
     non-native ACLs. For example, NTFS ACLs are not completely accessible on Linux with ntfs-3g.


### PR DESCRIPTION
NetBSD xattr support shipped in 2.0.0b20 (#1332, see src/borg/platform/netbsd.pyx), but the platform feature table still said No. Update the cell to Yes, drop the now-unreferenced footnote, and renumber the remaining ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)