### PR TITLE
info: add --quick-stats option

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -1603,7 +1603,7 @@ class Archiver:
             else:
                 info['duration'] = format_timedelta(timedelta(seconds=info['duration']))
                 info['command_line'] = format_cmdline(info['command_line'])
-                print(textwrap.dedent("""
+                text = textwrap.dedent("""
                 Archive name: {name}
                 Archive fingerprint: {id}
                 Comment: {comment}
@@ -1619,18 +1619,22 @@ class Archiver:
                 ------------------------------------------------------------------------------
                                        Original size      Compressed size    Deduplicated size
                 This archive:   {stats[original_size]:>20s} {stats[compressed_size]:>20s} {stats[deduplicated_size]:>20s}
-                {cache}
-                """).strip().format(cache=cache, **info))
+                """).strip().format(**info)
+                if not args.quick_stats:
+                    # computing the repository-wide "All archives" statistics is expensive.
+                    text += '\n' + str(cache)
+                print(text)
             if not args.json and len(archive_names) - i:
                 print()
 
         if args.json:
-            json_print(basic_json_data(manifest, cache=cache, extra={
+            json_print(basic_json_data(manifest, cache=None if args.quick_stats else cache, extra={
                 'archives': output_data,
             }))
 
     def _info_repository(self, args, repository, manifest, key, cache):
-        info = basic_json_data(manifest, cache=cache, extra={
+        # computing the repository-wide statistics is expensive, --quick-stats omits them.
+        info = basic_json_data(manifest, cache=None if args.quick_stats else cache, extra={
             'security_dir': cache.security_manager.dir,
         })
 
@@ -1650,15 +1654,17 @@ class Archiver:
             Repository ID: {id}
             Location: {location}
             {encryption}
-            Cache: {cache.path}
+            Cache: {cache_path}
             Security dir: {security_dir}
             """).strip().format(
                 id=bin_to_hex(repository.id),
                 location=repository._location.canonical_path(),
+                cache_path=cache.path,
                 **info))
-            print(DASHES)
-            print(STATS_HEADER)
-            print(str(cache))
+            if not args.quick_stats:
+                print(DASHES)
+                print(STATS_HEADER)
+                print(str(cache))
 
     @with_repository(exclusive=True, compatibility=(Manifest.Operation.DELETE,))
     def do_prune(self, args, repository, manifest, key):
@@ -4567,6 +4573,10 @@ class Archiver:
         The size of an archive relative to this limit depends on a number of factors,
         mainly the number of files, the lengths of paths and other metadata stored for files.
         This is shown as *utilization of maximum supported archive size*.
+
+        Computing the repository-wide "All archives" statistics is slow, because it needs to
+        read the metadata of all archives in the repository. If you do not need them, use
+        ``--quick-stats`` to skip them.
         """)
         subparser = subparsers.add_parser('info', parents=[common_parser], add_help=False,
                                           description=self.do_info.__doc__,
@@ -4579,6 +4589,8 @@ class Archiver:
                                help='repository or archive to display information about')
         subparser.add_argument('--json', action='store_true',
                                help='format output as JSON')
+        subparser.add_argument('--quick-stats', dest='quick_stats', action='store_true',
+                               help='skip the repository-wide "All archives" statistics')
         define_archive_filters_group(subparser)
 
         # borg version

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -1790,6 +1790,33 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         info_archive = self.cmd('info', '--first', '1', self.repository_location)
         assert 'Archive name: test\n' in info_archive
 
+    def test_info_quick_stats(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        info_repo = self.cmd('info', '--quick-stats', self.repository_location)
+        assert 'Repository ID: ' in info_repo
+        assert 'All archives:' not in info_repo
+        assert 'Chunk index:' not in info_repo
+        info_archive = self.cmd('info', '--quick-stats', self.repository_location + '::test')
+        assert 'Archive name: test\n' in info_archive
+        assert 'This archive:' in info_archive
+        assert 'All archives:' not in info_archive
+        assert 'Chunk index:' not in info_archive
+
+    def test_info_quick_stats_json(self):
+        self.create_regular_file('file1', size=1024 * 80)
+        self.cmd('init', '--encryption=repokey', self.repository_location)
+        self.cmd('create', self.repository_location + '::test', 'input')
+        info_repo = json.loads(self.cmd('info', '--json', '--quick-stats', self.repository_location))
+        assert len(info_repo['repository']['id']) == 64
+        assert 'cache' not in info_repo
+        info_archive = json.loads(self.cmd('info', '--json', '--quick-stats',
+                                           self.repository_location + '::test'))
+        assert info_archive['archives'][0]['name'] == 'test'
+        assert 'stats' in info_archive['archives'][0]
+        assert 'cache' not in info_archive
+
     def test_info_and_create_stats(self):
         # "This archive" deduplicated size should match between `borg info` and `borg create --stats`.
         # "All archives" deduplicated size should match between `borg info` and `borg create --stats`.


### PR DESCRIPTION
Adds `--quick-stats` to `borg info`, with the same meaning it already has for
`create` / `import-tar` / `delete` / `prune`: skip the repository-wide
"All archives" and chunk index statistics.

Computing those means walking the metadata of *all* archives in the repository
(`CacheStatsMixin.stats()`: `chunks.summarize()` plus one `Archive(...)` +
`calc_stats(want_unique=False)` per archive), which is unrelated to - and often
more expensive than - the information about the archive you asked about.
It hurts most with many archives, with remote repos (one round trip per archive)
and with repos still containing pre-1.2 archives (no `size`/`nfiles` metadata,
so their item metadata stream has to be read).

Behaviour:

- `borg info REPO::ARCHIVE --quick-stats`: only the archive's own stats.
- `borg info REPO --quick-stats`: only repository id, location, encryption,
  cache and security dir.
- with `--json`, the top-level `cache` object is omitted, so serializing it does
  not trigger the stats computation (same as for the other commands).

Note: this does not make the per-archive "Deduplicated size" cheaper - that one
still reads the archive's item metadata stream via `_calc_stats(want_unique=True)`.

Measured on a local repo with 300 archives: 0.19s -> 0.17s. The interesting cases
are remote repos and pre-1.2 archives.

Not included here (release-time work): `build_usage` / `build_man` regeneration,
and a `docs/changes.rst` entry (there is no "not yet released" section yet).

Tests: `test_info_quick_stats` and `test_info_quick_stats_json` added.
