### PR TITLE
docs: document that borg transfer is incremental

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -68,6 +68,9 @@ from repo1 to repo2 when done like that.
 An alternative is to use ``borg transfer`` to copy backup archives
 from repo1 to repo2. This is likely a bit more efficient and the archives would be identical,
 but it may suffer from potential error propagation.
+``borg transfer`` is incremental: it only copies the archives (and chunks) that repo2 does not
+have yet, so you can run it repeatedly (e.g. from a cron job) to keep repo2 up to date, see
+:ref:`borg_transfer`.
 
 Warning: Using Borg with multiple repositories that have identical repository IDs (such as
 creating 1:1 repository copies) is not supported and can lead to various issues,

--- a/docs/usage/transfer.rst.inc
+++ b/docs/usage/transfer.rst.inc
@@ -109,6 +109,39 @@ You could use the misc. archive filter options to limit which archives it will
 transfer, e.g. using the ``-a`` option. This is recommended for big
 repositories with multiple data sets to keep the runtime per invocation lower.
 
+Incremental transfer
+++++++++++++++++++++
+
+Transfer only copies what is missing in the DST_REPO, so you can run the same command
+repeatedly (e.g. from a cron job) to keep DST_REPO up to date - each run will only
+transfer what was added to SRC_REPO since the previous run.
+
+This works on two levels:
+
+- archive level: if the DST_REPO already has an archive with the same name and timestamp
+  (or the same name and archive ID), that archive is skipped and borg prints
+  "archive is already present in destination repo, skipping.".
+- chunk level: for archives that are copied, only the chunks not yet present in the
+  DST_REPO are read from the SRC_REPO and stored - deduplication works against
+  everything transferred before.
+
+The archive filter options can be used as usual, so multiple invocations with different
+filters are fine, e.g.::
+
+    borg --repo=DST_REPO transfer --other-repo=SRC_REPO -a 'sh:daily-*'
+    borg --repo=DST_REPO transfer --other-repo=SRC_REPO -a 'sh:myserver-*'
+
+Some things to keep in mind:
+
+- Interrupting a transfer is safe: an archive only becomes visible in the DST_REPO after
+  it was copied completely, so an interrupted archive is simply transferred again by the
+  next run. The chunks stored by the interrupted run are reused, so the retry is cheap -
+  unless you run ``borg compact`` on the DST_REPO in between, which would remove the
+  chunks that are not (yet) referenced by an archive.
+- Transfer only adds archives, it never deletes any. If you want old archives to expire
+  in the DST_REPO, run ``borg prune`` (and ``borg compact``) against the DST_REPO
+  separately.
+
 General purpose archive transfer
 ++++++++++++++++++++++++++++++++
 

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -302,6 +302,39 @@ class TransferMixIn:
         transfer, e.g. using the ``-a`` option. This is recommended for big
         repositories with multiple data sets to keep the runtime per invocation lower.
 
+        Incremental transfer
+        ++++++++++++++++++++
+
+        Transfer only copies what is missing in the DST_REPO, so you can run the same command
+        repeatedly (e.g. from a cron job) to keep DST_REPO up to date - each run will only
+        transfer what was added to SRC_REPO since the previous run.
+
+        This works on two levels:
+
+        - archive level: if the DST_REPO already has an archive with the same name and timestamp
+          (or the same name and archive ID), that archive is skipped and borg prints
+          "archive is already present in destination repo, skipping.".
+        - chunk level: for archives that are copied, only the chunks not yet present in the
+          DST_REPO are read from the SRC_REPO and stored - deduplication works against
+          everything transferred before.
+
+        The archive filter options can be used as usual, so multiple invocations with different
+        filters are fine, e.g.::
+
+            borg --repo=DST_REPO transfer --other-repo=SRC_REPO -a 'sh:daily-*'
+            borg --repo=DST_REPO transfer --other-repo=SRC_REPO -a 'sh:myserver-*'
+
+        Some things to keep in mind:
+
+        - Interrupting a transfer is safe: an archive only becomes visible in the DST_REPO after
+          it was copied completely, so an interrupted archive is simply transferred again by the
+          next run. The chunks stored by the interrupted run are reused, so the retry is cheap -
+          unless you run ``borg compact`` on the DST_REPO in between, which would remove the
+          chunks that are not (yet) referenced by an archive.
+        - Transfer only adds archives, it never deletes any. If you want old archives to expire
+          in the DST_REPO, run ``borg prune`` (and ``borg compact``) against the DST_REPO
+          separately.
+
         General purpose archive transfer
         ++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
Fixes #9878.

`borg transfer` already is incremental, but nothing in the docs said so, so users
have to guess whether re-running it (e.g. from a cron job) is safe and cheap.

This adds an "Incremental transfer" section to the `borg transfer` command help
(and thus to `docs/usage/transfer.rst.inc`) covering:

- archive level: archives already present in the destination repo are skipped
  (checked by name+timestamp and by name+id), printing
  `archive is already present in destination repo, skipping.`
- chunk level: for archives that do get copied, only chunks not yet present in
  the destination are read from the source and stored.
- the cron / multiple-invocations-with-`-a`-filters pattern from the issue.
- interrupting a transfer is safe: an archive only shows up in the destination
  after it was copied completely, and the chunks stored so far are reused on the
  next run - unless `borg compact` runs on the destination in between.
- transfer never deletes: prune/compact the destination repo separately.

Also adds a pointer from the related FAQ entry ("Can I copy or synchronize my
repo to another location?") to `borg transfer`.

`docs/usage/transfer.rst.inc` was regenerated with `scripts/make.py build_usage`
(only that one file changed); man pages were not regenerated, that is done at
release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
