### PR TITLE
CI: enable POSIX.1e ACLs on the FreeBSD VM's root fs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,10 @@ jobs:
               sudo -E kldload fusefs
               sudo -E sysctl vfs.usermount=1
               sudo -E chmod 666 /dev/fuse
+
+              # enable POSIX.1e ACLs on the UFS root fs (covers /tmp), so the ACL tests do not skip (#9144)
+              sudo mount -u -o acls /
+              mount | grep ' / ' | grep -w acls
               sudo -E pkg install -y rust
               sudo -E pkg install -y gmake
               sudo -E pkg install -y git


### PR DESCRIPTION
The cross-platform-actions FreeBSD image uses a plain UFS root without the `acls` mount option, so `are_acls_working()` failed and the FreeBSD ACL tests (`test_access_acl`, `test_default_acl`) were always skipped in CI.

Remount `/` with ACLs enabled — this also covers `/tmp`, where the tests create their temp files — and hard-fail the job early if the mount option did not take effect. The other ACL-gated tests in the suite are Linux-only, so exactly these two tests go live.

Groundwork for [#9144](https://github.com/borgbackup/borg/issues/9144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)