### PR TITLE
delete/undelete: fix dead "all archives" safety guard

### DIFF
--- a/src/borg/archiver/delete_cmd.py
+++ b/src/borg/archiver/delete_cmd.py
@@ -26,7 +26,8 @@ class DeleteMixIn:
         count = len(archive_infos)
         if count == 0:
             return
-        if not args.name and not args.match_archives and args.first == 0 and args.last == 0:
+        # --first / --last are PositiveInt and default to None, thus a falsy value means "not given".
+        if not args.name and not args.match_archives and not args.first and not args.last:
             raise CommandError(
                 "Aborting: if you really want to delete all archives, please use -a 'sh:*' "
                 "or just delete the whole repository (might be much faster)."

--- a/src/borg/archiver/undelete_cmd.py
+++ b/src/borg/archiver/undelete_cmd.py
@@ -26,7 +26,8 @@ class UnDeleteMixIn:
         count = len(archive_infos)
         if count == 0:
             return
-        if not args.name and not args.match_archives and args.first == 0 and args.last == 0:
+        # --first / --last are PositiveInt and default to None, thus a falsy value means "not given".
+        if not args.name and not args.match_archives and not args.first and not args.last:
             raise CommandError("Aborting: if you really want to undelete all archives, please use -a 'sh:*'.")
 
         undeleted = False

--- a/src/borg/testsuite/archiver/delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/delete_cmd_test.py
@@ -1,4 +1,7 @@
+import pytest
+
 from ...constants import *  # NOQA
+from ...helpers import CommandError
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
@@ -32,6 +35,58 @@ def test_delete_multiple(archivers, request):
     cmd(archiver, "delete", "-a", "test1")
     cmd(archiver, "delete", "-a", "test2")
     assert not cmd(archiver, "repo-list")
+
+
+def test_delete_all_without_filter_aborts(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input")
+    cmd(archiver, "create", "test3", "input")
+    # Without NAME, -a / --match-archives, --first or --last, borg must refuse to delete everything.
+    # The guard triggers before any archive is considered, so it also applies to --dry-run.
+    msg = "if you really want to delete all archives"
+    for extra_args in ([], ["--dry-run", "--list"]):
+        if archiver.FORK_DEFAULT:
+            output = cmd(archiver, "delete", *extra_args, exit_code=CommandError().exit_code)
+            assert msg in output
+            assert "Would delete" not in output
+        else:
+            with pytest.raises(CommandError, match=msg):
+                cmd(archiver, "delete", *extra_args)
+    output = cmd(archiver, "repo-list")  # no archive was deleted
+    assert "test1" in output
+    assert "test2" in output
+    assert "test3" in output
+
+
+def test_delete_all_with_match_archives(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input")
+    cmd(archiver, "delete", "-a", "sh:*")  # explicitly asking for all archives is fine
+    assert cmd(archiver, "repo-list") == ""
+
+
+def test_delete_first_last(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input")
+    cmd(archiver, "create", "test3", "input")
+    cmd(archiver, "delete", "--first", "1", "--sort-by", "name")  # test1
+    output = cmd(archiver, "repo-list")
+    assert "test1" not in output
+    assert "test2" in output
+    assert "test3" in output
+    cmd(archiver, "delete", "--last", "1", "--sort-by", "name")  # test3
+    output = cmd(archiver, "repo-list")
+    assert "test2" in output
+    assert "test3" not in output
 
 
 def test_delete_ignore_protected(archivers, request):

--- a/src/borg/testsuite/archiver/undelete_cmd_test.py
+++ b/src/borg/testsuite/archiver/undelete_cmd_test.py
@@ -1,4 +1,7 @@
+import pytest
+
 from ...constants import *  # NOQA
+from ...helpers import CommandError
 from . import cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
@@ -42,6 +45,50 @@ def test_undelete_multiple_dryrun(archivers, request):
     assert "normal" in output
     assert "deleted1" not in output
     assert "deleted2" not in output
+
+
+def test_undelete_all_without_filter_aborts(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "normal", "input")
+    cmd(archiver, "create", "deleted1", "input")
+    cmd(archiver, "create", "deleted2", "input")
+    cmd(archiver, "delete", "deleted1")
+    cmd(archiver, "delete", "deleted2")
+    # Without NAME, -a / --match-archives, --first or --last, borg must refuse to undelete everything.
+    # The guard triggers before any archive is considered, so it also applies to --dry-run.
+    msg = "if you really want to undelete all archives"
+    for extra_args in ([], ["--dry-run", "--list"]):
+        if archiver.FORK_DEFAULT:
+            output = cmd(archiver, "undelete", *extra_args, exit_code=CommandError().exit_code)
+            assert msg in output
+            assert "Would undelete" not in output
+        else:
+            with pytest.raises(CommandError, match=msg):
+                cmd(archiver, "undelete", *extra_args)
+    output = cmd(archiver, "repo-list")  # no archive was undeleted
+    assert "normal" in output
+    assert "deleted1" not in output
+    assert "deleted2" not in output
+
+
+def test_undelete_first_last(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "deleted1", "input")
+    cmd(archiver, "create", "deleted2", "input")
+    cmd(archiver, "delete", "deleted1")
+    cmd(archiver, "delete", "deleted2")
+    cmd(archiver, "undelete", "--first", "1", "--sort-by", "name")  # deleted1
+    output = cmd(archiver, "repo-list")
+    assert "deleted1" in output
+    assert "deleted2" not in output
+    cmd(archiver, "undelete", "--last", "1", "--sort-by", "name")  # deleted2
+    output = cmd(archiver, "repo-list")
+    assert "deleted1" in output
+    assert "deleted2" in output
 
 
 def test_undelete_multiple_run(archivers, request):


### PR DESCRIPTION
The guard that aborts a bare `borg delete` / `borg undelete` (no NAME, no `-a`, no `--first/--last`) with *"Aborting: if you really want to delete all archives, please use -a 'sh:*' ..."* has been dead since the jsonargparse migration (2cff41d89): it compared `args.first`/`args.last` against `0`, but their `default=0` was dropped in that migration, so both default to `None` and the guard could never trigger. Runtime-verified: a bare `borg delete` would soft-delete **every** archive in the repository.

`default=0` cannot simply be restored — jsonargparse validates defaults against `type=PositiveInt` and rejects `0`, which would break every command using the archive-filter group. The guards now test truthiness (`not args.first and not args.last`), which is equivalent: `PositiveInt` rejects `0` at parse time, and an audit of all `args.first`/`args.last` consumers (`manifest.py`, `check`, `analyze`, legacy) found none that distinguish `0` from `None`.

Adds tests (both in-process and forked-binary fixtures) asserting that bare delete/undelete abort without deleting anything and that `-a 'sh:*'` and `--first/--last` still work. Full testsuite green.

Note: re-arming the guard also makes `borg delete --older 7d` (date filters only) abort again — that is the long-standing pre-breakage behavior and fails safe, but flagging it for awareness since the guard was dead for ~6 months. If the date filters should count as an explicit selection, that would be a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)