### PR TITLE
create: follow symlinks given as recursion roots, fixes #4737

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -819,6 +819,8 @@ Warnings
         {}: {}
     BackupTimeoutError rc: 111
         {}: {}
+    BackupBrokenSymlinkError rc: 112
+        {}: {}
 
 Operations
     - cache.begin_transaction

--- a/docs/man/borg-create.1
+++ b/docs/man/borg-create.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg-create" "1" "2026-08-13" "" "borg backup tool"
+.TH "borg-create" "1" "2026-08-15" "" "borg backup tool"
 .SH Name
 borg-create \- Creates a new archive.
 .SH SYNOPSIS
@@ -45,6 +45,23 @@ The slashdot hack in paths (recursion roots) is triggered by using \fB/./\fP:
 \fB/this/gets/stripped/./this/gets/archived\fP means to process that fs object, but
 strip the prefix on the left side of \fB\&./\fP from the archived items (in this case,
 \fBthis/gets/archived\fP will be the path in the archived item).
+.sp
+If a recursion root (a path given on the command line or in a patterns file) is a
+symlink, borg follows it and archives what it points to \- using the path you gave.
+If \fBcurrent\fP is a symlink pointing to the directory \fB20260801\-2345\fP,
+\fBborg create ARCHIVE current\fP thus archives \fBcurrent\fP as a directory (with the
+metadata of \fB20260801\-2345\fP) and recurses into it, archiving the contained fs
+objects as \fBcurrent/...\fP\&. As the archived paths do not change when the symlink
+target changes, the files cache keeps working for such backups.
+.sp
+Note that the symlink itself is then not in the archive (and neither is its target
+path), so restoring will create a real directory (or file) where the symlink was.
+If you want the symlink archived as a symlink, do not give it as a recursion root,
+but let borg find it while recursing (symlinks found that way are never followed).
+A recursion root that is a symlink with a non\-existing target is skipped with a warning.
+.sp
+If you give both a symlink and its target as recursion roots, borg archives the fs
+objects only once, under the path given first (like for any other root given twice).
 .sp
 When specifying \(aq\-\(aq as a path, borg will read data from standard input and create a
 file named \(aqstdin\(aq in the created archive from that data. In some cases, it is more
@@ -71,9 +88,9 @@ the files cache.
 This comparison can operate in different modes as given by \fB\-\-files\-cache\fP:
 .INDENT 0.0
 .IP \(bu 2
-ctime,size,inode (default)
+ctime,size,inode (default on POSIX systems)
 .IP \(bu 2
-mtime,size,inode (default behaviour of borg versions older than 1.1.0rc4)
+mtime,size,inode (default on Windows)
 .IP \(bu 2
 ctime,size (ignore the inode number)
 .IP \(bu 2
@@ -109,6 +126,13 @@ can be arbitrarily set from userspace, e.g., to set mtime back to the same value
 it had before a content change happened. This can be used maliciously as well as
 well\-meant, but in both cases mtime\-based cache modes can be problematic.
 .UNINDENT
+.sp
+On Windows, ctime is the file \fIcreation\fP time, not the \(dqmetadata change time\(dq it is
+on POSIX systems. A ctime based mode would therefore not notice content changes of a
+file that keeps its size and inode number, so borg defaults to \fBmtime,size,inode\fP
+there. If a ctime based mode is given explicitly on Windows, borg warns and uses the
+corresponding mtime based mode instead: ctime,size,inode \-> mtime,size,inode,
+ctime,size \-> mtime,size, rechunk,ctime \-> rechunk,mtime.
 .INDENT 0.0
 .TP
 .B The \fB\-\-files\-changed\fP option controls how Borg detects if a file has changed during backup:
@@ -134,11 +158,22 @@ The \fB\-\-progress\fP option shows (from left to right) Original and (uncompres
 deduplicated size (O and U respectively), then the Number of files (N) processed so far,
 followed by the currently processed path.
 .sp
+Sizes of GB and above are shown with enough decimal places that even MB\-sized progress
+stays visible. On a terminal, this needs a width of at least 110 columns \- on narrower
+terminals, the compact format is used, so that the path stays readable. If the output
+does not go to a terminal (e.g. into a logfile), the precise format is always used.
+.sp
 When using \fB\-\-stats\fP, you will get some statistics about how much data was
 added \- the \(dqThis Archive\(dq deduplicated size there is most interesting as that is
 how much your repository will grow. Please note that the \(dqAll archives\(dq stats refer to
-the state after creation. Also, the \fB\-\-stats\fP and \fB\-\-dry\-run\fP options are mutually
-exclusive because the data is not actually compressed and deduplicated during a dry run.
+the state after creation.
+.sp
+When \fB\-\-stats\fP is used together with \fB\-\-dry\-run\fP, only the number of files and the
+original size are reported. They are computed from file system metadata, without reading
+the file contents, so a dry run stays fast. As data is not actually read, chunked, and
+deduplicated during a dry run, the deduplicated size is unknown. The sizes of data read
+from standard input, from a command\(aqs output, or from special files (\fB\-\-read\-special\fP)
+are also unknown in a dry run and counted as zero.
 .sp
 The \fB\-\-stats\fP output also reports the store statistics (lines prefixed with
 \(dqStore\(dq), taken from the storage layer after this run. These cover the backend and
@@ -275,7 +310,7 @@ do not read and store xattrs into archive
 detect sparse holes in input (supported only by fixed chunker)
 .TP
 .BI \-\-files\-cache \ MODE
-operate files cache in MODE. default: ctime,size,inode
+operate files cache in MODE. default: ctime,size,inode (on Windows: mtime,size,inode, because ctime is file creation time there).
 .TP
 .BI \-\-files\-changed \ MODE
 specify how to detect if a file has changed during backup (ctime, mtime, disabled). default: ctime (on Windows: mtime, because ctime is file creation time there).
@@ -559,6 +594,9 @@ to borg (maybe implementing your own recursion or your own rules), you can use
 .sp
 Borg supports paths with the slashdot hack to strip path prefixes here also.
 So, be careful not to unintentionally trigger that.
+.sp
+Symlinks given this way are never followed (unlike recursion roots are), they are
+archived as symlinks.
 .SH SEE ALSO
 .sp
 \fIborg\-common(1)\fP, \fIborg\-delete(1)\fP, \fIborg\-prune(1)\fP, \fIborg\-check(1)\fP, \fIborg\-patterns(1)\fP, \fIborg\-placeholders(1)\fP, \fIborg\-compression(1)\fP, \fIborg\-repo\-create(1)\fP

--- a/docs/usage/create.rst.inc
+++ b/docs/usage/create.rst.inc
@@ -196,6 +196,23 @@ The slashdot hack in paths (recursion roots) is triggered by using ``/./``:
 strip the prefix on the left side of ``./`` from the archived items (in this case,
 ``this/gets/archived`` will be the path in the archived item).
 
+If a recursion root (a path given on the command line or in a patterns file) is a
+symlink, borg follows it and archives what it points to - using the path you gave.
+If ``current`` is a symlink pointing to the directory ``20260801-2345``,
+``borg create ARCHIVE current`` thus archives ``current`` as a directory (with the
+metadata of ``20260801-2345``) and recurses into it, archiving the contained fs
+objects as ``current/...``. As the archived paths do not change when the symlink
+target changes, the files cache keeps working for such backups.
+
+Note that the symlink itself is then not in the archive (and neither is its target
+path), so restoring will create a real directory (or file) where the symlink was.
+If you want the symlink archived as a symlink, do not give it as a recursion root,
+but let borg find it while recursing (symlinks found that way are never followed).
+A recursion root that is a symlink with a non-existing target is skipped with a warning.
+
+If you give both a symlink and its target as recursion roots, borg archives the fs
+objects only once, under the path given first (like for any other root given twice).
+
 When specifying '-' as a path, borg will read data from standard input and create a
 file named 'stdin' in the created archive from that data. In some cases, it is more
 appropriate to use --content-from-command. See the section *Reading from stdin*
@@ -442,3 +459,6 @@ to borg (maybe implementing your own recursion or your own rules), you can use
 
 Borg supports paths with the slashdot hack to strip path prefixes here also.
 So, be careful not to unintentionally trigger that.
+
+Symlinks given this way are never followed (unlike recursion roots are), they are
+archived as symlinks.

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1454,7 +1454,7 @@ class FilesystemObjectProcessors:
                 item.update(self.metadata_collector.stat_attrs(st, path, fd=fd))
                 return status
 
-    def process_fifo(self, *, path, parent_fd, name, st, strip_prefix):
+    def process_fifo(self, *, path, parent_fd, name, st, strip_prefix, flags=flags_normal):
         with self.create_helper(path, st, "f", strip_prefix=strip_prefix) as (
             item,
             status,
@@ -1463,13 +1463,13 @@ class FilesystemObjectProcessors:
         ):  # fifo
             if item is None:
                 return status
-            with OsOpen(path=path, parent_fd=parent_fd, name=name, flags=flags_normal, noatime=True) as fd:
+            with OsOpen(path=path, parent_fd=parent_fd, name=name, flags=flags, noatime=True) as fd:
                 with backup_io("fstat"):
                     st = stat_update_check(st, os.fstat(fd))
                 item.update(self.metadata_collector.stat_attrs(st, path, fd=fd))
                 return status
 
-    def process_dev(self, *, path, parent_fd, name, st, dev_type, strip_prefix):
+    def process_dev(self, *, path, parent_fd, name, st, dev_type, strip_prefix, follow_symlinks=False):
         with self.create_helper(path, st, dev_type, strip_prefix=strip_prefix) as (
             item,
             status,
@@ -1480,7 +1480,9 @@ class FilesystemObjectProcessors:
             if item is None:
                 return status
             with backup_io("stat"):
-                st = stat_update_check(st, os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False))
+                st = stat_update_check(
+                    st, os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=follow_symlinks)
+                )
             item.rdev = st.st_rdev
             item.update(self.metadata_collector.stat_attrs(st, path))
             return status

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -21,10 +21,12 @@ from ..helpers import octal_int, nonnegative_seconds
 from ..helpers import eval_escapes
 from ..helpers import timestamp, archive_ts_now
 from ..helpers import get_cache_dir, os_stat, get_strip_prefix, slashify
+from ..helpers import BackupBrokenSymlinkError
 from ..helpers import dir_is_tagged
 from ..helpers import log_multi
 from ..helpers import basic_json_data, json_print, FileSize
-from ..helpers import flags_dir, flags_special_follow, flags_special
+from ..helpers import flags_dir, flags_dir_follow, flags_special_follow, flags_special
+from ..helpers import flags_normal, flags_normal_follow
 from ..helpers import prepare_subprocess_env
 from ..helpers import sig_int, ignore_sigint
 from ..helpers import iter_separated
@@ -38,6 +40,24 @@ from ..platform import is_win32, get_flags
 from ..logger import create_logger
 
 logger = create_logger()
+
+
+def stat_root(path):
+    """
+    stat a recursion root, following it if it is a symlink, see #4737.
+
+    Returns (st, followed): for a symlink, st is the stat of what it points to and followed
+    is True, so the caller knows that it must not use O_NOFOLLOW when opening path.
+
+    Raises BackupBrokenSymlinkError if path is a symlink with a non-existing target.
+    """
+    st = os_stat(path=path, parent_fd=None, name=None, follow_symlinks=False)
+    if not stat.S_ISLNK(st.st_mode):
+        return st, False
+    try:
+        return os_stat(path=path, parent_fd=None, name=None, follow_symlinks=True), True
+    except FileNotFoundError:
+        raise BackupBrokenSymlinkError("stat", "broken symlink, skipping it") from None
 
 
 class CreateMixIn:
@@ -144,6 +164,7 @@ class CreateMixIn:
                     path = posixpath.normpath(path)
                     try:
                         with backup_io("stat"):
+                            # symlinks given this way are never followed, see #4737.
                             st = os_stat(path=path, parent_fd=None, name=None, follow_symlinks=False)
                         status = self._process_any(
                             path=path,
@@ -199,7 +220,7 @@ class CreateMixIn:
                     path = posixpath.normpath(path)
                     try:
                         with backup_io("stat"):
-                            st = os_stat(path=path, parent_fd=None, name=None, follow_symlinks=False)
+                            st, followed = stat_root(path)
                         restrict_dev = st.st_dev if args.one_file_system else None
                         self._rec_walk(
                             path=path,
@@ -216,6 +237,7 @@ class CreateMixIn:
                             read_special=args.read_special,
                             dry_run=dry_run,
                             strip_prefix=strip_prefix,
+                            follow_symlink=followed,
                         )
                         # if we get back here, we've finished recursing into <path>,
                         # we do not ever want to get back in there (even if path is given twice as recursion root)
@@ -324,9 +346,14 @@ class CreateMixIn:
                         logger=logging.getLogger("borg.output.stats"),
                     )
 
-    def _process_any(self, *, path, parent_fd, name, st, fso, cache, read_special, dry_run, strip_prefix):
+    def _process_any(
+        self, *, path, parent_fd, name, st, fso, cache, read_special, dry_run, strip_prefix, followed_symlink=False
+    ):
         """
         Call the right method on the given FilesystemObjectProcessor.
+
+        If followed_symlink is True, *path* is a symlink we followed (recursion root, see #4737)
+        and *st* is the stat of its target, so we must not use O_NOFOLLOW when opening it.
         """
 
         if dry_run:
@@ -348,6 +375,9 @@ class CreateMixIn:
                     stats.nfiles += 1  # size unknown without reading the special file
             return "+"  # included
         MAX_RETRIES = 10  # count includes the initial try (initial try == "retry 0")
+        # if we followed a symlink, we must not refuse to open its target via the symlink:
+        flags_file = flags_normal_follow if followed_symlink else flags_normal
+        flags_specialfile = flags_special_follow if followed_symlink else flags_special
         for retry in range(MAX_RETRIES):
             last_try = retry == MAX_RETRIES - 1
             try:
@@ -358,10 +388,12 @@ class CreateMixIn:
                         name=name,
                         st=st,
                         cache=cache,
+                        flags=flags_file,
                         last_try=last_try,
                         strip_prefix=strip_prefix,
                     )
                 elif stat.S_ISDIR(st.st_mode):
+                    # note: a followed symlink to a directory does not get here, _rec_walk deals with it.
                     return fso.process_dir(path=path, parent_fd=parent_fd, name=name, st=st, strip_prefix=strip_prefix)
                 elif stat.S_ISLNK(st.st_mode):
                     if not read_special:
@@ -393,7 +425,12 @@ class CreateMixIn:
                 elif stat.S_ISFIFO(st.st_mode):
                     if not read_special:
                         return fso.process_fifo(
-                            path=path, parent_fd=parent_fd, name=name, st=st, strip_prefix=strip_prefix
+                            path=path,
+                            parent_fd=parent_fd,
+                            name=name,
+                            st=st,
+                            strip_prefix=strip_prefix,
+                            flags=flags_file,
                         )
                     else:
                         return fso.process_file(
@@ -402,14 +439,20 @@ class CreateMixIn:
                             name=name,
                             st=st,
                             cache=cache,
-                            flags=flags_special,
+                            flags=flags_specialfile,
                             last_try=last_try,
                             strip_prefix=strip_prefix,
                         )
                 elif stat.S_ISCHR(st.st_mode):
                     if not read_special:
                         return fso.process_dev(
-                            path=path, parent_fd=parent_fd, name=name, st=st, dev_type="c", strip_prefix=strip_prefix
+                            path=path,
+                            parent_fd=parent_fd,
+                            name=name,
+                            st=st,
+                            dev_type="c",
+                            strip_prefix=strip_prefix,
+                            follow_symlinks=followed_symlink,
                         )
                     else:
                         return fso.process_file(
@@ -418,14 +461,20 @@ class CreateMixIn:
                             name=name,
                             st=st,
                             cache=cache,
-                            flags=flags_special,
+                            flags=flags_specialfile,
                             last_try=last_try,
                             strip_prefix=strip_prefix,
                         )
                 elif stat.S_ISBLK(st.st_mode):
                     if not read_special:
                         return fso.process_dev(
-                            path=path, parent_fd=parent_fd, name=name, st=st, dev_type="b", strip_prefix=strip_prefix
+                            path=path,
+                            parent_fd=parent_fd,
+                            name=name,
+                            st=st,
+                            dev_type="b",
+                            strip_prefix=strip_prefix,
+                            follow_symlinks=followed_symlink,
                         )
                     else:
                         return fso.process_file(
@@ -434,7 +483,7 @@ class CreateMixIn:
                             name=name,
                             st=st,
                             cache=cache,
-                            flags=flags_special,
+                            flags=flags_specialfile,
                             last_try=last_try,
                             strip_prefix=strip_prefix,
                         )
@@ -469,7 +518,7 @@ class CreateMixIn:
                 # mode right (which could have changed due to a race condition and is important for
                 # dispatching) and also to get current inode number of that file.
                 with backup_io("stat"):
-                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False)
+                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=followed_symlink)
 
     def _rec_walk(
         self,
@@ -488,9 +537,14 @@ class CreateMixIn:
         read_special,
         dry_run,
         strip_prefix,
+        follow_symlink=False,
     ):
         """
         Process *path* (or, preferably, parent_fd/name) recursively according to the various parameters.
+
+        follow_symlink is only given for a recursion root that is a symlink, see #4737: we then
+        archive what the symlink points to (using the symlink's path). Symlinks encountered while
+        recursing are never followed, so this is never passed on to the recursive calls.
 
         This should only raise on critical errors. Per-item errors must be handled within this method.
         """
@@ -503,7 +557,7 @@ class CreateMixIn:
             recurse_excluded_dir = False
             if matcher.match(path):
                 with backup_io("stat"):
-                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False)
+                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=follow_symlink)
             else:
                 self.print_file_status("-", path)  # excluded
                 # get out here as quickly as possible:
@@ -514,7 +568,7 @@ class CreateMixIn:
                     return
                 recurse_excluded_dir = True
                 with backup_io("stat"):
-                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=False)
+                    st = os_stat(path=path, parent_fd=parent_fd, name=name, follow_symlinks=follow_symlink)
                 if not stat.S_ISDIR(st.st_mode):
                     return
 
@@ -547,10 +601,16 @@ class CreateMixIn:
                     read_special=read_special,
                     dry_run=dry_run,
                     strip_prefix=strip_prefix,
+                    followed_symlink=follow_symlink,
                 )
             else:
                 with OsOpen(
-                    path=path, parent_fd=parent_fd, name=name, flags=flags_dir, noatime=True, op="dir_open"
+                    path=path,
+                    parent_fd=parent_fd,
+                    name=name,
+                    flags=flags_dir_follow if follow_symlink else flags_dir,
+                    noatime=True,
+                    op="dir_open",
                 ) as child_fd:
                     # child_fd is None for directories on windows, in that case a race condition check is not possible.
                     if child_fd is not None:
@@ -645,6 +705,23 @@ class CreateMixIn:
         ``/this/gets/stripped/./this/gets/archived`` means to process that fs object, but
         strip the prefix on the left side of ``./`` from the archived items (in this case,
         ``this/gets/archived`` will be the path in the archived item).
+
+        If a recursion root (a path given on the command line or in a patterns file) is a
+        symlink, borg follows it and archives what it points to - using the path you gave.
+        If ``current`` is a symlink pointing to the directory ``20260801-2345``,
+        ``borg create ARCHIVE current`` thus archives ``current`` as a directory (with the
+        metadata of ``20260801-2345``) and recurses into it, archiving the contained fs
+        objects as ``current/...``. As the archived paths do not change when the symlink
+        target changes, the files cache keeps working for such backups.
+
+        Note that the symlink itself is then not in the archive (and neither is its target
+        path), so restoring will create a real directory (or file) where the symlink was.
+        If you want the symlink archived as a symlink, do not give it as a recursion root,
+        but let borg find it while recursing (symlinks found that way are never followed).
+        A recursion root that is a symlink with a non-existing target is skipped with a warning.
+
+        If you give both a symlink and its target as recursion roots, borg archives the fs
+        objects only once, under the path given first (like for any other root given twice).
 
         When specifying '-' as a path, borg will read data from standard input and create a
         file named 'stdin' in the created archive from that data. In some cases, it is more
@@ -892,6 +969,9 @@ class CreateMixIn:
 
         Borg supports paths with the slashdot hack to strip path prefixes here also.
         So, be careful not to unintentionally trigger that.
+
+        Symlinks given this way are never followed (unlike recursion roots are), they are
+        archived as symlinks.
         """
         )
 

--- a/src/borg/helpers/__init__.py
+++ b/src/borg/helpers/__init__.py
@@ -18,12 +18,14 @@ from .errors import BorgWarning, FileChangedWarning, BackupWarning, IncludePatte
 from .errors import BackupError, BackupOSError, BackupRaceConditionError, BackupItemExcluded
 from .errors import BackupPermissionError, BackupIOError, BackupFileNotFoundError, BackupTimeoutError
 from .errors import BackupSymlinkParentError, BackupPathTraversalError, BackupHardlinkSourceError
+from .errors import BackupBrokenSymlinkError
 from .fs import ensure_dir, join_base_dir
 from .fs import get_security_dir, get_keys_dir, get_base_dir, get_cache_dir, get_config_dir, get_runtime_dir
 from .fs import dir_is_tagged, dir_is_cachedir, remove_dotdot_prefixes, make_path_safe, scandir_inorder
 from .fs import secure_erase, safe_unlink, dash_open, os_open, os_stat, get_strip_prefix, umount, slashify
 from .fs import SpecialFileReader
-from .fs import O_, flags_dir, flags_special_follow, flags_special, flags_base, flags_normal, flags_noatime
+from .fs import O_, flags_dir, flags_dir_follow, flags_special_follow, flags_special
+from .fs import flags_base, flags_normal, flags_normal_follow, flags_noatime
 from .fs import HardLinkManager
 from .misc import sysinfo, log_multi, consume
 from .misc import ChunkIteratorFileWrapper, open_item, chunkit, iter_separated, ErrorIgnoringTextIOWrapper

--- a/src/borg/helpers/errors.py
+++ b/src/borg/helpers/errors.py
@@ -225,5 +225,13 @@ class BackupTimeoutError(BackupOSError):
     exit_mcode = 111
 
 
+class BackupBrokenSymlinkError(BackupError):
+    """{}: {}"""
+
+    # A recursion root that is a symlink pointing to a non-existing target: as we follow
+    # symlinked recursion roots, there is nothing to archive there, see #4737.
+    exit_mcode = 112
+
+
 class BackupItemExcluded(Exception):
     """Used internally to skip an item from processing when it is excluded."""

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -505,8 +505,10 @@ flags_base = O_("BINARY", "NOCTTY", "RDONLY")
 flags_special = flags_base | O_("NOFOLLOW")  # BLOCK == wait when reading devices or fifos
 flags_special_follow = flags_base  # BLOCK == wait when reading symlinked devices or fifos
 flags_normal = flags_base | O_("NONBLOCK", "NOFOLLOW")
+flags_normal_follow = flags_base | O_("NONBLOCK")  # follow a symlinked recursion root, see #4737
 flags_noatime = flags_normal | O_("NOATIME")
 flags_dir = O_("DIRECTORY", "RDONLY", "NOFOLLOW")
+flags_dir_follow = O_("DIRECTORY", "RDONLY")  # follow a symlinked recursion root, see #4737
 
 
 def os_open(*, flags, path=None, parent_fd=None, name=None, noatime=False):

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -16,7 +16,7 @@ from ...manifest import Manifest
 from ...platform import is_win32, is_cygwin
 from ...platformflags import is_msystem
 from ...repository import Repository
-from ...helpers import CommandError, BackupPermissionError, BackupTimeoutError
+from ...helpers import CommandError, BackupPermissionError, BackupTimeoutError, BackupBrokenSymlinkError
 from .. import has_lchflags, has_mknod
 from .. import changedir
 from .. import (
@@ -1203,6 +1203,114 @@ def test_create_read_special_broken_symlink(archivers, request):
     cmd(archiver, "create", "--read-special", "test", "input")
     output = cmd(archiver, "list", "test")
     assert "input/link -> somewhere does not exist" in output
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_root_dir(archivers, request):
+    # a recursion root that is a symlink to a directory is followed, see #4737
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target/file", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input/link")
+    output = cmd(archiver, "list", "test")
+    assert "input/link -> target" not in output  # not archived as a symlink, but as a directory
+    assert "input/link/file" in output  # we recursed into the symlink target
+    assert "input/target" not in output  # the target path is not in the archive
+    with changedir("output"):
+        cmd(archiver, "extract", "test")
+        assert not os.path.islink("input/link")
+        assert os.path.isdir("input/link")
+        with open("input/link/file", "rb") as f:
+            assert f.read() == b"content"
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_root_file(archivers, request):
+    # a recursion root that is a symlink to a regular file is followed, see #4737
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input/link")
+    output = cmd(archiver, "list", "test")
+    assert "input/link -> target" not in output  # not archived as a symlink, but as a regular file
+    assert "input/link" in output
+    with changedir("output"):
+        cmd(archiver, "extract", "test")
+        assert not os.path.islink("input/link")
+        with open("input/link", "rb") as f:
+            assert f.read() == b"content"
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_below_root_not_followed(archivers, request):
+    # only recursion roots are followed, symlinks found while recursing are not, see #4737
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target/file", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    output = cmd(archiver, "list", "test")
+    assert "input/link -> target" in output
+    assert "input/link/file" not in output
+    assert "input/target/file" in output
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_root_and_target(archivers, request):
+    # a followed symlink root and its target are the same fs objects, so they are archived
+    # only once, under the path given first (like any other recursion root given twice).
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target/file", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input/link", "input/target")
+    output = cmd(archiver, "list", "test")
+    assert "input/link/file" in output
+    assert "input/target/file" not in output
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_root_broken(archivers, request):
+    # a recursion root that is a symlink with a non-existing target is skipped with a warning
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file", contents=b"content")
+    os.symlink("somewhere does not exist", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    expected_ec = BackupBrokenSymlinkError("stat", "broken symlink, skipping it").exit_code
+    if expected_ec == EXIT_ERROR:  # workaround, TODO: fix it
+        expected_ec = EXIT_WARNING
+    out = cmd(archiver, "create", "test", "input/link", "input/file", exit_code=expected_ec)
+    assert "input/link: stat: broken symlink, skipping it" in out
+    output = cmd(archiver, "list", "test")
+    assert "input/link" not in output
+    assert "input/file" in output  # the other recursion root was archived
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_paths_from_stdin_not_followed(archivers, request):
+    # only recursion roots are followed, paths fed in via --paths-from-* are not, see #4737
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "--paths-from-stdin", "test", input=b"input/link")
+    output = cmd(archiver, "list", "test")
+    assert "input/link -> target" in output
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_create_symlink_root_dotslash_hack(archivers, request):
+    # the slashdot hack also works for a recursion root that is a symlink, see #4737
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "target/file", contents=b"content")
+    os.symlink("target", os.path.join(archiver.input_path, "link"))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input/link/./")  # hack!
+    output = cmd(archiver, "list", "test")
+    assert "input" not in output  # the prefix left of the slashdot was stripped
+    assert "file" in output
 
 
 def test_create_dotslash_hack(archivers, request):

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -17,6 +17,7 @@ from ...platform import is_win32, is_cygwin
 from ...platformflags import is_msystem
 from ...repository import Repository
 from ...helpers import CommandError, BackupPermissionError, BackupTimeoutError, BackupBrokenSymlinkError
+from ...helpers import BackupWarning
 from .. import has_lchflags, has_mknod
 from .. import changedir
 from .. import (
@@ -322,9 +323,8 @@ def test_create_no_permission_file(archivers, request):
         os.chmod(file_path + "2", 0o000)
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     flist = "".join(f"input/file{n}\n" for n in range(1, 4))
-    expected_ec = BackupPermissionError("open", OSError(13, "permission denied")).exit_code
-    if expected_ec == EXIT_ERROR:  # workaround, TODO: fix it
-        expected_ec = EXIT_WARNING
+    exc = BackupPermissionError("open", OSError(13, "permission denied"))
+    expected_ec = BackupWarning("input/file2", exc).exit_code
     out = cmd(
         archiver,
         "create",
@@ -1076,9 +1076,8 @@ def test_create_read_special_timeout_expired(archivers, request):
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     create_regular_file(archiver.input_path, "file1", size=1024)
     os.mkfifo(os.path.join(archiver.input_path, "fifo"))
-    expected_ec = BackupTimeoutError("read", OSError(errno.ETIMEDOUT, "timeout")).exit_code
-    if expected_ec == EXIT_ERROR:  # workaround, TODO: fix it
-        expected_ec = EXIT_WARNING
+    exc = BackupTimeoutError("read", OSError(errno.ETIMEDOUT, "timeout"))
+    expected_ec = BackupWarning("input/fifo", exc).exit_code
     started = time.monotonic()
     out = cmd(
         archiver,
@@ -1278,9 +1277,8 @@ def test_create_symlink_root_broken(archivers, request):
     create_regular_file(archiver.input_path, "file", contents=b"content")
     os.symlink("somewhere does not exist", os.path.join(archiver.input_path, "link"))
     cmd(archiver, "repo-create", RK_ENCRYPTION)
-    expected_ec = BackupBrokenSymlinkError("stat", "broken symlink, skipping it").exit_code
-    if expected_ec == EXIT_ERROR:  # workaround, TODO: fix it
-        expected_ec = EXIT_WARNING
+    exc = BackupBrokenSymlinkError("stat", "broken symlink, skipping it")
+    expected_ec = BackupWarning("input/link", exc).exit_code
     out = cmd(archiver, "create", "test", "input/link", "input/file", exit_code=expected_ec)
     assert "input/link: stat: broken symlink, skipping it" in out
     output = cmd(archiver, "list", "test")


### PR DESCRIPTION
If a recursion root (a path given on the command line or via a patterns file) is a symlink,
borg now follows it and archives what it points to, using the path as given.

So, if `current` is a symlink pointing to the directory `20260801-2345`,
`borg create ARCHIVE current` archives `current` as a directory (with the metadata of
`20260801-2345`) and recurses into it, archiving the contained fs objects as `current/...`.

As the archived paths do not change when the symlink target changes its name, the files
cache keeps working for such backups - that was the motivation in #4737.

Not affected:

- symlinks encountered while recursing: never followed, archived as symlinks like before.
  Thus, a `--exclude`d directory can not be pulled in via a symlink below a recursion root.
- symlinks given via `--paths-from-stdin` / `--paths-from-command` /
  `--paths-from-shell-command`: never followed either, archived as symlinks.

Notes:

- The symlink itself is then not in the archive (and neither is its target path), so
  restoring creates a real directory (or file) where the symlink was. If you want the
  symlink archived as a symlink, do not give it as a recursion root, but let borg find
  it while recursing.
- A recursion root that is a symlink with a non-existing target is skipped with a warning
  (new `BackupBrokenSymlinkError`, rc 112), so the other roots still get archived.
- If both a symlink and its target are given as recursion roots, they are the same fs
  objects, so they are archived only once, under the path given first (like for any other
  recursion root given twice).

Implementation: the root is stat'ed with `follow_symlinks=True` only if it is a symlink;
everything below uses `openat(parent_fd, name)` as before, so following happens exactly
once and symlink loops are impossible. As a followed symlink must be opened without
`O_NOFOLLOW`, `flags_dir_follow` / `flags_normal_follow` were added and the callers choose
the flags (`process_fifo` / `process_dev` got a parameter for this).
