### PR TITLE
CI: give the macOS runners a resolvable hostname

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -72,6 +72,9 @@ jobs:
       shell: bash
       run: |
         brew bundle install || true
+        # unresolvable .local runner hostname = ~35s resolver timeout per borg process, see #9470
+        sudo scutil --set HostName borg-ci-mac
+        echo "127.0.0.1 borg-ci-mac" | sudo tee -a /etc/hosts
 
     - name: Install Python requirements (UNLOCKED)
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,11 @@ jobs:
       run: |
         brew unlink pkg-config@0.29.2 || true
         brew bundle install
+        # the runner's unresolvable .local hostname takes macOS ~35s to give up on,
+        # which borg paid per spawned process (import-time fqdn) - hours of test time,
+        # see #9470. .local is mDNS territory, an /etc/hosts entry alone does not help.
+        sudo scutil --set HostName borg-ci-mac
+        echo "127.0.0.1 borg-ci-mac" | sudo tee -a /etc/hosts
 
     - name: Configure OpenSSH SFTP server (test only)
       if: ${{ runner.os == 'Linux' && !contains(matrix.toxenv, 'mypy') && !contains(matrix.toxenv, 'docs') }}


### PR DESCRIPTION
The macOS test jobs took ~3-4 hours (versus 10-20 minutes for the same suite on comparable linux runners), nearly all of it in the remote (rest://) tests. Found while working on [#9470](https://github.com/borgbackup/borg/issues/9470):

- The runner's hostname is a long, unresolvable `.local` name (e.g. `iad20-fj918-…-76FF332FBC6F.local`), and macOS needs **~35 s** to give up resolving it.
- borg resolves the fqdn **at import time** (`platform/base.py`, for `fqdn`/`hostid`), so every spawned borg process paid those 35 s. A remote test spawns ~10 serve/client processes → ~400 s per test; timestamp analysis of a master run put 97 % of the job's 9.1 h worker-time into the remote tests, in ~35 s quanta.

Verified on a macos-15 runner (diagnosis workflow on my fork):

| | before | after |
|---|---|---|
| `getaddrinfo(gethostname(), AI_CANONNAME)` | 35.0 s | 0.04 s |
| `python -m borg --version` (warm) | 35.9 s | 0.28 s |
| `test_basic_functionality[remote_archiver]` | 394 s | 5.2 s |

Two details that make it non-obvious: an `/etc/hosts` entry for the *original* name does **not** help (`.local` is mDNS territory, the canonical-name query never consults it — verified), hence the rename via `scutil --set HostName` plus a hosts entry for the new plain name. Applied to the ci.yml macOS step and the canary workflow.

Expected effect: the macOS jobs drop from ~3-4 h to roughly the runtime of the other platforms. Note the PR-event matrix contains no macOS jobs, so this shows up only on the post-merge master push (the numbers above are from a real macos-15 runner, though).

A complementary borg-side change (lazy fqdn/hostid, so spawned processes do not pay resolver costs on ANY host with broken name resolution) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)