### PR TITLE
keep forward slashes in remote repo URL paths, fixes #10199

### DIFF
--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import os.path
+import posixpath
 import re
 import shlex
 import stat
@@ -827,7 +828,8 @@ class Location:
             self.user = m.group("user")
             self._host = m.group("host")
             self.port = m.group("port") and int(m.group("port")) or None
-            self.path = os.path.normpath(m.group("path"))
+            # remote path: normalize with posixpath, not with the client's os.path, see #10199.
+            self.path = posixpath.normpath(m.group("path"))
             return True
         m = self.rest_re.match(text)
         if m:
@@ -835,7 +837,8 @@ class Location:
             self.user = m.group("user")
             self._host = m.group("host")
             self.port = m.group("port") and int(m.group("port")) or None
-            self.path = os.path.normpath(m.group("path"))
+            # remote path: normalize with posixpath, not with the client's os.path, see #10199.
+            self.path = posixpath.normpath(m.group("path"))
             return True
         m = self.file_re.match(text)
         if m:

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import ntpath
 import os
 
 import re
@@ -9,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from ...constants import *  # NOQA
+from ...helpers import parseformat
 from ...helpers.argparsing import ArgumentTypeError
 from ...helpers.parseformat import (
     bin_to_hex,
@@ -210,6 +212,28 @@ class TestLocationWithoutEnv:
             repr(Location("rest:////absolute/path"))
             == "Location(proto='rest', user=None, pass=None, host=None, port=None, path='/absolute/path')"
         )
+
+    def test_server_side_path_is_posix(self, monkeypatch):
+        # ssh:// and rest:// paths live on the *server*, so they must be normalized as POSIX
+        # paths, no matter what the client runs on. A Windows client used to normalize them
+        # with ntpath, turning "/path/to/repo" into "\path\to\repo"; ssh passes the command
+        # through the remote shell, which ate the backslashes and left "pathtorepo", see #10199.
+        #
+        # The windows_tests CI job can not catch this: it runs in an msys2 shell, and MSYS2's
+        # mingw python switches ntpath.sep to "/" when MSYSTEM is set, so ntpath behaves like
+        # posixpath there. Users running borg.exe from cmd/PowerShell get the real ntpath.
+        # Faking a Windows client by swapping in ntpath tests this on any platform instead.
+        monkeypatch.delenv("BORG_REPO", raising=False)
+        monkeypatch.setattr(parseformat.os, "path", ntpath)
+        for proto in ("ssh", "rest"):
+            assert Location(f"{proto}://user@host/relative/path").path == "relative/path"
+            assert Location(f"{proto}://user@host//absolute/path").path == "/absolute/path"
+            assert Location(f"{proto}://user@host:1234//absolute/path").path == "/absolute/path"
+            assert Location(f"{proto}://user@host//absolute/./x/../path").path == "/absolute/path"
+            assert (
+                Location(f"{proto}://user@host//absolute/path").canonical_path()
+                == f"{proto}://user@host//absolute/path"
+            )
 
     # For the protocols handled (parsed + validated) by borgstore itself, borg only detects
     # the scheme and passes the raw URL through; it no longer extracts user/host/port/path.


### PR DESCRIPTION
borg standardizes on forward slashes in repo URLs, whatever the client and the server run on —
see also `slashify()`. `Location._parse` did not: it normalized `ssh://` and `rest://` paths with
`os.path.normpath`, which is `ntpath` on a Windows client:

```
'path/to/repo'   -> 'path\to\repo'
'/path/to/repo'  -> '\path\to\repo'
'//path/to/repo' -> '\\path\to\repo'
```

For `rest://`, that path goes to the server as `borg serve --rest --backend FILE:\path\to\repo`
via ssh. ssh passes the command through the remote shell, which eats the backslashes, so the
repository ends up as `pathtorepo` below the home directory — matching every case in #10199, and
leaving no way at all to address an absolute path from a Windows client.

Fix: use `posixpath.normpath` for the URL protocols (`ssh`, `rest`), so normalization keeps the
slashes. Local `file` paths keep using `os.path`, as those are paths on the client's filesystem.

### Why the test fakes a Windows client

`test_ssh` / `test_rest` / `test_file` already assert forward-slash paths, and they **pass** in the
`windows_tests` CI job today — so CI did not catch this and would not catch a regression either.

The reason is that the job runs `shell: msys2 {0}`, and MSYS2's mingw python carries
[`0030-mingw-prefer-unix-sep-if-MSYSTEM-environment-variabl.patch`](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python/0030-mingw-prefer-unix-sep-if-MSYSTEM-environment-variabl.patch),
which flips `ntpath.sep` to `/` whenever `MSYSTEM` is set. Under CI, `ntpath` therefore behaves
like `posixpath`. Users running `borg.exe` from cmd/PowerShell have no `MSYSTEM`, get the real
`ntpath`, and hit the bug — exactly what the issue reports.

So the new test monkeypatches `os.path` to `ntpath` to fake a Windows client; that reproduces the
bug (and guards against it) on Linux and macOS, where `ntpath` is unpatched. Verified: it fails
without the fix. The job also runs `pytest -k "not remote"`, so the test name avoids `remote`.

Worth a separate look: the whole `windows_tests` job tests path handling in unix-separator mode,
which is not what the shipped binary does for users.

Not addressed here: the `--restrict-to-path` / exit code 83 confusion also mentioned in the issue,
and the dirty-checkout version number of the released Windows binary.
