### PR TITLE
windows: do not build the binaries from a "dirty" checkout, see #10199

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,14 @@
 borg/_version.py export-subst
 
+# Store text files with LF and check them out with LF everywhere, so that a
+# Windows checkout is not seen as modified by a git with a different
+# core.autocrlf setting - that made setuptools-scm build the Windows binaries
+# from a "dirty" checkout and give them a wrong version, see #10199.
+* text=auto eol=lf
+# git auto-detects binary content by looking for a NUL byte in the first 8000
+# bytes; logo.pdf is small enough to have none, so tell git explicitly.
+*.pdf -text
+
 *.py diff=python
 docs/usage/*.rst.inc merge=ours
 docs/man/* merge=ours

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,6 +724,16 @@ jobs:
         shell: msys2 {0}
 
     steps:
+      # actions/checkout runs Git for Windows, whose system config sets
+      # core.autocrlf=true, while the msys2 git the build steps below use does
+      # not: it would see every text file as modified, so setuptools-scm called
+      # the checkout dirty and gave the binaries a guessed-next .devN version
+      # instead of the tag version, see #10199.  .gitattributes takes care of
+      # this as well, this is here so that it also works for older tags.
+      - name: Do not convert line endings on checkout
+        shell: pwsh
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,25 @@ jobs:
         twine check dist/*
         ls -l dist/
 
+    - name: Check that the sdist has the version of the tag
+      # If the checkout is modified, setuptools-scm does not use the tag as the
+      # version, but silently guesses the next one and appends .devN, see
+      # #10199. Such a release must not be uploaded to PyPI.
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        set -euxo pipefail
+        python - "$TAG" dist/borgbackup-*.tar.gz <<'EOF'
+        import sys
+        from packaging.utils import parse_sdist_filename
+        from packaging.version import Version
+        tag, sdist = sys.argv[1], sys.argv[2]
+        _, version = parse_sdist_filename(sdist.rpartition("/")[2])
+        if version != Version(tag):
+            raise SystemExit(f"sdist version {version} is not the tag version {tag} - modified checkout?")
+        print(f"sdist version {version} is the tag version.")
+        EOF
+
     - name: Check that the sdist is complete and installable
       # A release that cannot be installed from PyPI is the worst kind of
       # release, and nothing else in CI ever installs borg from a sdist or


### PR DESCRIPTION
The 2.0.0b23 Windows binaries call themselves `2.0.0b24.dev0+g116435fa4.d20260823` (reported in #10199).

### What happens

In the tag's [CI run](https://github.com/borgbackup/borg/actions/runs/32642250525), the `windows_tests` job checks out the tag correctly (HEAD is `116435fa4`, the tagged commit, so distance is 0), but the *very first* build step, `pip install -e .`, already resolves `borgbackup==2.0.0b24.dev0+g116435fa4.d20260823` - long before pyinstaller or `python -m build` run. No workflow step modifies the checkout; it is dirty right out of `actions/checkout`.

The `.d20260823` suffix is setuptools-scm's `node-and-date` local scheme marking the tree dirty, and dirty also makes `ScmVersion.exact` false, which is what turns `2.0.0b23` into the guessed-next `2.0.0b24.dev0`. The Linux job of the same run builds a correct `2.0.0b23`, so this is Windows-only.

### Why the checkout is dirty

Two different gits with different `core.autocrlf` look at the same worktree:

- `actions/checkout` runs `C:\Program Files\Git\bin\git.exe`. The runner image installs Git for Windows silently without passing `/o:CRLFOption=...` ([Install-Git.ps1](https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Install-Git.ps1)), so the installer default applies and the system config has `core.autocrlf=true` - the worktree gets CRLF.
- everything afterwards runs in the msys2 shell against msys2's own git (installed by `scripts/msys2-install-deps`), which does not set `core.autocrlf` and so defaults to `false`. It compares the CRLF worktree against the LF blobs in the index and considers nearly every tracked file modified.

No tracked blob in the repository contains a CR, and `.gitattributes` set no `text`/`eol` attribute anywhere, so nothing prevented the conversion.

### The changes

- **`.gitattributes`: `* text=auto eol=lf`** - the actual fix, independent of any runner or contributor git config. It also stops the Windows test run from operating on CRLF-converted sources and test data.
  - all 14 tracked files that contain CR bytes (the PNGs, ODGs, the `.ico`, `repo12.tar.gz`) have a NUL within their first 8000 bytes, so `text=auto` classifies them binary and leaves them alone.
  - `docs/_static/logo.pdf` is the one genuine binary that git would classify as *text* (1316 bytes, no NUL) - hence the explicit `*.pdf -text`. Verified that this survives both check-in normalization and checkout conversion despite inheriting `eol=lf`.
  - `git add --renormalize .` changes nothing, so there is no diff churn.
- **`ci.yml`: `git config --global core.autocrlf false` before checkout** in `windows_tests` (needs `shell: pwsh`, the job default is `msys2 {0}` and msys2 is not set up yet). `actions/checkout` copies the existing `~/.gitconfig` into its temporary HOME, so the setting survives. Redundant with `.gitattributes` for new tags, but it also fixes building an older tag.
- **`release.yml`: refuse to publish a sdist that is not the tag version** - so a dirty checkout can never silently reach PyPI again.

Note for anyone with an existing **Windows** clone: your working copy is CRLF, so git will report those files as modified once until you run `git add --renormalize .` or re-checkout.

### Not covered

The guard added here is on the sdist, which is built on ubuntu from a clean checkout - it would not have caught this particular bug. A per-platform assertion that each built binary reports the tag version would; happy to add that too if wanted.
