### PR TITLE
support msgpack 1.2.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -182,6 +182,7 @@ Fixes:
 
 Other changes:
 
+- msgpack: also allow 1.2.2
 - require shtab >= 1.11.0: it completes an argument via its ``.complete`` function
   rather than via its choices, which is what lets the encryption modes have a
   description each, and it completes paths outside the cwd in fish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 dependencies = [
   "borghash ~= 0.2.0",
   "borgstore[rest,blake3] ~= 0.6.1",
-  "msgpack >=1.0.3, <=1.2.1",
+  "msgpack >=1.0.3, <=1.2.2",
   "packaging",
   "platformdirs >=3.0.0, <5.0.0; sys_platform == 'darwin'",  # for macOS: breaking changes in 3.0.0.
   "platformdirs >=2.6.0, <5.0.0; sys_platform != 'darwin'",  # for others: 2.6+ works consistently.

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -218,7 +218,7 @@ def is_supported_msgpack():
 
     if msgpack.version in []:  # < add bad releases here to deny list
         return False
-    return (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 1)
+    return (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 2)
 
 
 def get_limited_unpacker(kind):


### PR DESCRIPTION
Allow the msgpack 1.2.2 release: bump the upper bound in `pyproject.toml` and in `is_supported_msgpack()`, plus a changelog entry.

The 1.2.1 -> 1.2.2 diff contains only fixes, nothing that affects how borg uses msgpack:

- `Timestamp.from_datetime` now uses integer timedelta arithmetic instead of the float `datetime.timestamp()` (which was off by one second far from the epoch and raised `OverflowError` near `datetime.max`)
- out-of-range timestamp nanoseconds are rejected in all `timestamp=` modes
- `ExtraData.extra` is copied out of the temporary contiguous buffer before that buffer is released (non-contiguous memoryview input)
- `PyFloat_Pack4` return value is checked in `msgpack_pack_float`
- new `RuntimeError` guard against re-entrant `Unpacker.feed()` from a hook - borg never feeds from inside a hook
- fallback `Unpacker.skip()` translates `RecursionError` into `StackError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)