### PR TITLE
recreate: keep chunker_params if not rechunkifying, fixes #10127

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2533,11 +2533,13 @@ class ArchiveRecreater:
     def create_target(self, archive, target_name=None):
         """Create target archive."""
         target_name = target_name or archive.name + '.recreate'
-        target = self.create_target_archive(target_name)
-        # If the archives use the same chunker params, then don't rechunkify
         src_cp = archive.metadata.get('chunker_params')
         src_cp = normalize_chunker_params(src_cp) if src_cp is not None else None
-        dst_cp = target.chunker_params
+        # if we do not rechunkify, the target archive just reuses the source archive's chunks,
+        # so it must also keep the source archive's chunker params (if we know them), see #10127.
+        dst_cp = self.chunker_params if self.rechunkify else (src_cp or self.chunker_params)
+        target = self.create_target_archive(target_name, dst_cp)
+        # If the archives use the same chunker params, then don't rechunkify
         target.recreate_rechunkify = self.rechunkify and src_cp != dst_cp
         if target.recreate_rechunkify:
             logger.debug('Rechunking archive from %s to %s', src_cp or '(unknown)', dst_cp)
@@ -2548,10 +2550,10 @@ class ArchiveRecreater:
         target.chunker = get_chunker(*target.chunker_params, seed=self.key.chunk_seed, sparse=False)
         return target
 
-    def create_target_archive(self, name):
+    def create_target_archive(self, name, chunker_params=None):
         target = Archive(self.repository, self.key, self.manifest, name, create=True,
-                          progress=self.progress, chunker_params=self.chunker_params, cache=self.cache,
-                          checkpoint_interval=self.checkpoint_interval)
+                          progress=self.progress, chunker_params=chunker_params or self.chunker_params,
+                          cache=self.cache, checkpoint_interval=self.checkpoint_interval)
         return target
 
     def open_archive(self, name, **kwargs):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -3648,6 +3648,23 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         num_chunks_after_recreate = int(output)
         assert num_chunks == num_chunks_after_recreate
 
+    def test_recreate_keeps_chunker_params(self):
+        def chunker_params(archive):
+            info = json.loads(self.cmd('info', '--json', self.repository_location + '::' + archive))
+            return info['archives'][0]['chunker_params']
+
+        self.create_regular_file('file', size=1024)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        # first create an archive with non-default chunker params:
+        self.cmd('create', '--chunker-params', '7,9,8,127', self.repository_location + '::test', 'input')
+        assert chunker_params('test') == ['buzhash', 7, 9, 8, 127]
+        # recreating without --chunker-params does not rechunk, so the chunker params must be kept:
+        self.cmd('recreate', '--comment', 'a comment', self.repository_location + '::test')
+        assert chunker_params('test') == ['buzhash', 7, 9, 8, 127]
+        # recreating with --chunker-params rechunks, so the new chunker params must be recorded:
+        self.cmd('recreate', '--chunker-params', 'fixed,4096', self.repository_location + '::test')
+        assert chunker_params('test') == ['fixed', 4096, 0]
+
     def test_recreate_recompress(self):
         self.create_regular_file('compressible', size=10000)
         self.cmd('init', '--encryption=repokey', self.repository_location)


### PR DESCRIPTION
If no `--chunker-params` was given, `borg recreate` does not rechunk, so the target archive keeps the source archive's chunks. But it still recorded the *default* chunker params in the target archive's metadata: after e.g.

```
borg recreate --comment "This is a comment" repo::archive
```

an archive created with `--chunker-params=buzhash,10,23,16,4095` claimed `buzhash,19,23,21,4095` in `borg info --json`, although its chunks were still the original ones.

Now `ArchiveRecreater.create_target` computes the target chunker params first: if we rechunkify, the new params are used (and recorded, as before); otherwise the target inherits the source archive's chunker params, so the metadata keeps describing how the chunks were actually made. If the source archive has no chunker params in its metadata (very old archives), we fall back to the defaults as before.

Added a regression test that checks the recorded chunker params after recreating with and without `--chunker-params`.