### PR TITLE
support msgpack 1.2.2 (1.4-maint)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # Please note:
     # Using any other msgpack version is not supported by Borg development and
     # any feedback related to issues caused by this will be ignored.
-    "msgpack >=1.0.3, <=1.2.1",
+    "msgpack >=1.0.3, <=1.2.2",
     "packaging",
 ]
 

--- a/src/borg/helpers/msgpack.py
+++ b/src/borg/helpers/msgpack.py
@@ -145,7 +145,7 @@ def is_supported_msgpack():
     version_check = os.environ.get('BORG_MSGPACK_VERSION_CHECK', 'yes').strip().lower()
 
     return version_check == 'no' or (
-        (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 1) and
+        (1, 0, 3) <= msgpack.version[:3] <= (1, 2, 2) and
         msgpack.version not in []
     )
 


### PR DESCRIPTION
Allow the msgpack 1.2.2 release: bump the upper bound in `pyproject.toml` and in `is_supported_msgpack()`.

No changelog entry, as 1.4-maint currently has no "not released yet" section.

The 1.2.1 -> 1.2.2 diff contains only fixes, nothing that affects how borg uses msgpack:

- `Timestamp.from_datetime` now uses integer timedelta arithmetic instead of the float `datetime.timestamp()` (which was off by one second far from the epoch and raised `OverflowError` near `datetime.max`)
- out-of-range timestamp nanoseconds are rejected in all `timestamp=` modes
- `ExtraData.extra` is copied out of the temporary contiguous buffer before that buffer is released (non-contiguous memoryview input)
- `PyFloat_Pack4` return value is checked in `msgpack_pack_float`
- new `RuntimeError` guard against re-entrant `Unpacker.feed()` from a hook - borg never feeds from inside a hook
- fallback `Unpacker.skip()` translates `RecursionError` into `StackError`

Master: #10218

🤖 Generated with [Claude Code](https://claude.com/claude-code)