### PR TITLE
transfer --from-borg1: do not mistake a borg 1.x repokey repo for a swapped one

### DIFF
--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -232,7 +232,9 @@ def key_factory(repository, manifest_chunk, *, other=False, ro_cls=RepoObj):
         # tagged envelope modes (see MACKeyBase). The legacy key classes only exist to read borg
         # 1.x repositories (ro_cls is RepoObj1 then), e.g. for "borg transfer --from-borg1".
         raise UnsupportedPayloadError(manifest_data[0])
-    return key_cls.detect(repository, manifest_data, other=other)
+    key = key_cls.detect(repository, manifest_data, other=other)
+    key.stored_type = manifest_data[0]
+    return key
 
 
 def uses_same_chunker_secret(other_key, key):
@@ -270,6 +272,9 @@ class KeyBase:
     TYPE: int = None  # override in subclasses
     # set of key type IDs the class can handle as input
     TYPES_ACCEPTABLE: set[int] = None  # override in subclasses
+    # type ID this key was actually found with, None for a freshly created key. It can differ from
+    # TYPE: the borg 1.x keyfile/repokey classes are unified, so one class covers several IDs, #9767.
+    stored_type: int | None = None
 
     # The two orthogonal dimensions a creatable crypto suite is selected by on the command line:
     # ENC_NAME -> "borg repo-create --encryption" (cipher / AE algorithm)

--- a/src/borg/security.py
+++ b/src/borg/security.py
@@ -94,7 +94,9 @@ class SecurityManager:
         try:
             with self.key_type_file.open() as fd:
                 type = fd.read()
-                return type == str(key.TYPE)
+                # accept every type byte the key class can read: the borg 1.x keyfile/repokey
+                # classes are unified, so one class covers several stored type bytes, see #9767.
+                return type in {str(t) for t in key.TYPES_ACCEPTABLE}
         except OSError as exc:
             logger.warning("Could not read/parse key type file: %s", exc)
 
@@ -102,12 +104,13 @@ class SecurityManager:
         logger.debug("security: saving state for %s to %s", self.repository.id_str, str(self.dir))
         current_location = self.repository._location.canonical_path()
         logger.debug("security: current location   %s", current_location)
-        logger.debug("security: key type           %s", str(key.TYPE))
+        key_type = key.TYPE if key.stored_type is None else key.stored_type
+        logger.debug("security: key type           %s", str(key_type))
         logger.debug("security: manifest timestamp %s", manifest.timestamp)
         with SaveFile(self.location_file) as fd:
             fd.write(current_location)
         with SaveFile(self.key_type_file) as fd:
-            fd.write(str(key.TYPE))
+            fd.write(str(key_type))
         with SaveFile(self.manifest_ts_file) as fd:
             fd.write(manifest.timestamp)
 

--- a/src/borg/testsuite/archiver/transfer_cmd_test.py
+++ b/src/borg/testsuite/archiver/transfer_cmd_test.py
@@ -6,12 +6,14 @@ import random
 import re
 import stat
 import tarfile
+from configparser import ConfigParser
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
 from ...constants import *  # NOQA
-from ...helpers import open_item, IntegrityError
+from ...helpers import open_item, IntegrityError, Location
 from ...helpers.time import parse_timestamp
 from ...helpers.parseformat import parse_file_size, ChunkerParams
 from ..platform.platform_test import is_win32
@@ -326,6 +328,72 @@ def test_transfer_from_borg1_ssh(archivers, request, monkeypatch):
         expected_names = sorted(a["name"] for a in json.load(f)["archives"])
     got_names = sorted(a["name"] for a in json.loads(cmd(archiver, "repo-list", "--json"))["archives"])
     assert got_names == expected_names
