### PR TITLE
windows: restore timestamps via SetFileTime, fixes #7269

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -259,6 +259,12 @@ Fixes:
   did not notice content changes of files that kept their size and inode number.
   The default is ``mtime,size,inode`` there now and an explicitly given ctime based
   mode warns and uses the corresponding mtime based mode.
+- extract: restore the timestamps using SetFileTime on Windows, #7269.
+
+  os.utime can not set the birthtime (creation time) there, nor can it work on a file
+  descriptor or on a symlink itself. Thus, the birthtime was not restored at all and the
+  timestamps of a symlink were set on the symlink's target. Also, failing to set the
+  timestamps is not silently ignored anymore, but gives a warning.
 - re-add XXH64 to read borg 1.x integrity data, #9935
 - list: add {blake3} format key, #9984
 - support date: archive patterns for --from-borg1, #9949

--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -50,7 +50,7 @@ from .manifest import Manifest
 from .patterns import PathPrefixPattern, FnmatchPattern, IECommand
 from .item import Item, ArchiveItem, ItemDiff
 from . import platform
-from .platform import acl_get, acl_set, set_flags, get_flags, swidth
+from .platform import acl_get, acl_set, set_flags, get_flags, set_times, swidth
 from .repository import Repository, NoManifestError
 from .repoobj import RepoObj
 
@@ -1096,44 +1096,23 @@ Duration: {0.duration}
                 warning = xattr.set_all(fd or path, item.xattrs, follow_symlinks=False)
                 if warning:
                     set_ec(EXIT_WARNING)
-            # set timestamps rather late
-            mtime = item.mtime
-            atime = item.atime if "atime" in item else mtime
-            if "birthtime" in item:
-                birthtime = item.birthtime
-                try:
-                    # This should work on FreeBSD, NetBSD, and Darwin and be harmless on other platforms.
-                    # See utimes(2) on either of the BSDs for details.
-                    if fd:
-                        os.utime(fd, None, ns=(atime, birthtime))
-                    else:
-                        os.utime(path, None, ns=(atime, birthtime), follow_symlinks=False)
-                except OSError:
-                    # some systems don't support calling utime on a symlink
-                    pass
+        # set timestamps rather late
+        mtime = item.mtime
+        atime = item.atime if "atime" in item else mtime
+        birthtime = item.get("birthtime")
+        try:
+            set_times(path, atime_ns=atime, mtime_ns=mtime, birthtime_ns=birthtime, fd=fd, follow_symlinks=False)
+        except OSError as e:
+            # some POSIX systems don't support setting the timestamps of a symlink.
+            if is_win32:
+                # win32 can set the timestamps of a symlink itself, so this is a real problem.
+                logger.warning("%s: when setting timestamps: %s", remove_surrogates(item.path), e)
+                set_ec(EXIT_WARNING)
+        # bsdflags include the immutable flag and need to be set last:
+        if not is_win32 and not self.noflags and "bsdflags" in item:
             try:
-                if fd:
-                    os.utime(fd, None, ns=(atime, mtime))
-                else:
-                    os.utime(path, None, ns=(atime, mtime), follow_symlinks=False)
+                set_flags(path, item.bsdflags, fd=fd)
             except OSError:
-                # some systems don't support calling utime on a symlink
-                pass
-            # bsdflags include the immutable flag and need to be set last:
-            if not self.noflags and "bsdflags" in item:
-                try:
-                    set_flags(path, item.bsdflags, fd=fd)
-                except OSError:
-                    pass
-        else:  # win32
-            # set timestamps rather late
-            mtime = item.mtime
-            atime = item.atime if "atime" in item else mtime
-            try:
-                # note: no fd support on win32
-                os.utime(path, None, ns=(atime, mtime))
-            except OSError:
-                # some systems don't support calling utime on a symlink
                 pass
 
     def set_meta(self, key, value):

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -12,6 +12,7 @@ from .base import ENOATTR
 from .base import SaveFile, sync_dir, fdatasync, safe_fadvise
 from .base import get_process_id, fqdn, hostname, hostid, swidth
 from .base import acl_text_to_xattr  # overridden below for platforms supporting it
+from .base import set_times  # overridden below for win32
 
 # work around pyinstaller "forgetting" to include the xattr module
 from . import xattr  # noqa: F401
@@ -84,6 +85,7 @@ else:  # pragma: win32 only
     from .base import acl_get, acl_set
     from .base import set_flags, get_flags
     from .windows import SyncFile
