### PR TITLE
CI: upgrade cross-platform-actions to 1.4.0, NetBSD to 11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
             do_binaries: true
             artifact_prefix: borg-freebsd-14-x86_64-gh
           - os: netbsd
-            version: '10.1'
+            version: '11.0'
             display_name: NetBSD
             do_binaries: false
           - os: openbsd
@@ -313,7 +313,7 @@ jobs:
 
     - name: Test on ${{ matrix.display_name }}
       id: cross_os
-      uses: cross-platform-actions/action@v1.0.0
+      uses: cross-platform-actions/action@v1.4.0
       env:
         DO_BINARIES: ${{ matrix.do_binaries }}
       with:
@@ -381,7 +381,7 @@ jobs:
               hostname
               arch="$(uname -m)"
               sudo -E mkdir -p /usr/pkg/etc/pkgin
-              echo "http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/10.1/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
+              echo "https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/${arch}/11.0/All" | sudo tee /usr/pkg/etc/pkgin/repositories.conf > /dev/null
               sudo -E pkgin update
               sudo -E pkgin -y upgrade
               sudo -E pkgin -y install zstd lz4 xxhash git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,18 +394,9 @@ jobs:
               sudo -E ln -sf /usr/pkg/bin/tox-3.11 /usr/pkg/bin/tox3
               # Ensure base system admin tools are on PATH for the non-root shell
               export PATH="/sbin:/usr/sbin:$PATH"
-              echo "--- Preparing an extattr-enabled filesystem ---"
-              # On many NetBSD setups /tmp is tmpfs without extended attributes.
-              # Create a FFS image with extended attributes enabled and use it for TMPDIR.
-              VNDDEV="vnd0"
-              IMGFILE="/tmp/fs.img"
-              sudo -E dd if=/dev/zero of=${IMGFILE} bs=1m count=1024
-              sudo -E vndconfig -c "${VNDDEV}" "${IMGFILE}"
-              sudo -E newfs -O 2ea /dev/r${VNDDEV}a
-              MNT="/mnt/eafs"
-              sudo -E mkdir -p ${MNT}
-              sudo -E mount -t ffs -o extattr /dev/${VNDDEV}a $MNT
-              export TMPDIR="${MNT}/tmp"
+              # On the netbsd 11 VM, / is a fs with extended attributes,
+              # while /tmp is a tmpfs without them - so don't use /tmp.
+              export TMPDIR="/tmp_eafs"
               sudo -E mkdir -p ${TMPDIR}
               sudo -E chmod 1777 ${TMPDIR}
               touch ${TMPDIR}/testfile


### PR DESCRIPTION
Backport of the CI VM upgrade from master (#10071) to 1.4-maint.

- `cross-platform-actions/action` v1.0.0 -> v1.4.0. 1.4.0 adds NetBSD 11.0 images and bounds waiting for the VM to boot by a wall clock timeout, so a VM that never becomes ssh-reachable fails early instead of retrying for hours. FreeBSD 14.3, OpenBSD 7.7 and Haiku r1beta5 are all still supported by 1.4.0, so the other matrix entries are unchanged.
- NetBSD 10.1 -> 11.0, including the pkgin repository URL (now also https). The 11.0 package set has py311-pip / py311-virtualenv / py311-tox and everything else the job installs.
- On NetBSD 11 the root filesystem has extended attributes enabled, so `TMPDIR` can be a plain directory there. That drops the vnd/newfs FFS image that was built and mounted just to get an extattr-capable TMPDIR.