### PR TITLE
tests: keep pytest out of the chunkers testsuite package __init__

### DIFF
--- a/src/borg/testsuite/chunkers/__init__.py
+++ b/src/borg/testsuite/chunkers/__init__.py
@@ -1,29 +1,13 @@
+# Note: this is imported by borg.selftest via the *_self_test.py modules in this package,
+#       so it must not import pytest - a normal borg install does not have it.
+#       Helpers that need pytest belong into pytest_helpers.py.
+
 import os
 import tempfile
-
-import pytest
 
 from borg.constants import *  # noqa
 
 from ...chunkers import has_seek_hole
-
-
-def chunker_with_kernel(monkeypatch, envvar, kernel, make):
-    """Build a chunker with <envvar> set to <kernel>, or skip if it cannot run here.
-
-    Which kernels exist depends on the build (compiler support) and on the CPU, so a
-    kernel that cannot be selected is not a failure - the test is skipped, carrying
-    the reason the chunker gave, so `pytest -rs` shows which kernels a machine covered.
-    Requesting an unusable kernel raising (rather than falling back) is itself tested,
-    see test_kernel_env_rejects_unusable.
-    """
-    monkeypatch.setenv(envvar, kernel)
-    try:
-        chunker = make()
-    except ValueError as err:
-        pytest.skip(str(err))
-    assert chunker.kernel == kernel  # we must have got what we asked for, not a fallback
-    return chunker
 
 
 def cf(chunks):

--- a/src/borg/testsuite/chunkers/buzhash64_test.py
+++ b/src/borg/testsuite/chunkers/buzhash64_test.py
@@ -5,7 +5,8 @@ import random
 
 import pytest
 
-from . import cf, cf_expand, chunker_with_kernel
+from . import cf, cf_expand
+from .pytest_helpers import chunker_with_kernel
 from ...chunkers import ChunkerBuzHash64
 from ...chunkers.buzhash64 import buzhash64_get_table
 from ...constants import *  # NOQA

--- a/src/borg/testsuite/chunkers/fastcdc_test.py
+++ b/src/borg/testsuite/chunkers/fastcdc_test.py
@@ -5,7 +5,8 @@ import random
 
 import pytest
 
-from . import cf, cf_expand, chunker_with_kernel
+from . import cf, cf_expand
+from .pytest_helpers import chunker_with_kernel
 from ...chunkers import ChunkerFastCDC, get_chunker
 from ...chunkers.fastcdc import fastcdc_get_gear_table
 from ...constants import *  # NOQA

--- a/src/borg/testsuite/chunkers/phte_chunkers_test.py
+++ b/src/borg/testsuite/chunkers/phte_chunkers_test.py
@@ -14,7 +14,8 @@ import random
 
 import pytest
 
-from . import cf, cf_expand, chunker_with_kernel
+from . import cf, cf_expand
+from .pytest_helpers import chunker_with_kernel
 from ...chunkers import ChunkerRabinAES, ChunkerGoldilocksAES, ChunkerToeplitzAES, get_chunker
 from ...constants import *  # NOQA
 from ...helpers import hex_to_bin

--- a/src/borg/testsuite/chunkers/pytest_helpers.py
+++ b/src/borg/testsuite/chunkers/pytest_helpers.py
@@ -1,0 +1,26 @@
+"""Chunker test helpers that require pytest.
+
+These must not live in this package's __init__.py: borg.selftest imports the *_self_test.py
+modules from this package, so the package __init__ runs on every borg invocation - and a
+normal borg install has no pytest.
+"""
+
+import pytest
+
+
+def chunker_with_kernel(monkeypatch, envvar, kernel, make):
+    """Build a chunker with <envvar> set to <kernel>, or skip if it cannot run here.
+
+    Which kernels exist depends on the build (compiler support) and on the CPU, so a
+    kernel that cannot be selected is not a failure - the test is skipped, carrying
+    the reason the chunker gave, so `pytest -rs` shows which kernels a machine covered.
+    Requesting an unusable kernel raising (rather than falling back) is itself tested,
+    see test_kernel_env_rejects_unusable.
+    """
+    monkeypatch.setenv(envvar, kernel)
+    try:
+        chunker = make()
+    except ValueError as err:
+        pytest.skip(str(err))
+    assert chunker.kernel == kernel  # we must have got what we asked for, not a fallback
+    return chunker


### PR DESCRIPTION
## Problem

`borg` does not start on a normal (non-editable, no dev dependencies) install:

```
python -m venv /tmp/v && /tmp/v/bin/pip install . && /tmp/v/bin/borg --version
```

```
  File "borg/archiver/__init__.py", line 51, in <module>
    from ..selftest import selftest
  File "borg/selftest.py", line 24, in <module>
    from .testsuite.chunkers.buzhash_self_test import ChunkerTestCase
  File "borg/testsuite/chunkers/__init__.py", line 4, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'
```

`borg.selftest` imports the `*_self_test.py` modules from `src/borg/testsuite/chunkers/`, so that
package's `__init__` runs on every `borg` invocation. Since 8f2de9e80 ("tests: cover every scan
kernel, not just the default one") the `__init__` has a hard `import pytest`, needed only by the
`chunker_with_kernel()` helper - which indirectly breaks the rule stated at the top of
`selftest.py`.

This affects every user installing borgbackup from PyPI without dev dependencies. It is not in a
release yet (master is 2.0.0b22.dev989), so it should go in before the next one.

## Fix

`chunker_with_kernel()` moves into a new `pytest_helpers` module that only the pytest-based tests
import (`buzhash64_test.py`, `fastcdc_test.py`, `phte_chunkers_test.py`), so the self-test modules
can be imported without pytest again. Nothing else in the package `__init__` needs pytest.

## Verification

- Reproduced on master, then confirmed fixed: in a clean venv, `pip install .` + `borg --version`
  works, and `borg --debug` reports `19 self-tests completed`, i.e. the self-test really runs.
- `pytest src/borg/testsuite/chunkers/ -rs -n auto`: 114 passed, 303 skipped, kernel skip reasons
  unchanged (`BORG_FASTCDC_KERNEL='avx512': not a kernel of this build...`).
- ruff + black clean.

## Not addressed here

- Nothing prevents a recurrence. The `assert "pytest" not in dir(module)` guard in `selftest()`
  structurally cannot catch this: it only inspects the leaf self-test module, never a package
  `__init__` that module imports - as its own comment admits.
- No CI job catches it either. All jobs install editable plus `requirements.d/development.lock.txt`
  (which has pytest). `python -m build` runs in the Windows job, but the sdist/wheel are discarded,
  never installed. The tagged-release PyInstaller smoke test cannot catch it because that binary is
  built from a venv that has pytest, so pytest gets bundled into it.

Happy to add a regression test (a subprocess that blocks `import pytest` via a `sys.meta_path` hook,
then imports `borg.selftest` and runs `selftest()`) and/or a clean-install CI job in a follow-up if
wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)