### PR TITLE
CI: release automation for PyPI and GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,6 +685,11 @@ jobs:
     timeout-minutes: 90
     needs: [lint]
 
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     env:
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS2_ENV_CONV_EXCL: "*"
@@ -738,10 +743,36 @@ jobs:
           # build sdist and wheel in dist/...
           python -m build
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      # Same layout and naming as the binaries of the other platforms, so that
+      # the release job picks this up as a release asset, too. The single-file
+      # binary keeps its .exe extension - Windows needs it to run the file.
+      - name: Prepare binaries (borg-windows-x86_64-gh)
+        run: |
+          pushd dist/binary
+          echo "single-file binary"
+          ./borg.exe -V
+          echo "single-directory binary"
+          ./borg-dir/borg.exe -V
+          tar czf borg.tgz borg-dir
+          popd
+          mkdir -p artifacts
+          cp dist/binary/borg.exe artifacts/borg-windows-x86_64-gh.exe
+          cp dist/binary/borg.tgz artifacts/borg-windows-x86_64-gh.tgz
+          echo "binary files"
+          ls -l artifacts/
+
+      - name: Attest binaries provenance (borg-windows-x86_64-gh)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:
-          name: borg-windows
-          path: dist/binary/borg.exe
+          subject-path: 'artifacts/*'
+
+      - name: Upload binaries (borg-windows-x86_64-gh)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: borg-windows-x86_64-gh
+          path: artifacts/*
+          if-no-files-found: error
 
       - name: Run tests
         run: |
@@ -774,3 +805,61 @@ jobs:
           report_type: coverage
           env_vars: OS,python
           files: coverage.xml
+
+  release:
+    # Build the sdist and draft the GitHub release with the binaries the jobs
+    # above built for this tag, see .github/workflows/release.yml.
+    #
+    # vm_tests is continue-on-error (a flaky BSD VM must not stop a release), so
+    # this waits for it, but only requires native_tests to have succeeded. A
+    # binary that did not get built is warned about while drafting the release.
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/') && needs.native_tests.result == 'success' }}
+    needs: [native_tests, vm_tests]
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    uses: ./.github/workflows/release.yml
+
+  pypi:
+    # Upload the sdist the release job built to PyPI.
+    #
+    # This job can not live in release.yml with the rest of the release code:
+    # PyPI trusted publishing does not work from a reusable workflow, see
+    # https://docs.pypi.org/trusted-publishers/troubleshooting/
+    #
+    # One-time setup, so that no API token has to be stored anywhere:
+    #  - on pypi.org, add a trusted publisher to the "borgbackup" project:
+    #    owner "borgbackup", repository "borg", workflow "ci.yml",
+    #    environment "pypi".
+    #  - create the "pypi" environment in the repository settings. Configuring
+    #    required reviewers for it makes this (irreversible) upload wait for an
+    #    approval, which is the last chance to stop a release.
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.release.result == 'success' }}
+    needs: [release]
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/borgbackup/
+
+    permissions:
+      contents: read
+      id-token: write  # trusted publishing
+
+    steps:
+    - name: Get the sdist built by the release job
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        name: sdist
+        path: dist
+
+    - name: What we are about to upload
+      run: ls -l dist/
+
+    - name: Upload to PyPI
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+# Release automation: build the source distribution, publish it to PyPI and
+# create a GitHub release with the standalone binaries.
+#
+# This is called by ci.yml when a tag is pushed, and it deliberately runs as
+# part of that same workflow run: that is where the binaries for the tag are
+# built, and artifacts can only be downloaded within the run that created them.
+#
+# The GitHub release is created as a *draft* on purpose:
+#  - the release notes want a human,
+#  - the detached GPG signature of the sdist can only be made locally
+#    (scripts/sdist-sign), so it has to be added by hand,
+#  - and the binaries should be tried out before the release becomes visible.
+# Publishing the draft is a single click in the GitHub UI.
+#
+# The upload to PyPI is *not* done here, but by the "pypi" job in ci.yml: PyPI
+# trusted publishing can not be used from a reusable workflow, see
+# https://docs.pypi.org/trusted-publishers/troubleshooting/ - so that job has to
+# live in a workflow that is triggered by an event. This job hands the sdist
+# over to it as a workflow artifact.
+
+name: Release
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  # The standalone binaries expected for a release: for every platform the
+  # single-file binary and, as a .tgz, the single-directory variant.  See the
+  # "binary" entries of the native_tests matrix, the "artifact_prefix" entries
+  # of the vm_tests matrix and the windows_tests job in ci.yml - keep in sync.
+  EXPECTED_ASSETS: >-
+    borg-linux-glibc239-x86_64-gh
+    borg-linux-glibc239-x86_64-gh.tgz
+    borg-linux-glibc239-arm64-gh
+    borg-linux-glibc239-arm64-gh.tgz
+    borg-macos-15-arm64-gh
+    borg-macos-15-arm64-gh.tgz
+    borg-macos-15-x86_64-gh
+    borg-macos-15-x86_64-gh.tgz
+    borg-freebsd-15-x86_64-gh
+    borg-freebsd-15-x86_64-gh.tgz
+    borg-windows-x86_64-gh.exe
+    borg-windows-x86_64-gh.tgz
+
+jobs:
+  github_release:
+    name: Draft the GitHub release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: write      # to create the release
+      id-token: write      # to attest the sdist
+      attestations: write
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        python-version: '3.13'
+
+    - name: Install Linux packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config build-essential
+        sudo apt-get install -y libssl-dev libacl1-dev liblz4-dev
+
+    - name: Build the sdist
+      run: |
+        set -euxo pipefail
+        python -m pip install --upgrade pip build twine
+        # only a sdist: we do not publish wheels, they would be platform specific.
+        python -m build --sdist
+        twine check dist/*
+        ls -l dist/
+
+    - name: Check that the sdist is complete and installable
+      # A release that cannot be installed from PyPI is the worst kind of
+      # release, and nothing else in CI ever installs borg from a sdist or
+      # without the development requirements.
+      run: |
+        set -euxo pipefail
+        python -m venv "$RUNNER_TEMP/venv-sdist"
+        "$RUNNER_TEMP/venv-sdist/bin/pip" install --upgrade pip
+        "$RUNNER_TEMP/venv-sdist/bin/pip" install dist/borgbackup-*.tar.gz
+        "$RUNNER_TEMP/venv-sdist/bin/borg" --version
+        "$RUNNER_TEMP/venv-sdist/bin/borg" --help > /dev/null
+
+    - name: Attest the sdist provenance
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+      with:
+        subject-path: 'dist/*.tar.gz'
+
+    - name: Download the binaries built for this tag
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        path: assets
+        # the binary artifacts are all named like the binaries they contain
+        pattern: 'borg-*-gh'
+        merge-multiple: true
+
+    - name: Check that no binary is missing
+      run: |
+        set -uo pipefail
+        ls -l assets/ || true
+        missing=""
+        for asset in $EXPECTED_ASSETS; do
+          test -f "assets/$asset" || missing="$missing $asset"
+        done
+        if [ -n "$missing" ]; then
+          # not an error: vm_tests is continue-on-error, so e.g. a flaky FreeBSD
+          # VM should not stop the release - but do not lose it silently either.
+          echo "::warning::binaries missing from this release:$missing"
+        fi
+
+    - name: Create the draft release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        set -euxo pipefail
+        # 2.0.0b23 and friends are pre-releases, 2.1.0 is not.
+        prerelease=""
+        case "$TAG" in *a*|*b*|*rc*) prerelease="--prerelease" ;; esac
+        cat > release-notes.md <<EOF
+        See the [changelog](https://github.com/borgbackup/borg/blob/$TAG/CHANGES.rst) for what changed in this release.
+
+        ### Installation
+
+        \`pip install borgbackup==$TAG\`, or use one of the standalone binaries below - they
+        contain everything they need and just have to be made executable.
+
+        For each platform there is a single-file binary (\`borg-*-gh\`, \`.exe\` on Windows)
+        and, as a \`.tgz\`, the same thing as a directory (\`borg-dir/borg.exe\`), which
+        starts up faster.
+
+        The macOS binaries are built **with** FUSE support: \`borg mount\` needs a macFUSE
+        version that is compatible with the one they were built against.
+
+        All release assets have a [build provenance attestation](https://github.com/borgbackup/borg/attestations),
+        verifiable with \`gh attestation verify --owner borgbackup <file>\`.
+        EOF
+        mkdir -p assets  # there may not have been any artifact to download
+        if gh release view "$TAG" > /dev/null 2>&1; then
+          # a re-run of this job: keep the (possibly already edited) release and
+          # just replace its assets.
+          gh release upload "$TAG" --clobber dist/*.tar.gz $(find assets -type f | sort)
+        else
+          gh release create "$TAG" \
+            --draft $prerelease \
+            --title "borg $TAG" \
+            --notes-file release-notes.md \
+            dist/*.tar.gz $(find assets -type f | sort)
+        fi
+        gh release view "$TAG" --json isDraft,isPrerelease,assets
+
+    - name: Keep the sdist for the PyPI upload
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+        if-no-files-found: error

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -531,22 +531,29 @@ Checklist:
 - Optional: run tox and/or binary builds on all supported platforms via vagrant,
   check for test failures. This is now optional as we do platform testing and
   binary building on GitHub.
-- Create sdist, sign it, upload release to (test) PyPi:
+- When GitHub CI looks good on the release PR, merge it and push the release tag.
 
-  ::
+  Pushing the tag makes CI build the standalone binaries and then release:
+  the ``release`` job (``.github/workflows/release.yml``) builds the sdist,
+  checks that it can be installed, attests its provenance and drafts the GitHub
+  release with the sdist and all standalone binaries attached. The ``pypi`` job
+  then uploads the sdist to PyPI.
+
+  If the ``pypi`` environment has required reviewers configured, the upload to
+  PyPI waits for an approval - that is the last chance to stop it. Also watch
+  out for a warning while the release is drafted: it means that a binary is
+  missing because its build did not succeed.
+- Sign the sdist and add the signature to the drafted GitHub release::
 
     scripts/sdist-sign X.Y.Z
-    scripts/upload-pypi X.Y.Z test
-    scripts/upload-pypi X.Y.Z
 
   Note: the signature is not uploaded to PyPi any more, but we upload it to
   github releases.
-- When GitHub CI looks good on the release PR, merge it and then check "Actions":
-  GitHub will create binary assets after the release PR is merged within the
-  CI testing of the merge. Check the "Upload binaries" step on Ubuntu (AMD/Intel
-  and ARM64) and macOS (Intel and ARM64), fetch the ZIPs with the binaries.
-- Unpack the ZIPs and test the binaries, upload the binaries to the GitHub
-  release page (borg-OS-SPEC-ARCH-gh and borg-OS-SPEC-ARCH-gh.tgz).
+- Download the binaries from the drafted release and test them. For macOS
+  binaries **with** FUSE support, document the macFUSE version in the release
+  notes: macFUSE uses a kernel extension that needs to be compatible with the
+  code contained in the binary.
+- Review the release notes and publish the drafted GitHub release.
 
 - Close the release milestone on GitHub.
 - `Update borgbackup.org
@@ -557,13 +564,3 @@ Checklist:
   - Mailing list.
   - Mastodon / BlueSky / X (aka Twitter).
   - IRC channel (change ``/topic``).
-
-- Create a GitHub release, include:
-
-  - pypi dist package and signature
-  - Standalone binaries (see above for how to create them).
-
-    - For macOS binaries **with** FUSE support, document the macFUSE version
-      in the README of the binaries. macFUSE uses a kernel extension that needs
-      to be compatible with the code contained in the binary.
-  - A link to ``CHANGES.rst``.


### PR DESCRIPTION
Pushing a release tag so far only built the standalone binaries and uploaded them as workflow artifacts. Everything else was manual: build and sign the sdist, upload it to PyPI, fetch the binary artifacts from the CI run and create the GitHub release with them.

**`release` job** (`.github/workflows/release.yml`), called by ci.yml for tags after the tests and the binary builds succeeded - it runs inside the same workflow run, because that is where the binary artifacts are:

- builds the sdist and runs `twine check` on it,
- checks that the sdist is complete by installing it into a clean venv (no development requirements) and running `borg`,
- attests the provenance of the sdist,
- drafts the GitHub release with the sdist and all standalone binaries attached,
- warns if a binary is missing, e.g. because a VM build did not succeed.

**`pypi` job** uploads the sdist to PyPI via trusted publishing, so no API token has to be stored anywhere. It sits in ci.yml rather than in release.yml because PyPI trusted publishing [does not work from a reusable workflow](https://docs.pypi.org/trusted-publishers/troubleshooting/).

**Windows binaries** now use the same naming and layout as the other platforms (`borg-windows-x86_64-gh.exe` and `.tgz` with the single-directory variant, plus a provenance attestation), so they become release assets, too. The single-file `borg.exe` is also smoke tested now, like on the other platforms.

The GitHub release is created as a **draft**: the release notes want a human, the detached GPG signature of the sdist can only be made locally (`scripts/sdist-sign`), and the binaries should be tried out before the release becomes visible. Publishing it is one click.

`docs/development.rst` describes the resulting release procedure.

### One-time setup before this can publish

- on pypi.org, add a trusted publisher to the `borgbackup` project: owner `borgbackup`, repository `borg`, workflow `ci.yml`, environment `pypi`.
- create the `pypi` environment in the repository settings. Configuring required reviewers for it makes the irreversible upload wait for an approval.

### Testing

The sdist build, `twine check`, the clean-venv install check and the release drafting logic (pre-release detection, release notes, asset list, the missing-binary warning, and re-running the job) were tested locally. The artifact hand-off between the jobs and the PyPI upload itself can only be exercised by an actual release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)