### PR TITLE
README: update to reflect current borg2 master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ Main features
   and only chunks that have never been seen before are added to the repository.
 
   A chunk is considered duplicate if its id_hash value is identical.
-  A cryptographically strong hash or MAC function is used as id_hash, e.g.
-  (hmac-)sha256.
+  A cryptographically strong hash or MAC function is used as id_hash,
+  e.g. (hmac-)sha256 or (keyed) blake3.
 
   To deduplicate, all the chunks in the same repository are considered, no
   matter whether they come from different machines, from previous backups,
@@ -62,13 +62,16 @@ Main features
 
   Supported chunkers:
 
-  * buzhash (as in borg 1.x) / buzhash64 (improved)
-  * fastCDC
-  * fixed
+  * fastcdc (the default)
+  * buzhash64 (improved), buzhash (as in borg 1.x)
+  * toeplitz-aes / rabin-aes / goldilocks-aes (keyed, AES-based; they make
+    chunk-boundary fingerprinting attacks much harder)
+  * fixed (fixed blocksize, optionally with a differently sized header)
 
 **Speed**
   * performance-critical code (chunking, compression, encryption) is
-    implemented in C/Cython
+    implemented in C/Cython, using SIMD (NEON / AVX2 / AVX-512) where that
+    is a win - the scan kernel is picked per platform
   * local caching
   * quick detection of unmodified files
 
@@ -76,6 +79,10 @@ Main features
     All data can be protected client-side using 256-bit authenticated encryption
     (AES-OCB or chacha20-poly1305), ensuring data confidentiality, integrity and
     authenticity.
+
+    If you do not need confidentiality, there are also modes that only
+    authenticate (``authenticated-sha256`` / ``authenticated-blake3``) and
+    modes that do neither (``none-sha256`` / ``none-blake3``).
 
 **Hashing**
     You can choose between HMAC-SHA256 and Blake3.
@@ -96,12 +103,12 @@ Main features
 **Off-site backups**
     Borg can store data on any remote host accessible via misc. protocols:
 
-    * ssh (REST-http-over-stdio-over-ssh) and https (REST-http-over-tcp).
-      Significant performance gains can be achieved with this by having a
-      remote agent (borg must be installed on the repo server).
-    * sftp
-    * S3 / B2
-    * lots of protocols / providers supported by rclone
+    * ``rest://`` (REST-http-over-stdio-over-ssh) and ``http(s)://``
+      (REST-http-over-tcp). Significant performance gains can be achieved with
+      these by having a remote agent (borg must be installed on the repo server).
+    * ``sftp://``
+    * ``s3://`` / ``b2://``
+    * ``rclone:`` - lots of protocols / providers supported by rclone
 
 **Backups mountable as file systems**
     Backup archives are mountable as user-space file systems for easy interactive
@@ -111,12 +118,18 @@ Main features
     We offer single-file binaries that do not require installing anything -
     you can just run them on these platforms:
 
-    * Linux
-    * macOS
-    * FreeBSD
-    * OpenBSD and NetBSD (no xattrs/ACLs support or binaries yet)
-    * Cygwin (experimental, no binaries yet)
-    * Windows (MSYS2/MINGW borg.exe, experimental)
+    * Linux (x86_64, arm64)
+    * macOS (arm64, x86_64)
+    * FreeBSD (x86_64)
+    * Windows (x86_64, MSYS2/MINGW borg.exe, experimental)
+
+    Borg also runs on these platforms, but you need to install it from a
+    package or from source:
+
+    * NetBSD (xattrs, but no ACLs)
+    * OpenBSD (no xattrs/ACLs support)
+    * illumos / Solaris (xattrs, but no ACLs)
+    * Cygwin (experimental)
     * Windows Subsystem for Linux (WSL) on Windows 10/11 (experimental)
 
 **Free and Open Source Software**
@@ -142,15 +155,18 @@ Create a new backup archive::
 Now do another backup, just to show off the great deduplication::
 
     $ borg create -v --stats docs ~/Documents
+    Creating archive "docs" in repository /path/to/repo
     Repository: /path/to/repo
     Archive name: docs
     Archive fingerprint: 7714aef97c1a24539cc3dc73f79b060f14af04e2541da33d54c7ee8e81a00089
-    Time (start): Mon, 2022-10-03 19:57:35 +0200
-    Time (end):   Mon, 2022-10-03 19:57:35 +0200
+    Time (nominal): Mon, 2026-08-03 19:57:35 +0200
+    Time (start):   Mon, 2026-08-03 19:57:35 +0200
+    Time (end):     Mon, 2026-08-03 19:57:35 +0200
     Duration: 0.01 seconds
     Number of files: 24
     Original size: 29.73 MB
     Deduplicated size: 520 B
+    ...
 
 
 For demo videos, check out our homepage: https://www.borgbackup.org/#demo
@@ -217,8 +233,8 @@ see ``docs/support.rst`` in the source distribution).
         :alt: Test Coverage
         :target: https://codecov.io/github/borgbackup/borg?branch=master
 
-.. |bestpractices| image:: https://bestpractices.coreinfrastructure.org/projects/271/badge
+.. |bestpractices| image:: https://www.bestpractices.dev/projects/271/badge
         :alt: Best Practices Score
-        :target: https://bestpractices.coreinfrastructure.org/projects/271
+        :target: https://www.bestpractices.dev/projects/271
 
 .. end-badges


### PR DESCRIPTION
The README had drifted away from what master actually does.

**Chunkers**: the list only had buzhash / fastCDC / fixed. Master has 7, and
``fastcdc`` is the default now (``CHUNKER_PARAMS = FASTCDC_PARAMS``), which the
README did not say. Added the keyed AES-based chunkers (``toeplitz-aes`` /
``rabin-aes`` / ``goldilocks-aes``).

**Platforms**: this was the most misleading part. The list was introduced by "we
offer single-file binaries ... you can just run them on these platforms", but
then annotated some entries with "no binaries yet". Meanwhile Windows *does* get
a released binary now and was not marked as such. The list is now split into the
platforms we build and release binaries for (linux x86_64/arm64, macOS
arm64/x86_64, freebsd x86_64, windows x86_64 - see the artifact list in
``.github/workflows/release.yml``) and the platforms that run borg but need a
package or a source install.

Also, "OpenBSD and NetBSD (no xattrs/ACLs support)" is not true for NetBSD, which
does have xattrs (``src/borg/platform/__init__.py``), and illumos / Solaris
support (``src/borg/platform/solaris.py``, OmniOS in CI) was missing entirely.

**borg create --stats sample output**: ran the README commands against master -
the output has a ``Time (nominal)`` line now, the ``Time (start)/(end)`` lines
are aligned differently, and quite a lot of further counters follow (hashing /
chunking time, per-status file counts, store I/O stats). Truncated with "..."
rather than pasting all of it.

**Off-site backups**: it said "ssh" and "https"; the schemes are ``rest://`` and
``http(s)://`` these days, with ``ssh://`` only being for legacy borg 1.x repos.
Named the schemes explicitly.

**Smaller ones**: mention (keyed) blake3 next to (hmac-)sha256 for the id_hash,
mention the per-platform SIMD scan kernels under "Speed", mention the
``authenticated-*`` and ``none-*`` encryption modes, and point the best practices
badge at ``www.bestpractices.dev`` (the old coreinfrastructure.org URL only
redirects there).

Checked all README links, they are alive. Verified the file still renders without
warnings via docutils and via readme_renderer (it is the PyPI long_description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)