### PR TITLE
deps: pin argon2-cffi-bindings to 25.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.
   "argon2-cffi",
+  # 26.x builds via scikit-build-core and thus needs cmake, which has no wheels for
+  # the BSDs / OmniOS - pip builds it from source there for ~30min, then fails.
+  # Temporary: argon2 is moving to OpenSSL, which drops argon2-cffi entirely, see #9602.
+  "argon2-cffi-bindings == 25.1.0",
   "shtab>=1.9.3",  # older versions generate broken zsh (tqdm/shtab#224) or fish (tqdm/shtab#227) completions
   "backports-zstd; python_version < '3.14'", # for python < 3.14.
   "jsonargparse>=4.47.0",


### PR DESCRIPTION
`argon2-cffi-bindings` **26.1.0** switched its build backend from `setuptools` to **`scikit-build-core`**:

| version | build-system |
|---|---|
| 25.1.0 | `setuptools` + `cffi` |
| 26.1.0 | `scikit-build-core` |

scikit-build-core asks for `cmake>=3.20` as a *dynamic* build requirement whenever it cannot find a usable cmake on `PATH` — that is the `Installing backend dependencies: still running...` line. There are no cmake wheels for the BSDs or OmniOS, so pip builds the `cmake` **sdist**, which bootstraps CMake from source.

## What that costs us today

Measured on the VM jobs of [run 32412854000](https://github.com/borgbackup/borg/actions/runs/32412854000):

| platform | cmake bootstrap | outcome |
|---|---|---|
| FreeBSD | ~44 min | succeeds |
| NetBSD | ~26 min | **fails** |
| OpenBSD | ~30 min | **fails** |
| OmniOS | ~34 min | **fails** |

On the three that fail, the job dies in `pip install`, so **no tests run at all** — and because these jobs are `continue-on-error: true`, the run still reports green.

On OmniOS the bootstrapped cmake's curl has no TLS support, so it cannot even fetch the CMake tarball:

```
error: downloading 'https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2.tar.gz' failed
      status_string: "Unsupported protocol"
      log: Protocol "https" disabled
```

i.e. half an hour of compiling for a guaranteed failure.

## The change

Pin `argon2-cffi-bindings` to 25.1.0, which builds with setuptools + cffi and needs no cmake.

Verified on a Linux box, with cmake deliberately removed to mimic the affected platforms:

* `argon2-cffi-bindings==25.1.0` builds **from its sdist in 4 seconds**, no `Installing backend dependencies` step at all;
* `pip install -e .` resolves cleanly — the pin does not conflict with `argon2-cffi`, and no cmake is pulled in.

Side effects checked before pinning:

* 25.1.0 still ships `cp39-abi3` wheels, so 3.13 / 3.14 / 3.15 keep installing a wheel where one exists; it actually has *better* macOS coverage than 26.1.0, which dropped the macOS x86_64 wheel.
* It has no `pp311` wheel, so the (non-blocking) PyPy 3.11 nightly job builds it from sdist. That build is setuptools + cffi, so it needs no cmake either.
* We have no free-threaded CI jobs, so the missing `cp314t` / `cp315t` wheels do not matter.

## Temporary

This pin should go away together with the dependency itself once argon2 moves to OpenSSL, see [#9602](https://github.com/borgbackup/borg/pull/9602).

The alternative fix — installing cmake from each OS's package manager — also works (cmake alone is enough; scikit-build-core falls back to make, so no ninja is needed, which matters because OmniOS has no ninja package). It is just more moving parts for something we are about to delete anyway.
