### PR TITLE
don't mistake a malformed URL for a local path, #10215

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -173,6 +173,10 @@ New features:
 
 Fixes:
 
+- reject malformed ``rest://`` / ``ssh://`` / ``file://`` URLs instead of silently taking
+  them for a local path relative to the current directory. E.g. ``rest://host/`` (no repository
+  path) ended up as the local directory ``./rest:/host`` and then failed with a confusing
+  "does not exist" error. Such a URL is now rejected, telling the accepted forms, #10215
 - shell completions: complete local repository directories for ``-r`` / ``--repo``
   and ``--other-repo``, #3086
 - shell completions: use the command borg was invoked as, e.g. ``borg2``. A borg

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -64,9 +64,9 @@ If you only back up your own files, run it as your normal user (i.e. not root).
 
 For a local repository always use the same user to invoke borg.
 
-For a remote repository: always use e.g., rest://borg@remote_host (Borg connects
-via ssh and runs ``borg serve --rest`` on the remote). You can use this
-from different local users; the remote user running borg and accessing the
+For a remote repository: always use e.g., rest://borg@remote_host/path/to/repo
+(Borg connects via ssh and runs ``borg serve --rest`` on the remote). You can use
+this from different local users; the remote user running borg and accessing the
 repo will always be `borg`.
 
 If you need to access a local repository from different users, you can use the

