### PR TITLE
tests: fix inode-order dependence in test_multiple_link_exclusion, fixes #8740

### DIFF
--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -5450,10 +5450,6 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
 
 
     @requires_hardlinks
-    @pytest.mark.skipif(
-        (not are_hardlinks_supported()) or is_freebsd or is_netbsd,
-        reason='Skip when hardlinks unsupported or on FreeBSD/NetBSD due to differing ctime/link handling; see #9147, #9153.',
-    )
     def test_multiple_link_exclusion(self):
         path_a = os.path.join(self.input_path, 'a')
         path_b = os.path.join(self.input_path, 'b')
@@ -5463,12 +5459,20 @@ class DiffArchiverTestCase(ArchiverTestCaseBase):
         hl_b = os.path.join(path_b, 'hardlink')
         self.create_regular_file(hl_a, contents=b'123456')
         os.link(hl_a, hl_b)
+        # create processes dir entries in inode order (scandir_inorder), so the hardlink in the
+        # dir with the lower inode number becomes the hardlink master. dirs do not necessarily
+        # get their inode numbers assigned in creation order (e.g. ufs dirpref spreads dirs over
+        # cylinder groups), so determine master/slave from the actual inode numbers, see #8740.
+        if os.stat(path_a).st_ino < os.stat(path_b).st_ino:
+            hl_master, slave_dir = hl_a, 'b'
+        else:
+            hl_master, slave_dir = hl_b, 'a'
         self.cmd('init', '--encryption=repokey', self.repository_location)
         self.cmd('create', self.repository_location + '::test0', 'input')
-        os.unlink(hl_a)  # Don't duplicate warning message- one is enough.
+        os.unlink(hl_master)  # Don't duplicate warning message- one is enough.
         self.cmd('create', self.repository_location + '::test1', 'input')
 
-        output = self.cmd('diff', '--pattern=+ fm:input/b', '--pattern=! **/', self.repository_location + '::test0', 'test1', exit_code=EXIT_WARNING)
+        output = self.cmd('diff', '--pattern=+ fm:input/' + slave_dir, '--pattern=! **/', self.repository_location + '::test0', 'test1', exit_code=EXIT_WARNING)
         lines = output.splitlines()
         self.assert_line_exists(lines, 'cannot find hardlink source for.*skipping compare.')
 


### PR DESCRIPTION
Fixes https://github.com/borgbackup/borg/issues/8740.

`borg create` processes directory entries in inode order (`scandir_inorder`), so which of the two hardlinks becomes the hardlink master depends on the inode numbers the filesystem assigned to the dirs `a` and `b`. On linux ext4 these follow creation order, but e.g. FreeBSD ufs dirpref spreads new directories over cylinder groups, so `b` may get a lower inode than `a` — then `b/hardlink` became the master (with chunks) and `diff` restricted to `input/b` compared it successfully and printed just the ctime change (rc 0, exactly the output captured in the issue), instead of warning about the excluded hardlink source (rc 1). Same class of behavior on OpenIndiana.

The fix determines master/slave from the actual dir inode numbers, unlinks the master and restricts the diff to the slave's dir, so the test exercises the intended "hardlink source excluded" warning on any filesystem. Verified locally by simulating the FreeBSD inode order (creating `b` before `a`): the unfixed test fails with `AssertionError: 0 != 1` like on FreeBSD, the fixed test passes in both orders.

Also drops the FreeBSD/NetBSD skip on this test: its failure was traversal-order dependence, not the kernel ctime quirks of https://github.com/borgbackup/borg/issues/9147 / https://github.com/borgbackup/borg/issues/9153 (which concern `test_hard_link_deletion_and_replacement`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)