### PR TITLE
cache sync: log per-archive messages at debug level, fixes #9659

### DIFF
--- a/src/borg/cache.py
+++ b/src/borg/cache.py
@@ -801,7 +801,7 @@ class LocalCache(CacheStatsMixin):
 
         def read_archive_index(archive_id, archive_name):
             archive_chunk_idx_path = mkpath(archive_id)
-            logger.info("Reading cached archive chunk index for %s ...", archive_name)
+            logger.debug("Reading cached archive chunk index for %s ...", archive_name)
             try:
                 try:
                     # Attempt to load compact index first
@@ -869,14 +869,14 @@ class LocalCache(CacheStatsMixin):
                         if archive_id not in cached_ids:
                             # Do not make this an else branch; the FileIntegrityError exception handler
                             # above can remove *archive_id* from *cached_ids*.
-                            logger.info('Fetching and building archive index for %s ...', archive_name)
+                            logger.debug('Fetching and building archive index for %s ...', archive_name)
                             archive_chunk_idx = ChunkIndex()
                             fetch_and_build_idx(archive_id, decrypted_repository, archive_chunk_idx)
-                        logger.info("Merging into master chunks index ...")
+                        logger.debug("Merging into master chunks index ...")
                         chunk_idx.merge(archive_chunk_idx)
                     else:
                         chunk_idx = chunk_idx or ChunkIndex(usable=master_index_capacity)
-                        logger.info('Fetching archive index for %s ...', archive_name)
+                        logger.debug('Fetching archive index for %s ...', archive_name)
                         fetch_and_build_idx(archive_id, decrypted_repository, chunk_idx)
                 if not self.do_cache:
                     fetch_missing_csize(chunk_idx)

--- a/src/borg/testsuite/archiver.py
+++ b/src/borg/testsuite/archiver.py
@@ -5112,7 +5112,7 @@ class ArchiverCorruptionTestCase(ArchiverTestCaseBase):
             config.write(fd)
 
         # Cache sync notices corrupted archive chunks, but automatically recovers.
-        out = self.cmd('create', '-v', self.repository_location + '::test3', 'input', exit_code=1)
+        out = self.cmd('create', '--debug', self.repository_location + '::test3', 'input', exit_code=1)
         assert 'Reading cached archive chunk index for test1' in out
         assert 'Cached archive chunk index of test1 is corrupted' in out
         assert 'Fetching and building archive index for test1' in out


### PR DESCRIPTION
Fixes #9659.

The chunks cache sync emitted **2 INFO lines per archive**, so `-v` / `--info` floods on repos with many archives:

- warm `chunks.archive.d` (the usual case): `Reading cached archive chunk index for <name> ...` + `Merging into master chunks index ...`
- cache rebuild: `Fetching and building archive index for <name> ...` + `Merging into master chunks index ...`

The issue listed three lines (872/875/879), but missed `cache.py:804` (`Reading cached archive chunk index`), which is the partner of the `Merging` line in the common warm-cache path — without it, only half the noise would go away. This PR demotes all four.

`--info` output is now just the summary the reporter asked for:

```
Synchronizing chunks cache...
Archives: %d, w/ cached Idx: %d, w/ outdated Idx: %d, w/o cached Idx: %d.
Done.
```

Notes:

- Per-archive feedback for interactive use is unaffected: `--progress` still drives the `cache.sync` `ProgressIndicatorPercent`, which names each archive as it is processed.
- borg 2 (master) already logs this whole area at debug level — there is no per-archive INFO logging left in its `cache.py` — so this aligns the branches.
- `ArchiverCorruptionTestCase::test_chunks_archive` greps for two of these messages, so its `create -v` becomes `create --debug`. (Its third assert is a `logger.error` and is unaffected.)
- No CHANGES entry, matching the recent 1.4-maint PRs.