### PR TITLE
mount/webdav: BORG_MOUNT_ARCHIVE_DIR_FORMAT names the archive directories

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -250,6 +250,8 @@ New features:
 - list: --sort-by=field[,field,...], #9009
 - BORG_UNITS env var: si / iec / raw size formatting, replaces the --iec option, #5513
 - BORG_PROGRESS_FPS env var: how often --progress output is updated, #8041
+- BORG_MOUNT_ARCHIVE_DIR_FORMAT env var: how the archive directories of a repository
+  mount (borg mount, borg webdav) are named, #9991
 
 Fixes:
 

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -296,6 +296,11 @@ Output formatting:
         Giving the default value for ``borg repo-list --format=X``.
     BORG_PRUNE_FORMAT
         Giving the default value for ``borg prune --format=X``.
+    BORG_MOUNT_ARCHIVE_DIR_FORMAT
+        Giving the format of the archive directory names when ``borg mount`` or
+        ``borg webdav`` show a whole repository, default: ``{name}``. The placeholders
+        are the ones of ``borg repo-list --format``; names that are not unique get
+        ``-{id:.8}`` appended. See ``borg mount --help``.
 
 Some automatic "answerers" (if set, they automatically answer confirmation questions):
     BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)

--- a/docs/usage/mount.rst
+++ b/docs/usage/mount.rst
@@ -7,12 +7,20 @@ Examples
 
 ::
 
-    # Mounting the repository shows all archives.
+    # Mounting the repository shows all archives (here: two archives of the series
+    # "root", the short archive id is appended to make the directory names unique).
     # Archives are loaded lazily, expect some delay when navigating to an archive
     # for the first time.
     $ borg mount /tmp/mymountpoint
     $ ls /tmp/mymountpoint
-    root-2016-02-14 root-2016-02-15
+    root-1f7b3c2a  root-9e4d0b58
+    $ borg umount /tmp/mymountpoint
+
+    # BORG_MOUNT_ARCHIVE_DIR_FORMAT names the archive directories differently,
+    # using the placeholders of "borg repo-list --format":
+    $ BORG_MOUNT_ARCHIVE_DIR_FORMAT='{name}-{time:%Y-%m-%d}' borg mount /tmp/mymountpoint
+    $ ls /tmp/mymountpoint
+    root-2016-02-14  root-2016-02-15
     $ borg umount /tmp/mymountpoint
 
     # The "versions view" merges all archives in the repository

--- a/docs/usage/mount.rst.inc
+++ b/docs/usage/mount.rst.inc
@@ -120,9 +120,17 @@ are exposed (read-only) via the ``system.posix_acl_access`` and
 not enforce the ACLs for permission checks. On other platforms, ACLs are not
 supported.
 
-When mounting a repository, the top directories will be named like the
-archives and the directory structure below these will be loaded on-demand from
-the repository when entering these directories, so expect some delay.
+When mounting a repository, there is one top directory per archive and the
+directory structure below these will be loaded on-demand from the repository
+when entering these directories, so expect some delay.
+
+By default, these top directories are named like the archives; as the archives
+of a series all have the same name, ``-{id:.8}`` (the first 8 hex digits of the
+archive id) is appended whenever a name is not unique. To name them differently,
+set the ``BORG_MOUNT_ARCHIVE_DIR_FORMAT`` environment variable to a format string
+using the placeholders of ``borg repo-list --format``, e.g.
+``{name}-{time:%Y-%m-%dT%H:%M:%S}`` or ``{hostname}-{name}``; names that are
+still not unique get ``-{id:.8}`` appended.
 
 .. note::
 

