### PR TITLE
--bypass-lock: also skip the cache lock

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -193,7 +193,8 @@ def with_repository(fake=False, invert_fake=False, create=False, lock=True,
                     if 'compression' in args:
                         kwargs['key'].compressor = args.compression.compressor
                     if secure:
-                        assert_secure(repository, kwargs['manifest'], self.lock_wait)
+                        # --bypass-lock also skips the cache lock, we only read the cache config here, see #7255
+                        assert_secure(repository, kwargs['manifest'], self.lock_wait, lock=lock)
                 if cache:
                     with Cache(repository, kwargs['key'], kwargs['manifest'],
                                progress=getattr(args, 'progress', False), lock_wait=self.lock_wait,

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -130,7 +130,8 @@ class SecurityManager:
             logger.debug('security: updating location stored in cache and security dir')
             with SaveFile(self.location_file) as fd:
                 fd.write(repository_location)
-            if cache_config:
+            if cache_config and cache_config.lock is not None:
+                # only write to the cache config if we hold its lock, see #7255
                 cache_config.save()
 
     def assert_no_manifest_replay(self, manifest, key, cache_config=None):
@@ -161,14 +162,14 @@ class SecurityManager:
         if self.known() and not self.key_matches(key):
             raise Cache.EncryptionMethodMismatch()
 
-    def assert_secure(self, manifest, key, *, cache_config=None, warn_if_unencrypted=True, lock_wait=None):
+    def assert_secure(self, manifest, key, *, cache_config=None, warn_if_unencrypted=True, lock_wait=None, lock=True):
         # warn_if_unencrypted=False is only used for initializing a new repository.
         # Thus, avoiding asking about a repository that's currently initializing.
         self.assert_access_unknown(warn_if_unencrypted, manifest, key)
         if cache_config:
             self._assert_secure(manifest, key, cache_config)
         else:
-            cache_config = CacheConfig(self.repository, lock_wait=lock_wait)
+            cache_config = CacheConfig(self.repository, lock_wait=lock_wait, lock=lock)
             if cache_config.exists():
                 with cache_config:
                     self._assert_secure(manifest, key, cache_config)
@@ -203,9 +204,9 @@ class SecurityManager:
                 raise Cache.CacheInitAbortedError()
 
 
-def assert_secure(repository, manifest, lock_wait):
+def assert_secure(repository, manifest, lock_wait, lock=True):
     sm = SecurityManager(repository)
-    sm.assert_secure(manifest, manifest.key, lock_wait=lock_wait)
+    sm.assert_secure(manifest, manifest.key, lock_wait=lock_wait, lock=lock)
 
 
 def recanonicalize_relative_location(cache_location, repository):
@@ -238,12 +239,13 @@ def discover_files_cache_name(path):
 
 
 class CacheConfig:
-    def __init__(self, repository, path=None, lock_wait=None):
+    def __init__(self, repository, path=None, lock_wait=None, lock=True):
         self.repository = repository
         self.path = cache_dir(repository, path)
         self.config_path = os.path.join(self.path, 'config')
         self.lock = None
         self.lock_wait = lock_wait
+        self.do_lock = lock
 
     def __enter__(self):
         self.open()
@@ -268,7 +270,8 @@ class CacheConfig:
             config.write(fd)
 
     def open(self):
-        self.lock = Lock(os.path.join(self.path, 'lock'), exclusive=True, timeout=self.lock_wait).acquire()
+        if self.do_lock:
+            self.lock = Lock(os.path.join(self.path, 'lock'), exclusive=True, timeout=self.lock_wait).acquire()
         self.load()
 
     def load(self):

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -40,7 +40,7 @@ from ..crypto.key import KeyfileKeyBase, RepoKey, KeyfileKey, Passphrase, TAMReq
 from ..crypto.keymanager import RepoIdMismatch, NotABorgKeyFile
 from ..crypto.file_integrity import FileIntegrityError
 from ..hashindex import ChunkIndex
-from ..helpers import Location, get_security_dir
+from ..helpers import Location, get_cache_dir, get_security_dir
 from ..helpers import Manifest, MandatoryFeatureUnsupported, ArchiveInfo
 from ..helpers import init_ec_warnings
 from ..helpers import EXIT_SUCCESS, EXIT_WARNING, EXIT_ERROR, Error, CancelledByUser, RTError, CommandError
@@ -52,7 +52,7 @@ from ..helpers import utcnow
 from ..nanorst import RstToTextLazy, rst_to_terminal
 from ..patterns import IECommand, PatternMatcher, parse_pattern
 from ..item import Item, ItemDiff, chunks_contents_equal
-from ..locking import LockFailed
+from ..locking import Lock, LockFailed, LockTimeout
 from ..logger import setup_logging
 from ..remote import RemoteRepository, PathNotAllowed
 from ..repository import Repository
@@ -2118,6 +2118,24 @@ class ArchiverTestCase(ArchiverTestCaseBase):
             # verify that command works with read-only repo when using --bypass-lock
             with self.fuse_mount(self.repository_location, None, '--bypass-lock'):
                 pass
+
+    def test_bypass_lock_locked_cache(self):
+        # --bypass-lock shall not be blocked by the cache lock another borg process holds, see #7255
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.create_src_archive('test')
+        with Repository(self.repository_path) as repository:
+            cache_path = os.path.join(get_cache_dir(), repository.id_str)
+        host, pid, tid = platform.get_process_id()
+        with Lock(os.path.join(cache_path, 'lock'), exclusive=True, id=(host, pid, tid + 1)):
+            # verify that the cache lock normally blocks other borg processes
+            if self.FORK_DEFAULT:
+                self.cmd('list', self.repository_location, exit_code=EXIT_ERROR)
+            else:
+                with pytest.raises(LockTimeout):
+                    self.cmd('list', self.repository_location)
+            # verify that command works despite the locked cache when using --bypass-lock
+            output = self.cmd('list', self.repository_location, '--bypass-lock')
+        self.assert_in('test', output)
 
     @pytest.mark.skipif('BORG_TESTS_IGNORE_MODES' in os.environ, reason='modes unreliable')
     def test_umask(self):


### PR DESCRIPTION
Fixes https://github.com/borgbackup/borg/issues/7255.

`--bypass-lock` only skipped the repository lock, but the security checks run for every command still acquired the exclusive client-side cache lock via `CacheConfig`, although they only read the cache config. Thus, e.g. `borg list --bypass-lock` was blocked while a `borg create` using the same $HOME was running.

Now the bypass flag is passed down to `assert_secure` / `CacheConfig`, which then reads the cache config without locking. This is safe because the cache config is only ever written via `SaveFile` (atomic rename), so an unlocked reader always sees a complete file. When no lock is held, the relocated-repository handling only updates the security dir and does not write to the cache config.

Commands that really open the cache (e.g. `borg info`, `borg config --cache`) still acquire the cache lock, as they might write to the cache.

Not an issue on master: borg2 removed `--bypass-lock` and its cache has no lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)