### PR TITLE
repo-list: fix --format help, it did not show the actual default, #10204

### DIFF
--- a/docs/usage/repo-list.rst.inc
+++ b/docs/usage/repo-list.rst.inc
@@ -19,7 +19,7 @@ borg repo-list
     +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                                             | ``--from-borg1``                             | repository is Borg 1.x                                                                                                                                                          |
     +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    |                                                                             | ``--format FORMAT``                          | specify format for archive listing (default: "{archive:<36} {time} [{id}]{NL}")                                                                                                 |
+    |                                                                             | ``--format FORMAT``                          | specify format for archive listing (default: "{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}{NL}")                                   |
     +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                                             | ``--json``                                   | Format output as JSON. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text. |
     +-----------------------------------------------------------------------------+----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -63,7 +63,7 @@ borg repo-list
     options
         --short     only print the archive IDs, nothing else
         --from-borg1    repository is Borg 1.x
-        --format FORMAT    specify format for archive listing (default: "{archive:<36} {time} [{id}]{NL}")
+        --format FORMAT    specify format for archive listing (default: "{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}{NL}")
         --json      Format output as JSON. The form of ``--format`` is ignored, but keys used in it are added to the JSON output. Some keys are always present. Note: JSON can only represent text.
 
 

--- a/src/borg/archiver/repo_list_cmd.py
+++ b/src/borg/archiver/repo_list_cmd.py
@@ -12,6 +12,9 @@ from ..logger import create_logger
 
 logger = create_logger()
 
+# the default for "borg repo-list --format", also used to document the default in --format's help text.
+FORMAT_DEFAULT = "{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}{NL}"
+
 
 class RepoListMixIn:
     @with_repository(compatibility=(Manifest.Operation.READ,), allow_v1=True)
@@ -22,10 +25,7 @@ class RepoListMixIn:
         elif args.short:
             format = "{id}{NL}"
         else:
-            format = os.environ.get(
-                "BORG_REPO_LIST_FORMAT",
-                "{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}{NL}",
-            )
+            format = os.environ.get("BORG_REPO_LIST_FORMAT", FORMAT_DEFAULT)
         formatter = ArchiveFormatter(format, repository, manifest, manifest.key, deleted=args.deleted)
 
         output_data = []
@@ -97,7 +97,7 @@ class RepoListMixIn:
             metavar="FORMAT",
             dest="format",
             action=Highlander,
-            help="specify format for archive listing " '(default: "{archive:<36} {time} [{id}]{NL}")',
+            help=f'specify format for archive listing (default: "{FORMAT_DEFAULT}")',
         )
         subparser.add_argument(
             "--json",


### PR DESCRIPTION
Addresses point (b) of #10204.

`borg repo-list --help` documented the `--format` default as
`"{archive:<36} {time} [{id}]{NL}"`, but the actual code default is:

```
{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}{NL}
```

The default is now defined once as `FORMAT_DEFAULT` and used both for the
`BORG_REPO_LIST_FORMAT` fallback and in the `--format` help text, so the two
can not drift apart again.

No behaviour change, the default format itself is unchanged.
`docs/usage/repo-list.rst.inc` regenerated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)