+    from .windows import set_times  # type: ignore[no-redef]
     from .windows import process_alive, local_pid_alive
     from .windows import getosusername
     from . import windows_ug as platform_ug

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -112,6 +112,32 @@ def get_flags(path, st, fd=None):
     return getattr(st, "st_flags", 0)
 
 
+def set_times(path, *, atime_ns, mtime_ns, birthtime_ns=None, fd=None, follow_symlinks=True):
+    """
+    Set the timestamps of *path* (or of the open file descriptor *fd*, if given).
+
+    *birthtime_ns* is only honoured on platforms that can set the birthtime (creation time),
+    it is silently ignored on the other ones.
+
+    Raises OSError if the timestamps could not be set.
+    """
+    if birthtime_ns is not None:
+        try:
+            # This should work on FreeBSD, NetBSD, and Darwin and be harmless on other platforms.
+            # See utimes(2) on either of the BSDs for details.
+            if fd is not None:
+                os.utime(fd, None, ns=(atime_ns, birthtime_ns))
+            else:
+                os.utime(path, None, ns=(atime_ns, birthtime_ns), follow_symlinks=follow_symlinks)
+        except OSError:
+            # some systems don't support calling utime on a symlink
+            pass
+    if fd is not None:
+        os.utime(fd, None, ns=(atime_ns, mtime_ns))
+    else:
+        os.utime(path, None, ns=(atime_ns, mtime_ns), follow_symlinks=follow_symlinks)
+
+
 def sync_dir(path):
     if is_win32:
         # Opening directories is not supported on Windows.

--- a/src/borg/platform/windows.pyx
+++ b/src/borg/platform/windows.pyx
@@ -22,11 +22,23 @@ cdef extern from 'windows.h':
 # Win32 API constants for CreateFileW
 GENERIC_READ = 0x80000000
 GENERIC_WRITE = 0x40000000
+FILE_WRITE_ATTRIBUTES = 0x00000100
 FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_SHARE_DELETE = 0x00000004
 CREATE_NEW = 1
+OPEN_EXISTING = 3
 FILE_ATTRIBUTE_NORMAL = 0x80
 FILE_FLAG_WRITE_THROUGH = 0x80000000
+FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
 ERROR_FILE_EXISTS = 80
+
+# a FILETIME counts 100ns intervals since 1601-01-01, our timestamps count ns since 1970-01-01.
+FILETIME_EPOCH_OFFSET_NS = 11644473600 * 1000000000
+# SetFileTime gives a special meaning to 0 ("do not change") and to all bits set
+# ("do not update this timestamp for this handle any more"), so avoid these values.
+FILETIME_MIN, FILETIME_MAX = 1, 0xFFFFFFFFFFFFFFFE
 
 _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
 _CreateFileW = _kernel32.CreateFileW
@@ -41,6 +53,14 @@ _CreateFileW.argtypes = [
     ctypes.wintypes.HANDLE,
 ]
 _CloseHandle = _kernel32.CloseHandle
+_SetFileTime = _kernel32.SetFileTime
+_SetFileTime.restype = ctypes.wintypes.BOOL
+_SetFileTime.argtypes = [
+    ctypes.wintypes.HANDLE,
+    ctypes.POINTER(ctypes.wintypes.FILETIME),
+    ctypes.POINTER(ctypes.wintypes.FILETIME),
+    ctypes.POINTER(ctypes.wintypes.FILETIME),
+]
 INVALID_HANDLE_VALUE = ctypes.wintypes.HANDLE(-1).value
 
 
