### PR TITLE
Location: reject UNC paths everywhere early with a hint, fixes #10164

### DIFF
--- a/docs/usage/general/repository-urls.rst.inc
+++ b/docs/usage/general/repository-urls.rst.inc
@@ -12,6 +12,10 @@ expanded by your shell).
 
 Note: You may also prepend ``file://`` to a filesystem path to use URL style.
 
+Note: UNC paths (``//server/share/path``, ``\\server\share\path``) are not
+supported — mount the share (on Windows: map it to a drive letter, e.g.
+``net use X: \\server\share``) and use the mounted path instead.
+
 **Remote repositories** accessed via SSH user@host (REST http over stdio):
 
 ``rest://user@host:port//abs/path/to/repo`` — absolute path

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -724,9 +724,9 @@ class Location:
     BORGSTORE_SCHEMES = ("sftp", "http", "https", "s3", "b2", "rclone")
 
     # path may contain any chars. to avoid ambiguities with other regexes, it must not start with
-    # "//", a "scheme://" or one of the borgstore "scheme:" specifiers (all of which are matched
+    # a "scheme://" or one of the borgstore "scheme:" specifiers (all of which are matched
     # before local_re in _parse). the borgstore scheme list is sourced from BORGSTORE_SCHEMES.
-    local_path_re = r"(?!(//|(?:ssh|file)://|(?:" + "|".join(BORGSTORE_SCHEMES) + r"):))" r"(?P<path>.+)"
+    local_path_re = r"(?!((?:ssh|file)://|(?:" + "|".join(BORGSTORE_SCHEMES) + r"):))" r"(?P<path>.+)"
 
     # abs_path must start with a slash (or drive letter on Windows).
     abs_path_re = r"(?P<path>[A-Za-z]:/.+)" if is_win32 else r"(?P<path>/.+)"
@@ -796,11 +796,15 @@ class Location:
 
         self.raw = text  # as given by user, might contain placeholders
         self.processed = replace_placeholders(self.raw, overrides)  # after placeholder replacement
-        valid = self._parse(self.processed)
-        if valid:
-            self.valid = True
-        else:
+        if not self._parse(self.processed):
             raise ValueError('Invalid location format: "%s"' % self.processed)
+        if self.proto == "file" and self.path.startswith("//"):
+            # UNC path (//server/share/..., \\server\share\...): not supported, fail early with a hint, see #10164.
+            raise ValueError(
+                f'UNC paths are not supported: "{self.processed}". '
+                "Mount the share (Windows: net use X: \\\\server\\share) and use the mounted path instead."
+            )
+        self.valid = True
 
     def _parse(self, text):
         m = self.ssh_re.match(text)

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -264,13 +264,17 @@ class TestLocationWithoutEnv:
             repr(Location(url)) == f"Location(proto='file', user=None, pass=None, host=None, port=None, path='{path}')"
         )
 
-    @pytest.mark.skipif(is_win32, reason="still broken")
-    def test_smb(self, monkeypatch):
+    def test_unc_rejected(self, monkeypatch):
+        # UNC paths are not supported (#3141), the parser rejects all spellings early, see #10164.
         monkeypatch.delenv("BORG_REPO", raising=False)
-        assert (
-            repr(Location("file:////server/share/path"))
-            == "Location(proto='file', user=None, pass=None, host=None, port=None, path='//server/share/path')"
-        )
+        with pytest.raises(ValueError, match="UNC paths are not supported"):
+            Location("//server/share/repo")
+        # on win32, file:/// must be followed by a drive letter, so this is invalid even earlier.
+        with pytest.raises(ValueError, match="Invalid location" if is_win32 else "UNC paths are not supported"):
+            Location("file:////server/share/repo")
+        if is_win32:
+            with pytest.raises(ValueError, match="UNC paths are not supported"):
+                Location(r"\\server\share\repo")
 
     def test_folder(self, monkeypatch):
         monkeypatch.delenv("BORG_REPO", raising=False)


### PR DESCRIPTION
Fixes [#10164](https://github.com/borgbackup/borg/issues/10164) ("option A" there, extended to all platforms).

On Windows, `\\server\share\repo` was accepted by the `Location` parser and then failed deep inside borgstore with `Invalid or unsupported Backend Storage URL: file://server/share/repo` — a URL the user never typed (`Path.as_uri()` turns the server name into the URL authority).

UNC paths are not supported (see [#3141](https://github.com/borgbackup/borg/issues/3141)), so `Location.parse()` now rejects every local path that starts with `//` after resolving it, on all platforms, with a message that names the workaround:

```
borg: error: argument -r/--repo: UNC paths are not supported: "\\server\share\repo". Mount the share (Windows: net use X: \\server\share) and use the mounted path instead.
```

Details:

- The check runs on the resolved path (after `abspath`), so a relative repo path given while the current directory is a UNC path is caught as well.
- The `//` exclusion is removed from `local_re`: bare `//server/share/path` now gets the same message on every platform instead of a bare `Invalid location format`. `file:////server/share/path` gets it on POSIX too; on Windows that spelling was and still is rejected even earlier (`file:///` must be followed by a drive letter).
- The old `test_smb` asserted that `file:////server/share/path` is *accepted* on non-Windows platforms. On Linux/macOS/BSD a leading `//` is just `/`, so that was never SMB support; it only meant something on Cygwin (the 2017 change `c8ec698d7`) and was never tested there. It is replaced by `test_unc_rejected`, which pins all spellings as rejected on every platform.
- The repository URLs docs section now states the limitation and the workaround.
