### PR TITLE
help topics: fix wrong claims, document missing env vars and placeholders

### DIFF
--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -15,6 +15,10 @@ General:
         When set, use the value to answer the passphrase question for encrypted repositories.
         It is used when a passphrase is needed to access an encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo.
+        BORG_PASSPHRASE, BORG_PASSCOMMAND and BORG_PASSPHRASE_FD are mutually exclusive:
+        if more than one of them is set, borg refuses to guess and aborts with
+        "More than one passphrase environment variable is set". The same applies to the
+        ``BORG_OTHER_*`` variants (which are a separate, independent group).
         See also BORG_NEW_PASSPHRASE.
     BORG_PASSCOMMAND (and BORG_OTHER_PASSCOMMAND)
         When set, use the standard output of the command (trailing newlines are stripped) to answer the
@@ -22,7 +26,7 @@ General:
         It is used when a passphrase is needed to access an encrypted repo as well as when a new
         passphrase should be initially set when initializing an encrypted repo. Note that the command
         is executed without a shell. So variables, like ``$HOME`` will work, but ``~`` won't.
-        If BORG_PASSPHRASE is also set, it takes precedence.
+        Mutually exclusive with BORG_PASSPHRASE and BORG_PASSPHRASE_FD, see there.
         See also BORG_NEW_PASSPHRASE.
     BORG_PASSPHRASE_FD (and BORG_OTHER_PASSPHRASE_FD)
         When set, specifies a file descriptor to read a passphrase
@@ -30,11 +34,11 @@ General:
         and use it to pass a passphrase. This is safer than passing via
         BORG_PASSPHRASE, because on some systems (e.g. Linux) environment
         can be examined by other processes.
-        If BORG_PASSPHRASE or BORG_PASSCOMMAND are also set, they take precedence.
+        Mutually exclusive with BORG_PASSPHRASE and BORG_PASSCOMMAND, see there.
     BORG_NEW_PASSPHRASE
         When set, use the value to answer the passphrase question when a **new** passphrase is asked for.
-        This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will also
-        be checked.
+        This variable is checked first. If it is not set, BORG_PASSPHRASE, BORG_PASSCOMMAND and
+        BORG_PASSPHRASE_FD are checked (in that order).
         Main use case for this is to fully automate ``borg key change-passphrase``.
     BORG_DISPLAY_PASSPHRASE
         When set, use the value to answer the "display the passphrase for verification" question when defining a new passphrase for encrypted repositories.
@@ -122,6 +126,36 @@ General:
     BORG_FILES_CACHE_TTL
         When set to a numeric value, this determines the maximum "time to live" for the files cache
         entries (default: 2). The files cache is used to determine quickly whether a file is unchanged.
+    BORG_STORE_CACHE
+        When set, borg keeps a local writethrough cache of the repository's ``packs/``
+        namespace: on a cache miss the whole pack is fetched once and later reads of the
+        objects inside that pack are served from the cache. Use this for slow or
+        high-latency repositories.
+        Set it to ``1`` to use ``$BORG_CACHE_DIR/storecache``, or to a directory path to
+        use that directory (it is created if it does not exist). Packs are named by
+        content hash, so one cache directory can safely hold packs of multiple repositories.
+        If it is not set, no such caching happens.
+    BORG_PACK_CACHE_SIZE
+        When set to a numeric value, limit the pack cache to that many bytes.
+        Only has an effect if BORG_STORE_CACHE is set.
+    BORG_PACK_MAX_SIZE
+        When set to a numeric value, cap packs (the repository objects that batch up many
+        chunks, see the internals documentation about pack files) at that many bytes
+        instead of the default of 50000000.
+        Smaller packs mean more (but smaller) repository objects and more
+        fine-grained uploads; bigger packs mean fewer objects and fewer stores.
+    BORG_PACK_MAX_COUNT
+        When set to a numeric value, cap packs at that many objects per pack.
+        If BORG_PACK_MAX_SIZE is not also set, packs are then bound by count only.
+    BORG_PACK_ASYNC
+        When set to ``no``, disable the background thread that stores a finished pack
+        while the next one is being assembled, and store packs synchronously instead.
+        This is mainly a debugging aid.
+    BORG_PACK_TRACE
+        When set to ``yes``, print one-character lifecycle markers of the background
+        pack store-thread to stderr (``<`` thread started, ``H`` hashing starts,
+        ``S`` storing starts, ``>`` thread finished). This is a debugging aid to
+        visualize how pack stores overlap with the assembly of the next pack.
     BORG_ASSERT_ID
         Comma-separated list of the places where borg shall verify that a chunk's content matches
         its chunk id (``chunkid == id_hash(content)``) after decrypting and decompressing it.