--- a/docs/usage/webdav.rst.inc
+++ b/docs/usage/webdav.rst.inc
@@ -97,9 +97,11 @@ authentication and no encryption - anything that can connect to
 localhost TCP ports on the machine can read the served archive contents.
 
 The top level lists the selected archives (use the archive filter options
-to select fewer archives); below that, the archive contents can be
-browsed like a directory tree. The directory tree of an archive is built
-in memory when it is first entered, so expect some delay for big archives.
+to select fewer archives), named as for ``borg mount`` (see the
+``BORG_MOUNT_ARCHIVE_DIR_FORMAT`` environment variable there); below that,
+the archive contents can be browsed like a directory tree. The directory
+tree of an archive is built in memory when it is first entered, so expect
+some delay for big archives.
 
 Any directory can be downloaded as a tar archive by appending ``?tar`` to its
 URL (the web browser listings show a download icon next to the heading for this).

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -887,6 +887,11 @@ class HelpMixIn:
                 Giving the default value for ``borg repo-list --format=X``.
             BORG_PRUNE_FORMAT
                 Giving the default value for ``borg prune --format=X``.
+            BORG_MOUNT_ARCHIVE_DIR_FORMAT
+                Giving the format of the archive directory names when ``borg mount`` or
+                ``borg webdav`` show a whole repository, default: ``{name}``. The placeholders
+                are the ones of ``borg repo-list --format``; names that are not unique get
+                ``-{id:.8}`` appended. See ``borg mount --help``.
 
         Some automatic "answerers" (if set, they automatically answer confirmation questions):
             BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)

--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -68,9 +68,17 @@ class MountMixIn:
         not enforce the ACLs for permission checks. On other platforms, ACLs are not
         supported.
 
-        When mounting a repository, the top directories will be named like the
-        archives and the directory structure below these will be loaded on-demand from
-        the repository when entering these directories, so expect some delay.
+        When mounting a repository, there is one top directory per archive and the
+        directory structure below these will be loaded on-demand from the repository
+        when entering these directories, so expect some delay.
+
+        By default, these top directories are named like the archives; as the archives
+        of a series all have the same name, ``-{id:.8}`` (the first 8 hex digits of the
+        archive id) is appended whenever a name is not unique. To name them differently,
+        set the ``BORG_MOUNT_ARCHIVE_DIR_FORMAT`` environment variable to a format string
+        using the placeholders of ``borg repo-list --format``, e.g.
+        ``{name}-{time:%Y-%m-%dT%H:%M:%S}`` or ``{hostname}-{name}``; names that are
+        still not unique get ``-{id:.8}`` appended.
 
         .. note::
 

--- a/src/borg/archiver/webdav_cmd.py
+++ b/src/borg/archiver/webdav_cmd.py
@@ -90,9 +90,11 @@ class WebDAVMixIn:
         localhost TCP ports on the machine can read the served archive contents.
 
         The top level lists the selected archives (use the archive filter options
-        to select fewer archives); below that, the archive contents can be
-        browsed like a directory tree. The directory tree of an archive is built
-        in memory when it is first entered, so expect some delay for big archives.
+        to select fewer archives), named as for ``borg mount`` (see the
+        ``BORG_MOUNT_ARCHIVE_DIR_FORMAT`` environment variable there); below that,
+        the archive contents can be browsed like a directory tree. The directory
+        tree of an archive is built in memory when it is first entered, so expect
+        some delay for big archives.
 
         Any directory can be downloaded as a tar archive by appending ``?tar`` to its
         URL (the web browser listings show a download icon next to the heading for this).

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -282,6 +282,26 @@ def test_fuse_duplicate_name(archivers, request):
 
 
 @pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")
