### PR TITLE
conftest: fix rmtree cleanup crash on Linux (os.lchflags does not exist)

### DIFF
--- a/src/borg/conftest.py
+++ b/src/borg/conftest.py
@@ -15,6 +15,7 @@ from borg.logger import setup_logging  # noqa: E402
 setup_logging()
 
 from borg.archiver import Archiver  # noqa: E402
+from borg.platform import set_flags  # noqa: E402
 from borg.testsuite import has_lchflags, has_llfuse, has_pyfuse3, has_mfusepy  # noqa: E402
 from borg.testsuite import are_symlinks_supported, are_hardlinks_supported, is_utime_fully_supported  # noqa: E402
 from borg.testsuite.archiver import BORG_EXES
@@ -196,8 +197,10 @@ def archiver(tmp_path, set_env_variables):
     def maybe_clear_flags_and_retry(func, path, _exc_info):
         if has_lchflags:
             # Clear any BSD flags (e.g. UF_APPEND) that may have prevented removal, then retry once.
+            # Note: use borg's cross-platform set_flags, not os.lchflags - the latter does not exist
+            # on Linux even though has_lchflags is True there (Linux clears flags via ioctl).
             try:
-                os.lchflags(path, 0)
+                set_flags(path, 0)
                 func(path)
             except OSError:
                 pass


### PR DESCRIPTION
The `archiver` fixture cleans up with `shutil.rmtree(..., onerror=maybe_clear_flags_and_retry)`. That handler calls `os.lchflags(path, 0)` when `has_lchflags` is true, and retries the removal.

But `has_lchflags` is defined as:

```python
has_lchflags = hasattr(os, "lchflags") or sys.platform.startswith("linux")
```

so it is also true on Linux, where flags are cleared via ioctl and `os.lchflags` does not exist. The resulting `AttributeError` is not an `OSError`, so it escapes the surrounding `try`/`except OSError` and turns teardown into an ERROR - the handler that exists to recover from a failed removal is itself broken on Linux.

Use borg's cross-platform `platform.set_flags` instead, which is the intended API and works on both BSD and Linux.

Split out of https://github.com/borgbackup/borg/pull/9602 - the bug is independent of that PR and is present in master today.
