### PR TITLE
scripts/make.py: discover Cython sources for "clean" instead of hardcoding them

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -570,21 +570,12 @@ class BuildMan:
             write(option.ljust(padding), desc)
 
 
-cython_sources = """
-src/borg/compress.pyx
-src/borg/crypto/low_level.pyx
-src/borg/chunkers/buzhash.pyx
-src/borg/chunkers/buzhash64.pyx
-src/borg/chunkers/reader.pyx
-src/borg/hashindex.pyx
-src/borg/item.pyx
-src/borg/platform/posix.pyx
-src/borg/platform/linux.pyx
-src/borg/platform/syncfilerange.pyx
-src/borg/platform/darwin.pyx
-src/borg/platform/freebsd.pyx
-src/borg/platform/windows.pyx
-""".strip().splitlines()
+def cython_sources():
+    """Find all Cython sources below src/borg/.
+
+    They are discovered rather than hardcoded, so that new modules are covered automatically.
+    """
+    return sorted(glob.glob("src/borg/**/*.pyx", recursive=True))
 
 
 def rm(file):
@@ -598,7 +589,7 @@ def rm(file):
 
 class Clean:
     def run(self):
-        for source in cython_sources:
+        for source in cython_sources():
             genc = source.replace(".pyx", ".c")
             rm(genc)
             compiled_glob = source.replace(".pyx", ".cpython*")


### PR DESCRIPTION
The hardcoded `cython_sources` list in `scripts/make.py` had drifted from reality: it listed 13 of the 21 `.pyx` modules. Missing were `chunkers/base`, `chunkers/fastcdc`, `chunkers/goldilocks_aes`, `chunkers/phte_chunker`, `chunkers/rabin_aes`, `chunkers/toeplitz_aes`, `legacy/crypto/low_level` and `platform/netbsd`.

Consequence: `python scripts/make.py clean` silently left those modules' generated `.c` files and compiled extension modules behind. That is how stale `*.cpython-3XX.so` files from an older Python version end up lingering in a working tree, and it means the documented rebuild recipe (`make.py clean && pip install -e .`) does not actually give a clean rebuild for those modules.

Found while setting borg up on a fresh FreeBSD box: after switching that checkout from Python 3.12 to 3.14, `clean` left six `cpython-312` chunker extensions behind.

## Fix

Discover the sources with `glob("src/borg/**/*.pyx")` instead of maintaining a second hand-written list next to the one in `setup.py`. New modules are then covered automatically and the list cannot go stale again.

## Verification

- The glob reproduces `setup.py`'s `cython_sources` list exactly - same 21 paths.
- End-to-end on FreeBSD 15.1 / Python 3.14: before `clean`, 17 compiled `.so` and 21 generated `.c`; after `clean`, 0 and 0, with `git status` showing no leftover build artifacts. Previously the same command left 8 modules' artifacts untouched.
- Rebuilt from the cleaned tree and ran the full test suite: 2639 passed, 975 skipped.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)