### PR TITLE
import-tar: fix nfiles being counted twice for regular files

### DIFF
--- a/src/borg/archiver/tar_cmds.py
+++ b/src/borg/archiver/tar_cmds.py
@@ -569,7 +569,6 @@ class TarMixIn:
         while tarinfo := tar.next():
             if tarinfo.isreg():
                 status = tfo.process_file(tarinfo=tarinfo, status="A", type=stat.S_IFREG, tar=tar)
-                archive.stats.nfiles += 1
             elif tarinfo.isdir():
                 status = tfo.process_dir(tarinfo=tarinfo, status="d", type=stat.S_IFDIR)
             elif tarinfo.issym():

--- a/src/borg/testsuite/archiver/tar_cmds_test.py
+++ b/src/borg/testsuite/archiver/tar_cmds_test.py
@@ -1,3 +1,5 @@
+import io
+import json
 import os
 import random
 import shutil
@@ -123,6 +125,33 @@ def test_import_tar(archivers, request, tar_format="PAX"):
     with changedir(archiver.output_path):
         cmd(archiver, "extract", "dst")
     assert_dirs_equal("input", "output/input", ignore_ns=True, ignore_xattrs=True)
+
+
+def test_import_tar_nfiles(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    # Build a tar with 2 regular files, 1 hardlink, 1 directory and 1 symlink.
+    with tarfile.open("input.tar", "w") as tar:
+        for name in ("dir/file1", "dir/file2"):
+            data = name.encode()
+            tarinfo = tarfile.TarInfo(name)
+            tarinfo.size = len(data)
+            tar.addfile(tarinfo, io.BytesIO(data))
+        tarinfo = tarfile.TarInfo("dir/hardlink1")
+        tarinfo.type = tarfile.LNKTYPE
+        tarinfo.linkname = "dir/file1"
+        tar.addfile(tarinfo)
+        tarinfo = tarfile.TarInfo("dir/subdir")
+        tarinfo.type = tarfile.DIRTYPE
+        tar.addfile(tarinfo)
+        tarinfo = tarfile.TarInfo("dir/symlink1")
+        tarinfo.type = tarfile.SYMTYPE
+        tarinfo.linkname = "file1"
+        tar.addfile(tarinfo)
+    cmd(archiver, "repo-create", "--encryption=none-sha256")
+    cmd(archiver, "import-tar", "dst", "input.tar")
+    info = json.loads(cmd(archiver, "info", "--json", "dst"))
+    # as with borg create, each regular file and each hardlink counts, directories/symlinks do not
+    assert info["archives"][0]["stats"]["nfiles"] == 3
 
 
 def test_import_unusual_tar(archivers, request):


### PR DESCRIPTION
## Summary

`_import_tar` incremented `archive.stats.nfiles` for every regular tar member, but `TarfileObjectProcessors.process_file` already counts those in `tfo.stats` (and `process_hardlink` counts hardlink members). Since `archive.stats += tfo.stats` is added before `archive.save()`, imported archives persisted `nfiles = 2 * regular_files + hardlinks` into the archive metadata, so `borg info` / `borg repo-list` reported a wrong file count for imported archives.

Remove the redundant increment — `borg create` also relies solely on the processor-side accounting, so `import-tar` now matches its semantics (each regular file and each hardlink counts once; directories/symlinks/devices/fifos do not).

## Test

Added `test_import_tar_nfiles`: builds a tar via Python's `tarfile` module (no GNU tar or filesystem hardlink support needed) containing 2 regular files, 1 hardlink member, 1 directory and 1 symlink, imports it, and asserts the archive metadata reports `nfiles == 3`. Verified the test fails with `assert 5 == 3` on the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)