### PR TITLE
CI: upgrade OpenBSD to 7.9, move non-binary jobs to ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   lint:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
@@ -127,12 +127,12 @@ jobs:
         ${{ fromJSON(
           github.event_name == 'pull_request' && '{
             "include": [
-              {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
+              {"os": "ubuntu-24.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"}
             ]
           }' || '{
             "include": [
-              {"os": "ubuntu-22.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
+              {"os": "ubuntu-24.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
               {"os": "ubuntu-22.04", "python-version": "3.11", "toxenv": "py311-fuse3", "binary": "borg-linux-glibc235-x86_64-gh"},
               {"os": "ubuntu-22.04-arm", "python-version": "3.11", "toxenv": "py311-fuse3", "binary": "borg-linux-glibc235-arm64-gh"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-fuse3"},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
             display_name: NetBSD
             do_binaries: false
           - os: openbsd
-            version: '7.7'
+            version: '7.9'
             display_name: OpenBSD
             do_binaries: false
           - os: haiku
@@ -406,10 +406,10 @@ jobs:
             openbsd)
               sudo -E pkg_add xxhash lz4 zstd git
               sudo -E pkg_add rust
-              sudo -E pkg_add openssl%3.4
+              sudo -E pkg_add openssl%3.5
               sudo -E pkg_add py3-pip py3-virtualenv py3-tox
-              export BORG_OPENSSL_NAME=eopenssl34
-              tox -e py312-none
+              export BORG_OPENSSL_NAME=eopenssl35
+              tox -e py313-none
               ;;
             haiku)
               pkgman refresh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Two independent CI runner upgrades:

- **OpenBSD 7.7 -> 7.9.** The image is available since `cross-platform-actions/openbsd-builder` v0.14.0, which is contained in the `cross-platform-actions/action` v1.4.0 that this branch already uses. 7.9's default python3 is 3.13 (7.7 had 3.12), so the tox env changes to `py313-none`, and the packaged openssl is 3.5 now (was 3.4).
- **ubuntu-22.04 -> ubuntu-24.04** for all jobs that do not build release binaries: CodeQL, lint and the `py310-fuse2` test job.

The two remaining ubuntu-22.04 jobs (x86_64 and arm64) build the `borg-linux-glibc235-*` binaries and stay on 22.04 for glibc 2.35 compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)