### PR TITLE
lock exceptions: tell who holds the lock, #2261

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -165,6 +165,12 @@ Change Log 2.x
 Version 2.0.0b24 (not released yet)
 -----------------------------------
 
+New features:
+
+- locking: tell who is holding a lock we wait for or time out on: lock type, host,
+  pid and age of that lock. Also name the repository in the message (instead of just
+  the storage backend) and log which locks ``borg break-lock`` breaks, #2261
+
 Fixes:
 
 - shell completions: complete local repository directories for ``-r`` / ``--repo``

--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -1193,6 +1193,8 @@ Using that information, borg implements:
   cause one.
 - a warning if the clocks of concurrently active clients differ by more than
   a few minutes.
+- telling the user which lock blocks them (type, host, pid, age) while waiting
+  for it and in the error message if acquiring it times out.
 
 See the module docstring of ``src/borg/storelocking.py`` for the details
 (clock domains, how store "now" is derived, what happens without store-side

--- a/src/borg/repository.py
+++ b/src/borg/repository.py
@@ -881,7 +881,9 @@ class Repository:
         self.id = hex_to_bin(self.store.load("config/id").decode(), length=32)
         # important: lock *after* making sure that there actually is an existing, supported repository.
         if lock:
-            self.lock = Lock(self.store, exclusive, timeout=lock_wait).acquire()
+            self.lock = Lock(
+                self.store, exclusive, timeout=lock_wait, repository=self._location.canonical_path()
+            ).acquire()
         self._chunks = None
         # pack-sizing overrides: BORG_PACK_MAX_COUNT sets the max object count per pack,
         # BORG_PACK_MAX_SIZE the max pack size in bytes. Default: size-bound only.
@@ -1733,7 +1735,7 @@ class Repository:
         return new_pack_id, len(pack_data)
 
     def break_lock(self):
-        Lock(self.store).break_lock()
+        Lock(self.store, repository=self._location.canonical_path()).break_lock()
 
     def migrate_lock(self, old_id, new_id):
         # note: only needed for local repos

--- a/src/borg/storelocking.py
+++ b/src/borg/storelocking.py
@@ -83,7 +83,7 @@ from borgstore.store import ObjectNotFound
 
 from . import platform
 from .constants import MAX_MUTUAL_CLOCK_SKEW
-from .helpers import Error, ErrorWithTraceback
+from .helpers import Error, ErrorWithTraceback, format_timedelta
 from .logger import create_logger
 
 logger = create_logger(__name__)
@@ -93,6 +93,31 @@ logger = create_logger(__name__)
 # lock listings, None until harvested), plus time.monotonic() at its creation. always replaced as a
 # whole, so concurrent readers (e.g. a LockRefresher thread) never see a torn mix of its fields.
 LockAnchor = namedtuple("LockAnchor", "key dt mtime monotonic")
+
+# why a refresh gives up: our own lock object is gone, see refresh().
+LOCK_KILLED_MSG = (
+    "Our lock was killed by another borg (it considered our lock stale, e.g. because this machine "
+    "was suspended or too slow to refresh the lock in time, or because someone ran break-lock) - "
+    "there is no safe way to continue."
+)
+
+
+def format_lock(lock):
+    """Return a human readable description of a lock object: what it is, who holds it, since when."""
+    kind = "exclusive" if lock["exclusive"] else "shared"
+    age = format_timedelta(datetime.datetime.now(datetime.UTC) - lock["dt"])
+    return f"{kind} lock on host {lock['hostid']}, pid {lock['processid']}, age {age}"
+
+
+def format_locks(locks, max_shown=3):
+    """Return a human readable description of the given lock objects (at most max_shown of them)."""
+    if not locks:
+        # e.g. all the locks that blocked us went away while we were retrying, but we ran out of time.
+        return "unknown (no blocking lock seen)"
+    descriptions = [format_lock(lock) for lock in locks[:max_shown]]
+    if len(locks) > max_shown:
+        descriptions.append(f"and {len(locks) - max_shown} more")
+    return "; ".join(descriptions)
 
 
 class LockError(Error):
@@ -114,7 +139,7 @@ class LockFailed(LockErrorT):
 
 
 class LockTimeout(LockError):
-    """Failed to create/acquire the lock {} (timeout)."""
+    """Failed to create/acquire the lock {} (timeout). {}"""
 
     exit_mcode = 73
 
@@ -148,8 +173,11 @@ class Lock:
     (e.g., if an exception occurs).
     """
 
-    def __init__(self, store, exclusive=False, sleep=None, timeout=1.0, stale=30 * 60, id=None):
+    def __init__(self, store, exclusive=False, sleep=None, timeout=1.0, stale=30 * 60, id=None, repository=None):
         self.store = store
+        # how to call the locked repository in messages to the user. the store's repr does not tell
+        # which repository it is, so the caller should give a (credentials-free) repository name.
+        self.repository = repository if repository is not None else str(store)
         self.is_exclusive = exclusive
         self.sleep = sleep
         self.timeout = timeout
@@ -167,6 +195,7 @@ class Lock:
         # it deliberately outlives its lock object: the calibration stays valid after deletion.
         self.my_lock_anchor = None
         self.prev_lock_anchor = None  # the anchor before the current one, see _check_store_clock_step()
+        self.blocking_locks_logged = False  # tell the user only once per Lock instance who blocks us
         self.skew_warned = False  # emit the clock-skew warning only once per Lock instance
         self.store_clock_step_warned = False  # emit the storage-clock-step warning only once per Lock instance
         self.id = id or platform.get_process_id()
@@ -416,6 +445,7 @@ class Lock:
         # for non-exclusive lock: there can be multiple n-e locks, but there must not exist an exclusive lock.
         logger.debug(f"LOCK-ACQUIRE: trying to acquire a lock. exclusive: {self.is_exclusive}.")
         started = time.monotonic()
+        blocking_locks = []  # the foreign lock(s) that most recently kept us from acquiring
         while time.monotonic() - started < self.timeout:
             exclusive_locks = self._find_locks(only_exclusive=True)
             if all(lock.get("maybe_stale") for lock in exclusive_locks):
@@ -438,6 +468,8 @@ class Lock:
                             if len(locks) == 1 and locks[0]["key"] == key:
                                 logger.debug("LOCK-ACQUIRE: success! no non-exclusive locks are left!")
                                 return self
+                            blocking_locks = [lock for lock in locks if lock["key"] != key]
+                            self._log_blocking_locks(blocking_locks)
                             time.sleep(self.other_locks_go_away_delay)
                         logger.debug("LOCK-ACQUIRE: timeout while waiting for non-exclusive locks to go away.")
                         # we won't get the exclusive lock, so do not leave our lock behind:
@@ -446,6 +478,7 @@ class Lock:
                         break  # timeout
                     else:
                         logger.debug("LOCK-ACQUIRE: someone else also created an exclusive lock, deleting ours.")
+                        blocking_locks = [lock for lock in exclusive_locks if lock["key"] != key]
                         self._delete_lock(key, ignore_not_found=True, update_last_refresh=True)
                 else:  # not is_exclusive
                     if len(exclusive_locks) == 0:
@@ -454,13 +487,24 @@ class Lock:
                         return self
                     else:
                         logger.debug("LOCK-ACQUIRE: exclusive locks detected, deleting our shared lock.")
+                        blocking_locks = [lock for lock in exclusive_locks if lock["key"] != key]
                         self._delete_lock(key, ignore_not_found=True, update_last_refresh=True)
+            else:
+                # there is at least one exclusive lock we can not consider stale - it blocks us.
+                blocking_locks = exclusive_locks
+            self._log_blocking_locks(blocking_locks)
             # wait a random bit before retrying
             time.sleep(
                 self.retry_delay_min + (self.retry_delay_max - self.retry_delay_min) * random.random()  # nosec B311
             )
         logger.debug("LOCK-ACQUIRE: timeout while trying to acquire a lock.")
-        raise LockTimeout(str(self.store))
+        raise LockTimeout(self.repository, f"Repository is locked by: {format_locks(blocking_locks)}.")
+
+    def _log_blocking_locks(self, locks):
+        """Tell the user (once) which foreign lock(s) we are waiting for."""
+        if locks and not self.blocking_locks_logged:
+            self.blocking_locks_logged = True
+            logger.info(f"Waiting for the lock. Repository is locked by: {format_locks(locks)}.")
 
     def release(self, *, ignore_not_found=False):
         self.last_refresh_dt = None
@@ -470,7 +514,7 @@ class Lock:
                 logger.debug("LOCK-RELEASE: trying to release the lock, but none was found.")
                 return
             else:
-                raise NotLocked(str(self.store))
+                raise NotLocked(self.repository)
         assert len(locks) == 1
         lock = locks[0]
         logger.debug(f"LOCK-RELEASE: releasing lock: {lock}.")
@@ -485,6 +529,7 @@ class Lock:
         logger.debug("LOCK-BREAK: break_lock() was called - deleting ALL locks!")
         locks = self._get_locks()
         for key in locks:
+            logger.info(f"Breaking {format_lock(locks[key])}.")
             self._delete_lock(key, ignore_not_found=True)
         self.last_refresh_dt = None
         self.my_lock_key = None
@@ -531,7 +576,7 @@ class Lock:
                     # clean up the new lock (so it does not needlessly block others until it expires).
                     logger.debug("LOCK-REFRESH: our lock was killed, there is no safe way to continue.")
                     self._delete_lock(new_key, ignore_not_found=True, update_last_refresh=True)
-                    raise LockTimeout(str(self.store))
+                    raise LockTimeout(self.repository, LOCK_KILLED_MSG)
                 try:
                     self._delete_lock(old_key, update_last_refresh=False)
                 except ObjectNotFound:
@@ -541,7 +586,7 @@ class Lock:
                     # new lock (so it does not needlessly block others until it expires) and abort.
                     logger.debug("LOCK-REFRESH: our lock was killed while refreshing it, no safe way to continue.")
                     self._delete_lock(new_key, ignore_not_found=True, update_last_refresh=True)
-                    raise LockTimeout(str(self.store))
+                    raise LockTimeout(self.repository, LOCK_KILLED_MSG)
             finally:
                 self.my_old_lock_key = None
 

--- a/src/borg/testsuite/storelocking_test.py
+++ b/src/borg/testsuite/storelocking_test.py
@@ -62,6 +62,25 @@ class TestLock:
             with pytest.raises(LockTimeout):
                 Lock(lockstore, exclusive=True, id=ID2).acquire()
 
+    def test_lock_timeout_tells_who_holds_the_lock(self, lockstore):
+        # a client that does not get the lock shall learn who is blocking it, see #2261.
+        with Lock(lockstore, exclusive=True, id=ID1):
+            with pytest.raises(LockTimeout) as exc_info:
+                Lock(lockstore, exclusive=False, id=ID2).acquire()
+        message = exc_info.value.get_message()
+        assert "exclusive lock" in message
+        assert f"host {ID1[0]}" in message
+        assert f"pid {ID1[1]}" in message
+
+    def test_lock_timeout_tells_about_blocking_shared_locks(self, lockstore):
+        # same for an exclusive acquirer that waits in vain for shared lock(s) to go away.
+        with Lock(lockstore, exclusive=False, id=ID1):
+            with pytest.raises(LockTimeout) as exc_info:
+                Lock(lockstore, exclusive=True, id=ID2).acquire()
+        message = exc_info.value.get_message()
+        assert "shared lock" in message
+        assert f"host {ID1[0]}" in message
+
     def test_exclusive_lock_timeout_leaves_no_lock(self, lockstore):
         # When acquiring an exclusive lock times out because a non-exclusive lock does not go away,
         # the not-acquired exclusive lock must not stay behind in the store: it would block all


### PR DESCRIPTION
Fixes #2261.

The lock objects already carried hostid / pid / threadid / timestamp / lock type, but none of it ever reached the user - and `str(store)` is borgstore's repr, so the message did not even name the repository:

```
Failed to create/acquire the lock <Store(backend='PosixFS')> (timeout).
```

Changes:

- `acquire()` remembers the lock(s) that blocked it (foreign exclusive lock, lost exclusive race, shared locks that do not go away) and names them in the `LockTimeout`.
- it also tells the user once *while* waiting, not only after `--lock-wait` has expired.
- the repository is named by its canonical path (credentials stripped), not by the store repr.
- `break-lock` logs each lock it breaks.
- a `refresh()` that has to give up because our own lock was killed says so, instead of just claiming a timeout.

Output now:

```
Waiting for the lock. Repository is locked by: exclusive lock on host myhost@1234567, pid 51939, age 2.000 seconds.
Failed to create/acquire the lock /path/to/repo (timeout). Repository is locked by: exclusive lock on host myhost@1234567, pid 51939, age 6.361 seconds.
Breaking exclusive lock on host myhost@1234567, pid 48924, age 1.955 seconds.
```

Not included: the "reason" for the lock (the borg command being run, or the free-text `--message` suggested in the issue). That would mean putting more into the lock objects; this PR only surfaces what they already contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)