@@ -101,6 +121,55 @@ class SyncFile(BaseSyncFile):
         """
         self.f.flush()
         os.fsync(self.fd)
+
+
+def _ns_to_filetime(ns):
+    """Convert a timestamp in ns since 1970-01-01 to a Win32 FILETIME."""
+    ft = (ns + FILETIME_EPOCH_OFFSET_NS) // 100
+    # clamp to what a FILETIME can express (borg timestamps have a much wider range).
+    ft = min(max(ft, FILETIME_MIN), FILETIME_MAX)
+    return ctypes.wintypes.FILETIME(ft & 0xFFFFFFFF, ft >> 32)
+
+
+def set_times(path, *, atime_ns, mtime_ns, birthtime_ns=None, fd=None, follow_symlinks=True):
+    """
+    Set the timestamps of *path* (or of the open file descriptor *fd*, if given).
+
+    Uses SetFileTime rather than os.utime, because os.utime on Windows can neither work on
+    a file descriptor nor on a symlink itself, nor can it set the birthtime (creation time).
+
+    Raises OSError if the timestamps could not be set.
+    """
+    if fd is not None:
+        handle, close_handle = msvcrt.get_osfhandle(fd), False
+    else:
+        # FILE_FLAG_BACKUP_SEMANTICS is required to get a handle for a directory.
+        flags = FILE_FLAG_BACKUP_SEMANTICS
+        if not follow_symlinks:
+            flags |= FILE_FLAG_OPEN_REPARSE_POINT
+        handle = _CreateFileW(
+            str(path),
+            FILE_WRITE_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            None,
+            OPEN_EXISTING,
+            flags,
+            None,
+        )
+        if handle == INVALID_HANDLE_VALUE:
+            raise ctypes.WinError(ctypes.get_last_error())
+        close_handle = True
+    try:
+        atime = _ns_to_filetime(atime_ns)
+        mtime = _ns_to_filetime(mtime_ns)
+        birthtime = _ns_to_filetime(birthtime_ns) if birthtime_ns is not None else None
+        if not _SetFileTime(
+            handle, ctypes.byref(birthtime) if birthtime is not None else None, ctypes.byref(atime), ctypes.byref(mtime)
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+    finally:
+        if close_handle:
+            _CloseHandle(handle)
 
 
 def getosusername():

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -326,6 +326,28 @@ def test_birthtime(archivers, request):
     assert same_ts_ns(sto.st_mtime_ns, mtime * 10**9)
 
 
+@pytest.mark.skipif(not is_win32, reason="Windows-only test")
+def test_timestamps_win32(archivers, request):
+    """windows: extract restores atime, mtime and (with Python >= 3.12) birthtime, see #7269"""
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file", contents=b"stuff")
+    # os.utime can not set the birthtime on Windows, so use our own platform code for the setup.
+    # a FILETIME has a resolution of 100ns, thus only use timestamps that are a multiple of 100ns.
+    atime_ns, mtime_ns, birthtime_ns = 1500000000000000100, 1400000000000000200, 1300000000000000300
+    platform.set_times("input/file", atime_ns=atime_ns, mtime_ns=mtime_ns, birthtime_ns=birthtime_ns)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "--atime", "test", "input")
+    sti = os.stat("input/file")
+    with changedir("output"):
+        cmd(archiver, "extract", "test")
+    sto = os.stat("output/input/file")
+    assert sto.st_mtime_ns == mtime_ns
+    # reading the input file for the backup might have updated its atime, so compare with the input file.
+    assert sto.st_atime_ns == sti.st_atime_ns
+    if hasattr(sti, "st_birthtime_ns"):  # Python >= 3.12
+        assert sto.st_birthtime_ns == birthtime_ns
+
+
 def test_sparse_file(archivers, request):
     archiver = request.getfixturevalue(archivers)
 

--- a/src/borg/testsuite/platform/windows_test.py
+++ b/src/borg/testsuite/platform/windows_test.py
@@ -1,12 +1,18 @@
+import os
 import tempfile
 
 import pytest
 
 from .platform_test import skipif_not_win32
-from ...platform import SyncFile
+from .. import are_symlinks_supported
+from ...platform import SyncFile, set_times
 
 # Set module-level skips
 pytestmark = [skipif_not_win32]
+
+# timestamps used by the set_times tests. a FILETIME has a resolution of 100ns,
+# so only use values that are a multiple of 100ns to be able to compare exactly.
+ATIME_NS, MTIME_NS, BIRTHTIME_NS = 1500000000000000100, 1400000000000000200, 1300000000000000300
 
 
 def test_syncfile_basic(tmp_path):
@@ -70,3 +76,67 @@ def test_syncfile_uses_write_through(tmp_path, monkeypatch):
     assert len(calls) == 1
     flags_attrs = calls[0][5]  # 6th arg: dwFlagsAndAttributes
     assert flags_attrs & windows.FILE_FLAG_WRITE_THROUGH
