### PR TITLE
docs: update deployment docs to borg2 commands and rest protocol

### DIFF
--- a/docs/deployment/automated-local.rst
+++ b/docs/deployment/automated-local.rst
@@ -123,17 +123,19 @@ modify it to suit your needs (e.g., more backup sets, dumping databases, etc.).
 
     # This is just an example, change it however you see fit
     borg create $BORG_OPTS \
+      --repo $TARGET \
       --exclude root/.cache \
       --exclude var/lib/docker/devicemapper \
-      $TARGET::$DATE-$$-system \
+      $DATE-$$-system \
       / /boot
 
     # /home is often a separate partition/filesystem.
     # Even if it is not (add --exclude /home above), it probably makes sense
     # to have /home in a separate archive.
     borg create $BORG_OPTS \
+      --repo $TARGET \
       --exclude 'sh:home/*/.cache' \
-      $TARGET::$DATE-$$-home \
+      $DATE-$$-home \
       /home/
 
     echo "Completed backup for $DATE"
@@ -181,9 +183,9 @@ Record the UUID in the ``/etc/backups/backup.disks`` file.
 
 Mount the drive at /mnt/backup.
 
-Initialize a Borg repository at the location indicated by ``TARGET``::
+Create a Borg repository at the location indicated by ``TARGET``::
 
-    borg init --encryption ... /mnt/backup/borg-backups/backup.borg
+    borg repo-create -r /mnt/backup/borg-backups/backup.borg --encryption ...
 
 Unmount and reconnect the drive, or manually start the ``automatic-backup`` service
 to start the first backup::

--- a/docs/deployment/hosting-repositories.rst
+++ b/docs/deployment/hosting-repositories.rst
@@ -29,7 +29,7 @@ SSH access to safe operations only.
 
 ::
 
-  command="borg serve --restrict-to-repository /home/<user>/repository",restrict
+  command="borg serve --rest --restrict-to-repository /home/<user>/repository",restrict
   <key type> <key> <key host>
 
 .. note:: The text shown above needs to be written on a **single** line!
@@ -48,12 +48,19 @@ If any future restriction capabilities are added to authorized_keys
 files they will be included in this set.
 
 The ``command`` keyword forces execution of the specified command
