### PR TITLE
CI: give the macOS runners a resolvable hostname (1.4-maint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,13 @@ jobs:
 
     - name: Install macOS packages
       if: ${{ runner.os == 'macOS' }}
-      run: brew bundle install
+      run: |
+        brew bundle install
+        # the runner's unresolvable .local hostname takes macOS ~35s to give up on,
+        # which borg paid per spawned process (import-time fqdn) - hours of test time,
+        # see #9470. .local is mDNS territory, an /etc/hosts entry alone does not help.
+        sudo scutil --set HostName borg-ci-mac
+        echo "127.0.0.1 borg-ci-mac" | sudo tee -a /etc/hosts
 
     - name: Install Python requirements
       run: |


### PR DESCRIPTION
Backport of [#10135](https://github.com/borgbackup/borg/pull/10135) to 1.4-maint (adapted: the macOS package step is a one-liner here, and there is no canary workflow).

Same root cause as on master ([#9470](https://github.com/borgbackup/borg/issues/9470)): the runner's unresolvable `.local` hostname costs ~35 s of resolver timeout in every spawned borg process via the import-time fqdn lookup in `platform/base.py` — 1.4's remote tests spawn a `borg serve` per test, so the macOS jobs here are hit just as hard: the latest 1.4-maint run took **4 h 47 min** on macos-15-intel.

On master this took the macOS jobs from ~4 h to 9-15 min ([verified run](https://github.com/borgbackup/borg/actions/runs/31981336636)). Also filed upstream as [actions/runner-images#14568](https://github.com/actions/runner-images/issues/14568).

🤖 Generated with [Claude Code](https://claude.com/claude-code)