### PR TITLE
tests: drop the netbsd ctime workaround, fixes #8703

### DIFF
--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -176,8 +176,7 @@ def test_basic_functionality(archivers, request):
         assert unexpected not in get_changes("input/file_touched", joutput)
         if not content_only:
             # on win32, ctime is the file creation time and does not change.
-            # not sure why netbsd only has mtime, but it does, #8703.
-            expected = {"mtime"} if (is_win32 or is_netbsd) else {"mtime", "ctime"}
+            expected = {"mtime"} if is_win32 else {"mtime", "ctime"}
             assert expected.issubset({c["type"] for c in get_changes("input/file_touched", joutput)})
         else:
             # And if we're doing content-only, don't show the file at all.


### PR DESCRIPTION
Removes the netbsd special case in `test_basic_functionality` that commit 1589489bd added for
[#8703](https://github.com/borgbackup/borg/issues/8703) while CI still tested netbsd 9: after
`Path("input/file_touched").touch()`, borg's diff only showed an mtime change there, no ctime
change. The test again expects `{"mtime", "ctime"}` on netbsd like on any other posix OS.

CI now tests netbsd 11 and `test_basic_functionality[archiver]` passes there without the
workaround, so the issue is gone (a first revision of this PR also printed `st_mtime_ns` /
`st_ctime_ns` around the `touch()` to tell an OS quirk from a borg bug - not needed anymore,
so it is not part of the commit).