+
+
+def assert_times(st, *, atime_ns=ATIME_NS, mtime_ns=MTIME_NS, birthtime_ns=BIRTHTIME_NS):
+    assert st.st_atime_ns == atime_ns
+    assert st.st_mtime_ns == mtime_ns
+    if hasattr(st, "st_birthtime_ns"):  # Python >= 3.12 on Windows
+        assert st.st_birthtime_ns == birthtime_ns
+
+
+def test_set_times_file(tmp_path):
+    """set_times sets atime, mtime and birthtime of a file given by path."""
+    path = tmp_path / "file"
+    path.write_bytes(b"data")
+    set_times(str(path), atime_ns=ATIME_NS, mtime_ns=MTIME_NS, birthtime_ns=BIRTHTIME_NS)
+    assert_times(os.stat(path))
+
+
+def test_set_times_fd(tmp_path):
+    """set_times works on an open file descriptor, like borg extract uses it."""
+    path = tmp_path / "file"
+    with open(path, "wb") as f:
+        f.write(b"data")
+        f.flush()
+        set_times(str(path), atime_ns=ATIME_NS, mtime_ns=MTIME_NS, birthtime_ns=BIRTHTIME_NS, fd=f.fileno())
+    # the timestamps must survive closing the file we have written to.
+    assert_times(os.stat(path))
+
+
+def test_set_times_directory(tmp_path):
+    """set_times works on a directory (needs FILE_FLAG_BACKUP_SEMANTICS)."""
+    path = tmp_path / "dir"
+    path.mkdir()
+    set_times(str(path), atime_ns=ATIME_NS, mtime_ns=MTIME_NS, birthtime_ns=BIRTHTIME_NS)
+    assert_times(os.stat(path))
+
+
+def test_set_times_without_birthtime(tmp_path):
+    """set_times leaves the birthtime alone if we do not give one."""
+    path = tmp_path / "file"
+    path.write_bytes(b"data")
+    birthtime_ns = getattr(os.stat(path), "st_birthtime_ns", None)
+    set_times(str(path), atime_ns=ATIME_NS, mtime_ns=MTIME_NS)
+    assert_times(os.stat(path), birthtime_ns=birthtime_ns)
+
+
+@pytest.mark.skipif(not are_symlinks_supported(), reason="symlinks not supported")
+def test_set_times_symlink_not_followed(tmp_path):
+    """set_times(follow_symlinks=False) works on the symlink itself, not on its target."""
+    target = tmp_path / "target"
+    target.write_bytes(b"data")
+    target_times = os.stat(target)
+    link = tmp_path / "link"
+    os.symlink(str(target), str(link))
+    set_times(str(link), atime_ns=ATIME_NS, mtime_ns=MTIME_NS, birthtime_ns=BIRTHTIME_NS, follow_symlinks=False)
+    assert_times(os.stat(link, follow_symlinks=False))
+    st_target = os.stat(target)
+    assert st_target.st_mtime_ns == target_times.st_mtime_ns
+    assert st_target.st_atime_ns == target_times.st_atime_ns
+
+
+def test_set_times_nonexistent(tmp_path):
+    """set_times raises OSError if there is no such file."""
+    with pytest.raises(OSError):
+        set_times(str(tmp_path / "nonexistent"), atime_ns=ATIME_NS, mtime_ns=MTIME_NS)


### PR DESCRIPTION
On Windows, `borg extract` only restored atime and mtime, using `os.utime`. That is a bad fit there:

- `os.utime` can not set the birthtime (creation time). Python >= 3.12 has `st_birthtime_ns` on Windows, so borg *archives* the creation time, but it was never restored.
- `os.utime` does not support `follow_symlinks=False` on Windows (CPython only has that with `utimensat`/`lutimes`), so the timestamps of an extracted symlink were set on the symlink's **target**.
- `os.utime` does not support file descriptors on Windows, so the path had to be used even though borg has the file open already.

Add `platform.set_times(path, *, atime_ns, mtime_ns, birthtime_ns=None, fd=None, follow_symlinks=True)`:

- The POSIX implementation in `platform/base.py` is the `os.utime` code moved out of `Archive.restore_attrs`, including the `utimes(2)` trick that sets the birthtime on the BSDs and Darwin. No behavior change there.
- The win32 implementation in `platform/windows.pyx` uses `CreateFileW` (with `FILE_FLAG_BACKUP_SEMANTICS`, plus `FILE_FLAG_OPEN_REPARSE_POINT` if the symlink itself is meant) or `msvcrt.get_osfhandle(fd)`, and then `SetFileTime`. So it works on symlinks, directories and file descriptors and it also sets the birthtime.

`Archive.restore_attrs` now has one code path for the timestamps instead of two. Additionally, failing to set the timestamps is not silently ignored on win32 anymore: it warns and sets the warning exit code.

Tests: `set_times` unit tests (file, file descriptor with pending writes, directory, symlink - checking that the target is not touched, missing file) and a create/extract round trip of atime, mtime and birthtime on win32.