@@ -258,6 +292,12 @@ General:
         - ``pyfuse3``: only try to load pyfuse3
         - ``llfuse``: only try to load llfuse
         - ``none``: do not try to load an implementation
+    BORG_MOUNT_DATA_CACHE_ENTRIES
+        Number of decrypted file content chunks ``borg mount`` and ``borg webdav`` keep
+        in an in-memory cache, so that the many small, sequential reads a mounted file
+        system does for a big file do not re-fetch and re-decrypt the same chunk over and
+        over (default: the cpu count). Additional memory usage can be up to the chunk size
+        times this number.
     BORG_SELFTEST
         This can be used to influence borg's built-in self-tests. The default is to execute the tests
         at the beginning of each borg command invocation.
@@ -285,9 +325,13 @@ General:
             in WSL1 (Windows Subsystem for Linux 1).
 
         authenticated_no_key
-            Work around a lost passphrase or key for an ``authenticated-*`` mode repository
+            Work around a lost passphrase for an ``authenticated-*`` mode repository
             (these are only authenticated, but not encrypted).
-            If the key is missing in the repository config, add ``key = anything`` there.
+            Borg still has to find the repository's borg key - an object below ``keys/``
+            in the repository (repokey) resp. a key file in the keys directory (keyfile) -
+            but it does not unlock it any more, so the passphrase does not matter. If the
+            borg key itself is gone, this workaround does not help: borg then fails with
+            "No key entry found ...".
 
             Without the key, borg can not verify anything that needs it: neither the
             authentication tag of the repository objects nor the chunk ids. It therefore
@@ -302,13 +346,17 @@ General:
 
             After you have extracted all data you need, you MUST delete the repository::
 
-                BORG_WORKAROUNDS=authenticated_no_key borg delete repo
+                BORG_WORKAROUNDS=authenticated_no_key borg repo-delete --repo repo
 
-            Now you can init a fresh repo. Make sure you do not use the workaround any more.
+            Now you can create a fresh repository with ``borg repo-create``. Make sure you
+            do not use the workaround any more.
 
 Output formatting:
     BORG_CHECK_FORMAT
         Giving the default value for ``borg check --format=X``.
+    BORG_DIFF_FORMAT
+        Giving the default value for ``borg diff --format=X``.
+        Note: ``borg diff --content-only`` uses its own format and ignores this.
     BORG_FIND_FORMAT
         Giving the default value for ``borg find --format=X``.
     BORG_LIST_FORMAT
@@ -322,6 +370,11 @@ Output formatting:
         ``borg webdav`` show a whole repository, default: ``{name}``. The placeholders
         are the ones of ``borg repo-list --format``; names that are not unique get
         ``-{id:.8}`` appended. See ``borg mount --help``.
+    BORG_JSON_INDENT
+        Indentation of the ``--json`` output (default: ``4``).
+        A number gives that many spaces per nesting level (``0`` still puts every item on
+        its own line), ``none`` gives compact single-line JSON, and any other value is used
+        as the literal indent string (e.g. a tab or the empty string).
 
 Some automatic "answerers" (if set, they automatically answer confirmation questions):
     BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)
@@ -343,7 +396,7 @@ Directories and files:
 
     - Linux: XDG Base Directory Specification paths are used (e.g. ``~/.config/borg``,
       ``~/.cache/borg``, ``~/.local/share/borg``). ``XDG_*`` environment variables are