+def test_fuse_archive_dir_format(archivers, request, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "duplicate", "input")
+    cmd(archiver, "create", "duplicate", "input")
+    cmd(archiver, "create", "unique", "input")
+    output = cmd(archiver, "repo-list", "--format={name} {hostname} {id}{NL}")
+    archives = [line.split() for line in output.splitlines()]
+    mountpoint = os.path.join(archiver.tmpdir, "mountpoint")
+    # BORG_MOUNT_ARCHIVE_DIR_FORMAT names the archive directories, using the repo-list placeholders:
+    monkeypatch.setenv("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "{name}-{id}")
+    with fuse_mount(archiver, mountpoint):
+        assert set(os.listdir(mountpoint)) == {f"{name}-{id}" for name, hostname, id in archives}
+    # names that are not unique get the short archive id appended (here: all of them):
+    monkeypatch.setenv("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "{hostname}")
+    with fuse_mount(archiver, mountpoint):
+        assert set(os.listdir(mountpoint)) == {f"{hostname}-{id[:8]}" for name, hostname, id in archives}
+
+
+@pytest.mark.skipif(not has_any_fuse, reason="FUSE not available")
 def test_fuse_allow_damaged_files(archivers, request):
     archiver = request.getfixturevalue(archivers)
     cmd(archiver, "repo-create", RK_ENCRYPTION)

--- a/src/borg/testsuite/archiver/webdav_cmd_test.py
+++ b/src/borg/testsuite/archiver/webdav_cmd_test.py
@@ -22,6 +22,7 @@ import pytest
 
 from ...constants import *  # NOQA
 from ...archive import Archive
+from ...helpers import Error
 from ...manifest import Manifest
 from ...platform import is_win32
 from ...repository import Repository
@@ -147,6 +148,40 @@ def test_webdav_browse(archivers, request):
         if are_symlinks_supported():
             assert "link1 -&gt; somewhere/else" in page
             assert 'href="link1"' not in page  # symlinks are not downloadable
+
+
+def test_webdav_archive_dir_format(archivers, request, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", contents=b"data1")
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "duplicate", "input")
+    cmd(archiver, "create", "duplicate", "input")
+    cmd(archiver, "create", "unique", "input")
+    output = cmd(archiver, "repo-list", "--format={name} {id}{NL}")
+    archives = [line.split() for line in output.splitlines()]
+
+    def archive_dirs(base_url):
+        _, _, body = propfind(base_url + "/", depth="1")
+        return {href.strip("/") for href in propfind_hrefs(body) if href != "/"}
+
+    # by default, the archive directories are named like the archives, with the short
+    # archive id appended where the name is not unique (the archives of a series):
+    with webdav_server(archiver) as base_url:
+        expected = {f"duplicate-{id[:8]}" for name, id in archives if name == "duplicate"} | {"unique"}
+        assert archive_dirs(base_url) == expected
+    # BORG_MOUNT_ARCHIVE_DIR_FORMAT gives another format, using the repo-list placeholders:
+    monkeypatch.setenv("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "{name}-{id}")
+    with webdav_server(archiver) as base_url:
+        assert archive_dirs(base_url) == {f"{name}-{id}" for name, id in archives}
+    # a format that gives the same name for all archives: the short archive id is appended to all
+    monkeypatch.setenv("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "archive")
+    with webdav_server(archiver) as base_url:
+        assert archive_dirs(base_url) == {f"archive-{id[:8]}" for name, id in archives}
+    # unknown placeholders are rejected
+    monkeypatch.setenv("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "{nonsense}")
+    with pytest.raises(Error, match="BORG_MOUNT_ARCHIVE_DIR_FORMAT"):
+        with webdav_server(archiver):
+            pass
 
 
 def test_webdav_download(archivers, request):

--- a/src/borg/vfs.py
+++ b/src/borg/vfs.py
@@ -32,7 +32,7 @@ from typing import NamedTuple
 from .archive import Archive, DownloadPipeline, get_item_uid_gid
 from .constants import ROBJ_FILE_STREAM
 from .hashindex import FuseVersionsIndex
-from .helpers import Error, bin_to_hex, format_file_size, remove_surrogates
+from .helpers import ArchiveFormatter, CommandError, Error, bin_to_hex, format_file_size, remove_surrogates
 from .helpers import msgpack
 from .helpers.lrucache import LRUCache
 from .item import ChunkListEntry, Item
@@ -198,11 +198,11 @@ def versioned_name(name, version):
 class ArchiveVFS:
     """A read-only file system view of the archives selected by *args*.
 
-    The root directory has one directory per (deduplicated) archive name; each of
-    these archive trees is built when it is first accessed - building it means
-    reading the whole item metadata stream of that archive, which takes a while for
-    a big archive. In the versions view, the contents of all selected archives are
-    merged into one tree instead, which is built completely upfront.
+    The root directory has one directory per archive (see create_filesystem for how
+    they are named); each of these archive trees is built when it is first accessed -
+    building it means reading the whole item metadata stream of that archive, which
+    takes a while for a big archive. In the versions view, the contents of all selected
+    archives are merged into one tree instead, which is built completely upfront.
 
     Directories are addressable by inode number (get_node); everything else is
     reached by looking up names in a directory node (lookup / resolve).
@@ -237,11 +237,12 @@ class ArchiveVFS:
     def create_filesystem(self):
         """Populate the root directory (this also selects the archives to be shown)."""
         archives = self.manifest.archives.list_considering(self.args)
-        # archives of a series all have the same name, so make the display names unique
-        name_counter = Counter(archive.name for archive in archives)
-        for archive in archives:
-            name = archive.name
-            if name_counter[name] > 1:
+        names = self._archive_dir_names(archives)
+        # the archives of a series all have the same name (and other formats can be
+        # ambiguous, too), so append the archive id to the names that are not unique.
+        name_counter = Counter(names)
+        for archive, name in zip(archives, names):
+            if name_counter[name] > 1 or name in ("", ".", ".."):
                 name += f"-{bin_to_hex(archive.id):.8}"
             self.archives[name] = archive
         timestamps = [archive.ts for archive in archives]
@@ -259,6 +260,17 @@ class ArchiveVFS:
                 self._set_item(node.ino, self._dir_item(int(archive.ts.timestamp() * 1e9)))
                 self.root.children[name] = node
                 self._pending[node] = archive
+
+    def _archive_dir_names(self, archives):
+        """The root directory names of *archives*, see BORG_MOUNT_ARCHIVE_DIR_FORMAT (borg mount --help)."""
+        format = os.environ.get("BORG_MOUNT_ARCHIVE_DIR_FORMAT", "{name}")
+        try:
+            formatter = ArchiveFormatter(format, self.repository, self.manifest, self.manifest.key)
+            names = [formatter.format_item(archive) for archive in archives]
+        except (CommandError, ValueError) as err:  # unknown placeholder, malformed format string / format spec
+            raise Error(f"BORG_MOUNT_ARCHIVE_DIR_FORMAT: {err}") from None
+        # "/" and NUL can not be part of a directory name
+        return [name.replace("/", "_").replace("\0", "_") for name in names]
 
     def _dir_item(self, mtime):
         """Return the item used for a synthesized directory, with mtime *mtime*."""


### PR DESCRIPTION
Fixes https://github.com/borgbackup/borg/issues/9991

When `borg mount` (or `borg webdav`) shows a whole repository, the archive directories were named `{name}`, with `-{id:.8}` appended to names that are not unique (the archives of a series). Finding a specific archive among `docs-1f7b3c2a`, `docs-9e4d0b58`, ... is not very user-friendly.

The new `BORG_MOUNT_ARCHIVE_DIR_FORMAT` environment variable gives the format of these directory names, using the placeholders of `borg repo-list --format`, e.g. `{name}-{time:%Y-%m-%dT%H:%M:%S}`, `{hostname}-{name}` or `{name}-{id}`.

- default: `{name}` - the same naming as before.
- names that are still not unique (or empty, `.`, `..`) get `-{id:.8}` appended, so formats like `{hostname}` or `{name}-{time:%Y-%m-%d}` can not make archives vanish from the view.
- `/` and NUL are replaced by `_`; an unknown placeholder or a malformed format string is an error, raised before the mount / daemonization.
- implemented in the shared `ArchiveVFS`, so it applies to `borg mount` and `borg webdav` alike.
- docs: `borg mount --help`, `borg webdav --help`, `borg help environment`, mount usage examples, changelog. Tests for mount (FUSE) and webdav (platform independent, also covers the error case).
