### PR TITLE
CI: add big-endian (s390x) test under qemu emulation

### DIFF
--- a/.github/workflows/bigendian.yml
+++ b/.github/workflows/bigendian.yml
@@ -1,0 +1,200 @@
+# Big-endian test: build and test borg on s390x (big-endian) under qemu
+# user-mode emulation, and check that a repository written on a big-endian
+# machine can be read on a little-endian one and the other way round.
+#
+# Why: borg's repository format is architecture independent and the native code
+# has explicit big-endian code paths (e.g. the __builtin_bswap64 calls in the
+# chunker kernels), but every other machine we test on is little-endian, so
+# those code paths are never executed and a bug in them would only be found by
+# the users of s390x, some ppc64 and some mips machines.
+#
+# Everything inside the container is emulated instruction by instruction, so
+# this is slow. Therefore it does not run for every pull request, but only when
+# native code or format relevant code was touched (plus weekly and on demand).
+
+name: Big-endian
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '**.pyx'
+    - '**.pxd'
+    - 'src/borg/**/*.c'
+    - 'src/borg/**/*.h'
+    - 'src/borg/chunkers/**'
+    - 'src/borg/crypto/**'
+    - 'src/borg/repository.py'
+    - 'src/borg/repoobj.py'
+    - 'src/borg/archive.py'
+    - 'scripts/endian_interop_test.py'
+    - '.github/workflows/bigendian.yml'
+  schedule:
+    - cron: '43 5 * * 3'  # Wednesdays at 05:43 UTC
+  workflow_dispatch:      # Allow manual trigger
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  PY_COLORS: "1"
+
+jobs:
+  s390x:
+    name: s390x (big-endian, emulated)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    env:
+      # Debian trixie has python 3.13, and all our dependencies that ship binary
+      # wheels (blake3, backports-zstd, PyYAML, cffi) have s390x wheels for it -
+      # only the small C/Cython extensions are compiled (emulated) from source.
+      IMAGE: docker.io/s390x/debian:trixie-slim
+      CONTAINER: borg-s390x
+      # both sides of the interoperability test share this directory:
+      INTEROP: ${{ github.workspace }}/.interop
+      # a hung emulated test must fail instead of eating the job timeout:
+      PYTEST_TIMEOUT: "600"
+      # The endianness sensitive parts: the native code (chunkers, crypto,
+      # compression, hashindex, item) and the code that reads/writes the
+      # repository format. Extend this if it turns out to be too narrow.
+      PYTEST_TARGETS: >-
+        borg.testsuite.chunkers
+        borg.testsuite.crypto
+        borg.testsuite.compress_test
+        borg.testsuite.hashindex_test
+        borg.testsuite.item_test
+        borg.testsuite.repoobj_test
+        borg.testsuite.repository_test
+        borg.testsuite.archive_test
+        borg.testsuite.helpers.msgpack_test
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        # same python version as in the container, so both sides are comparable
+        python-version: '3.13'
+
+    # The wheels pip has to build from source inside the emulated container
+    # (msgpack, argon2-cffi-bindings, borghash, borgstore) are the expensive
+    # part of the container setup, so keep them from run to run.
+    - name: Cache pip-built wheels (s390x)
+      uses: actions/cache@v6
+      with:
+        path: .pip-cache-s390x
+        key: s390x-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          s390x-pip-
+
+    - name: Install Linux packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config build-essential
+        sudo apt-get install -y libssl-dev libacl1-dev liblz4-dev
+
+    - name: Build borg (native, little-endian)
+      run: |
+        set -euxo pipefail
+        # Note: a non-editable install on purpose - the s390x build below uses
+        # the same source tree and an editable install would put the extension
+        # modules of one architecture in there for the other one to pick up.
+        python -m venv "$RUNNER_TEMP/venv-native"
+        "$RUNNER_TEMP/venv-native/bin/pip" install --upgrade pip wheel
+        # Note: no pytest and no other development dependencies in this venv on
+        # purpose - this is what a normal borg installation looks like.
+        "$RUNNER_TEMP/venv-native/bin/pip" install .
+        "$RUNNER_TEMP/venv-native/bin/borg" --version
+        "$RUNNER_TEMP/venv-native/bin/python" -c 'import sys; assert sys.byteorder == "little", sys.byteorder'
+        # the container has no git, so tell setuptools-scm the version we got here:
+        echo "BORG_VERSION=$("$RUNNER_TEMP/venv-native/bin/borg" --version | cut -d' ' -f2)" >> $GITHUB_ENV
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: s390x
+
+    - name: Start the s390x container
+      run: |
+        set -euxo pipefail
+        mkdir -p .pip-cache-s390x
+        docker run -d --name "$CONTAINER" --platform linux/s390x \
+          -v "${{ github.workspace }}:/borg" -w /borg \
+          -e PIP_CACHE_DIR=/borg/.pip-cache-s390x \
+          -e SETUPTOOLS_SCM_PRETEND_VERSION_FOR_BORGBACKUP="$BORG_VERSION" \
+          -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
+          "$IMAGE" sleep infinity
+        # if this says anything but s390x, the emulation did not kick in:
+        test "$(docker exec "$CONTAINER" uname -m)" = "s390x"
+
+    - name: Build borg (s390x, big-endian)
+      run: |
+        docker exec -i "$CONTAINER" bash -s <<'EOF'
+        set -euxo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          python3 python3-dev python3-venv \
+          build-essential pkg-config libssl-dev libacl1-dev liblz4-dev
+        python3 -c 'import sys; assert sys.byteorder == "big", sys.byteorder; print("byteorder:", sys.byteorder)'
+        python3 -m venv /venv
+        /venv/bin/pip install --upgrade pip wheel
+        /venv/bin/pip install pytest pytest-xdist pytest-benchmark pytest-timeout
+        /venv/bin/pip install /borg
+        /venv/bin/borg --version
+        chown -R "$HOST_UID:$HOST_GID" /borg/.pip-cache-s390x
+        EOF
+
+    - name: Run the endianness sensitive tests on s390x
+      run: |
+        docker exec -i \
+          -e PYTEST_TARGETS="$PYTEST_TARGETS" \
+          -e PYTEST_TIMEOUT="$PYTEST_TIMEOUT" \
+          -e PY_COLORS="$PY_COLORS" \
+          "$CONTAINER" bash -s <<'EOF'
+        set -euxo pipefail
+        # run against the installed borg, not against the source tree:
+        cd /tmp
+        /venv/bin/python -m pytest -v -n4 -rs --benchmark-skip --pyargs $PYTEST_TARGETS
+        EOF
+
+    - name: Write test data and a repository on s390x
+      run: |
+        set -euxo pipefail
+        "$RUNNER_TEMP/venv-native/bin/python" scripts/endian_interop_test.py testdata "$INTEROP"
+        docker exec -i -e INTEROP=/borg/.interop "$CONTAINER" bash -s <<'EOF'
+        set -euxo pipefail
+        BORG=/venv/bin/borg /venv/bin/python /borg/scripts/endian_interop_test.py write "$INTEROP" be
+        chown -R "$HOST_UID:$HOST_GID" "$INTEROP"
+        EOF
+
+    - name: Read the s390x repository on x86_64 (and write to it)
+      run: |
+        set -euxo pipefail
+        export BORG="$RUNNER_TEMP/venv-native/bin/borg"
+        PY="$RUNNER_TEMP/venv-native/bin/python"
+        $PY scripts/endian_interop_test.py verify "$INTEROP" be --as le
+        $PY scripts/endian_interop_test.py write "$INTEROP" le
+        $PY scripts/endian_interop_test.py compare "$INTEROP" be le
+
+    - name: Read the x86_64 archives on s390x
+      run: |
+        docker exec -i -e INTEROP=/borg/.interop "$CONTAINER" bash -s <<'EOF'
+        set -euxo pipefail
+        BORG=/venv/bin/borg /venv/bin/python /borg/scripts/endian_interop_test.py verify "$INTEROP" le --as be
+        chown -R "$HOST_UID:$HOST_GID" "$INTEROP"
+        EOF
+
+    - name: Stop the s390x container
+      if: ${{ always() }}
+      run: docker rm -f "$CONTAINER" || true

