### PR TITLE
create: do not use ctime for the files cache on Windows, fixes #7193

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -253,6 +253,12 @@ New features:
 
 Fixes:
 
+- create: do not use ctime for the files cache on Windows, #7193.
+
+  ctime is the file *creation* time on Windows, so a ctime based files cache mode
+  did not notice content changes of files that kept their size and inode number.
+  The default is ``mtime,size,inode`` there now and an explicitly given ctime based
+  mode warns and uses the corresponding mtime based mode.
 - re-add XXH64 to read borg 1.x integrity data, #9935
 - list: add {blake3} format key, #9984
 - support date: archive patterns for --from-borg1, #9949

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -91,7 +91,7 @@ borg create
     +-------------------------------------------------------+---------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                       | ``--sparse``                                      | detect sparse holes in input (supported only by fixed chunker)                                                                                                                                                                                 |
     +-------------------------------------------------------+---------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    |                                                       | ``--files-cache MODE``                            | operate files cache in MODE. default: ctime,size,inode                                                                                                                                                                                         |
+    |                                                       | ``--files-cache MODE``                            | operate files cache in MODE. default: ctime,size,inode (on Windows: mtime,size,inode, because ctime is file creation time there).                                                                                                              |
     +-------------------------------------------------------+---------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                       | ``--files-changed MODE``                          | specify how to detect if a file has changed during backup (ctime, mtime, disabled). default: ctime (on Windows: mtime, because ctime is file creation time there).                                                                             |
     +-------------------------------------------------------+---------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -169,7 +169,7 @@ borg create
         --noacls                  do not read and store ACLs into archive
         --noxattrs                do not read and store xattrs into archive
         --sparse                  detect sparse holes in input (supported only by fixed chunker)
