### PR TITLE
tests: skip test_create_no_permission_file if read access can not be revoked

### DIFF
--- a/src/borg/testsuite/__init__.py
+++ b/src/borg/testsuite/__init__.py
@@ -132,6 +132,34 @@ def is_root():
 
 
 @functools.lru_cache
+def can_revoke_read_access():
+    """Return True if taking away our own read permissions for a file really works.
+
+    Highly privileged users can read files no matter what the permissions say: root ignores
+    the permission bits, and on cygwin a user holding SeBackupPrivilege bypasses the ACL
+    checks (cygwin always opens files with FILE_OPEN_FOR_BACKUP_INTENT). Tests that need an
+    unreadable file must be skipped for such users.
+    """
+    if is_win32:
+        # there, read access is revoked via a deny ACE (see the icacls calls in the tests)
+        # rather than via chmod, and such an ACE is honoured also for privileged users.
+        return True
+    with unopened_tempfile() as filepath:
+        with open(filepath, "wb") as fd:
+            fd.write(b"secret")
+        os.chmod(filepath, 0o000)
+        try:
+            with open(filepath, "rb") as fd:
+                fd.read(1)
+        except OSError:
+            return True  # good, we can not read it any more.
+        else:
+            return False
+        finally:
+            os.chmod(filepath, 0o600)  # make sure the tempfile can be cleaned up.
+
+
+@functools.lru_cache
 def are_symlinks_supported():
     with unopened_tempfile() as filepath:
         try:

--- a/src/borg/testsuite/archiver/create_cmd_test.py
+++ b/src/borg/testsuite/archiver/create_cmd_test.py
@@ -27,7 +27,7 @@ from .. import (
     is_utime_fully_supported,
     is_birthtime_fully_supported,
     same_ts_ns,
-    is_root,
+    can_revoke_read_access,
     granularity_sleep,
 )
 from . import (
@@ -308,7 +308,7 @@ def test_create_erroneous_file(archivers, request):
     assert "input/file3" in out
 
 
-@pytest.mark.skipif(is_root(), reason="test must not be run as (fake)root")
+@pytest.mark.skipif(not can_revoke_read_access(), reason="can not revoke our own read permissions")
 def test_create_no_permission_file(archivers, request):
     archiver = request.getfixturevalue(archivers)
     file_path = os.path.join(archiver.input_path, "file")
@@ -317,7 +317,9 @@ def test_create_no_permission_file(archivers, request):
     create_regular_file(archiver.input_path, file_path + "3", size=1000)
     # revoke read permissions on file2 for everybody, including us:
     if is_win32:
-        subprocess.run(["icacls.exe", file_path + "2", "/deny", "everyone:(R)"])
+        # "*S-1-1-0" is the well-known SID of the "Everyone" group. Using the SID instead of the
+        # group name keeps this working on non-English Windows installations.
+        subprocess.run(["icacls.exe", file_path + "2", "/deny", "*S-1-1-0:(R)"])
     else:
         # note: this will NOT take away read permissions for root
         os.chmod(file_path + "2", 0o000)


### PR DESCRIPTION
## Problem

`test_create_no_permission_file` revokes read permissions on `file2` and then expects `borg create` to warn about not being able to back it up (rc 105).

On cygwin (running as an elevated Administrator) it fails with `assert 0 == 105`: borg happily backs up all 3 files.

`chmod(0o000)` is not the problem — it maps to a correct NTFS DACL, and a native Windows read of the file does get `UnauthorizedAccessException`. The problem is that cygwin always opens files with `FILE_OPEN_FOR_BACKUP_INTENT`, which makes the kernel bypass the DACL check for any token holding `SeBackupPrivilege` (enabled for an elevated admin). Verified by toggling just that privilege in the running process:

```
SeBackupPrivilege ENABLED : READ SUCCEEDED -> b'hello\n'
  disable SeBackupPrivilege: ok=True
SeBackupPrivilege DISABLED: READ FAILED -> [Errno 13] Permission denied
```

So borg behaved correctly here — the test's precondition just was not met.

The existing guard `@pytest.mark.skipif(is_root(), ...)` did not catch it, because `is_root()` only checks `os.getuid() == 0` and such an admin has a non-zero uid.

## Change

Add `can_revoke_read_access()` to `borg.testsuite` and guard the test with it. Rather than enumerating privileged identities per platform, it just tries to revoke read access on a temp file and looks at whether it worked, so it also covers root, `CAP_DAC_OVERRIDE` and similar cases.

Also use the well-known SID `*S-1-1-0` instead of the `everyone` group name in the `icacls` call, so that path also works on non-English Windows installations.

## Notes for review

- This replaces the `is_root()` guard rather than adding to it. For real root the two agree (root reads the file, so the probe returns False and we skip). Under **fakeroot** they can differ: `is_root()` is True (skip), while the probe reports what actually happens on the real filesystem — if the read really fails there, the test now runs and should pass. Worth an eye on the fakeroot CI run.
- `can_revoke_read_access()` short-circuits to True on win32, where tests revoke access via a deny ACE instead of `chmod`, and such an ACE is honoured also for privileged users.

## Testing

- macOS: test passes (unchanged behaviour).
- cygwin/Windows 11, Python 3.12, elevated admin: previously 2 failures (`archiver` + `remote_archiver`), now skipped with `can not revoke our own read permissions`.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)