### PR TITLE
recreate: keep chunker_params if not rechunkifying, fixes #10127

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2626,12 +2626,15 @@ class ArchiveRecreater:
 
     def create_target(self, archive, target_name):
         """Create target archive."""
-        target = self.create_target_archive(target_name)
-        # If the archives use the same chunker params, then don't rechunkify
         source_chunker_params = tuple(archive.metadata.get("chunker_params", []))
         if len(source_chunker_params) == 4 and isinstance(source_chunker_params[0], int):
             # this is a borg < 1.2 chunker_params tuple, no chunker algo specified, but we only had buzhash:
             source_chunker_params = (CH_BUZHASH,) + source_chunker_params
+        # if we do not rechunkify, the target archive just reuses the source archive's chunks,
+        # so it must also keep the source archive's chunker params (if we know them), see #10127.
+        target_chunker_params = self.chunker_params if self.rechunkify else source_chunker_params
+        target = self.create_target_archive(target_name, target_chunker_params or self.chunker_params)
+        # If the archives use the same chunker params, then don't rechunkify
         target.recreate_rechunkify = self.rechunkify and source_chunker_params != target.chunker_params
         if target.recreate_rechunkify:
             logger.debug(
@@ -2643,13 +2646,13 @@ class ArchiveRecreater:
         target.chunker = get_chunker(*target.chunker_params, key=self.key, sparse=False)
         return target
 
-    def create_target_archive(self, name):
+    def create_target_archive(self, name, chunker_params=None):
         target = Archive(
             self.manifest,
             name,
             create=True,
             progress=self.progress,
-            chunker_params=self.chunker_params,
+            chunker_params=chunker_params or self.chunker_params,
             cache=self.cache,
         )
         return target

--- a/src/borg/testsuite/archiver/recreate_cmd_test.py
+++ b/src/borg/testsuite/archiver/recreate_cmd_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import time
@@ -213,6 +214,26 @@ def test_recreate_no_rechunkify(archivers, request):
     output = cmd(archiver, "list", "test", "input/file", "--format", "{num_chunks}")
     num_chunks_after_recreate = int(output)
     assert num_chunks == num_chunks_after_recreate
+
+
+def test_recreate_keeps_chunker_params(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+
+    def chunker_params():
+        info = json.loads(cmd(archiver, "info", "--json", "-a", "test"))
+        return info["archives"][0]["chunker_params"]
+
+    create_regular_file(archiver.input_path, "file", size=1024)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    # first create an archive with non-default params for the default chunker:
+    cmd(archiver, "create", "test", "input", "--chunker-params", "fastcdc,7,9,8,2")
+    assert chunker_params() == ["fastcdc", 7, 9, 8, 2]
+    # recreating without --chunker-params does not rechunk, so the chunker params must be kept:
+    cmd(archiver, "recreate", "-a", "test", "--comment", "a comment")
+    assert chunker_params() == ["fastcdc", 7, 9, 8, 2]
+    # recreating with --chunker-params rechunks, so the new chunker params must be recorded:
+    cmd(archiver, "recreate", "-a", "test", "--chunker-params", "default")
+    assert chunker_params() == list(CHUNKER_PARAMS)
 
 
 def test_recreate_keep_original_timestamp(archivers, request):


### PR DESCRIPTION
Same fix as [#10130](https://github.com/borgbackup/borg/pull/10130), but for master.

If no `--chunker-params` was given, `borg recreate` does not rechunk, so the target archive keeps the source archive's chunks. But it still recorded the *default* chunker params in the target archive's metadata, so e.g. `borg recreate -a ARCHIVE --comment ...` of an archive created with non-default chunker params claimed the default params in `borg info --json` afterwards, although its chunks were still the original ones.

Now `ArchiveRecreater.create_target` computes the target chunker params first: if we rechunkify, the new params are used (and recorded, as before); otherwise the target inherits the source archive's chunker params, so the metadata keeps describing how the chunks were actually made. If the source archive has no chunker params in its metadata (very old archives), we fall back to the defaults as before.

Added a regression test that checks the recorded chunker params after recreating with and without `--chunker-params`.