-upon login. This must be ``borg serve``. The ``--restrict-to-repository``
-option permits access to exactly **one** repository. It can be given
-multiple times to permit access to more than one repository.
+upon login. This must be ``borg serve --rest``: ``--rest`` serves a current
+repository (the server side of a ``rest://`` repository URL), while ``borg serve``
+without it serves a legacy borg 1.x repository using the legacy RPC protocol.
+The client cannot supply ``--rest`` itself - the mode is deliberately pinned by
+the forced command - so a forced command without ``--rest`` locks out all clients
+using current (``rest://``) repositories.
 
-The repository may not exist yet; it can be initialized by the user,
-which allows for encryption.
+The ``--restrict-to-repository`` option permits access to exactly **one**
+repository. It can be given multiple times to permit access to more than
+one repository.
+
+The repository may not exist yet; it can be created by the user with
+``borg repo-create``, which allows for encryption.
 
 Refer to the `sshd(8) <https://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man8/sshd.8>`_
 man page for more details on SSH options.

--- a/docs/deployment/image-backup.rst
+++ b/docs/deployment/image-backup.rst
@@ -78,7 +78,7 @@ Restoration is a similar process::
 
     borg extract --stdout --repo repo hostname-partinfo | dd of=$DISK && partprobe
     PARTITIONS=$(sfdisk -lo Device,Type $DISK | sed -e '1,/Device\s*Type/d')
-    borg list --format {archive}{NL} repo | grep 'part[0-9]*$' | while read x; do
+    borg repo-list --format '{archive}{NL}' -r repo | grep 'part[0-9]*$' | while read x; do
         PARTNUM=$(echo $x | grep -Eo "[0-9]+$")
         PARTITION=$(echo "$PARTITIONS" | grep -E "$DISKp?$PARTNUM" | head -n1)
         if echo "$PARTITION" | cut -d' ' -f2- | grep -q NTFS; then
@@ -87,6 +87,15 @@ Restoration is a similar process::
             borg extract --stdout --repo repo $x | dd of=$(echo "$PARTITION" | cut -d' ' -f1)
         fi
     done
+
+.. note::
+
+   The archive names used above do not contain a timestamp, so repeated backup runs
+   add more archives with the same name to the same archive series. As ``borg extract``
+   requires the given name to match exactly one archive, select the archive by its ID
+   in that case: list the archives with
+   ``borg repo-list --format '{id}{TAB}{archive}{NL}' -r repo`` and extract with
+   ``borg extract --stdout --repo repo aid:<id>``.
 
 .. note::
 

--- a/docs/deployment/pull-backup.rst
+++ b/docs/deployment/pull-backup.rst
@@ -227,7 +227,7 @@ The program socat has to be available on the backup server and on the client
 to be backed up.
 
 When **pushing** a backup the borg client (holding the data to be backed up)
-connects to the backup server via ssh, starts ``borg serve`` on the backup
+connects to the backup server via ssh, starts ``borg serve --rest`` on the backup
 server and communicates via standard input and output (transported via SSH)
 with the process on the backup server.
 
@@ -244,7 +244,7 @@ accessible to the users that run the backup process. So on both systems,
    sudo mkdir -m 0700 /run/borg
 
 On *borg-server* the socket file is opened by the user running the ``borg
-serve`` process writing to the repository
+serve --rest`` process writing to the repository
 so the user has to have read and write permissions on ``/run/borg``::
 
    borg-server:~$ sudo chown borgs /run/borg
@@ -254,19 +254,30 @@ to *borg-client* has to have read and write permissions on ``/run/borg``::
 
    borg-client:~$ sudo chown borgc /run/borg
 
-On *borg-server*, we have to start the command ``borg serve`` and make its
+On *borg-server*, we have to start the command ``borg serve --rest`` and make its
 standard input and output available to a unix socket::
 
-   borg-server:~$ socat UNIX-LISTEN:/run/borg/reponame.sock,fork EXEC:"borg serve --restrict-to-path /path/to/repo"
+   borg-server:~$ socat UNIX-LISTEN:/run/borg/reponame.sock,fork EXEC:"borg serve --rest --backend FILE:/path/to/repo --restrict-to-path /path/to/repo"
 
 Socat will wait until a connection is opened. Then socat will execute the
-command given, redirecting Standard Input and Output to the unix socket. The
-optional arguments for ``borg serve`` are not necessary but a sane default.
+command given, redirecting Standard Input and Output to the unix socket.
+``--rest`` and ``--backend`` are required here: ``--rest`` serves a current
+repository (talking HTTP over stdio, the server side of a ``rest://`` repository
+URL), and ``--backend`` selects the repository to serve. ``--restrict-to-path``
+is not necessary but a sane default.
+
+.. note::
+   Because socat runs a fixed command, everything the borg client appends to it
+   (see ``BORG_RSH`` below) is discarded - including the ``--backend`` option the
+   client would normally use to tell the server which repository it wants. The
+   repository therefore is the one given by ``--backend`` in the socat command
+   above, no matter which path the client uses in its ``rest://`` URL. Use the
+   same path in both places to avoid confusion.
 
 .. note::
    When used in production you may also use systemd socket-based activation
-   instead of socat on the server side. You would wrap the ``borg serve`` command
-   in a `service unit`_ and configure a matching `socket unit`_
+   instead of socat on the server side. You would wrap the ``borg serve --rest``
+   command in a `service unit`_ and configure a matching `socket unit`_
    to start the service whenever a client connects to the socket.
 
    .. _service unit: https://www.freedesktop.org/software/systemd/man/systemd.service.html
@@ -290,28 +301,28 @@ forwarding can do this for us::
    When you are done, you have to remove the socket file manually, otherwise
    you may see an error like this when trying to execute borg commands::
 
-      Remote: YYYY/MM/DD HH:MM:SS socat[XXX] E connect(5, AF=1 "/run/borg/reponame.sock", 13): Connection refused
-      Connection closed by remote host. Is borg working on the server?
+      YYYY/MM/DD HH:MM:SS socat[XXX] E connect(5, AF=1 "/run/borg/reponame.sock", 13): Connection refused
+      BackendError: stdio server exited with code 1
 
 
 When a process opens the socket on *borg-client*, SSH will forward all
 data to the socket on *borg-server*.
 
 The next step is to tell borg on *borg-client* to use the unix socket to communicate with the
-``borg serve`` command on *borg-server* via the socat socket instead of SSH::
+``borg serve --rest`` command on *borg-server* via the socat socket instead of SSH::
 
    borg-client:~$ export BORG_RSH="sh -c 'exec socat STDIO UNIX-CONNECT:/run/borg/reponame.sock'"
 
 The default value for ``BORG_RSH`` is ``ssh``. By default Borg uses SSH to create
 the connection to the backup server. Therefore Borg parses the repo URL
-and adds the server name (and other arguments) to the SSH command. Those
-arguments can not be handled by socat. We wrap the command with ``sh`` to
-ignore all arguments intended for the SSH command.
+and adds the server name (and the remote ``borg serve --rest ...`` command) to the
+SSH command. Those arguments can not be handled by socat. We wrap the command with
+``sh`` to ignore all arguments intended for the SSH command.
 
 All Borg commands can now be executed on *borg-client*. For example to create a
 backup execute the ``borg create`` command::
 
-   borg-client:~$ borg create --repo ssh://borg-server/path/to/repo archive /path_to_backup
+   borg-client:~$ borg create --repo rest://borg-server//path/to/repo archive /path_to_backup
 
 When automating backup creation, the
 interactive ssh session may seem inappropriate. An alternative way of creating
@@ -322,7 +333,7 @@ a backup may be the following command::
       borgc@borg-client \
       BORG_RSH="sh -c 'exec socat STDIO UNIX-CONNECT:/run/borg/reponame.sock'" \
       borg create \
-      --repo ssh://borg-server/path/to/repo archive /path_to_backup \
+      --repo rest://borg-server//path/to/repo archive /path_to_backup \
       ';' rm /run/borg/reponame.sock
 
 This command also automatically removes the socket file after the ``borg
@@ -336,7 +347,7 @@ agent connection.
 
 After that, it works similar to the push mode:
 *borg-client* initiates another SSH connection back to *borg-server* using the forwarded authentication agent
-connection to authenticate itself, starts ``borg serve`` and communicates with it.
+connection to authenticate itself, starts ``borg serve --rest`` and communicates with it.
 
 Using this method requires ssh access of user *borgs* to *borgc@borg-client*, where:
 
@@ -360,7 +371,7 @@ dedicated ssh key:
 
   borgs@borg-server$ install -m 700 -d ~/.ssh/
   borgs@borg-server$ ssh-keygen -N '' -t rsa -f ~/.ssh/borg-client_key
-  borgs@borg-server$ { echo -n 'command="borg serve --restrict-to-repo ~/repo",restrict '; cat ~/.ssh/borg-client_key.pub; } >> ~/.ssh/authorized_keys
+  borgs@borg-server$ { echo -n 'command="borg serve --rest --restrict-to-repository ~/repo",restrict '; cat ~/.ssh/borg-client_key.pub; } >> ~/.ssh/authorized_keys
   borgs@borg-server$ chmod 600 ~/.ssh/authorized_keys
 
 ``install -m 700 -d ~/.ssh/``
@@ -375,10 +386,12 @@ dedicated ssh key:
   Another more complex approach is using a unique ssh key for each pull operation.
   This is more secure as it guarantees that the key will not be used for other purposes.
 
-``{ echo -n 'command="borg serve --restrict-to-repo ~/repo",restrict '; cat ~/.ssh/borg-client_key.pub; } >> ~/.ssh/authorized_keys``
+``{ echo -n 'command="borg serve --rest --restrict-to-repository ~/repo",restrict '; cat ~/.ssh/borg-client_key.pub; } >> ~/.ssh/authorized_keys``
 
   Add borg-client's ssh public key to ~/.ssh/authorized_keys with forced command and restricted mode.
   The borg client is restricted to use one repo at the specified path.
+  ``--rest`` is required to serve a current repository; the client cannot supply that
+  option itself, it is pinned by the forced command.
 
 ``chmod 600 ~/.ssh/authorized_keys``
 
@@ -387,13 +400,13 @@ dedicated ssh key:
 Pull operation
 ~~~~~~~~~~~~~~
 
-Initiating borg command execution from *borg-server* (e.g. init)::
+Initiating borg command execution from *borg-server* (e.g. repo-create)::
 
   borgs@borg-server$ (
     eval $(ssh-agent) > /dev/null
     ssh-add -q ~/.ssh/borg-client_key
     echo 'your secure borg key passphrase' | \
-      ssh -A -o StrictHostKeyChecking=no borgc@borg-client "BORG_PASSPHRASE=\$(cat) BORG_RSH='ssh -o StrictHostKeyChecking=no' borg init --encryption repokey ssh://borgs@borg-server/~/repo"
+      ssh -A -o StrictHostKeyChecking=no borgc@borg-client "BORG_PASSPHRASE=\$(cat) BORG_RSH='ssh -o StrictHostKeyChecking=no' borg repo-create --encryption aes256-ocb --key-location repokey -r rest://borgs@borg-server/repo"
     kill "${SSH_AGENT_PID}"
   )
 
@@ -419,11 +432,16 @@ Parentheses are not needed when using a dedicated bash process.
   * The keys meant to be loaded into the agent must be specified explicitly, not from default locations.
   * The *borg-client*'s entry in *borgs@borg-server:~/.ssh/authorized_keys* must be as restrictive as possible.
 
-``echo 'your secure borg key passphrase' | ssh -A -o StrictHostKeyChecking=no borgc@borg-client "BORG_PASSPHRASE=\$(cat) BORG_RSH='ssh -o StrictHostKeyChecking=no' borg init --encryption repokey ssh://borgs@borg-server/~/repo"``
+``echo 'your secure borg key passphrase' | ssh -A -o StrictHostKeyChecking=no borgc@borg-client "BORG_PASSPHRASE=\$(cat) BORG_RSH='ssh -o StrictHostKeyChecking=no' borg repo-create --encryption aes256-ocb --key-location repokey -r rest://borgs@borg-server/repo"``
 
-  Run the *borg init* command on *borg-client*.
+  Run the *borg repo-create* command on *borg-client*.
 
-  *ssh://borgs@borg-server/~/repo* refers to the repository *repo* within borgs's home directory on *borg-server*.
+  *rest://borgs@borg-server/repo* refers to the repository *repo* within borgs's home directory on *borg-server*
+  (a path given with a single leading slash is relative to the directory ssh logs into; use
+  *rest://borgs@borg-server//path/to/repo* for an absolute path).
+
+  Borg on *borg-client* connects via ssh (using *BORG_RSH*) and runs ``borg serve --rest`` on
+  *borg-server*, which the forced command in *borgs@borg-server:~/.ssh/authorized_keys* pins down.
 
   *StrictHostKeyChecking=no* is used to add host keys automatically to *~/.ssh/known_hosts* without user intervention.
 
@@ -472,7 +490,7 @@ using ``localhost`` instead of ``mybackup``
 
 2. On machine ``myclient``
 
-``borg create -v --progress --stats ssh://backup@localhost:8022/home/backup/repos/myclient /``
+``borg create -v --progress --stats -r rest://backup@localhost:8022//home/backup/repos/myclient system /``
 
 Make sure to use port ``8022`` and ``localhost`` for the repository as this instructs borg on ``myclient`` to use the
 remote forwarded ssh connection.
@@ -497,7 +515,7 @@ path and client-fqdn:
 
 ::
 
-  command="cd /home/backup/repos/<client fqdn>;borg serve --restrict-to-path /home/backup/repos/<client fqdn>"
+  command="cd /home/backup/repos/<client fqdn>;borg serve --rest --restrict-to-path /home/backup/repos/<client fqdn>"
 
 
 All the additional security considerations for borg should be applied, see :ref:`central-backup-server` for some additional


### PR DESCRIPTION
The deployment guides still taught `borg init`, ssh:// for current repos, and forced commands that pin the legacy borg1 RPC. All four pages are now borg2-correct, with every replacement command actually verified:

- **pull-backup.rst** — the socat recipe now uses `borg serve --rest` + `rest://` URLs. The mechanism was verified end-to-end (socat stand-ins driving the page's exact `BORG_RSH` construction through repo-create/create/repo-list): `propagate_rsh()` still makes the page's `BORG_RSH` approach work, and a new note documents that socat discards the client's appended `--backend`, so the server-side pinned repo wins. The ssh-agent section replaces `borg init --encryption repokey ssh://...` with `borg repo-create --encryption aes256-ocb --key-location repokey -r rest://...` (repokey is a key location, not an encryption mode, in borg2) and fixes the forced command; the remote-forwarding example gets a rest:// URL, `-r`, and the now-mandatory archive name.
- **automated-local.rst** — `borg init` → `borg repo-create -r`; the two `$TARGET::$DATE-...` create calls converted from borg1 `repo::archive` syntax.
- **hosting-repositories.rst** — the authorized_keys forced command becomes `borg serve --rest --restrict-to-repository ...`, with prose explaining that `--rest` must be in the forced command: it is deliberately not client-suppliable (the client-arg allowlist is only debug-topics/lock-wait/log-level/backend), verified via `Archiver.get_args()` — without it, clients with current rest:// repos are locked out.
- **image-backup.rst** — `borg list --format ... repo` → `borg repo-list --format ... -r repo` (run against a scratch repo including the grep pipe), plus a note that the snippets' timestamp-less archive names build a series, making bare `borg extract NAME` fail once two runs exist — pointing at `aid:<id>` extraction (verified, incl. short-id prefixes).

Sphinx clean build: 0 warnings.

Found in passing, left for a separate change: `docs/usage/serve.rst` shows the same forced command without `--rest`, and its allowlist prose omits `backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)