### PR TITLE
CI: speed up the NetBSD and OpenBSD VM jobs (1.4-maint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,8 @@ jobs:
             version: '7.9'
             display_name: OpenBSD
             do_binaries: false
+            # extra RAM for the mfs-backed TMPDIR, see the openbsd test step
+            memory: 12G
           - os: haiku
             version: 'r1beta5'
             display_name: Haiku
@@ -414,6 +416,17 @@ jobs:
               tox3 -e py314-none
               ;;
             openbsd)
+              # Put the temp tree (pip/cc build temps, pytest tmp dirs and the
+              # borg test repos in them) on a memory-backed filesystem instead
+              # of the slow FFS disk. Sized generously (the pytest tmp tree is
+              # only cleaned up after the run); the VM gets 12G RAM for this.
+              sudo mkdir -p /mfs
+              # -O2: FFS2 format - mfs defaults to FFS1, whose 32 bit
+              # timestamps silently wrap (breaks test_extract_y2261).
+              sudo mount_mfs -O2 -s 6g swap /mfs
+              sudo chmod 1777 /mfs
+              export TMPDIR=/mfs
+
               sudo -E pkg_add xxhash lz4 zstd git
               sudo -E pkg_add rust
               sudo -E pkg_add openssl%3.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,9 @@ jobs:
         operating_system: ${{ matrix.os }}
         version: ${{ matrix.version }}
         shell: bash
+        # the default VM size (2 cpus) leaves half of the runner's 4 vcpus idle
+        cpu_count: 4
+        memory: ${{ matrix.memory || '8G' }}
         run: |
           set -euxo pipefail
           case "${{ matrix.os }}" in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,11 +393,12 @@ jobs:
               sudo -E pkgin -y install zstd lz4 xxhash git
               sudo -E pkgin -y install rust
               sudo -E pkgin -y install pkg-config
-              sudo -E pkgin -y install py311-pip py311-virtualenv py311-tox
-              sudo -E ln -sf /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
-              sudo -E ln -sf /usr/pkg/bin/pip3.11 /usr/pkg/bin/pip3
-              sudo -E ln -sf /usr/pkg/bin/virtualenv-3.11 /usr/pkg/bin/virtualenv3
-              sudo -E ln -sf /usr/pkg/bin/tox-3.11 /usr/pkg/bin/tox3
+              # python 3.14 for coverage's fast sysmon core, see #9470
+              sudo -E pkgin -y install py314-pip py314-virtualenv py314-tox
+              sudo -E ln -sf /usr/pkg/bin/python3.14 /usr/pkg/bin/python3
+              sudo -E ln -sf /usr/pkg/bin/pip3.14 /usr/pkg/bin/pip3
+              sudo -E ln -sf /usr/pkg/bin/virtualenv-3.14 /usr/pkg/bin/virtualenv3
+              sudo -E ln -sf /usr/pkg/bin/tox-3.14 /usr/pkg/bin/tox3
               # Ensure base system admin tools are on PATH for the non-root shell
               export PATH="/sbin:/usr/sbin:$PATH"
               # On the netbsd 11 VM, / is a fs with extended attributes,
@@ -407,7 +408,7 @@ jobs:
               sudo -E chmod 1777 ${TMPDIR}
               touch ${TMPDIR}/testfile
               lsextattr user ${TMPDIR}/testfile && echo "[xattr] *** xattrs SUPPORTED on ${TMPDIR}! ***"
-              tox3 -e py311-none
+              tox3 -e py314-none
               ;;
             openbsd)
               sudo -E pkg_add xxhash lz4 zstd git


### PR DESCRIPTION
Three backports of already-merged master changes, one commit each. Current 1.4-maint VM times: NetBSD ~20-24 min, OpenBSD ~21 min (FreeBSD ~9-12 min for comparison).

**1. NetBSD → python 3.14.** It runs 3.11 here, so it uses coverage's C tracer core, which roughly doubles the suite's user CPU; on 3.14 coverage uses the `sys.monitoring` core, which is nearly free ([#9470](https://github.com/borgbackup/borg/issues/9470)). On master this cut the NetBSD pytest phase from 972 s to 627 s ([#10133](https://github.com/borgbackup/borg/pull/10133), verified in CI). pkgsrc for NetBSD 11.0 ships `python314` + `py314-pip/tox/virtualenv` (checked the 11.0 package tree), and 1.4's tox already has `py314-none`.

**2. All VMs → 4 cpus.** cross-platform-actions defaults to a 2-cpu VM, so half of the runner's 4 vcpus sat idle and `pytest -n auto` only got 2 workers. Master sets `cpu_count: 4`; this also adds the `memory: ${{ matrix.memory || '8G' }}` line master has. This is the one change that helps *every* VM job here.

**3. OpenBSD → memory-backed tmp tree.** OpenBSD 7.9 has **no python 3.14 package** (its package set only has `python-3.13.13`), so it cannot get the faster coverage core. Instead this backports [#10075](https://github.com/borgbackup/borg/pull/10075) from master: the pytest tmp dirs (and the borg test repos inside them) move from the slow FFS disk to an mfs, with the matching 12G VM memory.

Unrelated pre-existing issue spotted while looking at these jobs: NetBSD currently fails `test_recreate_no_rechunkify` on 1.4-maint (last two runs; FreeBSD passes) — not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)