+
+
+def _setup_borg1_transfer(archiver, monkeypatch, tmp_path):
+    """Unpack the borg 1.2 testdata repo, isolate the security dir and return (src_repo, security_dir)."""
+    # borg 1.2 repo dir contents, created by: scripts/make-testdata/test_transfer_upgrade.sh
+    repo12_tar = os.path.join(os.path.dirname(__file__), "repo12.tar.gz")
+    original_location = archiver.repository_location
+    src_repo = f"{original_location}1"
+    os.makedirs(src_repo)
+    with tarfile.open(repo12_tar) as tf:
+        tf.extractall(src_repo)
+
+    # borg 1.x kept its security dir in the config dir; keep it out of the real one.
+    security_dir = tmp_path / "security"
+    monkeypatch.setenv("BORG_SECURITY_DIR", str(security_dir))
+    parser = ConfigParser(interpolation=None)
+    parser.read(os.path.join(src_repo, "config"))
+
+    archiver.repository_location = f"{original_location}2"
+    monkeypatch.setenv("BORG_PASSPHRASE", "pw2")
+    monkeypatch.setenv("BORG_OTHER_PASSPHRASE", "waytooeasyonlyfortests")
+    # must use the strong kdf here or borg2 can't decrypt the borg1 key
+    monkeypatch.setenv("BORG_TESTONLY_WEAKEN_KDF", "0")
+    return src_repo, security_dir / parser["repository"]["id"]
+
+
+def test_transfer_from_borg1_known_repo(archivers, request, monkeypatch, tmp_path):
+    """A borg 1.x repokey repo the user already accessed with borg 1.x must not look like a swapped repo."""
+    archiver = request.getfixturevalue(archivers)
+    if archiver.get_kind() != "local":
+        pytest.skip("only works locally")
+
+    src_repo, repo_security_dir = _setup_borg1_transfer(archiver, monkeypatch, tmp_path)
+
+    # Recreate what borg 1.x left behind: a security dir recording the KeyType.REPO type byte
+    # (the testdata repo was created with "borg init -e repokey").
+    repo_security_dir.mkdir(parents=True)
+    key_type_file = repo_security_dir / "key-type"
+    key_type_file.write_text(str(KeyType.REPO))
+    (repo_security_dir / "location").write_text(Location(Path(src_repo).absolute().as_uri()).canonical_path())
+    (repo_security_dir / "manifest-timestamp").write_text("1970-01-01T00:00:00.000000")
+
+    other_repo1 = f"--other-repo={src_repo}"
+    cmd(archiver, "repo-create", RK_ENCRYPTION, other_repo1, "--from-borg1")
+    cmd(archiver, "transfer", other_repo1, "--from-borg1")
+    cmd(archiver, "check")
+
+    assert key_type_file.read_text() == str(KeyType.REPO)
+
+
+def test_transfer_from_borg1_unknown_repo(archivers, request, monkeypatch, tmp_path):
+    """borg 2 remembering a borg 1.x repokey repo must not lock borg 1.x out of it afterwards."""
+    archiver = request.getfixturevalue(archivers)
+    if archiver.get_kind() != "local":
+        pytest.skip("only works locally")
+
+    src_repo, repo_security_dir = _setup_borg1_transfer(archiver, monkeypatch, tmp_path)
+
+    other_repo1 = f"--other-repo={src_repo}"
+    cmd(archiver, "repo-create", RK_ENCRYPTION, other_repo1, "--from-borg1")
+    cmd(archiver, "transfer", other_repo1, "--from-borg1")
+    cmd(archiver, "check")
+
+    # borg 2 must record the type byte borg 1.x uses for a repokey repo, not the one its own
+    # (unified keyfile/repokey) key class defaults to.
+    assert (repo_security_dir / "key-type").read_text() == str(KeyType.REPO)
 
 
 @contextmanager


### PR DESCRIPTION
Found while doing a manual borg 1.4 -> borg 2 transfer test. Fixes #10189.

## The blocker

`borg repo-create --other-repo <borg1repo> --from-borg1` (and `borg transfer`) aborts with:

```
Repository encryption method changed since last access, refusing to continue
```

for any borg 1.x **repokey** repository that already has a security dir - that is, any repository the user has ever accessed with borg 1.x on that machine, which is the normal case. `EncryptionMethodMismatch` has no override env var, so the only way through was to delete `$BORG_CONFIG_DIR/security/<repoid>/` first.

Reproducer:

```
borg14 init -e repokey repo1
borg14 create repo1::backup1 somedir
borg2 repo-create -e chacha20-poly1305 --copy-crypt-key --repo repo2 --other-repo repo1 --from-borg1
```

Cause: #9767 unified the borg 1.x keyfile and repokey classes, so one class now covers several stored key type bytes - `AESCTRKey.TYPES_ACCEPTABLE` is `{KEYFILE, REPO, PASSPHRASE}` while its canonical `TYPE` is `KEYFILE` (0). `SecurityManager.key_matches()` compared the stored byte against that single canonical `TYPE`, and borg 1.x had stored `3` (`REPO`). Same shape for `Blake2AESCTRKey` (`TYPE` = `BLAKE2KEYFILE` = 4 vs stored `BLAKE2REPO` = 5).

Fix: compare against `TYPES_ACCEPTABLE`. Those sets are disjoint (`identify_key` relies on that already), so a genuine encryption method swap is still detected.

## The other direction

When borg 2 was the *first* to create the security dir of a borg 1.x repository, it wrote the canonical `TYPE` (0) there. v1 repos share borg 1.x's security dir (`_security_dir` -> `legacy.fs.get_security_dir`), so afterwards **borg 1.x refused its own repository** with the identical error - verified with borg 1.4-maint against a repo borg 2 had just transferred from.

Fix: remember the type byte the key was actually found with (`key_factory` has it as `manifest_data[0]`) and write that back instead of the class default.

## Tests

Two regression tests on the existing `repo12.tar.gz` borg 1.2 testdata (created with `borg init -e repokey`):

- `test_transfer_from_borg1_known_repo` - seeds the security dir the way borg 1.x leaves it (`key-type` = `KeyType.REPO`), then transfers; also asserts the byte was not rewritten.
- `test_transfer_from_borg1_unknown_repo` - no security dir; asserts borg 2 records `KeyType.REPO`, not `KeyType.KEYFILE`.

Both fail on master and pass with this change. Full local test suite green (2653 passed, 369 skipped), black and mypy clean.

No `docs/changes.rst` entry, since b23 was just released and there is no unreleased section yet - happy to add one if you want it in b24.

Side note, unrelated to this change: the "other repo" passphrase must come from `BORG_OTHER_PASSPHRASE`, but when it is missing and the interactive prompt fails, the error reads `Cannot acquire a passphrase: BORG_PASSPHRASE is set. BORG_PASSCOMMAND is not set.` - which points at the wrong variable. Worth a separate issue?
