### PR TITLE
goldilocks-aes: build on 32bit archs (no __uint128_t there)

### DIFF
--- a/docs/internals/chunker.rst
+++ b/docs/internals/chunker.rst
@@ -200,7 +200,12 @@ The three universal hashes
     8 bytes. All table indices are plaintext bytes (no secret-dependent
     loads); the rolling multiply keeps every state canonical since the state
     feeds AES verbatim. Verified bit-equivalent (states and ciphertexts) to
-    the authors' artifact implementation.
+    the authors' artifact implementation. The field multiply needs the full
+    128-bit product of two 64-bit values: on 64-bit platforms that is the
+    compiler's ``__uint128_t``, on 32-bit ones (armhf, i386, ...) a portable
+    fallback built from 32x32 -> 64 multiplies. Both compute the same
+    product, so cut points are identical everywhere - 32-bit platforms just
+    run this chunker (and only this one) slower.
 
 Constructions considered and rejected: Gear as the UHF (triangular aging
 gives ε ≈ 1/2 via the oldest byte), hardware CRC (fixed public polynomial,

--- a/src/borg/chunkers/goldilocks_aes_impl.c
+++ b/src/borg/chunkers/goldilocks_aes_impl.c
@@ -29,6 +29,41 @@ struct GL_CTX {
     uint64_t k2;              /* K^2 (stride-2 state multiplier) */
 };
 
+/* --- 64x64 -> 128 bit widening multiply ---------------------------------
+ *
+ * The field multiply needs the full 128-bit product. GCC and clang offer
+ * __uint128_t for that, but only on 64-bit targets - on 32-bit ones (armhf,
+ * i386, ...) the type does not exist and using it is a hard compile error,
+ * so there a portable fallback built from four 32x32 -> 64 multiplies is
+ * used instead. Both compute the same product, so this chunker's cut points
+ * are identical on all architectures; the fallback is just slower.
+ *
+ * Defining BORG_GL_NO_INT128 forces the fallback also where __uint128_t
+ * exists, so the 32-bit path can be tested on a 64-bit machine. */
+#if defined(__SIZEOF_INT128__) && !defined(BORG_GL_NO_INT128)
+
+static inline void gl_mul_wide(uint64_t a, uint64_t b, uint64_t *lo, uint64_t *hi)
+{
+    __uint128_t t = (__uint128_t)a * b;
+    *lo = (uint64_t)t;
+    *hi = (uint64_t)(t >> 64);
+}
+
+#else
+
+static inline void gl_mul_wide(uint64_t a, uint64_t b, uint64_t *lo, uint64_t *hi)
+{
+    uint64_t a0 = (uint32_t)a, a1 = a >> 32;
+    uint64_t b0 = (uint32_t)b, b1 = b >> 32;
+    uint64_t p00 = a0 * b0, p01 = a0 * b1, p10 = a1 * b0, p11 = a1 * b1;
+    /* the cross terms carry into the top half; neither sum can overflow */
+    uint64_t mid = p10 + (p00 >> 32) + (uint32_t)p01;
+    *lo = (mid << 32) | (uint32_t)p00;
+    *hi = p11 + (mid >> 32) + (p01 >> 32);
+}
+
+#endif
+
 /* --- Goldilocks field arithmetic ---------------------------------------
  *
  * Every digest the scan produces is canonical (< p): it is fed to AES
@@ -57,8 +92,8 @@ static inline uint64_t gl_add(uint64_t a, uint64_t b)
  * 2^64 = eps and 2^96 = -1 (mod p) give lo - hi_hi + hi_lo*eps. */
 static inline uint64_t gl_mul(uint64_t a, uint64_t b)
 {
-    __uint128_t t = (__uint128_t)a * b;
-    uint64_t lo = (uint64_t)t, hi = (uint64_t)(t >> 64);
+    uint64_t lo, hi;
+    gl_mul_wide(a, b, &lo, &hi);
     uint64_t hi_hi = hi >> 32, hi_lo = hi & GL_EPS;
     uint64_t t0, r, u;
     unsigned char borrow = __builtin_sub_overflow(lo, hi_hi, &t0);
@@ -82,8 +117,8 @@ static inline uint64_t gl_mul(uint64_t a, uint64_t b)
  * this kernel loses its trailing compare and select. */
 static inline uint64_t gl_mul_lazy(uint64_t a, uint64_t b)
 {
-    __uint128_t t = (__uint128_t)a * b;
-    uint64_t lo = (uint64_t)t, hi = (uint64_t)(t >> 64);
+    uint64_t lo, hi;
+    gl_mul_wide(a, b, &lo, &hi);
     uint64_t hi_hi = hi >> 32, hi_lo = hi & GL_EPS;
     uint64_t t0, r;
     unsigned char borrow = __builtin_sub_overflow(lo, hi_hi, &t0);


### PR DESCRIPTION
The goldilocks-aes chunker fails to compile on 32bit architectures
(reported for the Ubuntu armhf build of 2.0.0b23, thanks LocutusOfBorg):

```
src/borg/chunkers/goldilocks_aes_impl.c: In function 'gl_mul_lazy':
src/borg/chunkers/goldilocks_aes_impl.c:85:5: error: unknown type name '__uint128_t'; did you mean '__uint32_t'?
   85 |     __uint128_t t = (__uint128_t)a * b;
      |     ^~~~~~~~~~~
```

gcc/clang only offer `__uint128_t` on 64bit targets. The Goldilocks field
multiply needs the full 128bit product of two 64bit values, and these two
places were the only users of the type in the whole tree - in that armhf
build log they are also the only errors, everything else compiles fine.

Rather than making the chunker unavailable on 32bit, this wraps the wide
multiply in `gl_mul_wide()` with a portable fallback built from four
32x32 -> 64 multiplies, used where `__SIZEOF_INT128__` is undefined. Both
compute the same product, so cut points - and thus dedup - are identical
on all architectures; 32bit machines just run this one chunker slower
(and it is not the default chunker anyway).

Defining `BORG_GL_NO_INT128` forces the fallback also on 64bit, so the
32bit path can be tested on a normal machine.

Verification:

- extension rebuilt with `-DBORG_GL_NO_INT128` (forced 32bit path):
  `src/borg/testsuite/chunkers/` passes, including the known-answer test
  `test_chunkpoints_goldilocks_aes_unchanged` - same chunk points.
- standalone C harness comparing the fallback against `__uint128_t` over
  the interesting edge cases plus 20M random operand pairs: no mismatch.
- fallback path compiles warning-free with Debian's build flags
  (`-Wall -Wextra -Wpointer-arith -Wstrict-prototypes`).

Not verified here: an actual build on a 32bit machine.
