### PR TITLE
borgfs: make it work again

### DIFF
--- a/docs/usage/general/config.rst.inc
+++ b/docs/usage/general/config.rst.inc
@@ -56,8 +56,10 @@ File format
     under a subcommand name (e.g. ``create:``) are only applied when that
     subcommand is invoked.
 
-    ``borgfs`` reads the same default config file, but as it has no subcommands,
-    it only uses the top-level keys and ignores all subcommand sections.
+    ``borgfs`` reads the same config files, but as it has no subcommands, it uses
+    the top-level keys and the keys of the ``mount:`` section (``borgfs`` is the
+    ``borg mount`` command, and its keys win over the top-level ones); all other
+    subcommand sections are ignored.
 
 .. note::
     ``--print_config`` shows the merged effective configuration and is a

--- a/docs/usage/general/config.rst.inc
+++ b/docs/usage/general/config.rst.inc
@@ -56,6 +56,9 @@ File format
     under a subcommand name (e.g. ``create:``) are only applied when that
     subcommand is invoked.
 
+    ``borgfs`` reads the same default config file, but as it has no subcommands,
+    it only uses the top-level keys and ignores all subcommand sections.
+
 .. note::
     ``--print_config`` shows the merged effective configuration and is a
     convenient way to check what values Borg will actually use, and to

