### PR TITLE
archive: resolve the item metadata stream chunk ids lazily, #10204

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -597,6 +597,7 @@ class Archive:
         self.name_in_manifest = name  # can differ from .name later (if borg check fixed duplicate archive names)
         self.comment = None
         self.tags = None
+        self._item_ids = None  # see the item_ids property
         self.numeric_ids = numeric_ids
         self.noatime = noatime
         self.noctime = noctime
@@ -630,8 +631,6 @@ class Archive:
         metadata = ArchiveItem(internal_dict=archive)
         if metadata.version not in (1, 2):  # legacy: still need to read v1 archives
             raise Exception("Unknown archive metadata version")
-        # note: metadata.items must not get written to disk!
-        metadata.items = archive_get_items(metadata, repo_objs=self.repo_objs, repository=self.repository)
         return metadata
 
     def load(self, id):
@@ -640,6 +639,19 @@ class Archive:
         self.name = self.metadata.name
         self.comment = self.metadata.get("comment", "")
         self.tags = set(self.metadata.get("tags", []))
+        self._item_ids = None  # see the item_ids property
+
+    @property
+    def item_ids(self):
+        """The ids of this archive's item metadata stream chunks.
+
+        Resolved lazily and cached: for a v2 archive, getting them means reading the item_ptrs
+        chunks from the repository, so archive metadata consumers that do not iterate over the
+        items (e.g. "borg repo-list") must not pay for it.
+        """
+        if self._item_ids is None:
+            self._item_ids = archive_get_items(self.metadata, repo_objs=self.repo_objs, repository=self.repository)
+        return self._item_ids
 
     @property
     def ts(self):
@@ -731,7 +743,7 @@ Duration: {0.duration}
         return filter(item) if filter else True
 
     def iter_items(self, filter=None):
-        yield from self.pipeline.unpack_many(self.metadata.items, filter=lambda item: self.item_filter(item, filter))
+        yield from self.pipeline.unpack_many(self.item_ids, filter=lambda item: self.item_filter(item, filter))
 
     def add_item(self, item, show_progress=True, stats=None):
         if show_progress and self.show_progress:
@@ -1134,8 +1146,6 @@ Duration: {0.duration}
     def set_meta(self, key, value):
         metadata = self._load_meta(self.id)
         setattr(metadata, key, value)
-        if "items" in metadata:
-            del metadata.items
         data = self.key.pack_metadata(metadata.as_dict())
         new_id = self.key.id_hash(data)
         self.cache.add_chunk(new_id, {}, data, stats=self.stats, ro_type=ROBJ_ARCHIVE_META)