-      honoured (see https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html).
+      honoured (see https://specifications.freedesktop.org/basedir/latest/).
     - macOS: native macOS directories are used by default (e.g. ``~/Library/Application Support/borg``,
       ``~/Library/Caches/borg``). ``XDG_*`` environment variables are honoured if set.
     - Windows: Windows AppData directories are used (e.g. ``C:\Users\<user>\AppData\Roaming\borg``,
@@ -364,7 +417,8 @@ Directories and files:
         Security   <data_dir>/security   <data_dir>/security                   <data_dir>\security
 
     BORG_BASE_DIR
-        Defaults to ``$HOME`` or ``~$USER`` or ``~`` (in that order).
+        Not set by default - then the platform-specific directories shown in the table above
+        are used.
         If you want to move all borg-specific folders to a custom path at once, all you need to do is
         to modify ``BORG_BASE_DIR``: the other paths for cache, config etc. will adapt accordingly
         (assuming you didn't set them to a different custom value).
@@ -415,16 +469,25 @@ Directories and files:
         for details.
 
 Building:
-    BORG_OPENSSL_NAME
-        Defines the subdirectory name for OpenSSL (setup.py).
+    These are only read by ``setup.py`` while building borg's C extensions. Each
+    ``BORG_*_PREFIX`` variable names the install prefix of a library that borg links
+    against: if it is set, ``$PREFIX/include`` and ``$PREFIX/lib`` are used unconditionally.
+    If it is not set, the library is located via pkg-config, and if that does not find it
+    either, the build fails - there is no bundled fallback implementation.
+
     BORG_OPENSSL_PREFIX
-        Adds given OpenSSL header file directory to the default locations (setup.py).
-    BORG_LIBACL_PREFIX
-        Adds given prefix directory to the default locations. If an 'include/acl/libacl.h' is found
-        Borg will be linked against the system libacl instead of a bundled implementation. (setup.py)
+        Prefix of the OpenSSL installation to build libcrypto against.
+        On Windows, the libraries are expected in ``$PREFIX`` itself rather than in
+        ``$PREFIX/lib``. On OpenBSD, this defaults to ``/usr/local``, pkg-config is not
+        used and libcrypto is linked statically (borg needs AES-OCB via the EVP API, which
+        LibreSSL does not have).
+    BORG_OPENSSL_NAME
+        OpenBSD only: the OpenSSL flavour to use, i.e. the ``include/`` and ``lib/``
+        subdirectory name below ``BORG_OPENSSL_PREFIX`` (default: ``eopenssl35``).
     BORG_LIBLZ4_PREFIX
-        Adds given prefix directory to the default locations. If a 'include/lz4.h' is found Borg
-        will be linked against the system liblz4 instead of a bundled implementation. (setup.py)
+        Prefix of the liblz4 installation to build against.
+    BORG_LIBACL_PREFIX
+        Linux only: prefix of the libacl installation to build against.
 
 Automatic option environment variables:
     Borg uses jsonargparse (https://jsonargparse.readthedocs.io/) with ``default_env=True``,

--- a/docs/usage/help.rst.inc
+++ b/docs/usage/help.rst.inc
@@ -143,11 +143,11 @@ run ``borg create --list --dry-run ...``.
 
 Examples::
 
-    # Exclude a directory anywhere in the tree named ``steamapps/common``
+    # Exclude a directory anywhere in the tree named steamapps/common
     # (and everything below it), regardless of where it appears:
     $ borg create -e 'sh:**/steamapps/common/**' archive /
 
-    # Exclude the contents of ``/home/user/.cache``:
+    # Exclude the contents of /home/user/.cache:
     $ borg create -e 'sh:home/user/.cache/**' archive /home/user
     $ borg create -e home/user/.cache/ archive /home/user
 
@@ -198,12 +198,15 @@ Pattern style prefix ``P`` (only useful within patterns files)
 
 Exclude pattern prefix ``-``
     Use the prefix ``-``, followed by a pattern, to define an exclusion.
-    This has the same effect as the ``--exclude`` option.
+    Borg still recurses into a directory excluded this way, so a later
+    include pattern can still match files below it.
 
 Exclude no-recurse pattern prefix ``!``
     Use the prefix ``!``, followed by a pattern, to define an exclusion
     that does not recurse into subdirectories. This saves time, but
     prevents include patterns to match any files in subdirectories.
+    The ``--exclude`` option and the patterns in an ``--exclude-from``
+    file give this kind of exclusion, not the recursing one of ``-``.
 
 Include pattern prefix ``+``
     Use the prefix ``+``, followed by a pattern, to define inclusions.
@@ -248,9 +251,10 @@ character that indicates the action (e.g. 'x' for excluding, see
     directories are not. In that case, parent directories are not backed
     up and thus their user, group, permission, etc. cannot be restored.
 
-Patterns (``--pattern``) and excludes (``--exclude``) from the command line are
-considered first (in the order of appearance). Then patterns from ``--patterns-from``
-are added. Exclusion patterns from ``--exclude-from`` files are appended last.
+``--pattern``, ``--patterns-from``, ``--exclude`` and ``--exclude-from`` all feed the
+same single list of patterns, in the order in which they appear on the command line.
+The patterns of a pattern file resp. exclude file are inserted where the option naming
+that file stands, in the order of the lines in that file.
 
 Examples::
 
@@ -403,8 +407,9 @@ borg help placeholders
 ~~~~~~~~~~~~~~~~~~~~~~
 
 
-Repository URLs, ``--name``, ``-a`` / ``--match-archives``, ``--comment``
-and ``BORG_REMOTE_PATH`` values support these placeholders:
+Repository URLs, the archive name arguments (``NAME``, ``OLDNAME``, ``NEWNAME``,
+``ARCHIVE1``, ``ARCHIVE2``), ``-a`` / ``--match-archives``, ``--comment`` and
+``BORG_REMOTE_PATH`` values support these placeholders:
 
 {hostname}
     The (short) hostname of the machine.
@@ -423,11 +428,18 @@ and ``BORG_REMOTE_PATH`` values support these placeholders:
     The current UTC date and time, by default in ISO-8601 format.
     You can also supply your own `format string <https://docs.python.org/3.11/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
 
+{unixtime}
+    The current time as a UNIX timestamp, i.e. whole seconds since the epoch,
+    e.g.: 1735732800
+
 {user}
     The user name (or UID, if no name is available) of the user running borg.
 
 {pid}
     The current process ID.
+
+{uuid4}
+    A random UUID (version 4), freshly generated each time placeholders are replaced.
 
 {borgversion}
     The version of borg, e.g.: 1.0.8rc1

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -147,11 +147,11 @@ class HelpMixIn:
 
         Examples::
 
-            # Exclude a directory anywhere in the tree named ``steamapps/common``
+            # Exclude a directory anywhere in the tree named steamapps/common
             # (and everything below it), regardless of where it appears:
             $ borg create -e 'sh:**/steamapps/common/**' archive /
 
-            # Exclude the contents of ``/home/user/.cache``:
+            # Exclude the contents of /home/user/.cache:
             $ borg create -e 'sh:home/user/.cache/**' archive /home/user
             $ borg create -e home/user/.cache/ archive /home/user
 
@@ -202,12 +202,15 @@ class HelpMixIn:
 
         Exclude pattern prefix ``-``
             Use the prefix ``-``, followed by a pattern, to define an exclusion.
-            This has the same effect as the ``--exclude`` option.
+            Borg still recurses into a directory excluded this way, so a later
+            include pattern can still match files below it.
 
         Exclude no-recurse pattern prefix ``!``
             Use the prefix ``!``, followed by a pattern, to define an exclusion
             that does not recurse into subdirectories. This saves time, but
             prevents include patterns to match any files in subdirectories.
+            The ``--exclude`` option and the patterns in an ``--exclude-from``
+            file give this kind of exclusion, not the recursing one of ``-``.
 
         Include pattern prefix ``+``
             Use the prefix ``+``, followed by a pattern, to define inclusions.
@@ -252,9 +255,10 @@ class HelpMixIn:
             directories are not. In that case, parent directories are not backed
             up and thus their user, group, permission, etc. cannot be restored.
 
-        Patterns (``--pattern``) and excludes (``--exclude``) from the command line are
-        considered first (in the order of appearance). Then patterns from ``--patterns-from``
-        are added. Exclusion patterns from ``--exclude-from`` files are appended last.
+        ``--pattern``, ``--patterns-from``, ``--exclude`` and ``--exclude-from`` all feed the
+        same single list of patterns, in the order in which they appear on the command line.
+        The patterns of a pattern file resp. exclude file are inserted where the option naming
+        that file stands, in the order of the lines in that file.
 
         Examples::
 
@@ -399,8 +403,9 @@ class HelpMixIn:
     )
     helptext["placeholders"] = textwrap.dedent(
         """
-        Repository URLs, ``--name``, ``-a`` / ``--match-archives``, ``--comment``
-        and ``BORG_REMOTE_PATH`` values support these placeholders:
+        Repository URLs, the archive name arguments (``NAME``, ``OLDNAME``, ``NEWNAME``,
+        ``ARCHIVE1``, ``ARCHIVE2``), ``-a`` / ``--match-archives``, ``--comment`` and
+        ``BORG_REMOTE_PATH`` values support these placeholders:
 
         {hostname}
             The (short) hostname of the machine.
@@ -419,11 +424,18 @@ class HelpMixIn:
             The current UTC date and time, by default in ISO-8601 format.
             You can also supply your own `format string <https://docs.python.org/3.11/library/datetime.html#strftime-and-strptime-behavior>`_, e.g. {utcnow:%Y-%m-%d_%H:%M:%S}
 
+        {unixtime}
+            The current time as a UNIX timestamp, i.e. whole seconds since the epoch,
+            e.g.: 1735732800
+
         {user}
             The user name (or UID, if no name is available) of the user running borg.
 
         {pid}
             The current process ID.
+
+        {uuid4}
+            A random UUID (version 4), freshly generated each time placeholders are replaced.
 
         {borgversion}
             The version of borg, e.g.: 1.0.8rc1
@@ -591,6 +603,10 @@ class HelpMixIn:
                 When set, use the value to answer the passphrase question for encrypted repositories.
                 It is used when a passphrase is needed to access an encrypted repo as well as when a new
                 passphrase should be initially set when initializing an encrypted repo.
+                BORG_PASSPHRASE, BORG_PASSCOMMAND and BORG_PASSPHRASE_FD are mutually exclusive:
+                if more than one of them is set, borg refuses to guess and aborts with
+                "More than one passphrase environment variable is set". The same applies to the
+                ``BORG_OTHER_*`` variants (which are a separate, independent group).
                 See also BORG_NEW_PASSPHRASE.
             BORG_PASSCOMMAND (and BORG_OTHER_PASSCOMMAND)
                 When set, use the standard output of the command (trailing newlines are stripped) to answer the
@@ -598,7 +614,7 @@ class HelpMixIn:
                 It is used when a passphrase is needed to access an encrypted repo as well as when a new
                 passphrase should be initially set when initializing an encrypted repo. Note that the command
                 is executed without a shell. So variables, like ``$HOME`` will work, but ``~`` won't.
-                If BORG_PASSPHRASE is also set, it takes precedence.
+                Mutually exclusive with BORG_PASSPHRASE and BORG_PASSPHRASE_FD, see there.
                 See also BORG_NEW_PASSPHRASE.
             BORG_PASSPHRASE_FD (and BORG_OTHER_PASSPHRASE_FD)
                 When set, specifies a file descriptor to read a passphrase
@@ -606,11 +622,11 @@ class HelpMixIn:
                 and use it to pass a passphrase. This is safer than passing via
                 BORG_PASSPHRASE, because on some systems (e.g. Linux) environment
                 can be examined by other processes.
-                If BORG_PASSPHRASE or BORG_PASSCOMMAND are also set, they take precedence.
+                Mutually exclusive with BORG_PASSPHRASE and BORG_PASSCOMMAND, see there.
             BORG_NEW_PASSPHRASE
                 When set, use the value to answer the passphrase question when a **new** passphrase is asked for.
-                This variable is checked first. If it is not set, BORG_PASSPHRASE and BORG_PASSCOMMAND will also
-                be checked.
+                This variable is checked first. If it is not set, BORG_PASSPHRASE, BORG_PASSCOMMAND and
+                BORG_PASSPHRASE_FD are checked (in that order).
                 Main use case for this is to fully automate ``borg key change-passphrase``.
             BORG_DISPLAY_PASSPHRASE
                 When set, use the value to answer the "display the passphrase for verification" question when defining a new passphrase for encrypted repositories.
@@ -698,6 +714,36 @@ class HelpMixIn:
             BORG_FILES_CACHE_TTL
                 When set to a numeric value, this determines the maximum "time to live" for the files cache
                 entries (default: 2). The files cache is used to determine quickly whether a file is unchanged.
+            BORG_STORE_CACHE
+                When set, borg keeps a local writethrough cache of the repository's ``packs/``
+                namespace: on a cache miss the whole pack is fetched once and later reads of the
+                objects inside that pack are served from the cache. Use this for slow or
+                high-latency repositories.
+                Set it to ``1`` to use ``$BORG_CACHE_DIR/storecache``, or to a directory path to
+                use that directory (it is created if it does not exist). Packs are named by
+                content hash, so one cache directory can safely hold packs of multiple repositories.
+                If it is not set, no such caching happens.
+            BORG_PACK_CACHE_SIZE
+                When set to a numeric value, limit the pack cache to that many bytes.
+                Only has an effect if BORG_STORE_CACHE is set.
+            BORG_PACK_MAX_SIZE
+                When set to a numeric value, cap packs (the repository objects that batch up many
+                chunks, see the internals documentation about pack files) at that many bytes
+                instead of the default of 50000000.
+                Smaller packs mean more (but smaller) repository objects and more
+                fine-grained uploads; bigger packs mean fewer objects and fewer stores.
+            BORG_PACK_MAX_COUNT
+                When set to a numeric value, cap packs at that many objects per pack.
+                If BORG_PACK_MAX_SIZE is not also set, packs are then bound by count only.
+            BORG_PACK_ASYNC
+                When set to ``no``, disable the background thread that stores a finished pack
+                while the next one is being assembled, and store packs synchronously instead.
+                This is mainly a debugging aid.
+            BORG_PACK_TRACE
+                When set to ``yes``, print one-character lifecycle markers of the background
+                pack store-thread to stderr (``<`` thread started, ``H`` hashing starts,
+                ``S`` storing starts, ``>`` thread finished). This is a debugging aid to
+                visualize how pack stores overlap with the assembly of the next pack.
             BORG_ASSERT_ID
                 Comma-separated list of the places where borg shall verify that a chunk's content matches
                 its chunk id (``chunkid == id_hash(content)``) after decrypting and decompressing it.
@@ -834,6 +880,12 @@ class HelpMixIn:
                 - ``pyfuse3``: only try to load pyfuse3
                 - ``llfuse``: only try to load llfuse
                 - ``none``: do not try to load an implementation
+            BORG_MOUNT_DATA_CACHE_ENTRIES
+                Number of decrypted file content chunks ``borg mount`` and ``borg webdav`` keep
+                in an in-memory cache, so that the many small, sequential reads a mounted file
+                system does for a big file do not re-fetch and re-decrypt the same chunk over and
+                over (default: the cpu count). Additional memory usage can be up to the chunk size
+                times this number.
             BORG_SELFTEST
                 This can be used to influence borg's built-in self-tests. The default is to execute the tests
                 at the beginning of each borg command invocation.
@@ -861,9 +913,13 @@ class HelpMixIn:
                     in WSL1 (Windows Subsystem for Linux 1).
 
                 authenticated_no_key
-                    Work around a lost passphrase or key for an ``authenticated-*`` mode repository
+                    Work around a lost passphrase for an ``authenticated-*`` mode repository
                     (these are only authenticated, but not encrypted).
-                    If the key is missing in the repository config, add ``key = anything`` there.
+                    Borg still has to find the repository's borg key - an object below ``keys/``
+                    in the repository (repokey) resp. a key file in the keys directory (keyfile) -
+                    but it does not unlock it any more, so the passphrase does not matter. If the
+                    borg key itself is gone, this workaround does not help: borg then fails with
+                    "No key entry found ...".
 
                     Without the key, borg can not verify anything that needs it: neither the
                     authentication tag of the repository objects nor the chunk ids. It therefore
@@ -878,13 +934,17 @@ class HelpMixIn:
 
                     After you have extracted all data you need, you MUST delete the repository::
 
-                        BORG_WORKAROUNDS=authenticated_no_key borg delete repo
+                        BORG_WORKAROUNDS=authenticated_no_key borg repo-delete --repo repo
 
-                    Now you can init a fresh repo. Make sure you do not use the workaround any more.
+                    Now you can create a fresh repository with ``borg repo-create``. Make sure you
+                    do not use the workaround any more.
 
         Output formatting:
             BORG_CHECK_FORMAT
                 Giving the default value for ``borg check --format=X``.
+            BORG_DIFF_FORMAT
+                Giving the default value for ``borg diff --format=X``.
+                Note: ``borg diff --content-only`` uses its own format and ignores this.
             BORG_FIND_FORMAT
                 Giving the default value for ``borg find --format=X``.
             BORG_LIST_FORMAT
@@ -898,6 +958,11 @@ class HelpMixIn:
                 ``borg webdav`` show a whole repository, default: ``{name}``. The placeholders
                 are the ones of ``borg repo-list --format``; names that are not unique get
                 ``-{id:.8}`` appended. See ``borg mount --help``.
+            BORG_JSON_INDENT
+                Indentation of the ``--json`` output (default: ``4``).
+                A number gives that many spaces per nesting level (``0`` still puts every item on
+                its own line), ``none`` gives compact single-line JSON, and any other value is used
+                as the literal indent string (e.g. a tab or the empty string).
 
         Some automatic "answerers" (if set, they automatically answer confirmation questions):
             BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no (or =yes)
@@ -919,7 +984,7 @@ class HelpMixIn:
 
             - Linux: XDG Base Directory Specification paths are used (e.g. ``~/.config/borg``,
               ``~/.cache/borg``, ``~/.local/share/borg``). ``XDG_*`` environment variables are
-              honoured (see https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html).
+              honoured (see https://specifications.freedesktop.org/basedir/latest/).
             - macOS: native macOS directories are used by default (e.g. ``~/Library/Application Support/borg``,
               ``~/Library/Caches/borg``). ``XDG_*`` environment variables are honoured if set.
             - Windows: Windows AppData directories are used (e.g. ``C:\\Users\\<user>\\AppData\\Roaming\\borg``,
@@ -940,7 +1005,8 @@ class HelpMixIn:
                 Security   <data_dir>/security   <data_dir>/security                   <data_dir>\\security
 
             BORG_BASE_DIR
-                Defaults to ``$HOME`` or ``~$USER`` or ``~`` (in that order).
+                Not set by default - then the platform-specific directories shown in the table above
+                are used.
                 If you want to move all borg-specific folders to a custom path at once, all you need to do is
                 to modify ``BORG_BASE_DIR``: the other paths for cache, config etc. will adapt accordingly
                 (assuming you didn't set them to a different custom value).
@@ -991,16 +1057,25 @@ class HelpMixIn:
                 for details.
 
         Building:
-            BORG_OPENSSL_NAME
-                Defines the subdirectory name for OpenSSL (setup.py).
+            These are only read by ``setup.py`` while building borg's C extensions. Each
+            ``BORG_*_PREFIX`` variable names the install prefix of a library that borg links
+            against: if it is set, ``$PREFIX/include`` and ``$PREFIX/lib`` are used unconditionally.
+            If it is not set, the library is located via pkg-config, and if that does not find it
+            either, the build fails - there is no bundled fallback implementation.
+
             BORG_OPENSSL_PREFIX
-                Adds given OpenSSL header file directory to the default locations (setup.py).
-            BORG_LIBACL_PREFIX
-                Adds given prefix directory to the default locations. If an 'include/acl/libacl.h' is found
-                Borg will be linked against the system libacl instead of a bundled implementation. (setup.py)
+                Prefix of the OpenSSL installation to build libcrypto against.
+                On Windows, the libraries are expected in ``$PREFIX`` itself rather than in
+                ``$PREFIX/lib``. On OpenBSD, this defaults to ``/usr/local``, pkg-config is not
+                used and libcrypto is linked statically (borg needs AES-OCB via the EVP API, which
+                LibreSSL does not have).
+            BORG_OPENSSL_NAME
+                OpenBSD only: the OpenSSL flavour to use, i.e. the ``include/`` and ``lib/``
+                subdirectory name below ``BORG_OPENSSL_PREFIX`` (default: ``eopenssl35``).
             BORG_LIBLZ4_PREFIX
-                Adds given prefix directory to the default locations. If a 'include/lz4.h' is found Borg
-                will be linked against the system liblz4 instead of a bundled implementation. (setup.py)
+                Prefix of the liblz4 installation to build against.
+            BORG_LIBACL_PREFIX
+                Linux only: prefix of the libacl installation to build against.
 
         Automatic option environment variables:
             Borg uses jsonargparse (https://jsonargparse.readthedocs.io/) with ``default_env=True``,


### PR DESCRIPTION
Fixes the verified issues in the built-in help topics (`help_cmd.py`) and regenerates the two derived docs files (`docs/usage/help.rst.inc`, `docs/usage/general/environment.rst.inc`). Every claim was checked against the implementation, most also at runtime:

- **Passphrase env vars**: the docs claimed BORG_PASSPHRASE "takes precedence" over BORG_PASSCOMMAND — borg actually errors when more than one of BORG_PASSPHRASE / BORG_PASSCOMMAND / BORG_PASSPHRASE_FD is set (verified). Now documented as mutually exclusive (both var groups).
- **authenticated_no_key**: dropped the borg1-era "add `key = anything` to the repository config" advice (no repo config file in borg2; the key object under `keys/` must still exist) and fixed `borg delete repo` / "init a fresh repo" to `borg repo-delete` / `borg repo-create` (workaround behavior re-verified end-to-end, including the rc 44 no-key case).
- **BORG_BASE_DIR**: removed the `$HOME`/`~$USER`/`~` fallback claim — borg2's `get_base_dir()` does no such guessing.
- **Building section**: rewritten — the `BORG_*_PREFIX` vars are used unconditionally (no `include/...` header probing, no "bundled implementation" fallback; pkg-config otherwise, else the build fails), covering all four existing vars incl. `BORG_OPENSSL_NAME` and the OpenBSD static-libcrypto case.
- **Patterns topic**: the `-` prefix *recurses* — it is `!` that matches the no-recurse behavior of `-e/--exclude`/`--exclude-from` (verified via parser dumps); the documented staged ordering (CLI first, then --patterns-from, then --exclude-from) doesn't exist — all four options feed one list in command-line order.
- **Placeholders**: removed the nonexistent `--name` option reference; added missing `{unixtime}` and `{uuid4}` (full sweep of the placeholder table — those were the only two missing).
- **auto compression**: documents all three outcomes now (stored uncompressed / lz4-only / C[,L] only when ≥1% better).
- Removed ``...`` markup inside patterns code-block comments (rendered literally in both terminal and HTML).
- **Environment topic additions**: BORG_DIFF_FORMAT, BORG_JSON_INDENT, BORG_STORE_CACHE, BORG_PACK_CACHE_SIZE, BORG_MOUNT_DATA_CACHE_ENTRIES. A follow-up commit also documents the pack tuning/debugging knobs BORG_PACK_MAX_SIZE, BORG_PACK_MAX_COUNT, BORG_PACK_ASYNC and BORG_PACK_TRACE.

All five help topics render clean from the patched tree (no RST leakage, no tracebacks); Sphinx clean build: zero warnings; ruff clean.

Noted in passing, not part of this PR: `RepoKeyNotFoundError`'s message still says "in the config of repository" (stale borg1 wording), and CLAUDE.md still lists `BORG_LIBZSTD_PREFIX`/`BORG_LIBXXHASH_PREFIX`, which setup.py no longer has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
