### PR TITLE
tests: relax wall-clock bound in read-special-timeout test

### DIFF
--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -1037,7 +1037,9 @@ def test_create_read_special_timeout_expired(archivers, request):
         "input",
         exit_code=expected_ec,  # WARNING status: could not back up the fifo.
     )
-    assert time.monotonic() - started < 30  # timed out, no eternal hang
+    # Generous bound for heavily loaded CI runners: proves borg gave up soon after the requested
+    # 1s timeout (and did not e.g. wait for the 30 minutes default timeout).
+    assert time.monotonic() - started < 300
     assert "retry: 1 of " not in out  # timeouts are NOT retried
     listing = cmd(archiver, "list", "test", "--format={path}{NL}")
     assert "input/file1" in listing


### PR DESCRIPTION
test_create_read_special_timeout_expired asserted that `borg create` with `--read-special-timeout=1` returns within 30s. On heavily loaded CI runners the whole command (including remote archiver setup) occasionally takes longer than that — observed twice on master, e.g. 37s on a macOS runner whose tox step took almost 3 hours — failing the test although the timeout mechanism worked correctly (expected warning exit code, fifo skipped, file1 backed up).

Relax the bound to 300s: that still proves borg gave up soon after the requested 1s timeout instead of waiting for the 30 minutes default timeout (or forever), but no longer trips over slow runners.

Test added in #10090.