### PR TITLE
chunkers: do not re-read a file map that does not reach EOF

### DIFF
--- a/src/borg/chunkers/reader.pyx
+++ b/src/borg/chunkers/reader.pyx
@@ -213,8 +213,10 @@ class FileFMAPReader:
                     offset += got
                     range_size -= got
                     yield Chunk(data, size=got, allocation=allocation)
-                if got < wanted:
-                    # We did not get enough data; looks like EOF.
+                if got == 0:
+                    # Nothing read at all - this is EOF. A short read (0 < got < wanted) is
+                    # not EOF: file objects may return less than requested, so just continue
+                    # with the rest of the range.
                     return
 
 
@@ -235,6 +237,7 @@ class FileReader:
         self.offset = 0  # offset into the first buffer object's data
         self.remaining_bytes = 0  # total bytes available in buffer
         self.blockify_gen = None  # generator from FileFMAPReader.blockify
+        self.blockify_done = False  # the blockify generator was exhausted (do not restart it)
         self.fd = fd
         self.fh = fh
         self.fmap = fmap
@@ -265,7 +268,7 @@ class FileReader:
         Fill the buffer with more data from the blockify generator.
         Returns True if more data was added, False if EOF.
         """
-        if self.blockify_gen is None:
+        if self.blockify_gen is None or self.blockify_done:
             return False
 
         try:
@@ -275,7 +278,9 @@ class FileReader:
             self.remaining_bytes += chunk.meta["size"]
             return True
         except StopIteration:
-            self.blockify_gen = None
+            # do NOT clear blockify_gen here: an fmap that does not extend to EOF would
+            # otherwise be replayed from its start by the next read()/readinto() call.
+            self.blockify_done = True
             return False
 
     def read(self, size):
@@ -297,7 +302,7 @@ class FileReader:
                  than requested.
         """
         # Initialize if not already done
-        if self.blockify_gen is None:
+        if self.blockify_gen is None and not self.blockify_done:
             self.buffer = []
             self.offset = 0
             self.remaining_bytes = 0
@@ -437,7 +442,7 @@ class FileReader:
                 return self._readinto_direct(tv, size)
 
         # Initialize if not already done
-        if self.blockify_gen is None:
+        if self.blockify_gen is None and not self.blockify_done:
             self.buffer = []
             self.offset = 0
             self.remaining_bytes = 0

--- a/src/borg/testsuite/chunkers/reader_test.py
+++ b/src/borg/testsuite/chunkers/reader_test.py
@@ -410,3 +410,58 @@ def test_filereader_no_direct_for_fifo(tmpdir):
     st = os.stat(fifo_fn)
     reader = FileReader(fd=BytesIO(b""), fh=-1, read_size=1024, sparse=False, fmap=None, st=st)
     assert not reader.direct
+
+
+def test_filereader_fmap_not_covering_eof(tmpdir):
+    """An fmap that ends before EOF must not be replayed once it is exhausted, see #4363.
+
+    --map with --reuse-from reads only the parts of a file that are not reused, so the
+    fmap it gives ends before EOF. FileReader used to restart the blockify generator
+    then, which re-read the file from the current position (appending duplicate data)
+    or looped forever for an fmap that does not start at 0.
+    """
+    fn = str(tmpdir / "file")
+    with open(fn, "wb") as f:
+        f.write(b"0123456789" * 10)  # 100 bytes
+    fd = os.open(fn, os.O_RDONLY)
+    try:
+        for fmap, expected in [
+            ([(0, 30, True)], b"0123456789" * 3),  # prefix only
+            ([(20, 20, True)], b"0123456789" * 2),  # neither at offset 0 nor at EOF
+            ([(0, 10, True), (10, 20, True)], b"0123456789" * 3),  # multiple ranges, still not to EOF
+        ]:
+            os.lseek(fd, 0, os.SEEK_SET)
+            reader = FileReader(fd=None, fh=fd, read_size=1024, sparse=False, fmap=list(fmap))
+            got = b""
+            while True:
+                chunk = reader.read(1024)
+                if not chunk.meta["size"]:
+                    break
+                got += chunk.data
+                assert len(got) <= len(expected)  # do not loop forever if this regresses
+            assert got == expected
+    finally:
+        os.close(fd)
+
+
+def test_filereader_short_reads_are_not_eof():
+    """A file object returning less than requested is not at EOF - keep reading, see #4363."""
+
+    class SmallReadFile:
+        def __init__(self, data):
+            self.data = data
+
+        def read(self, nbytes):
+            chunk, self.data = self.data[:1], self.data[1:]  # always at most 1 byte
+            return chunk
+
+    content = b"a" * 20
+    reader = FileReader(fd=SmallReadFile(content), fh=-1, read_size=1024, sparse=False, fmap=[(0, 20, True)])
+    got = b""
+    while True:
+        chunk = reader.read(1024)
+        if not chunk.meta["size"]:
+            break
+        got += chunk.data
+        assert len(got) <= len(content)
+    assert got == content