--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -384,6 +384,12 @@ class Archiver(
             if getattr(args, list_attr, None) is None:
                 setattr(args, list_attr, [])
 
+        # borgfs takes the repository as its first positional argument (fstab calling convention,
+        # see build_parser_borgfs). Put it where -r/--repo would have put it, so with_repository works.
+        repository = getattr(args, "repository", None)
+        if repository is not None:
+            args.location = repository
+
         func = self.get_func(args, parser)
         if func == self.do_create and args.paths and args.paths_from_stdin:
             parser.error("Must not pass PATH with --paths-from-stdin.")
@@ -416,6 +422,9 @@ class Archiver(
 
     def get_func(self, args, parser):
         if not getattr(args, "subcommand", None):
+            if parser.prog == "borgfs":
+                # the borgfs parser has no subcommands, it *is* the "borg mount" command
+                return self.do_mount
             return functools.partial(self.do_maincommand_help, parser)
 
         method_name = "do_" + args.subcommand.replace(" ", "_").replace("-", "_")

--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -199,6 +199,9 @@ class MountMixIn:
         # borgfs is a top-level parser, thus it reads the same default config file as borg does,
         # but it has no subcommands - just ignore the per-subcommand sections of that config file.
         parser.ignore_unknown_config_keys = True
+        # borgfs *is* the mount command, so the "mount:" section applies to it: adopt its keys as
+        # top-level keys (they win over same-named top-level keys of the config file).
+        parser.adopt_config_sections = ("mount",)
         self._define_borg_mount(parser, borgfs=True)
         return parser
 

--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -4,6 +4,7 @@ from ._common import with_repository, Highlander
 from ..constants import *  # NOQA
 from ..helpers import RTError
 from ..helpers import PathSpec, FilesystemDirSpec
+from ..helpers import location_validator
 from ..helpers import umount
 from ..helpers.argparsing import ArgumentParser
 from ..manifest import Manifest
@@ -113,8 +114,10 @@ class MountMixIn:
         - Only mount a specific archive, not the whole repository.
         - Only mount specific paths in a specific archive, not the complete archive.
 
-        The command ``borgfs`` provides a wrapper for ``borg mount``. This can also be
-        used in fstab entries:
+        The command ``borgfs`` provides a wrapper for ``borg mount``. It is invoked as
+        ``borgfs [REPOSITORY] MOUNTPOINT [PATH...]``, taking the repository as its first
+        positional argument (if it is not given, ``-r`` / ``BORG_REPO`` is used). This can
+        also be used in fstab entries:
         ``/path/to/repo /mnt/point fuse.borgfs defaults,noauto 0 0``
 
         To allow a regular user to use fstab entries, add the ``user`` option:
@@ -193,12 +196,29 @@ class MountMixIn:
         parser.description = self.do_mount.__doc__
         parser.epilog = "For more information, see borg mount --help."
         parser.help = "mount a repository"
-        self._define_borg_mount(parser)
+        # borgfs is a top-level parser, thus it reads the same default config file as borg does,
+        # but it has no subcommands - just ignore the per-subcommand sections of that config file.
+        parser.ignore_unknown_config_keys = True
+        self._define_borg_mount(parser, borgfs=True)
         return parser
 
-    def _define_borg_mount(self, parser):
+    def _define_borg_mount(self, parser, borgfs=False):
         from ._common import define_exclusion_group, define_archive_filters_group
 
+        if borgfs:
+            # mount(8) / mount.fuse(8) invoke "borgfs <spec> <mountpoint> -o <options>", so for an
+            # /etc/fstab entry like "/path/to/repo /mnt/point fuse.borgfs defaults,noauto 0 0" to work,
+            # borgfs must accept the repository as its first positional argument.
+            # It is optional: if it is not given, -r/--repo or BORG_REPO is used, like for borg mount.
+            # Archiver.parse_args() copies it to args.location, where -r/--repo would have put it.
+            parser.add_argument(
+                "repository",
+                metavar="REPOSITORY",
+                nargs="?",
+                type=location_validator(other=False),
+                default=None,
+                help="repository to mount (default: as given by -r/--repo or BORG_REPO)",
+            )
         parser.add_argument(
             "mountpoint", metavar="MOUNTPOINT", type=FilesystemDirSpec, help="where to mount the filesystem"
         )

--- a/src/borg/helpers/argparsing.py
+++ b/src/borg/helpers/argparsing.py
@@ -123,15 +123,27 @@ class ArgumentParser(_ArgumentParser):
     # "create:" section) would otherwise be rejected as unknown options.
     ignore_unknown_config_keys = False
 
+    # Names of config file sections whose keys this parser lifts up to the top level. This is used by
+    # the "borgfs" parser: borgfs *is* the "borg mount" command, so the "mount:" section of the config
+    # file applies to it - but as borgfs has no subcommands, the mount options are top-level options
+    # there. A key from an adopted section overrides the same key at the top level (more specific wins).
+    adopt_config_sections: tuple[str, ...] = ()
+
     # the borg code always uses RawDescriptionHelpFormatter and add_help=False:
     def __init__(self, *args, formatter_class=RawDescriptionHelpFormatter, add_help=False, **kwargs):
         super().__init__(*args, formatter_class=formatter_class, add_help=add_help, **kwargs)
 
     def _load_config_parser_mode(self, content, path="", ext_vars=None, prev_cfg=None):
-        """Load a config file into a namespace, optionally dropping keys this parser does not know."""
+        """Load a config file into a namespace, adopting/dropping keys as this parser wants it."""
         cfg = super()._load_config_parser_mode(content, path, ext_vars, prev_cfg)
+        for section in self.adopt_config_sections:
+            if isinstance(cfg.get(section), Namespace):
+                # Namespace.pop() removes the section (and returns it), Namespace.update() then copies
+                # its leaf keys into the top level, overwriting same-named top-level keys.
+                cfg.update(cfg.pop(section))
         if self.ignore_unknown_config_keys:
-            # strip_unknown() removes all keys that have no action in this parser.
+            # strip_unknown() removes all keys that have no action in this parser. Note: this also
+            # applies to keys just adopted from a section, e.g. a "mount: {output_filter: ...}".
             cfg = self.strip_unknown(cfg)
         return cfg
 

--- a/src/borg/helpers/argparsing.py
+++ b/src/borg/helpers/argparsing.py
@@ -116,9 +116,24 @@ MISSING_REQUIRED_RES = (
 
 
 class ArgumentParser(_ArgumentParser):
+    # If True, keys of a config file (e.g. the default config file) that this parser does not know
+    # about are silently dropped instead of making the parser fail. This is needed for the "borgfs"
+    # parser: it is a top-level parser (so it reads the same default config file as "borg" does), but
+    # it has no subcommands, so the per-subcommand sections that config file usually has (e.g. a
+    # "create:" section) would otherwise be rejected as unknown options.
+    ignore_unknown_config_keys = False
+
     # the borg code always uses RawDescriptionHelpFormatter and add_help=False:
     def __init__(self, *args, formatter_class=RawDescriptionHelpFormatter, add_help=False, **kwargs):
         super().__init__(*args, formatter_class=formatter_class, add_help=add_help, **kwargs)
+
+    def _load_config_parser_mode(self, content, path="", ext_vars=None, prev_cfg=None):
+        """Load a config file into a namespace, optionally dropping keys this parser does not know."""
+        cfg = super()._load_config_parser_mode(content, path, ext_vars, prev_cfg)
+        if self.ignore_unknown_config_keys:
+            # strip_unknown() removes all keys that have no action in this parser.
+            cfg = self.strip_unknown(cfg)
+        return cfg
 
     def _find_by_key(self, key):
         """Resolve a jsonargparse config key to the (sub)parser it belongs to and its action."""

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -14,7 +14,7 @@ import pytest
 from ... import xattr, platform
 from ...constants import *  # NOQA
 from ...storelocking import Lock
-from ...helpers import flags_noatime, flags_normal
+from ...helpers import flags_noatime, flags_normal, Location
 from .. import has_lchflags, has_any_fuse, ENOATTR
 from .. import changedir, filter_xattrs, same_ts_ns
 from .. import are_symlinks_supported, are_hardlinks_supported, are_fifos_supported
@@ -504,7 +504,8 @@ def test_borgfs_mounts_repository_positional():
     args = archiver.parse_args(["/path/to/repo", "/mnt/point", "some/path"])
     assert args.func == archiver.do_mount
     # the REPOSITORY positional must end up where -r/--repo would have put it
-    assert args.location.path == "/path/to/repo"
+    # (compare against Location's canonicalization, e.g. Windows prepends the current drive)
+    assert args.location.path == Location("/path/to/repo").path
     assert args.mountpoint == "/mnt/point"
     assert args.paths == ["some/path"]
 
@@ -514,23 +515,67 @@ def test_borgfs_repository_positional_is_optional():
     archiver = Archiver(prog="borgfs")
     args = archiver.parse_args(["--repo", "/path/to/repo", "/mnt/point"])
     assert args.func == archiver.do_mount
-    assert args.location.path == "/path/to/repo"
+    assert args.location.path == Location("/path/to/repo").path
     assert args.mountpoint == "/mnt/point"
     assert args.paths == []
+
+
+def write_default_config(monkeypatch, tmp_path, content):
+    """Point BORG_CONFIG_DIR at a fresh config dir containing a default.yaml with *content*."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "default.yaml").write_text(content)
+    monkeypatch.setenv("BORG_CONFIG_DIR", str(config_dir))
 
 
 def test_borgfs_ignores_subcommand_sections_in_default_config(monkeypatch, tmp_path):
     # borgfs is a top-level parser, thus it reads the same default config file as borg does.
     # That file usually has per-subcommand sections, which borgfs has to ignore rather than reject.
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    (config_dir / "default.yaml").write_text("log_level: info\ncreate:\n  output_filter: AME\n")
-    monkeypatch.setenv("BORG_CONFIG_DIR", str(config_dir))
+    write_default_config(monkeypatch, tmp_path, "log_level: info\ncreate:\n  output_filter: AME\n")
     archiver = Archiver(prog="borgfs")
     args = archiver.parse_args(["/path/to/repo", "/mnt/point"])
     assert args.func == archiver.do_mount
-    assert args.location.path == "/path/to/repo"
+    assert args.location.path == Location("/path/to/repo").path
     assert args.log_level == "info"  # top-level keys of the config file still apply
+
+
+def test_borgfs_adopts_mount_section_of_default_config(monkeypatch, tmp_path):
+    # borgfs *is* the mount command, so the "mount:" section applies to it, while the sections of
+    # the other subcommands are still ignored.
+    content = "log_level: info\nmount:\n  numeric_ids: true\ncreate:\n  output_filter: AME\n"
+    write_default_config(monkeypatch, tmp_path, content)
+    archiver = Archiver(prog="borgfs")
+    args = archiver.parse_args(["/path/to/repo", "/mnt/point"])
+    assert args.func == archiver.do_mount
+    assert args.numeric_ids is True
+    assert args.log_level == "info"
+
+
+def test_borgfs_mount_section_wins_over_top_level(monkeypatch, tmp_path):
+    # the more specific "mount:" key overrides the same key given at the top level
+    write_default_config(monkeypatch, tmp_path, "numeric_ids: false\nmount:\n  numeric_ids: true\n")
+    args = Archiver(prog="borgfs").parse_args(["/path/to/repo", "/mnt/point"])
+    assert args.numeric_ids is True
+
+
+def test_borg_applies_mount_section_to_mount_subcommand_only(monkeypatch, tmp_path):
+    # borg has subcommands, so nothing is adopted there: the "mount:" section applies to borg mount
+    # (as any subcommand section does) and to no other subcommand.
+    write_default_config(monkeypatch, tmp_path, "mount:\n  numeric_ids: true\n")
+    archiver = Archiver(prog="borg")
+    assert archiver.parse_args(["mount", "/mnt/point"]).numeric_ids is True
+    assert getattr(archiver.parse_args(["repo-list"]), "numeric_ids", None) is None
+
+
+def test_borg_rejects_unknown_config_keys(monkeypatch, tmp_path):
+    # only borgfs tolerates config keys it does not know - borg must still reject them
+    write_default_config(monkeypatch, tmp_path, "log_level: info\nnosuchoption: 1\n")
+    with pytest.raises(SystemExit):
+        Archiver(prog="borg").parse_args(["repo-list"])
+    archiver = Archiver(prog="borgfs")
+    args = archiver.parse_args(["/path/to/repo", "/mnt/point"])
+    assert args.func == archiver.do_mount
+    assert args.log_level == "info"
 
 
 def test_borg_mount_has_no_repository_positional():

--- a/src/borg/testsuite/archiver/mount_cmds_test.py
+++ b/src/borg/testsuite/archiver/mount_cmds_test.py
@@ -22,6 +22,7 @@ from ..platform.platform_test import fakeroot_detected, skipif_not_linux, skipif
 from ..platform.platform_test import skipif_acls_not_working
 from . import RK_ENCRYPTION, cmd, assert_dirs_equal, create_regular_file, create_src_archive, open_archive, src_file
 from . import requires_hardlinks, _extract_hardlinks_setup, fuse_mount, create_test_files, generate_archiver_tests
+from . import Archiver
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
@@ -490,3 +491,53 @@ def test_fuse_lock_refresh_calls_repository_info():
 
     assert held_while_calling and all(held_while_calling), "repository.info() must run while holding the lock"
     assert not lock.locked(), "lock must be released again after refreshing"
+
+
+# The borgfs tests below only exercise argument parsing and dispatch, so they do not need FUSE.
+# borgfs is the "borg mount" wrapper for /etc/fstab: mount(8) / mount.fuse(8) invoke it as
+# "borgfs <spec> <mountpoint> -o <options>". Its parser is a top-level parser without subcommands,
+# see MountMixIn.build_parser_borgfs and Archiver.get_func.
+
+
+def test_borgfs_mounts_repository_positional():
+    archiver = Archiver(prog="borgfs")
+    args = archiver.parse_args(["/path/to/repo", "/mnt/point", "some/path"])
+    assert args.func == archiver.do_mount
+    # the REPOSITORY positional must end up where -r/--repo would have put it
+    assert args.location.path == "/path/to/repo"
+    assert args.mountpoint == "/mnt/point"
+    assert args.paths == ["some/path"]
+
+
+def test_borgfs_repository_positional_is_optional():
+    # without REPOSITORY, the repository comes from -r/--repo (or BORG_REPO), like for borg mount
+    archiver = Archiver(prog="borgfs")
+    args = archiver.parse_args(["--repo", "/path/to/repo", "/mnt/point"])
+    assert args.func == archiver.do_mount
+    assert args.location.path == "/path/to/repo"
+    assert args.mountpoint == "/mnt/point"
+    assert args.paths == []
+
+
+def test_borgfs_ignores_subcommand_sections_in_default_config(monkeypatch, tmp_path):
+    # borgfs is a top-level parser, thus it reads the same default config file as borg does.
+    # That file usually has per-subcommand sections, which borgfs has to ignore rather than reject.
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "default.yaml").write_text("log_level: info\ncreate:\n  output_filter: AME\n")
+    monkeypatch.setenv("BORG_CONFIG_DIR", str(config_dir))
+    archiver = Archiver(prog="borgfs")
+    args = archiver.parse_args(["/path/to/repo", "/mnt/point"])
+    assert args.func == archiver.do_mount
+    assert args.location.path == "/path/to/repo"
+    assert args.log_level == "info"  # top-level keys of the config file still apply
+
+
+def test_borg_mount_has_no_repository_positional():
+    # borg mount is unchanged: MOUNTPOINT [PATH...], the repository only comes from -r/--repo.
+    archiver = Archiver(prog="borg")
+    args = archiver.parse_args(["mount", "/mnt/point", "some/path"])
+    assert args.func == archiver.do_mount
+    assert args.mountpoint == "/mnt/point"
+    assert args.paths == ["some/path"]
+    assert not args.location.valid


### PR DESCRIPTION
The jsonargparse migration broke `borgfs` completely. This PR fixes all three problems:

- **It never mounted**: `get_func()` fell back to printing the main help (rc 0) because the borgfs parser has no subcommand and nothing routed it to `do_mount`. It now dispatches to `do_mount` for `prog == "borgfs"`.
- **The fstab calling convention was gone**: mount(8) invokes `borgfs <repo> <mountpoint> -o <options>`, but the parser only defined `MOUNTPOINT [PATH...]`. borgfs accepts an optional `REPOSITORY` first positional again, mapped to where `-r/--repo` lands, so `with_repository` is untouched. `-r/--repo` and `BORG_REPO` keep working; the positional wins.
- **Any `default.yaml` with per-subcommand sections aborted borgfs** (e.g. `error: Option 'create.output_filter' is not accepted`) — exactly the config layout the docs recommend. The borgfs parser now opts into dropping unknown config keys via jsonargparse's own `strip_unknown()`; the `borg` parser still rejects unknown keys (verified both directions).

Includes parser-level tests for the dispatch, the optional positional, the default.yaml tolerance, and a regression guard that `borg mount` grows no repository positional. Full testsuite green; also verified with real FUSE mounts (`borgfs REPO MNT`, `-r`, `BORG_REPO`, `-o ignore_permissions`) with an offending `default.yaml` in place.

Follow-up commit: borgfs now also adopts the `mount:` section of the config file(s) (its keys are lifted to the top level and win over same-named top-level keys); all other subcommand sections are still ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