--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -125,7 +125,7 @@ class ArchiveGarbageCollector:
         content chunks of its items."""
         yield archive.id
         yield from archive.metadata.item_ptrs
-        yield from archive.metadata.items
+        yield from archive.item_ids
         for item in archive.iter_items():
             if "chunks" in item:
                 for id, _ in item.chunks:

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -33,7 +33,7 @@ class DebugMixIn:
         repo_objs = manifest.repo_objs
         archive_info = manifest.archives.get_one([args.name])
         archive = Archive(manifest, archive_info.id)
-        for i, item_id in enumerate(archive.metadata.items):
+        for i, item_id in enumerate(archive.item_ids):
             _, data = repo_objs.parse(item_id, repository.get(item_id), ro_type=ROBJ_ARCHIVE_STREAM)
             filename = "%06d_%s.items" % (i, bin_to_hex(item_id))
             print("Dumping", filename)

--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -1060,7 +1060,7 @@ def scan_archive_references(manifest, archive_id: bytes):
     ids[archive.id] = ArchiveReferenceEntry(size=0)
     for id in archive.metadata.item_ptrs:
         ids[id] = ArchiveReferenceEntry(size=0)
-    for id in archive.metadata.items:
+    for id in archive.item_ids:
         ids[id] = ArchiveReferenceEntry(size=0)
     file_count, content_size = 0, 0
     for item in archive.iter_items():

--- a/src/borg/testsuite/archiver/check_cmd_test.py
+++ b/src/borg/testsuite/archiver/check_cmd_test.py
@@ -440,7 +440,7 @@ def test_missing_archive_item_chunk(archivers, request):
     check_cmd_setup(archiver)
     archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
-        repository.delete(archive.metadata.items[0])
+        repository.delete(archive.item_ids[0])
     cmd(archiver, "check", exit_code=1)
     cmd(archiver, "check", "--repair", exit_code=0)
     cmd(archiver, "check", exit_code=0)
@@ -825,7 +825,7 @@ def test_repair_wrong_item_metadata_chunk_content(archivers, request, monkeypatc
     check_cmd_setup(archiver)
     archive, repository = open_archive(archiver.repository_path, "archive1")
     with repository:
-        chunk_id = archive.metadata.items[0]  # first chunk of the item metadata stream
+        chunk_id = archive.item_ids[0]  # first chunk of the item metadata stream
         data = read_chunk(archive, repository, chunk_id, ro_type=ROBJ_ARCHIVE_STREAM)
         # append a msgpack nil: the item stream still unpacks (so a read that does not check the id gets
         # away with it), but the content does not hash to the chunk id any more.

--- a/src/borg/testsuite/archiver/repo_list_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_list_cmd_test.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from ...constants import *  # NOQA
+from ...repository import Repository
 from . import cmd, checkts, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 from .prune_cmd_test import _create_archive_ts
 
@@ -40,6 +41,27 @@ def test_archives_format(archivers, request, backup_files):
     output = cmd(archiver, "repo-list", "--format", "{name} {comment}{NL}")
     assert "test-1 comment 1" + os.linesep in output
     assert "test-2 comment 2" + os.linesep in output
+
+
+def test_repo_list_does_not_read_item_metadata(archiver, monkeypatch):
+    # listing a repository only needs the archive metadata objects, never the item metadata
+    # streams the archives point to. reading those means reading the item_ptrs chunks, which
+    # sit in the (potentially large) data packs -- expensive for remote repositories, see #10204.
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "create", "test", "input")
+    get_many_calls = []
+    original_get_many = Repository.get_many
+
+    def get_many(self, ids, *args, **kwargs):
+        ids = list(ids)
+        get_many_calls.append(ids)
+        return original_get_many(self, ids, *args, **kwargs)
+
+    monkeypatch.setattr(Repository, "get_many", get_many)
+    output = cmd(archiver, "repo-list")
+    assert "test" in output
+    assert get_many_calls == []
 
 
 def test_size_nfiles(archivers, request):


### PR DESCRIPTION
Addresses the whole-pack downloads reported in #10204.

`Archive._load_meta()` eagerly resolved the archive's item metadata stream chunk
ids and stuck them onto the metadata object as `items`, so merely *opening* an
archive read its `item_ptrs` chunks. Those chunks sit in the (potentially large)
data packs, and `Repository.get_many()` always loads a whole pack, so opening an
archive downloaded a full pack even when the caller only wanted
`name`/`comment`/`tags`/`username`/`hostname`.

`borg repo-list` with the default format does exactly that, once per archive,
because `ArchiveFormatter` builds an `Archive` for those keys.

The ids are now provided by a new, lazily resolved and cached
`Archive.item_ids` property, used in the places that actually iterate the item
metadata stream (`iter_items`, `scan_archive_references`, `compact`,
`debug dump-archive-items`).

`_load_meta()` now returns the archive metadata exactly as stored, so `set_meta()`
no longer has to strip the injected `items` key before re-packing.

Measured on a local test repo with 3 archives, `borg --debug repo-list` with the
default format:

- before: one whole-pack load per archive (49 MB + 3 MB + 3 MB)
- after: only the three ~547 byte ranged reads of the archive metadata chunks

Output is identical.

Regression test `test_repo_list_does_not_read_item_metadata` counts
`Repository.get_many()` calls during a `repo-list` run and asserts there are
none; it fails on master and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)