### PR TITLE
testsuite/CI: cut coverage overhead in the test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
         set -euo pipefail
         export LD_PRELOAD="$(gcc -print-file-name=libasan.so):$(gcc -print-file-name=libubsan.so)"
         echo "Using LD_PRELOAD=$LD_PRELOAD"
-        pytest -v --benchmark-skip -k "not remote"
+        # the sanitizer runtimes write their reports to stderr, so they still show up per worker
+        pytest -v -n auto --benchmark-skip -k "not remote"
 
   native_tests:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,26 +146,28 @@ jobs:
       # the matrix, see continue-on-error below.
       fail-fast: true
       # noinspection YAMLSchemaValidation
+      # "coverage": "1" collects coverage in that entry - we only do that for the
+      # oldest and the newest supported python, measuring is not free, see #9470.
       matrix: >-
         ${{ fromJSON(
           github.event_name == 'pull_request' && '{
             "include": [
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "mypy"},
               {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "docs"},
-              {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse"},
+              {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse", "coverage": "1"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3", "store_cache": "1"},
-              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy"},
+              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-mfusepy", "coverage": "1"},
               {"os": "ubuntu-24.04", "python-version": "3.15-dev", "toxenv": "py315-mfusepy", "allow-failure": true}
             ]
           }' || '{
             "include": [
-              {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse"},
+              {"os": "ubuntu-24.04", "python-version": "3.11", "toxenv": "py311-llfuse", "coverage": "1"},
               {"os": "ubuntu-24.04", "python-version": "3.12", "toxenv": "py312-pyfuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-mfusepy", "store_cache": "1"},
-              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-x86_64-gh"},
-              {"os": "ubuntu-24.04-arm", "python-version": "3.14", "toxenv": "py314-pyfuse3", "binary": "borg-linux-glibc239-arm64-gh"},
-              {"os": "macos-15", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-arm64-gh"},
-              {"os": "macos-15-intel", "python-version": "3.14", "toxenv": "py314-none", "binary": "borg-macos-15-x86_64-gh"},
+              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-pyfuse3", "coverage": "1", "binary": "borg-linux-glibc239-x86_64-gh"},
+              {"os": "ubuntu-24.04-arm", "python-version": "3.14", "toxenv": "py314-pyfuse3", "coverage": "1", "binary": "borg-linux-glibc239-arm64-gh"},
+              {"os": "macos-15", "python-version": "3.14", "toxenv": "py314-none", "coverage": "1", "binary": "borg-macos-15-arm64-gh"},
+              {"os": "macos-15-intel", "python-version": "3.14", "toxenv": "py314-none", "coverage": "1", "binary": "borg-macos-15-x86_64-gh"},
               {"os": "ubuntu-24.04", "python-version": "3.15-dev", "toxenv": "py315-mfusepy", "allow-failure": true}
             ]
           }'
@@ -365,6 +367,9 @@ jobs:
         if-no-files-found: error
 
     - name: run tox env
+      env:
+        # tox passes this through to pytest (pass_env = ["*"])
+        PYTEST_ADDOPTS: ${{ !matrix.coverage && '--no-cov' || '' }}
       run: |
         # do not use fakeroot, but run as root. avoids the dreaded EISDIR sporadic failures. see #2482.
         #sudo -E bash -c "tox -e py"
@@ -385,7 +390,7 @@ jobs:
         files: test-results.xml
 
     - name: Upload coverage to Codecov
-      if: ${{ !cancelled() && !contains(matrix.toxenv, 'mypy') && !contains(matrix.toxenv, 'docs') }}
+      if: ${{ !cancelled() && matrix.coverage }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       env:
         OS: ${{ runner.os }}

--- a/src/borg/conftest.py
+++ b/src/borg/conftest.py
@@ -213,8 +213,11 @@ def archiver(tmp_path, set_env_variables):
 
 
 @pytest.fixture()
-def remote_archiver(archiver):
+def remote_archiver(archiver, monkeypatch):
     archiver.repository_location = "rest://" + "/" + str(archiver.repository_path)
+    # don't measure coverage in the "borg serve --rest" children, see #9470
+    monkeypatch.delenv("COVERAGE_PROCESS_CONFIG", raising=False)
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
     yield archiver
 
 


### PR DESCRIPTION
Three independent speedups from the [#9470](https://github.com/borgbackup/borg/issues/9470) measurements, one commit each.

**1. Don't measure coverage in the `rest://` serve subprocesses.** Every remote test spawns `borg serve --rest` children (via borgstore) which inherit `COVERAGE_PROCESS_CONFIG` and therefore boot coverage: ~80-190ms plus a sqlite data file per spawn, and the traced serve loop mostly runs borgstore code, which is not in our coverage `source` anyway. The `remote_archiver` fixture now drops that env var.

| create_cmd_test.py, remote tests | py3.11 | py3.14 |
|---|---|---|
| no coverage | 172 s | 152 s |
| coverage, before | 248 s | 209 s |
| coverage, after | 177 s | 150 s |

Cost: 43 covered lines (~0.24 % of stmts on that subset), all per-process boilerplate — serve_cmd.py +10, helpers/process.py +14, etc. The local and binary fixtures are untouched, so the daemonized `borg mount` children (the reason we enabled `patch = subprocess` in the first place, see [#9463](https://github.com/borgbackup/borg/issues/9463)) are still measured. I verified both directions with a throwaway test: the env var is still present under the `archiver` fixture and gone under `remote_archiver`.

**2. Only measure coverage on the oldest and newest python.** The native matrix ran `--cov` on every python version, so most lines were measured 4x over — and with the C tracer core (python < 3.14) measuring roughly doubles the suite's user CPU. Coverage now stays on 3.11 (oldest supported) and 3.14 (newest; there coverage uses the nearly free sys.monitoring core) and is switched off for 3.12, 3.13 and 3.15-dev via a new `"coverage": "1"` matrix flag that gates `PYTEST_ADDOPTS=--no-cov` and the codecov upload. macOS keeps it (only source of darwin platform coverage), as do the BSD/Windows jobs.

**3. Run the sanitizer tests in parallel.** `asan_ubsan` was the only test job running pytest single process (~11 min, and it already skips the remote tests). Now `-n auto`. The sanitizer runtimes write to stderr, so their reports still reach the job log per worker; this PR's own CI run is the test for it.

The canary workflow is untouched — it is scheduled, not PR blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)