### PR TITLE
benchmark cpu: also benchmark zstd,-4

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -399,6 +399,7 @@ class BenchmarkMixIn:
                 number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
                 for spec in [
                     "lz4",
+                    "zstd,-4",
                     "zstd,1",
                     "zstd,3",
                     "zstd,5",


### PR DESCRIPTION
Adds `zstd,-4` to the compression section of `borg benchmark cpu`, so the benchmark covers zstd's negative ("fast") levels instead of starting at `zstd,1`.