--- a/scripts/endian_interop_test.py
+++ b/scripts/endian_interop_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Cross-architecture repository interoperability test.
+
+borg's on-disk / on-the-wire format is architecture independent, but almost all
+of our CI runs on little-endian machines only, so the big-endian code paths in
+the native code (e.g. the __builtin_bswap64() in the chunker kernels) are never
+executed.  This script drives a repository from two sides, so a repository that
+was written on one architecture can be verified on the other one:
+
+    # on machine/container A (e.g. big-endian):
+    endian_interop_test.py testdata WORKDIR       # deterministic test data
+    endian_interop_test.py write    WORKDIR be    # write archives "be-*"
+
+    # on machine/container B (e.g. little-endian), same WORKDIR:
+    endian_interop_test.py verify   WORKDIR be    # read what A wrote
+    endian_interop_test.py write    WORKDIR le    # write archives "le-*"
+    endian_interop_test.py compare  WORKDIR be le # same data, same chunks?
+
+    # on machine/container A again:
+    endian_interop_test.py verify   WORKDIR le    # read what B wrote
+
+"verify" runs "borg check --verify-data", extracts the other side's archives and
+compares the extracted files against the test data.  "compare" additionally
+requires that both sides cut the data into exactly the same chunks with exactly
+the same chunk IDs - if they did not, the archives would still be correct, but
+deduplication between machines of different endianness would silently not work.
+
+The environment (BORG_REPO, BORG_PASSPHRASE, cache and config dir) is set up by
+this script; the borg to use can be given via the BORG environment variable.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import shutil
+import subprocess
+import sys
+
+# fastcdc is borg's default chunker (and its kernel is one of the places with a
+# byte-order dependent code path).  Much smaller chunks than the default: the
+# test data then gets cut into thousands of chunks == thousands of chances to
+# notice a byte-order dependent cut point.
+#
+# The second archive uses different chunker parameters on purpose: with the same
+# parameters it would just deduplicate against the first one and its compression
+# would never be exercised.  So both sides also have to agree about the chunk
+# format of more than one compression method.
+ARCHIVE_SPECS = [
+    ("fastcdc-zstd", ["--chunker-params", "fastcdc,10,16,12,2", "--compression", "zstd,3"]),
+    ("fastcdc-lz4", ["--chunker-params", "fastcdc,12,18,14,2", "--compression", "lz4"]),
+]
+
+PASSPHRASE = "borg-endian-interop-test"
+
+# the test data lives in this subdirectory of the work directory
+DATA = "data"
+
+
+def borg(workdir, label, *args, cwd=None, capture=False):
+    """run a borg command against the test repository"""
+    env = os.environ.copy()
+    env["BORG_REPO"] = os.path.join(workdir, "repo")
+    env["BORG_PASSPHRASE"] = PASSPHRASE
+    # the KDF does not need to be strong for a throwaway test repository and
+    # argon2 is *slow* under emulation:
+    env["BORG_TESTONLY_WEAKEN_KDF"] = "1"
+    # keep the two sides (and the machine's own borg config) apart:
+    env["BORG_BASE_DIR"] = os.path.join(workdir, "home-%s" % label)
+    env["BORG_CACHE_DIR"] = os.path.join(workdir, "home-%s" % label, "cache")
+    env["BORG_CONFIG_DIR"] = os.path.join(workdir, "home-%s" % label, "config")
+    cmd = [os.environ.get("BORG", "borg")] + [str(a) for a in args]
+    print("+ %s" % " ".join(cmd), flush=True)
+    if capture:
+        return subprocess.run(cmd, env=env, cwd=cwd, check=True, stdout=subprocess.PIPE).stdout
+    subprocess.run(cmd, env=env, cwd=cwd, check=True)
+    return None
+
+
+def datadir(workdir):
+    return os.path.join(workdir, DATA)
+
+
+def cmd_testdata(args):
+    """create deterministic test data - content must not depend on the machine"""
+    path = datadir(args.workdir)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(os.path.join(path, "nested", "dir"))
+    rnd = random.Random(20260814)
+
+    # incompressible, gets cut into many chunks:
+    with open(os.path.join(path, "random.bin"), "wb") as f:
+        f.write(rnd.randbytes(8 * 1024 * 1024))
+    # compressible, but not uniform - many different chunker cut points:
+    with open(os.path.join(path, "text.bin"), "wb") as f:
+        for i in range(64 * 1024):
+            f.write(b"line %d: %s\n" % (i, b"borg" * (i % 17)))
+    # all-zero data (the chunkers have a shortcut for this):
+    with open(os.path.join(path, "zeros.bin"), "wb") as f:
+        f.write(b"\0" * (2 * 1024 * 1024))
+    # the same data as random.bin, but shifted by a few bytes: the rolling hash
+    # has to find the same cut points again after the insertion.
+    with open(os.path.join(path, "random.bin"), "rb") as f:
+        data = f.read()
+    with open(os.path.join(path, "nested", "shifted.bin"), "wb") as f:
+        f.write(b"insertion" + data)
+    with open(os.path.join(path, "nested", "dir", "small.txt"), "wb") as f:
+        f.write(b"hello borg\n")
+    with open(os.path.join(path, "nested", "empty"), "wb"):
+        pass
+    with open(os.path.join(path, "nested", "\u00fcmlaut-\u65e5\u672c\u8a9e.txt"), "wb") as f:
+        f.write("non-ascii file name and content: \u00e4\u00f6\u00fc\n".encode())
+    os.symlink("dir/small.txt", os.path.join(path, "nested", "symlink"))
+    os.link(os.path.join(path, "nested", "dir", "small.txt"), os.path.join(path, "nested", "hardlink"))
+    print("test data created in %s" % path)
+
+
+def scan(path):
+    """map relative path -> file content hash / symlink target, for comparing 2 trees"""
+    result = {}
+    for dirpath, dirnames, filenames in os.walk(path):
+        dirnames.sort()
+        for name in sorted(dirnames + filenames):
+            full = os.path.join(dirpath, name)
+            rel = os.path.relpath(full, path)
+            if os.path.islink(full):
+                result[rel] = "symlink:%s" % os.readlink(full)
+            elif os.path.isdir(full):
+                result[rel] = "dir"
+            else:
+                digest = hashlib.sha256()
+                with open(full, "rb") as f:
+                    for block in iter(lambda: f.read(1024 * 1024), b""):
+                        digest.update(block)
+                result[rel] = "file:%s" % digest.hexdigest()
+    return result
+
+
+def dump_path(workdir, archive, label):
+    return os.path.join(workdir, "dumps", "%s.read-by-%s.json" % (archive, label))
+
+
+def dump_archive(workdir, label, archive):
+    """dump the archive metadata as read by *this* machine"""
+    os.makedirs(os.path.join(workdir, "dumps"), exist_ok=True)
+    borg(workdir, label, "debug", "dump-archive", archive, dump_path(workdir, archive, label))
+
+
+def chunk_list(dump_file):
+    """(path, size, chunks) of all items, everything that must not depend on the architecture"""
+    with open(dump_file) as f:
+        dump = json.load(f)
+    items = []
+    for item in dump["_items"]:
+        items.append((item["path"], item.get("size"), item.get("target"), item.get("chunks")))
+    return items
+
+
+def cmd_write(args):
+    workdir, label = args.workdir, args.label
+    if not os.path.exists(os.path.join(workdir, "repo")):
+        borg(workdir, label, "repo-create", "--encryption=aes256-ocb")
+    for suffix, options in ARCHIVE_SPECS:
+        archive = "%s-%s" % (label, suffix)
+        # --files-cache=disabled: really chunk the files, do not trust any cache.
+        # Archive the relative path "data" from within the work directory: the
+        # two sides usually see the work directory at different absolute paths
+        # (e.g. one of them inside a container), but the item paths in the
+        # archives must be comparable.
+        borg(workdir, label, "create", "--files-cache=disabled", *options, archive, DATA, cwd=workdir)
+        dump_archive(workdir, label, archive)
+    borg(workdir, label, "repo-list")
+
+
+def cmd_verify(args):
+    """check and extract the archives written by the *other* side"""
+    workdir, other, label = args.workdir, args.label, args.as_label
+    borg(workdir, label, "check", "--verify-data")
+    expected = scan(datadir(workdir))
+    assert expected, "no test data found in %s" % datadir(workdir)
+    for suffix, _ in ARCHIVE_SPECS:
+        archive = "%s-%s" % (other, suffix)
+        extract_to = os.path.join(workdir, "extract-%s-by-%s" % (archive, label))
+        if os.path.exists(extract_to):
+            shutil.rmtree(extract_to)
+        os.makedirs(extract_to)
+        borg(workdir, label, "extract", archive, cwd=extract_to)
+        got = scan(os.path.join(extract_to, DATA))
+        if got != expected:
+            for key in sorted(set(expected) | set(got)):
+                if expected.get(key) != got.get(key):
+                    print("MISMATCH %s: expected %r, got %r" % (key, expected.get(key), got.get(key)))
+            raise SystemExit("archive %s does not extract to the original test data!" % archive)
+        print("OK: %s extracted identically (%d entries)" % (archive, len(got)))
+        # the same archive, but read (and its metadata decoded) on this machine:
+        dump_archive(workdir, label, archive)
+        written_by_other = chunk_list(dump_path(workdir, archive, other))
+        read_by_us = chunk_list(dump_path(workdir, archive, label))
+        if written_by_other != read_by_us:
+            raise SystemExit("archive %s does not decode identically on both architectures!" % archive)
+        print("OK: %s metadata (incl. chunk ids) decodes identically on both architectures" % archive)
+
+
+def cmd_compare(args):
+    """both sides archived the same data: they must have produced the same chunks"""
+    workdir, a, b = args.workdir, args.label, args.other_label
+    for suffix, _ in ARCHIVE_SPECS:
+        archive_a, archive_b = "%s-%s" % (a, suffix), "%s-%s" % (b, suffix)
+        items_a = chunk_list(dump_path(workdir, archive_a, a))
+        items_b = chunk_list(dump_path(workdir, archive_b, b))
+        if items_a != items_b:
+            for item_a, item_b in zip(items_a, items_b):
+                if item_a != item_b:
+                    print("MISMATCH %s:\n  %s: %r\n  %s: %r" % (item_a[0], a, item_a[1:], b, item_b[1:]))
+            raise SystemExit(
+                "%s and %s chunked the same data differently - "
+                "deduplication between these architectures would not work!" % (archive_a, archive_b)
+            )
+        chunks = sum(len(item[3] or []) for item in items_a)
+        print("OK: %s and %s have identical items and chunk ids (%d chunks)" % (archive_a, archive_b, chunks))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    sub = commands.add_parser("testdata", help="create the deterministic test data")
+    sub.add_argument("workdir")
+    sub.set_defaults(func=cmd_testdata)
+
+    sub = commands.add_parser("write", help="create the repository and this side's archives")
+    sub.add_argument("workdir")
+    sub.add_argument("label", help="label of this side, e.g. 'be'")
+    sub.set_defaults(func=cmd_write)
+
+    sub = commands.add_parser("verify", help="check/extract the archives the other side wrote")
+    sub.add_argument("workdir")
+    sub.add_argument("label", help="label of the *other* side, e.g. 'be'")
+    sub.add_argument("--as", dest="as_label", required=True, help="label of this side, e.g. 'le'")
+    sub.set_defaults(func=cmd_verify)
+
+    sub = commands.add_parser("compare", help="compare the chunk ids both sides produced")
+    sub.add_argument("workdir")
+    sub.add_argument("label")
+    sub.add_argument("other_label")
+    sub.set_defaults(func=cmd_compare)
+
+    args = parser.parse_args()
+    os.makedirs(args.workdir, exist_ok=True)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
All our CI machines are little-endian, so the big-endian code paths in the native code (e.g. the `__builtin_bswap64` calls in the chunker kernels) are never executed and the architecture independence of the repository format is not tested at all.

This adds a `Big-endian` workflow that builds and tests borg on s390x in an emulated container:

- it runs the tests of the endianness sensitive parts: chunkers, crypto, compression, hashindex, item, repoobj, repository, archive and the msgpack helpers.
- it runs a cross-architecture interoperability test (`scripts/endian_interop_test.py`): a repository written on the big-endian side is checked (`check --verify-data`), extracted and compared against the original test data on the little-endian side - and the other way round.
- both sides also have to produce identical chunk ids for the same data. If they did not, the archives would still be correct, but deduplication between machines of different endianness would silently not work.

The interoperability script archives relative paths and keeps cache/config of both sides apart, so it can also be used by hand between two real machines of different endianness, see its docstring.

Triggers: pull requests touching native or format relevant code, plus weekly and `workflow_dispatch`. Everything in the container is emulated instruction by instruction, so a run takes ~35 minutes (most of it the s390x build) and it deliberately does not run for every pull request.

Test run of this branch: s390x build 15m49s, 675 tests passed / 111 skipped, interop OK in both directions. The skips are only the avx2/avx512/neon kernel variants (which do not exist on s390x - the `blockwise` and `scalar` kernels that contain the byte-order dependent code do run) and the `BORG_TESTS_SLOW` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)