### PR TITLE
CI: give the black workflow read-only token permissions

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
`black.yaml` was the only workflow without a `permissions:` declaration, so its `GITHUB_TOKEN` gets whatever the repository default happens to be. The job only checks out the repository and runs black, so `contents: read` is all it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)