### PR TITLE
setuptools-scm: drop tag.strict, fixes #10193

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,11 @@ build-backend = "setuptools.build_meta"
 # https://github.com/borgbackup/borg/issues/6875
 write_to = "src/borg/_version.py"
 write_to_template = "__version__ = version = {version!r}\n"
-tag.strict = false
+# Do not add keys here that only exist in recent setuptools-scm (e.g. the "tag" table,
+# needing setuptools-scm >= 10.1): older versions pass this table as kwargs to their
+# Configuration class and hard-fail with TypeError on unknown keys, breaking builds
+# against the setuptools-scm versions shipped by distributions.
+# https://github.com/borgbackup/borg/issues/10193
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
The `[tool.setuptools_scm.tag]` table only exists since setuptools-scm 10.1 (vcs-versioning 2.0.0, both released 2026-06-22). Older setuptools-scm passes the whole `[tool.setuptools_scm]` table as kwargs to its `Configuration` class (`from_file` -> `from_data` -> `cls(**data)`), so an unknown `tag` key is a hard `TypeError`, not an ignored option:

```
TypeError: Configuration.__init__() got an unexpected keyword argument 'tag'
```

That breaks builds against the setuptools-scm versions distributions ship (Debian has 9.x and builds with `--no-isolation`): fixes #10193, https://bugs.debian.org/1144303. Affected releases: 2.0.0b22 and 2.0.0b23.

Setting `tag.strict` was only about silencing the `FutureWarning` about the coming default change. It is a no-op for borg: strict matching only narrows the `git describe --match` glob from `*[0-9]*` to `*[0-9]*.*[0-9]*`, and all borg release tags contain a dot - both globs describe master as `2.0.0b23-14-g4a85be421`. vcs-versioning 2.3.0 also made that notice conditional (only when the future default would actually select a different tag) and log-level, so with a current setuptools-scm nothing is emitted here anyway.

A comment is added in place of the removed line so the key does not come back before distributions ship setuptools-scm >= 10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)