--- a/docs/usage/general/repository-urls.rst.inc
+++ b/docs/usage/general/repository-urls.rst.inc
@@ -20,21 +20,25 @@ supported — mount the share (on Windows: map it to a drive letter, e.g.
 
 ``rest://user@host:port//abs/path/to/repo`` — absolute path
 
-``rest://user@host:port/rel/path/to/repo`` — path relative to the current directory
+``rest://user@host:port/rel/path/to/repo`` — path relative to the remote login directory
 
 **Remote repositories** accessed via SSH user@host (legacy borg RPC protocol):
 
 ``ssh://user@host:port//abs/path/to/repo`` — absolute path
 
-``ssh://user@host:port/rel/path/to/repo`` — path relative to the current directory
+``ssh://user@host:port/rel/path/to/repo`` — path relative to the remote login directory
 
 **Remote repositories** accessed via SFTP:
 
 ``sftp://user@host:port//abs/path/to/repo`` — absolute path
 
-``sftp://user@host:port/rel/path/to/repo`` — path relative to the current directory
+``sftp://user@host:port/rel/path/to/repo`` — path relative to the remote login directory
 
-For SSH and SFTP URLs, the ``user@`` and ``:port`` parts are optional.
+For REST, SSH and SFTP URLs, the ``user@`` and ``:port`` parts are optional, but the
+path is required: a URL without one, e.g. ``rest://host`` or ``rest://host/``, is
+rejected. Mind the difference between one and two slashes after the host: one slash
+means a path relative to the directory the remote login lands in (usually the remote
+user's home directory), two slashes mean an absolute path.
 
 **Remote repositories** accessed via rclone:
 

--- a/src/borg/helpers/parseformat.py
+++ b/src/borg/helpers/parseformat.py
@@ -738,10 +738,16 @@ class Location:
     # passes the raw URL through. covers both "scheme://..." and opaque "scheme:..." forms.
     BORGSTORE_SCHEMES = ("sftp", "http", "https", "s3", "b2", "rclone")
 
-    # path may contain any chars. to avoid ambiguities with other regexes, it must not start with
-    # a "scheme://" or one of the borgstore "scheme:" specifiers (all of which are matched
-    # before local_re in _parse). the borgstore scheme list is sourced from BORGSTORE_SCHEMES.
-    local_path_re = r"(?!((?:ssh|file)://|(?:" + "|".join(BORGSTORE_SCHEMES) + r"):))" r"(?P<path>.+)"
+    # locations that borg parses itself, see ssh_re / rest_re / file_re below.
+    BORG_SCHEMES = ("ssh", "rest", "file")
+
+    # path may contain any chars, but to avoid ambiguities with the other regexes it must not start
+    # with any of the scheme specifiers above (all of which are matched before local_re in _parse).
+    # Rejecting them here makes a malformed URL fail with a helpful error instead of being silently
+    # taken for a local path - e.g. "rest://host/" used to end up as the local directory
+    # "./rest:/host", see #10215. A local path that really starts with such a prefix can still be
+    # used by prefixing it with "./" (or by giving it as an absolute path).
+    local_path_re = r"(?!(?:" + "|".join(BORG_SCHEMES + BORGSTORE_SCHEMES) + r"):)" r"(?P<path>.+)"
 
     # abs_path must start with a slash (or drive letter on Windows).
     abs_path_re = r"(?P<path>[A-Za-z]:/.+)" if is_win32 else r"(?P<path>/.+)"
@@ -786,6 +792,15 @@ class Location:
 
     local_re = re.compile(local_path_re, re.VERBOSE)
 
+    # accepted forms per scheme borg parses itself, used to explain a URL we could not parse.
+    scheme_hints = {
+        "rest": "rest://[user@]host[:port]/path/to/repo (path relative to the remote directory ssh "
+        "logs into) or rest://[user@]host[:port]//path/to/repo (absolute path)",
+        "ssh": "ssh://[user@]host[:port]/path/to/repo (path relative to the remote directory ssh "
+        "logs into) or ssh://[user@]host[:port]//path/to/repo (absolute path)",
+        "file": "file:///C:/path/to/repo" if is_win32 else "file:///path/to/repo",
+    }
+
     def __init__(self, text="", overrides={}, other=False):
         if isinstance(text, Location):
             self.__dict__.update(text.__dict__)
@@ -812,7 +827,7 @@ class Location:
         self.raw = text  # as given by user, might contain placeholders
         self.processed = replace_placeholders(self.raw, overrides)  # after placeholder replacement
         if not self._parse(self.processed):
-            raise ValueError('Invalid location format: "%s"' % self.processed)
+            raise ValueError(self._invalid_location_msg(self.processed))
         if self.proto == "file" and self.path.startswith("//"):
             # UNC path (//server/share/..., \\server\share\...): not supported, fail early with a hint, see #10164.
             raise ValueError(
@@ -820,6 +835,12 @@ class Location:
                 "Mount the share (Windows: net use X: \\\\server\\share) and use the mounted path instead."
             )
         self.valid = True
+
+    def _invalid_location_msg(self, text):
+        msg = 'Invalid location format: "%s"' % text
+        m = self.scheme_re.match(text)
+        hint = self.scheme_hints.get(m.group("scheme")) if m else None
+        return f"{msg}. Expected: {hint}" if hint else msg
 
     def _parse(self, text):
         m = self.ssh_re.match(text)

--- a/src/borg/testsuite/helpers/parseformat_test.py
+++ b/src/borg/testsuite/helpers/parseformat_test.py
@@ -236,6 +236,41 @@ class TestLocationWithoutEnv:
                 == f"{proto}://user@host//absolute/path"
             )
 
+    @pytest.mark.parametrize(
+        "location",
+        [
+            "rest://host",  # no path
+            "rest://host/",  # empty path
+            "rest://user@host/",  # empty path
+            "rest://user@host:1234/",  # empty path
+            "rest://",  # nothing at all
+            "rest:/host/path",  # only one slash after the scheme
+            "rest:host/path",  # no slash after the scheme
+        ],
+    )
+    def test_rest_invalid(self, monkeypatch, location):
+        # a malformed rest:// URL must be rejected - it used to be taken for a local path
+        # (relative to the cwd) and then failed with a confusing error, see #10215.
+        monkeypatch.delenv("BORG_REPO", raising=False)
+        with pytest.raises(ValueError, match="Invalid location format"):
+            Location(location)
+
+    def test_invalid_location_hint(self, monkeypatch):
+        # an unparsable URL of a scheme we parse ourselves tells the user the accepted forms.
+        monkeypatch.delenv("BORG_REPO", raising=False)
+        for location, scheme in [("rest://host/", "rest"), ("ssh://host/", "ssh"), ("file://rel", "file")]:
+            with pytest.raises(ValueError, match=f"Expected: {scheme}:"):
+                Location(location)
+
+    @pytest.mark.skipif(is_win32, reason="Windows does not support colons in paths")
+    def test_local_path_with_scheme_prefix(self, monkeypatch):
+        # a local path starting with a scheme name is not mistaken for a URL if it is made
+        # unambiguous with "./" or by giving it as an absolute path.
+        monkeypatch.delenv("BORG_REPO", raising=False)
+        assert Location("./rest:/host").proto == "file"
+        assert Location("./rest:/host").path == os.path.abspath("rest:/host")
+        assert Location("/abs/rest:/host").path == "/abs/rest:/host"
+
     # For the protocols handled (parsed + validated) by borgstore itself, borg only detects
     # the scheme and passes the raw URL through; it no longer extracts user/host/port/path.
 
@@ -360,6 +395,10 @@ class TestLocationWithoutEnv:
             "ssh://host/relative/path",
             "ssh://host//absolute/path",
             "ssh://user@host:1234/relative/path",
+            "rest://host/relative/path",
+            "rest://host//absolute/path",
+            "rest://user@host:1234/relative/path",
+            "rest:///relative/path",
             "sftp://host/relative/path",
             "sftp://host//absolute/path",
             "sftp://user@host:1234/relative/path",


### PR DESCRIPTION
Fixes the confusing behaviour reported in discussion #10215: `borg -r rest://dcm/ repo-info` failed with

```
Repository proto='file', user=None, pass=None, host=None, port=None, path='/home/borg/rest:/dcm' does not exist.
```

## Cause

`rest://dcm/` carries no repository path, so it does not match `rest_re` (which needs at least one
character after the separating slash). It then fell through to `local_re`, whose negative lookahead
excluded `ssh://`, `file://` and the borgstore schemes, but **not** `rest://`. So the URL was taken
for a relative local path and prefixed with the cwd.

## Change

All schemes borg parses itself (`ssh`, `rest`, `file`) are now excluded from `local_re`, in the
opaque `scheme:` form as well as in the `scheme://` form. Nothing starting with those prefixes can
silently become a local path any more - such input is rejected instead. A local path that really
starts with such a prefix can still be given as `./rest:...` or as an absolute path (there is a test
for that).

The reporter said they had tried numerous permutations without getting any useful feedback, so the
error now also names the accepted forms:

```
error: argument -r/--repo: Invalid location format: "rest://dcm/". Expected: rest://[user@]host[:port]/path/to/repo (path relative to the remote directory ssh logs into) or rest://[user@]host[:port]//path/to/repo (absolute path)
```

## Docs

- `quickstart.rst` recommended `rest://borg@remote_host` (no path), which would have run into
  exactly this error.
- The repository URL reference called the single-slash form "path relative to the current directory"
  for the remote protocols, but it is relative to the *remote* login directory. Corrected for
  rest/ssh/sftp, and added a note that the path is required and what one vs. two slashes mean.

## Tests

New tests cover the malformed `rest://` forms, the hint per scheme, local paths starting with a
scheme name, and `rest://` canonical-path round trips. Full test suite passes locally.