-        --files-cache MODE        operate files cache in MODE. default: ctime,size,inode
+        --files-cache MODE        operate files cache in MODE. default: ctime,size,inode (on Windows: mtime,size,inode, because ctime is file creation time there).
         --files-changed MODE      specify how to detect if a file has changed during backup (ctime, mtime, disabled). default: ctime (on Windows: mtime, because ctime is file creation time there).
         --read-special            open and read block and char device files as well as FIFOs as if they were regular files. Also follows symlinks pointing to these kinds of files.
         --read-special-timeout SECONDS    when reading from FIFOs or character devices (see --read-special): skip the file with an error if no data arrives for more than SECONDS (this includes waiting for a FIFO's writer to connect). Give 0 to wait forever. default: 1800 seconds.
@@ -220,8 +220,8 @@ the files cache.
 
 This comparison can operate in different modes as given by ``--files-cache``:
 
-- ctime,size,inode (default)
-- mtime,size,inode (default behaviour of borg versions older than 1.1.0rc4)
+- ctime,size,inode (default on POSIX systems)
+- mtime,size,inode (default on Windows)
 - ctime,size (ignore the inode number)
 - mtime,size (ignore the inode number)
 - rechunk,ctime (all files are considered modified - rechunk, cache ctime)
@@ -248,6 +248,13 @@ ctime vs. mtime: safety vs. speed
   can be arbitrarily set from userspace, e.g., to set mtime back to the same value
   it had before a content change happened. This can be used maliciously as well as
   well-meant, but in both cases mtime-based cache modes can be problematic.
+
+On Windows, ctime is the file *creation* time, not the "metadata change time" it is
+on POSIX systems. A ctime based mode would therefore not notice content changes of a
+file that keeps its size and inode number, so borg defaults to ``mtime,size,inode``
+there. If a ctime based mode is given explicitly on Windows, borg warns and uses the
+corresponding mtime based mode instead: ctime,size,inode -> mtime,size,inode,
+ctime,size -> mtime,size, rechunk,ctime -> rechunk,mtime.
 
 The ``--files-changed`` option controls how Borg detects if a file has changed during backup:
  - ctime (default on POSIX): Use ctime to detect changes. This is the safest option.

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -16,7 +16,8 @@ from ..archive import FilesystemObjectProcessors, MetadataCollector, ChunksProce
 from ..cache import Cache
 from ..constants import *  # NOQA
 from ..helpers import comment_validator, ChunkerParams, FilesystemPathSpec, CompressionSpec
-from ..helpers import archivename_validator, FilesCacheMode, octal_int, nonnegative_seconds
+from ..helpers import archivename_validator, FilesCacheMode, files_cache_mode_no_ctime
+from ..helpers import octal_int, nonnegative_seconds
 from ..helpers import eval_escapes
 from ..helpers import timestamp, archive_ts_now
 from ..helpers import get_cache_dir, os_stat, get_strip_prefix, slashify
@@ -50,6 +51,19 @@ class CreateMixIn:
             read_special_timeout = READ_SPECIAL_TIMEOUT_DEFAULT
         if read_special_timeout == 0:
             read_special_timeout = None  # wait forever
+        if is_win32:
+            # st_ctime is the file *creation* time on Windows, not the "metadata change time",
+            # so a ctime based files cache mode would not detect content changes of a file that
+            # keeps its size and inode number. Use the mtime based equivalent instead, see #7193.
+            # note: this must happen before the Cache is created (it gets the files cache mode).
+            files_cache_mode, changed = files_cache_mode_no_ctime(args.files_cache_mode)
+            if changed:
+                self.print_warning(
+                    "--files-cache=ctime,... is not supported on Windows "
+                    "(ctime is file creation time, not change time). Using mtime instead.",
+                    wc=None,
+                )
+                args.files_cache_mode = files_cache_mode
         key = manifest.key
         matcher = PatternMatcher(fallback=True)
         matcher.add_inclexcl(args.patterns)
@@ -619,8 +633,8 @@ class CreateMixIn:
 
         This comparison can operate in different modes as given by ``--files-cache``:
 
-        - ctime,size,inode (default)
-        - mtime,size,inode (default behaviour of borg versions older than 1.1.0rc4)
+        - ctime,size,inode (default on POSIX systems)
+        - mtime,size,inode (default on Windows)
         - ctime,size (ignore the inode number)
         - mtime,size (ignore the inode number)
         - rechunk,ctime (all files are considered modified - rechunk, cache ctime)
@@ -647,6 +661,13 @@ class CreateMixIn:
           can be arbitrarily set from userspace, e.g., to set mtime back to the same value
           it had before a content change happened. This can be used maliciously as well as
           well-meant, but in both cases mtime-based cache modes can be problematic.
+
+        On Windows, ctime is the file *creation* time, not the "metadata change time" it is
+        on POSIX systems. A ctime based mode would therefore not notice content changes of a
+        file that keeps its size and inode number, so borg defaults to ``mtime,size,inode``
+        there. If a ctime based mode is given explicitly on Windows, borg warns and uses the
+        corresponding mtime based mode instead: ctime,size,inode -> mtime,size,inode,
+        ctime,size -> mtime,size, rechunk,ctime -> rechunk,mtime.
 
         The ``--files-changed`` option controls how Borg detects if a file has changed during backup:
          - ctime (default on POSIX): Use ctime to detect changes. This is the safest option.
@@ -971,8 +992,9 @@ class CreateMixIn:
             dest="files_cache_mode",
             action=Highlander,
             type=FilesCacheMode,
-            default=FILES_CACHE_MODE_UI_DEFAULT,
-            help="operate files cache in MODE. default: %s" % FILES_CACHE_MODE_UI_DEFAULT,
+            default=FILES_CACHE_MODE_UI_DEFAULT_WIN32 if is_win32 else FILES_CACHE_MODE_UI_DEFAULT_POSIX,
+            help="operate files cache in MODE. default: %s (on Windows: %s, because ctime is "
+            "file creation time there)." % (FILES_CACHE_MODE_UI_DEFAULT_POSIX, FILES_CACHE_MODE_UI_DEFAULT_WIN32),
         )
         fs_group.add_argument(
             "--files-changed",

--- a/src/borg/constants.py
+++ b/src/borg/constants.py
@@ -177,8 +177,12 @@ ITEMS_CHUNKER_PARAMS = (CH_FASTCDC, 15, 19, 17, NC_LEVEL)
 # normal on-disk data, allocated (but not written, all zeros), not allocated hole (all zeros)
 CH_DATA, CH_ALLOC, CH_HOLE = 0, 1, 2
 
-# operating mode of the files cache (for fast skipping of unchanged files)
-FILES_CACHE_MODE_UI_DEFAULT = "ctime,size,inode"  # default for "borg create" command (CLI UI)
+# operating mode of the files cache (for fast skipping of unchanged files).
+# note: on Windows, os.stat_result.st_ctime[_ns] is the file *creation* time, not the
+# "metadata change time" it is on POSIX systems. A ctime based mode would not detect
+# content changes of a file that keeps its size and inode number there. See #7193.
+FILES_CACHE_MODE_UI_DEFAULT_POSIX = "ctime,size,inode"  # default for "borg create" command (CLI UI)
+FILES_CACHE_MODE_UI_DEFAULT_WIN32 = "mtime,size,inode"  # same, but on Windows
 FILES_CACHE_MODE_DISABLED = "d"  # most borg commands do not use the files cache at all (disable)
 
 # account for clocks being slightly out-of-sync, timestamps granularity.

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -38,6 +38,7 @@ from .parseformat import (
     CompressionSpec,
     ChunkerParams,
     FilesCacheMode,
+    files_cache_mode_no_ctime,
     partial_format,
     DatetimeWrapper,
 )

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -429,6 +429,23 @@ def FilesCacheMode(s):
     return mode
 
 
+# ctime based files cache modes and their mtime based equivalent, see #7193.
+FILES_CACHE_MODE_CTIME_TO_MTIME = {"cis": "ims", "cs": "ms", "cr": "mr"}
+
+
+def files_cache_mode_no_ctime(mode):
+    """
+    Return (new_mode, changed): <mode> with ctime replaced by mtime.
+
+    <mode> may be given in long form ("ctime,size,inode") or in short form ("cis"),
+    the returned mode is always the short form, as FilesCacheMode() gives it.
+    "changed" tells whether a ctime -> mtime replacement actually happened.
+    """
+    mode = FilesCacheMode(mode)  # long form -> short form (idempotent for the short form)
+    new_mode = FILES_CACHE_MODE_CTIME_TO_MTIME.get(mode, mode)
+    return new_mode, new_mode != mode
+
+
 def partial_format(format, mapping):
     """
     Apply format.format_map(mapping) while preserving unknown keys

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -741,7 +741,7 @@ def test_create_invalid_tags(archivers, request):
 
 
 @pytest.mark.skipif(
-    is_win32, reason="ctime attribute is file creation time on Windows"
+    is_win32, reason="ctime is file creation time on Windows, ctime cache modes fall back to mtime there, see #7193"
 )  # see https://docs.python.org/3/library/os.html#os.stat_result.st_ctime
 def test_file_status_cs_cache_mode(archivers, request):
     archiver = request.getfixturevalue(archivers)
@@ -756,6 +756,25 @@ def test_file_status_cs_cache_mode(archivers, request):
     create_regular_file(archiver.input_path, "file1", contents=b"321")
     os.utime("input/file1", ns=(st.st_atime_ns, st.st_mtime_ns))
     # this mode uses ctime for change detection, so it should find file1 as modified
+    output = cmd(archiver, "create", "test", "input", "--list", "--files-cache=ctime,size")
+    assert "M input/file1" in output
+
+
+@pytest.mark.skipif(not is_win32, reason="Windows-only: ctime is file creation time there, see #7193")
+def test_files_cache_ctime_fallback_win32(archivers, request):
+    """test that a ctime based --files-cache mode warns and falls back to the mtime based mode on Windows"""
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", contents=b"123")
+    granularity_sleep()  # file2 must have newer timestamps than file1
+    create_regular_file(archiver.input_path, "file2", size=10)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    # note: cmd() asserts rc == 0, so this also covers that the warning does not change the exit code.
+    output = cmd(archiver, "create", "test", "input", "--list", "--files-cache=ctime,size")
+    assert "ctime is file creation time" in output
+    granularity_sleep()  # the rewrite below must get a newer mtime
+    # rewrite in place: same size, same inode, same creation time (== st_ctime on Windows),
+    # only the mtime changes. Without the fallback, this file would be considered unchanged.
+    create_regular_file(archiver.input_path, "file1", contents=b"321")
     output = cmd(archiver, "create", "test", "input", "--list", "--files-cache=ctime,size")
     assert "M input/file1" in output
 

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -30,6 +30,7 @@ from ...helpers.parseformat import (
     swidth_slice,
     eval_escapes,
     ChunkerParams,
+    files_cache_mode_no_ctime,
     get_size_units,
     normalize_local_path,
     ArchiveFormatter,
@@ -913,6 +914,35 @@ def test_valid_chunkerparams(chunker_params, expected_return):
 def test_invalid_chunkerparams(invalid_chunker_params):
     with pytest.raises(ArgumentTypeError):
         ChunkerParams(invalid_chunker_params)
+
+
+@pytest.mark.parametrize(
+    "mode, expected_mode, expected_changed",
+    [
+        # ctime based modes get replaced by their mtime based equivalent:
+        ("ctime,size,inode", "ims", True),
+        ("cis", "ims", True),
+        ("ctime,size", "ms", True),
+        ("cs", "ms", True),
+        ("rechunk,ctime", "mr", True),
+        ("cr", "mr", True),
+        # everything else stays as it is (but is normalized to the short form):
+        ("mtime,size,inode", "ims", False),
+        ("ims", "ims", False),
+        ("mtime,size", "ms", False),
+        ("rechunk,mtime", "mr", False),
+        ("disabled", "d", False),
+        ("d", "d", False),
+    ],
+)
+def test_files_cache_mode_no_ctime(mode, expected_mode, expected_changed):
+    assert files_cache_mode_no_ctime(mode) == (expected_mode, expected_changed)
+
+
+def test_files_cache_mode_ui_default():
+    # borg create must not default to a ctime based files cache mode on Windows, see #7193.
+    assert FILES_CACHE_MODE_UI_DEFAULT_POSIX == "ctime,size,inode"
+    assert FILES_CACHE_MODE_UI_DEFAULT_WIN32 == "mtime,size,inode"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
On Windows, `os.stat_result.st_ctime[_ns]` is the file **creation** time (CPython
literally assigns `st_ctime = st_birthtime` there), not the "metadata change time"
it is on POSIX systems. It therefore never changes when a file's contents change.

With the default files cache mode `ctime,size,inode`, a file that was modified in
place while keeping its size and inode number was thus considered unchanged and its
new contents were silently not backed up - only the very first archive was complete.

So, on Windows:

- the default files cache mode is `mtime,size,inode` now
- an explicitly given ctime based mode warns and uses the corresponding mtime based
  mode instead: `ctime,size,inode` -> `mtime,size,inode`, `ctime,size` -> `mtime,size`,
  `rechunk,ctime` -> `rechunk,mtime`

This is the same approach as already used for `--files-changed`.

Notes:

- The files cache always memorizes both ctime and mtime (and refreshes both, whatever
  the mode is), so this does not invalidate existing files cache entries - no mass
  rechunking when a Windows user updates.
- The fallback has to happen before the `Cache` is created in `do_create`, because that
  is what gets the files cache mode.
- Doing this properly (a real "change time" from the WinAPI, see the discussion in #7193
  and #8730) is left for later - CPython still documents the ctime change as something
  that "will" happen at some unspecified point, and it may even end up returning zero.

`test_file_status_cs_cache_mode` stays skipped on Windows (it fakes the mtime back, so
it cannot work with the mtime based fallback), but its skip reason now says why. Added:

- a Windows-only test that a ctime mode warns and that a file rewritten in place (same
  size, same inode, same creation time) is detected as modified - that is the actual
  regression test for the data loss
- unit tests for the mode mapping helper