### PR TITLE
CI: give the macOS runners a resolvable hostname (1.2-maint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,11 @@ jobs:
         brew install lz4 || brew upgrade lz4
         brew install xxhash || brew upgrade xxhash
         brew install openssl@3.0 || brew upgrade openssl@3.0
+        # the runner's unresolvable .local hostname takes macOS ~35s to give up on,
+        # which borg pays per spawned process (import-time fqdn) - hours of test time,
+        # see #9470. .local is mDNS territory, an /etc/hosts entry alone does not help.
+        sudo scutil --set HostName borg-ci-mac
+        echo "127.0.0.1 borg-ci-mac" | sudo tee -a /etc/hosts
 
     - name: Install Python requirements
       run: |


### PR DESCRIPTION
Backport of #10135 (master) / #10139 (1.4-maint) to 1.2-maint.

The macOS runner's hostname is a long, unresolvable `.local` name, and macOS
takes ~35s to give up resolving it. `src/borg/platform/base.py` computes
`fqdn = getfqdn(hostname)` at import time, so every spawned borg process pays
those 35s. The last 1.2-maint macOS job ran into the 6h GitHub job limit and
was cancelled.

`.local` is mDNS territory, so an `/etc/hosts` entry alone does not help -
the hostname has to be changed via `scutil --set HostName` as well.

Refs #9470.