### PR TITLE
tests: do not pin the zsh --sort-by label, shtab 1.11.0 changed it

### DIFF
--- a/src/borg/testsuite/archiver/completion_cmd_test.py
+++ b/src/borg/testsuite/archiver/completion_cmd_test.py
@@ -279,7 +279,10 @@ def test_zsh_sortby_wiring(archivers, request, command, fn):
     lines = completion_lines(archivers, request, "zsh")
     block = lines[lines.index(f"_shtab_borg_{command.replace('-', '_')}_options=(") :]
     block = block[: block.index(")")]
-    assert any(f':sort_by:{fn}"' in line for line in block)
+    # The ":<label>:<helper>" label is only what zsh displays while completing: shtab used the
+    # argument's dest for it and uses its metavar since 1.11.0. Do not pin the label down, just
+    # require that --sort-by is wired to our helper.
+    assert any(re.search(rf'^\s*"--sort-by\[.*\]:[^:]+:{fn}"', line) for line in block)
     assert f"{fn}() {{" in lines
 
 


### PR DESCRIPTION
`test_zsh_sortby_wiring` fails on master since 2026-08-15 (e.g. the `asan_ubsan` job of the master run for 6d99e87ee), without any borg change causing it:

```
FAILED src/borg/testsuite/archiver/completion_cmd_test.py::test_zsh_sortby_wiring[archiver-repo-list-_borg_complete_sortby] - assert False
FAILED src/borg/testsuite/archiver/completion_cmd_test.py::test_zsh_sortby_wiring[archiver-list-_borg_complete_item_sortby] - assert False
```

**Cause:** shtab 1.11.0 was released on 2026-08-15 and labels a zsh option argument with the argument's *metavar* instead of its *dest*. For `borg list --sort-by` (metavar `KEYS`, dest `sort_by`) the generated spec changed from

```
"--sort-by[...]:sort_by:_borg_complete_item_sortby"
```

to

```
"--sort-by[...]:KEYS:_borg_complete_item_sortby"
```

The test matched the `:sort_by:` form literally. `borg diff --sort-by` has no metavar, so shtab still falls back to the dest there - which is why that third parametrization keeps passing and only `list` and `repo-list` fail.

**The completions themselves are fine.** That label is only what zsh displays while completing; `--sort-by` is still wired to the correct helper function. So this matches the helper and leaves the label open, and passes with either shtab behaviour.

Verified locally against both versions - 46 passed with shtab 1.9.3 and 46 passed with 1.11.0 - and the relaxed assertion still rejects a renamed or missing helper, so it does not become vacuous.

Note: shtab is not pinned in `requirements.d/`; it is pulled in by the `shtab>=1.9.3` dependency in `pyproject.toml`, so CI resolves a fresh shtab on every run and new releases can break master overnight. This has happened before (https://github.com/borgbackup/borg/pull/9983 excluded 1.8.2/1.9.0/1.9.1). Adding it to `requirements.d/development.lock.txt` would make CI reproducible, but that is a separate change from this fix.
