### PR TITLE
CI: run the pypy job on pushes and PRs, see #1755

### DIFF
--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -1,28 +1,35 @@
-# Optional (non-blocking) test run on a PyPy 3.11 nightly build, see #1755.
-#
-# borg does not officially support pypy, this job is here to notice breakage on
-# either side early: pypy nightlies change daily, and borg's C extension code
-# keeps running into cpyext differences (pypy/pypy#5543, #5544, #5545, #5546,
-# #5564, #5565 all came out of this).
-#
-# Deliberately not part of ci.yml: it runs on a schedule (and on demand), not on
-# every PR, and continue-on-error keeps a red pypy from looking like a broken
-# build. If pypy support ever becomes a supported target, move it into ci.yml's
-# native_tests matrix instead (that matrix has an "allow-failure" flag).
+# Tests on a PyPy 3.11 nightly build, see #1755. Non-blocking: pypy is a
+# best-effort target. Nightly, because the cpyext fixes borg needs land
+# there long before they get released.
 
 name: PyPy (nightly)
 
 on:
-  schedule:
-    - cron: '0 5 * * *'  # Run at 05:00 UTC
-  workflow_dispatch:      # Allow manual trigger
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '**.py'
+    - '**.pyx'
+    - '**.c'
+    - '**.h'
+    - '**.yml'
+    - '**.toml'
+    - '**.cfg'
+    - '**.ini'
+    - 'requirements.d/*'
+    - '!docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 env:
-  # Force colored pytest output even without a tty - the GitHub Actions log
-  # viewer renders ANSI colors.
   PY_COLORS: "1"
 
 jobs:
@@ -30,7 +37,7 @@ jobs:
     name: Tests (pypy-3.11-nightly, ubuntu-24.04)
     runs-on: ubuntu-24.04
     timeout-minutes: 120
-    continue-on-error: true  # optional job: pypy is a best-effort target
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -49,14 +56,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y pkg-config build-essential
         sudo apt-get install -y libssl-dev libacl1-dev liblz4-dev
-        # no fuse packages: the fuse bindings do not support pypy, the mount tests skip.
+        # no fuse packages: the fuse bindings do not support pypy
 
     - name: Install Python requirements
       shell: bash
       run: |
         python -VV
         python -m pip install --upgrade pip setuptools wheel
-        # unlocked requirements: development.lock.txt pins versions/wheels for CPython.
+        # unlocked requirements: the lock file is for CPython
         python -m pip install -r requirements.d/development.txt
 
     - name: Install borgbackup


### PR DESCRIPTION
## Summary

Follow-up to #10142: the pypy job used the right *interpreter* (a pypy 3.11 nightly build),
but the wrong *triggers* - it only ran on a schedule, so a PR could break borg on pypy
without anyone noticing until the next morning.

It now runs like the other test jobs: on pushes to master and on pull requests, with the same
paths filter and concurrency group as `ci.yml`. The daily schedule is gone.

Unchanged: the interpreter stays `pypy-3.11-nightly`, and the job stays `continue-on-error`,
so it reports without blocking. The comments in the workflow got shorter, too.

See #1755.