### PR DESCRIPTION
`FileReader` re-reads a file map that does not extend to EOF, which appends duplicate data to the file it is reading — or never terminates.

## The bug

`FileReader` uses `blockify_gen is None` for two different things: *"not started yet"* and *"exhausted"*. `_fill_buffer()` clears the attribute on `StopIteration`, and `read()` / `readinto()` take a cleared generator as their cue to build a fresh `FileFMAPReader.blockify()` — which replays the fmap from its start.

`dread()` reads sequentially and ignores its `offset` argument, so the consequences depend on the fmap:

* an fmap that ends before EOF is replayed from the current file position, so the caller gets the mapped ranges **plus** whatever follows them, up to EOF;
* an fmap that does not start at 0 `dseek()`s back to its start on every replay and **loops forever**.

`FileFMAPReader.blockify()` itself is fine — it yields exactly the mapped ranges and stops.

This stayed invisible because an fmap that *does* reach EOF is replayed into an immediate 0-byte read and stops there, and until now every caller produced such a map: `sparsemap()` covers the whole file, and so does `create --map`. `create --map --reuse-from` from [#10137](https://github.com/borgbackup/borg/pull/10137) is the first caller that deliberately reads only *parts* of a file — it skips the ranges whose chunks it reuses from the reference archive — and it hits this immediately. It is not specific to a chunker; the `fixed` chunker is affected the same way.

## The fix

Track exhaustion in its own `blockify_done` flag and never restart the generator.

That alone is not enough, though: `blockify()` also returned on `got < wanted`, i.e. it treated **any short read** as EOF. The restart happened to paper over that, so removing the restart without fixing it truncates the input instead. `buzhash_self_test.py::test_small_reads` — whose fake file object returns one byte per `read()` call — passes on current master *only* because of the restart, and is the tripwire for getting this half-right. So `blockify()` now returns only on `got == 0`.

## Tests

Two regression tests in `reader_test.py`:

* `test_filereader_fmap_not_covering_eof` — prefix-only, not-starting-at-0, and multi-range partial fmaps. Fails on master (`assert 60 <= 30`). The in-loop length assert stops a regression from hanging the suite instead of failing it.
* `test_filereader_short_reads_are_not_eof` — pins the short-read contract. This one passes on master too (the restart hides it); it fails on a half-applied fix, which is the point.

## Verification

Built from this branch on Linux (Debian 13, Python 3.13):

* `src/borg/testsuite/chunkers/` + `create_cmd_test.py` + `extract_cmd_test.py`: **328 passed, 346 skipped, 0 failed**.
* Reading a 1 MiB file through partial fmaps returns exactly the mapped byte count in every case, including the previously non-terminating ones.
* Against [#10137](https://github.com/borgbackup/borg/pull/10137), where this surfaced: its intermittently failing `test_create_map_reuse_from_cdc` went from **5 failures / 100 runs** to **0 / 200**, and a `create --read-special --map ... --reuse-from` of a real LVM thin snapshot — which previously spun for ~12 minutes of CPU on a single file — now completes and `borg extract --stdout ... | cmp - /dev/vgtest/snap2` matches byte for byte over 4 GiB.
