### PR TITLE
placeholders: only determine the fqdn if a fqdn placeholder is used

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -508,16 +508,32 @@ def format_line(format, data):
         raise PlaceholderError(format, data, e.__class__.__name__, str(e))
 
 
+class LazyValue:
+    """A placeholder value that is only computed if the placeholder is actually used."""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __format__(self, format_spec):
+        return format(self.fn(), format_spec)
+
+    def __str__(self):
+        return str(self.fn())
+
+    def __repr__(self):
+        return repr(self.fn())
+
+
 def _replace_placeholders(text, overrides={}):
     """Replace placeholders in text with their values."""
     from ..platform import get_fqdn, get_hostname, getosusername
 
-    fqdn = get_fqdn()
     current_time = datetime.now(UTC)
     data = {
         "pid": os.getpid(),
-        "fqdn": fqdn,
-        "reverse-fqdn": ".".join(reversed(fqdn.split("."))),
+        # lazy: get_fqdn() does a DNS query, which is slow if our own hostname does not resolve, see #10181
+        "fqdn": LazyValue(get_fqdn),
+        "reverse-fqdn": LazyValue(lambda: ".".join(reversed(get_fqdn().split(".")))),
         "hostname": os.environ.get("BORG_HOSTNAME") or get_hostname(),
         "now": DatetimeWrapper(current_time.astimezone()),
         "utcnow": DatetimeWrapper(current_time),

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -840,6 +840,29 @@ def test_override_placeholders():
     assert replace_placeholders("{uuid4}", overrides={"uuid4": "overridden"}) == "overridden"
 
 
+def test_fqdn_placeholder_is_lazy(monkeypatch):
+    """the (potentially slow) DNS query must only happen if a fqdn placeholder is used, see #10181"""
+    from ...platform import base
+
+    base.get_fqdn.cache_clear()
+    calls = []
+
+    def spy(name):
+        calls.append(name)
+        return "test.example.org"
+
+    monkeypatch.setattr(base, "getfqdn", spy)
+    try:
+        replace_placeholders.reset()
+        assert replace_placeholders("{hostname}-{now:%Y}-{user}-{pid}")
+        assert calls == []
+        assert replace_placeholders("{fqdn}") == "test.example.org"
+        assert replace_placeholders("{reverse-fqdn}") == "org.example.test"
+        assert len(calls) == 1  # get_fqdn() is cached
+    finally:
+        base.get_fqdn.cache_clear()
+
+
 def working_swidth():
     from ...platform import swidth
 


### PR DESCRIPTION
`replace_placeholders()` called `get_fqdn()` unconditionally, so every borg command that
goes through placeholder replacement triggered a DNS query — even a plain archive name with
no placeholder in it, and even just parsing the repo location. On a host whose own hostname
does not resolve, that query can take minutes (see #10181).

`{fqdn}` and `{reverse-fqdn}` are now `LazyValue`s: the DNS query only happens when the
placeholder is actually formatted. `get_fqdn()` stays `functools.cache`d, so using both
placeholders still costs one query.

### What this does and does not buy

`get_fqdn()` being cached means only the *first* caller in a process pays. Measured
`getfqdn()` calls for `init` / `create` / `list` on 1.4-maint:

| | before (#10182 only) | after |
|---|---|---|
| no `BORG_HOST_ID` | 1 — first caller is argparse (Location → `replace_placeholders`) | 1 — first caller is the lock (`get_hostid`) |
| `BORG_HOST_ID` set | 1 — placeholders resolved anyway | **0** |

So for the default case this is a wash: the query moves from arg parsing to lock
acquisition. The real gain is that `BORG_HOST_ID` now works as a *complete* escape hatch,
which it previously did not — setting it still left you with the placeholder lookup.

Therefore this is `see #10181`, not `fixes #10181`. Making a repo-touching command DNS-free
without `BORG_HOST_ID` needs `get_hostid()` to stop requiring the FQDN; one option is to
skip the query when `socket.gethostname()` already contains a dot (it *is* an FQDN then —
and that is exactly the reporter's situation), but that changes `{fqdn}`/hostid values on
hosts whose DNS canonical name differs from their local dotted hostname, so it is a separate
decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
