### PR TITLE
platform: determine hostname / fqdn / hostid lazily

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -743,7 +743,7 @@ Duration: {0.duration}
             "item_ptrs": item_ptrs,  # see #1473
             "command_line": join_cmd(sys.argv),
             "cwd": self.cwd,
-            "hostname": os.environ.get("BORG_HOSTNAME") or platform.hostname,
+            "hostname": os.environ.get("BORG_HOSTNAME") or platform.get_hostname(),
             "username": os.environ.get("BORG_USERNAME") or getuser(),
             "time": nominal.isoformat(timespec="microseconds"),
             "start": start.isoformat(timespec="microseconds"),

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -496,14 +496,15 @@ def format_line(format, data):
 
 def _replace_placeholders(text, overrides={}):
     """Replace placeholders in text with their values."""
-    from ..platform import fqdn, hostname, getosusername
+    from ..platform import get_fqdn, get_hostname, getosusername
 
+    fqdn = get_fqdn()
     current_time = datetime.now(UTC)
     data = {
         "pid": os.getpid(),
         "fqdn": fqdn,
         "reverse-fqdn": ".".join(reversed(fqdn.split("."))),
-        "hostname": os.environ.get("BORG_HOSTNAME") or hostname,
+        "hostname": os.environ.get("BORG_HOSTNAME") or get_hostname(),
         "now": DatetimeWrapper(current_time.astimezone()),
         "utcnow": DatetimeWrapper(current_time),
         "unixtime": int(current_time.timestamp()),

--- a/src/borg/platform/__init__.py
+++ b/src/borg/platform/__init__.py
@@ -10,9 +10,10 @@ from ..platformflags import is_win32, is_linux, is_freebsd, is_netbsd, is_darwin
 
 from .base import ENOATTR
 from .base import SaveFile, sync_dir, fdatasync, safe_fadvise
-from .base import get_process_id, fqdn, hostname, hostid, swidth
+from .base import get_process_id, get_hostname, get_fqdn, get_hostid, swidth
 from .base import acl_text_to_xattr  # overridden below for platforms supporting it
 from .base import set_times  # overridden below for win32
+
 
 # work around pyinstaller "forgetting" to include the xattr module
 from . import xattr  # noqa: F401

--- a/src/borg/platform/base.py
+++ b/src/borg/platform/base.py
@@ -1,4 +1,5 @@
 import errno
+import functools
 import io
 import os
 import socket
@@ -350,20 +351,33 @@ def getfqdn(name=""):
     return name
 
 
-# for performance reasons, only determine hostname / fqdn / hostid once.
-# XXX this sometimes requires live internet access for issuing a DNS query in the background.
-hostname = socket.gethostname()
-fqdn = getfqdn(hostname)
-# some people put the fqdn into /etc/hostname (which is wrong, should be the short hostname)
-# fix this (do the same as "hostname --short" cli command does internally):
-hostname = hostname.split(".")[0]
+@functools.cache
+def _gethostname():
+    """socket.gethostname(), cached so all derived values are consistent for the process lifetime."""
+    return socket.gethostname()
 
-# uuid.getnode() is problematic in some environments (e.g. OpenVZ, see #3968) where the virtual MAC address
-# is all-zero. uuid.getnode falls back to returning a random value in that case, which is not what we want.
-# thus, we offer BORG_HOST_ID where a user can set an own, unique id for each of his hosts.
-hostid = os.environ.get("BORG_HOST_ID")
-if not hostid:
-    hostid = f"{fqdn}@{uuid.getnode()}"
+
+def get_hostname():
+    """Return the (short) hostname of this machine."""
+    # some people put the fqdn into /etc/hostname (which is wrong, should be the short hostname)
+    # fix this (do the same as "hostname --short" cli command does internally):
+    return _gethostname().split(".")[0]
+
+
+@functools.cache
+def get_fqdn():
+    """Return the fully qualified domain name of this machine."""
+    # cached: this issues a DNS query, which can take very long on hosts whose own
+    # hostname does not resolve (e.g. ~35s per query on github's macOS CI runners, see #9470).
+    return getfqdn(_gethostname())
+
+
+def get_hostid():
+    """Return an identifier that is unique for this machine (host)."""
+    # uuid.getnode() is problematic in some environments (e.g. OpenVZ, see #3968) where the virtual MAC address
+    # is all-zero. uuid.getnode falls back to returning a random value in that case, which is not what we want.
+    # thus, we offer BORG_HOST_ID where a user can set an own, unique id for each of his hosts.
+    return os.environ.get("BORG_HOST_ID") or f"{get_fqdn()}@{uuid.getnode()}"
 
 
 def get_process_id():
@@ -375,4 +389,4 @@ def get_process_id():
     """
     thread_id = 0
     pid = os.getpid()
-    return hostid, pid, thread_id
+    return get_hostid(), pid, thread_id

--- a/src/borg/platform/posix.pyx
+++ b/src/borg/platform/posix.pyx
@@ -18,8 +18,9 @@ def process_alive(host, pid, thread):
     always returns True, since there is no real way to check.
     """
     from . import local_pid_alive
-    from . import hostid
+    from . import get_hostid
 
+    hostid = get_hostid()
     assert isinstance(host, str)
     assert isinstance(hostid, str)
     assert isinstance(pid, int)


### PR DESCRIPTION
Determining the fqdn issues a DNS query, and it happened at **import time** — so every borg process paid for it, even ones that never use the fqdn. On hosts whose own hostname does not resolve, that query can take very long: ~35 s per process on GitHub's macOS runners (unresolvable `.local` hostname), which is what made the macOS test jobs take hours — each remote test spawns ~10 `borg serve`/client processes. Diagnosis in [#9470](https://github.com/borgbackup/borg/issues/9470); the CI-side companion fix was [#10135](https://github.com/borgbackup/borg/pull/10135) (merged; macOS jobs 3h55m → 9 min).

The module-level `hostname` / `fqdn` / `hostid` attributes are replaced by cached `get_hostname()` / `get_fqdn()` / `get_hostid()` functions (`functools.cache`), computed on first use and still only once per process. The few consumers (parseformat placeholders, archive metadata, `posix.pyx`'s `process_alive`, `get_process_id`) now call them. The three values are computed independently: `get_hostname()` never needs DNS, and a set `BORG_HOST_ID` avoids the fqdn lookup entirely. Processes that never use them — like the spawned `borg serve --rest` children — no longer resolve anything at all, on any platform.

Verified: importing `borg.archiver` performs no `getaddrinfo` call at all (asserted via socket monkeypatching); `process_alive()` works against the rebuilt `posix` extension; storelocking/fslocking/parseformat/repo-create tests pass (306 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)