### PR TITLE
docs: fix outdated --encryption mode names in examples

### DIFF
--- a/docs/man/borg-key-change-passphrase.1
+++ b/docs/man/borg-key-change-passphrase.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg-key-change-passphrase" "1" "2026-08-23" "" "borg backup tool"
+.TH "borg-key-change-passphrase" "1" "2026-08-26" "" "borg backup tool"
 .SH Name
 borg-key-change-passphrase \- Changes the repository key file passphrase.
 .SH SYNOPSIS
@@ -52,7 +52,7 @@ See \fIborg\-common(1)\fP for common options of Borg commands.
 .sp
 .EX
 # Create a key file protected repository
-$ borg repo\-create \-\-encryption=aes\-ocb \-\-key\-location=keyfile \-v
+$ borg repo\-create \-\-encryption=aes256\-ocb \-\-key\-location=keyfile \-v
 Initializing repository at \(dq/path/to/repo\(dq
 Enter new passphrase:
 Enter same passphrase again:
@@ -100,7 +100,7 @@ Fully automated using environment variables:
 .INDENT 3.5
 .sp
 .EX
-$ BORG_NEW_PASSPHRASE=old borg repo\-create \-\-encryption=aes\-ocb
+$ BORG_NEW_PASSPHRASE=old borg repo\-create \-\-encryption=aes256\-ocb
 # now \(dqold\(dq is the current passphrase.
 $ BORG_PASSPHRASE=old BORG_NEW_PASSPHRASE=new borg key change\-passphrase
 # now \(dqnew\(dq is the current passphrase.

--- a/docs/man/borg-repo-create.1
+++ b/docs/man/borg-repo-create.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg-repo-create" "1" "2026-08-23" "" "borg backup tool"
+.TH "borg-repo-create" "1" "2026-08-26" "" "borg backup tool"
 .SH Name
 borg-repo-create \- Creates a new, empty repository.
 .SH SYNOPSIS
@@ -203,7 +203,7 @@ select the mode: \(aqaes256\-ocb\(aq, \(aqchacha20\-poly1305\(aq, \(aqauthentica
 select the id hash function of the encrypted modes: \(aqsha256\(aq or \(aqblake3\(aq. The \(aqnone\-\fI\(aq and \(aqauthenticated\-\fP\(aq modes name their hash themselves.
 .TP
 .BI \-\-key\-location \ LOCATION
-where to store the key: \(aqrepokey\(aq (in the repository, default) or \(aqkeyfile\(aq (in the local keys directory). Ignored for the \(aqnone\(aq mode (which has no key).
+where to store the key: \(aqrepokey\(aq (in the repository, default) or \(aqkeyfile\(aq (in the local keys directory). Ignored for the \fBnone\-*\fP modes (which have no key).
 .TP
 .B  \-\-copy\-crypt\-key
 copy the crypt_key (used for authenticated encryption) from the key of the other repository (default: new random key).
@@ -219,16 +219,19 @@ $ export BORG_REPO=/path/to/repo
 $ borg repo\-create \-\-encryption=aes256\-ocb
 $ borg repo\-create \-\-encryption=chacha20\-poly1305
 # No encryption (not recommended)
-$ borg repo\-create \-\-encryption=authenticated
-$ borg repo\-create \-\-encryption=none
+$ borg repo\-create \-\-encryption=authenticated\-sha256
+$ borg repo\-create \-\-encryption=none\-sha256
 
-# \-\-encryption (the cipher / AE algorithm) and \-\-id\-hash (the id hash function) are
-# chosen independently. \-\-id\-hash defaults to sha256; use blake3 if it is faster on
-# your hardware (run \(aqborg benchmark cpu\(aq to find out). The \(aqnone\(aq encryption only
-# supports the sha256 id hash.
+# For the encrypted modes, \-\-encryption (the cipher / AE algorithm) and \-\-id\-hash
+# (the id hash function) are chosen independently. \-\-id\-hash defaults to sha256;
+# use blake3 if it is faster on your hardware (run \(aqborg benchmark cpu\(aq to find out).
 $ borg repo\-create \-\-encryption=aes256\-ocb \-\-id\-hash=blake3
 $ borg repo\-create \-\-encryption=chacha20\-poly1305 \-\-id\-hash=blake3
-$ borg repo\-create \-\-encryption=authenticated \-\-id\-hash=blake3
+
+# The \(aqauthenticated\-*\(aq and \(aqnone\-*\(aq modes name their id hash themselves, so they
+# do not take a separate \-\-id\-hash.
+$ borg repo\-create \-\-encryption=authenticated\-blake3
+$ borg repo\-create \-\-encryption=none\-blake3
 
 # Where the key is stored (\-\-key\-location) is also chosen independently.
 # \-\-key\-location defaults to repokey.

--- a/docs/man/borg.1
+++ b/docs/man/borg.1
@@ -29,7 +29,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "borg" "1" "2026-08-23" "" "borg backup tool"
+.TH "borg" "1" "2026-08-26" "" "borg backup tool"
 .SH Name
 borg \- deduplicating and encrypting backup tool
 .SH SYNOPSIS
@@ -61,7 +61,7 @@ Before a backup can be made, a repository has to be initialized:
 .INDENT 3.5
 .sp
 .EX
-$ borg \-r /path/to/repo repo\-create \-\-encryption=aes\-ocb
+$ borg \-r /path/to/repo repo\-create \-\-encryption=aes256\-ocb
 .EE
 .UNINDENT
 .UNINDENT

--- a/docs/quickstart_example.rst.inc
+++ b/docs/quickstart_example.rst.inc
@@ -1,6 +1,6 @@
 1. Before a backup can be made, a repository has to be initialized::
 
-    $ borg -r /path/to/repo repo-create --encryption=aes-ocb
+    $ borg -r /path/to/repo repo-create --encryption=aes256-ocb
 
 2. Back up the ``~/src`` and ``~/Documents`` directories into an archive called
    *docs*::

--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -9,7 +9,7 @@ Examples
 ::
 
     # Create a key file protected repository
-    $ borg repo-create --encryption=aes-ocb --key-location=keyfile -v
+    $ borg repo-create --encryption=aes256-ocb --key-location=keyfile -v
     Initializing repository at "/path/to/repo"
     Enter new passphrase:
     Enter same passphrase again:
@@ -46,7 +46,7 @@ Fully automated using environment variables:
 
 ::
 
-    $ BORG_NEW_PASSPHRASE=old borg repo-create --encryption=aes-ocb
+    $ BORG_NEW_PASSPHRASE=old borg repo-create --encryption=aes256-ocb
     # now "old" is the current passphrase.
     $ BORG_PASSPHRASE=old BORG_NEW_PASSPHRASE=new borg key change-passphrase
     # now "new" is the current passphrase.

--- a/docs/usage/repo-create.rst
+++ b/docs/usage/repo-create.rst
@@ -12,16 +12,19 @@ Examples
     $ borg repo-create --encryption=aes256-ocb
     $ borg repo-create --encryption=chacha20-poly1305
     # No encryption (not recommended)
-    $ borg repo-create --encryption=authenticated
-    $ borg repo-create --encryption=none
+    $ borg repo-create --encryption=authenticated-sha256
+    $ borg repo-create --encryption=none-sha256
 
-    # --encryption (the cipher / AE algorithm) and --id-hash (the id hash function) are
-    # chosen independently. --id-hash defaults to sha256; use blake3 if it is faster on
-    # your hardware (run 'borg benchmark cpu' to find out). The 'none' encryption only
-    # supports the sha256 id hash.
+    # For the encrypted modes, --encryption (the cipher / AE algorithm) and --id-hash
+    # (the id hash function) are chosen independently. --id-hash defaults to sha256;
+    # use blake3 if it is faster on your hardware (run 'borg benchmark cpu' to find out).
     $ borg repo-create --encryption=aes256-ocb --id-hash=blake3
     $ borg repo-create --encryption=chacha20-poly1305 --id-hash=blake3
-    $ borg repo-create --encryption=authenticated --id-hash=blake3
+
+    # The 'authenticated-*' and 'none-*' modes name their id hash themselves, so they
+    # do not take a separate --id-hash.
+    $ borg repo-create --encryption=authenticated-blake3
+    $ borg repo-create --encryption=none-blake3
 
     # Where the key is stored (--key-location) is also chosen independently.
     # --key-location defaults to repokey.

--- a/scripts/rest_perf_test.sh
+++ b/scripts/rest_perf_test.sh
@@ -172,7 +172,7 @@ run_profile() {
     run_borg repo-delete --repo "$REPO_URL" >/dev/null 2>&1 || true
     # start each profile with a cold pack cache (only when the opt-in cache is enabled)
     if [ -n "${BORG_PACKCACHE_URL:-}" ]; then rm -rf "${BORG_PACKCACHE_URL#file://}"; fi
-    run_borg repo-create --encryption none --repo "$REPO_URL"
+    run_borg repo-create --encryption none-sha256 --repo "$REPO_URL"
 
     # backup 1 (cold)
     run_borg create --stats --json --repo "$REPO_URL" backup1 "$DATA_DIR"


### PR DESCRIPTION
The `repo-create` examples in the docs still used `--encryption` mode names that
argparse rejects today.

Since the id hash became part of the mode name for the modes that do not encrypt,
the valid names are `none-sha256` / `none-blake3` and `authenticated-sha256` /
`authenticated-blake3` — plain `none` and `authenticated` are gone:

```
$ borg repo-create --encryption=none
usage: borg repo-create [...]
borg repo-create: error: argument -e/--encryption: invalid choice: 'none'
```

One example was doubly wrong: `--encryption=authenticated --id-hash=blake3`. Those
modes name their id hash themselves and reject a separate `--id-hash`, so even with
the name fixed it would error out. It is replaced by plain `authenticated-blake3` /
`none-blake3` examples, and the comment above it claiming the non-encrypting modes
only support sha256 is dropped — that has not been true since `none-blake3` exists.

Two more invalid names turned up in the same sweep: `--encryption=aes-ocb` in
`docs/usage/key.rst` and `docs/quickstart_example.rst.inc` (it is `aes256-ocb`), and
`--encryption none` in `scripts/rest_perf_test.sh`.

The short form `-e` is fine everywhere: the only tracked uses are
`-e aes256-ocb -i blake3` in `docs/usage/transfer.rst`.

`docs/changes.rst`, `docs/changes_1.x.rst` and `docs/misc/benchmark-crud.txt` also
mention `aes-ocb` / `repokey-blake2`, but those are changelogs and old benchmark notes
describing borg 1.x as it was, so they are left alone.

I regenerated the three man pages that embed the changed examples and reverted the
other 48, which only differed by the generation date. `borg-repo-create.1` also picked
up the `--key-location` help text that was already fixed in the code but never
regenerated (`repo-create.rst.inc` already had it).

All nine documented `repo-create` invocations were verified by actually running them
against master; every one succeeds.
