### PR TITLE
archiver: fix wrong/stale epilog help texts, raw-RST rendering, version --from-borg1

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -459,15 +459,16 @@ class BenchmarkMixIn:
             """
         This command benchmarks borg CRUD (create, read, update, delete) operations.
 
-        It creates input data below the given PATH and backs up this data into the given REPO.
-        The REPO must already exist (it could be a fresh empty repo or an existing repo, the
+        It creates input data below the given PATH and backs up this data into the repository
+        given via -r/--repo (or the BORG_REPO environment variable).
+        The repository must already exist (it could be a fresh empty repo or an existing repo, the
         command will create / read / update / delete some archives named borg-benchmark-crud\\* there.
 
         Make sure you have free space there; you will need about 1 GB each (+ overhead).
 
         If your repository is encrypted and borg needs a passphrase to unlock the key, use::
 
-            BORG_PASSPHRASE=mysecret borg benchmark crud REPO PATH
+            BORG_PASSPHRASE=mysecret borg -r REPO benchmark crud PATH
 
         Measurements are done with different input file sizes and counts.
         The file contents are very artificial (either all zero or all random),
@@ -488,9 +489,11 @@ class BenchmarkMixIn:
               U-Z- == needs to check the 2 all-zero chunks' existence in the repo.
               U-R- == needs to check existence of a lot of different chunks in the repo.
 
-        D- == borg delete archive (delete last remaining archive, measure deletion + compaction)
-              D-Z- == few chunks to delete / few segments to compact/remove.
-              D-R- == many chunks to delete / many segments to compact/remove.
+        D- == borg delete archive (soft-delete the last remaining archive, measure deletion)
+              Deletion only removes the archive from the archives list, it does not free any
+              repository space - that is what borg compact does (not measured here).
+              D-Z- == all-zero files archive.
+              D-R- == random files archive.
 
         Please note that there might be quite some variance in these measurements.
         Try multiple measurements and having a otherwise idle machine (and network, if you use it).

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -111,13 +111,18 @@ class CheckMixIn:
         The check command verifies the consistency of a repository and its archives.
         It consists of two major steps:
 
-        1. Checking the consistency of the repository itself. This includes checking
-           the file magic headers, and both the metadata and data of all objects in
-           the repository. The read data is checked by size and hash. Bit rot and other
-           types of accidental damage can be detected this way. Running the repository
-           check can be split into multiple partial checks using ``--max-duration``.
-           When checking an ssh:// remote repository, please note that the checks run on
-           the server and do not cause significant network traffic.
+        1. Checking the consistency of the repository itself. The objects in the ``index/``
+           and ``packs/`` namespaces are named by the sha256 hash of their content, so such
+           an object is intact if and only if the hash of its content still equals its name.
+           The check verifies the (small) index objects first and, only if they are intact,
+           all packs. It also cross-checks the chunk index against the packs present in the
+           repository to detect referenced but missing packs. Bit rot and other types of
+           accidental damage can be detected this way, but as sha256 content-addressing is
+           not a MAC, this step does not detect tampering. Running the repository check can
+           be split into multiple partial checks using ``--max-duration``.
+           For rest:// repositories, the server computes the hashes, so the pack contents do
+           not have to travel over the network. For other remote backends, borg usually has
+           to read (download) the objects to hash them.
 
         2. Checking consistency and correctness of the archive metadata and optionally
            archive data (requires ``--verify-data``). This includes ensuring that the
@@ -160,11 +165,13 @@ class CheckMixIn:
         nor repair mode, so ``--max-duration`` requires ``--repository-only`` and
         cannot be combined with ``--archives-only`` or ``--repair``.
 
-        **Warning:** Please note that partial repository checks (i.e., running with
-        ``--max-duration``) can only perform non-cryptographic checksum checks on the
-        repository files. Enabling partial repository checks excludes archive checks
-        for the same reason. Therefore, partial checks may be useful only with very large
-        repositories where a full check would take too long.
+        **Note:** A partial repository check verifies the repository files in exactly the
+        same way as a full repository check does - the difference is only how many of them
+        one run gets to. What a partial run does not do are the archive checks: because
+        ``--max-duration`` requires ``--repository-only``, neither the archive metadata
+        checks nor the cryptographic data verification of ``--verify-data`` run. Partial
+        checks are therefore mostly useful for very large repositories where a full check
+        would take too long.
 
         The ``--verify-data`` option will perform a full integrity verification of data,
         which means reading the data from the repository, decrypting and decompressing it.

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -950,6 +950,7 @@ class CreateMixIn:
         - '+' = included, item would be backed up (if not in dry-run mode)
         - '-' = excluded, item would not be / was not backed up
         - 'i' = backup data was read from standard input (stdin)
+        - 'x' = skipped due to ``--exclude-dataless`` (file is flagged DATALESS)
         - '?' = missing status code (if you see this, please file a bug report!)
 
         Errors and (incomplete) archives

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -409,7 +409,7 @@ class DebugMixIn:
             metavar="WANTED",
             type=str,
             action=Highlander,
-            help="term to search the repo for, either 0x1234abcd hex term or a string",
+            help="term to search the repo for: either ``hex:1234abcd`` (hex bytes) or ``str:foobar`` (text)",
         )
         debug_id_hash_epilog = process_epilog(
             """

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -175,8 +175,8 @@ class DiffMixIn:
         from ._common import process_epilog
         from ._common import define_exclusion_group
 
-        diff_epilog = (
-            process_epilog(
+        diff_epilog = process_epilog(
+            textwrap.dedent(
                 """
         This command finds differences (file contents, metadata) between ARCHIVE1 and ARCHIVE2.
 

--- a/src/borg/archiver/find_cmd.py
+++ b/src/borg/archiver/find_cmd.py
@@ -51,8 +51,8 @@ class FindMixIn:
     def build_parser_find(self, subparsers, common_parser, mid_common_parser):
         from ._common import process_epilog, define_exclusion_group
 
-        find_epilog = (
-            process_epilog(
+        find_epilog = process_epilog(
+            textwrap.dedent(
                 """
         This command finds files matching the given paths or patterns in the archives
         selected by the usual archive filter options (all archives, if no filters are

--- a/src/borg/archiver/key_cmds.py
+++ b/src/borg/archiver/key_cmds.py
@@ -218,14 +218,19 @@ class KeysMixIn:
         process in which each line is checked for plausibility before
         proceeding to the next line. For this format PATH must not be given.
 
-        For repositories using keyfile encryption, the key file which ``borg key
-        import`` writes to depends on several factors. If the ``BORG_KEY_FILE``
-        environment variable is set and non-empty, ``borg key import`` creates
-        or overwrites that file named by ``$BORG_KEY_FILE``. Otherwise, ``borg
-        key import`` searches in the ``$BORG_KEYS_DIR`` directory for a key file
-        associated with the repository. If a key file is found in
-        ``$BORG_KEYS_DIR``, ``borg key import`` overwrites it; otherwise, ``borg
-        key import`` creates a new key file in ``$BORG_KEYS_DIR``.
+        Where the imported key is stored is decided by ``--key-location``:
+
+        - ``repokey`` (the default): the key is stored **in the repository**, no local
+          key file is written.
+        - ``keyfile``: the key is stored in a local key file.
+
+        The key file that ``--key-location=keyfile`` writes to depends on several
+        factors. If the ``BORG_KEY_FILE`` environment variable is set and non-empty,
+        ``borg key import`` creates or overwrites the file named by ``$BORG_KEY_FILE``.
+        Otherwise, ``borg key import`` searches the ``$BORG_KEYS_DIR`` directory for a
+        key file associated with the repository. If one is found there, ``borg key
+        import`` overwrites it; otherwise it creates a new key file in
+        ``$BORG_KEYS_DIR``.
         """
         )
         subparser = ArgumentParser(

--- a/src/borg/archiver/list_cmd.py
+++ b/src/borg/archiver/list_cmd.py
@@ -91,8 +91,8 @@ class ListMixIn:
     def build_parser_list(self, subparsers, common_parser, mid_common_parser):
         from ._common import process_epilog, define_exclusion_group
 
-        list_epilog = (
-            process_epilog(
+        list_epilog = process_epilog(
+            textwrap.dedent(
                 """
         This command lists the contents of an archive.
 

--- a/src/borg/archiver/mount_cmds.py
+++ b/src/borg/archiver/mount_cmds.py
@@ -98,8 +98,8 @@ class MountMixIn:
             On Linux, this can be prevented by remounting the mountpoint with the
             ``nosymfollow`` VFS mount option, for example:
 
-                borg mount <repo path> <mountpoint>
-                mount -o remount,nosymfollow <repo path> <mountpoint>
+                borg -r <repo path> mount <mountpoint>
+                mount -o remount,nosymfollow <mountpoint>
 
             Alternatively, access the mounted archive from an appropriately isolated
             environment (for example, a container or ``chroot``).

--- a/src/borg/archiver/recreate_cmd.py
+++ b/src/borg/archiver/recreate_cmd.py
@@ -75,8 +75,9 @@ class RecreateMixIn:
         Note that all paths in an archive are relative, therefore absolute patterns/paths
         will *not* match (``--exclude``, ``--exclude-from``, PATHs).
 
-        ``--chunker-params`` will re-chunk all files in the archive, this can be
-        used to have upgraded Borg 0.xx archives deduplicate with Borg 1.x archives.
+        ``--chunker-params`` will re-chunk all files in the archive. This can be used to
+        switch existing archives to different chunker parameters (or a different chunker
+        algorithm), so they deduplicate with archives created using these parameters.
 
         **USE WITH CAUTION.**
         Depending on the paths and patterns given, recreate can be used to
@@ -84,9 +85,10 @@ class RecreateMixIn:
         When in doubt, use ``--dry-run --verbose --list`` to see how patterns/paths are
         interpreted. See :ref:`list_item_flags` in ``borg create`` for details.
 
-        The archive being recreated is only removed after the operation completes. The
-        archive that is built during the operation exists at the same time at
-        "<ARCHIVE>.recreate". The new archive will have a different archive ID.
+        The archive being recreated is only removed after the new archive has been saved
+        completely. The new archive is created under the same name as the original one, so
+        while the operation runs, both exist side by side; they are told apart by their
+        archive IDs, as the new archive gets a different archive ID.
 
         With ``--target`` the original archive is not replaced, instead a new archive is created.
 
@@ -127,7 +129,7 @@ class RecreateMixIn:
             default=None,
             type=archivename_validator,
             action=Highlander,
-            help="create a new archive with the name ARCHIVE, do not replace existing archive",
+            help="create a new archive with the name TARGET, do not replace existing archive",
         )
         archive_group.add_argument(
             "--comment",
@@ -165,9 +167,11 @@ class RecreateMixIn:
             type=ChunkerParams,
             default=None,
             action=Highlander,
-            help="rechunk using given chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, "
-            "HASH_MASK_BITS, NC_LEVEL) or `default` to use the chunker defaults. "
-            "default: do not rechunk",
+            help="rechunk using given chunker parameters: "
+            "buzhash,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE or "
+            "buzhash64,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE,NC_LEVEL or "
+            "fastcdc,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,NC_LEVEL or "
+            "`default` to use the chunker defaults. default: do not rechunk",
         )
 
         subparser.add_argument(

--- a/src/borg/archiver/repo_create_cmd.py
+++ b/src/borg/archiver/repo_create_cmd.py
@@ -97,8 +97,8 @@ class RepoCreateMixIn:
         2. Create a borg key (which contains some random secrets. See :ref:`key_files`).
         3. Derive a "key encryption key" from your passphrase
         4. Encrypt and sign the key with the key encryption key
-        5. Store the encrypted borg key inside the repository directory (in the repo config).
-           This is why it is essential to use a secure passphrase.
+        5. Store the encrypted borg key in the repository (as an object in the ``keys/``
+           namespace of the store). This is why it is essential to use a secure passphrase.
         6. Encrypt and sign your backups to prevent anyone from reading or forging them unless they
            have the key and know the passphrase. Make sure to keep a backup of
            your key **outside** the repository - do not lock yourself out by

--- a/src/borg/archiver/repo_delete_cmd.py
+++ b/src/borg/archiver/repo_delete_cmd.py
@@ -117,7 +117,8 @@ class RepoDeleteMixIn:
             dest="forced",
             action="count",
             default=0,
-            help="force deletion of corrupted archives; use ``--force --force`` if a single ``--force`` does not work.",
+            help="do not ask for confirmation, just delete the repository. this also works if the "
+            "repository is damaged to a point where its archives can not be listed anymore.",
         )
         subparser.add_argument(
             "--cache-only",

--- a/src/borg/archiver/repo_list_cmd.py
+++ b/src/borg/archiver/repo_list_cmd.py
@@ -42,8 +42,8 @@ class RepoListMixIn:
     def build_parser_repo_list(self, subparsers, common_parser, mid_common_parser):
         from ._common import process_epilog, define_archive_filters_group
 
-        repo_list_epilog = (
-            process_epilog(
+        repo_list_epilog = process_epilog(
+            textwrap.dedent(
                 """
         This command lists the archives contained in a repository.
 
@@ -65,8 +65,9 @@ class RepoListMixIn:
 
             # {VAR:NUMBER} - pad to NUMBER columns.
             # Strings are left-aligned, numbers are right-aligned.
-            # Note: time columns except ``isomtime``, ``isoctime`` and ``isoatime`` cannot be padded.
-            $ borg repo-list --format '{archive:36} {time} [{id}]{NL}' /path/to/repo
+            # Note: the time keys (time, start, end) can not be padded - for them, the
+            # format spec is a strftime format string, e.g. {time:%Y-%m-%d}.
+            $ borg repo-list --format '{archive:36} {time} [{id}]{NL}'
             ArchiveFoo                           Thu, 2021-12-09 10:22:28 [0b8e9...3b274]
             ...
 

--- a/src/borg/archiver/serve_cmd.py
+++ b/src/borg/archiver/serve_cmd.py
@@ -80,7 +80,9 @@ class ServeMixIn:
         repository via the `--repo` option or the `BORG_REPO` environment variable - it is the
         borg client that specifies the repository to use.
 
-        The --permissions option enforces repository permissions:
+        The --permissions option enforces repository permissions. It only applies to
+        ``--rest`` mode; in legacy mode it is ignored, because legacy (borg 1.x) repositories
+        have no permission system:
 
         - `all`: All permissions are granted. (Default; the permissions system is not used.)
         - `no-delete`: Allow reading and writing; disallow deleting and overwriting data.
@@ -134,5 +136,6 @@ class ServeMixIn:
             "--permissions",
             dest="permissions",
             choices=["all", "no-delete", "write-only", "read-only"],
-            help="Set repository permission mode. Overrides BORG_REPO_PERMISSIONS environment variable.",
+            help="(with --rest) set repository permission mode. "
+            "Overrides BORG_REPO_PERMISSIONS environment variable.",
         )

--- a/src/borg/archiver/tar_cmds.py
+++ b/src/borg/archiver/tar_cmds.py
@@ -823,8 +823,11 @@ class TarMixIn:
             default=CHUNKER_PARAMS,
             action=Highlander,
             metavar="PARAMS",
-            help="specify the chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, "
-            "HASH_MASK_BITS, NC_LEVEL). default: %s,%d,%d,%d,%d" % CHUNKER_PARAMS,
+            help="specify the chunker parameters: "
+            "buzhash,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE or "
+            "buzhash64,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE,NC_LEVEL or "
+            "fastcdc,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,NC_LEVEL. "
+            "default: %s,%d,%d,%d,%d" % CHUNKER_PARAMS,
         )
         archive_group.add_argument(
             "-C",

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -294,7 +294,7 @@ class TransferMixIn:
         any case) and keep data compressed "as is" (saves time as no data compression is needed).
 
         If you want to globally change compression while transferring archives to the DST_REPO,
-        give ``--compress=WANTED_COMPRESSION --recompress=always``.
+        give ``--compression=WANTED_COMPRESSION --recompress=always``.
 
         The default is to transfer all archives.
 
@@ -359,11 +359,11 @@ class TransferMixIn:
 
             # to continue using lz4 compression as you did in SRC_REPO:
             borg --repo=DST_REPO transfer --other-repo=SRC_REPO --from-borg1 \\
-                 --compress=lz4 --recompress=never
+                 --compression=lz4 --recompress=never
 
             # alternatively, to recompress everything to zstd,3:
             borg --repo=DST_REPO transfer --other-repo=SRC_REPO --from-borg1 \\
-                 --compress=zstd,3 --recompress=always
+                 --compression=zstd,3 --recompress=always
 
             # to re-chunk using different chunker parameters:
             borg --repo=DST_REPO transfer --other-repo=SRC_REPO \\
@@ -433,9 +433,11 @@ class TransferMixIn:
             type=ChunkerParams,
             default=None,
             action=Highlander,
-            help="rechunk using given chunker parameters (ALGO, CHUNK_MIN_EXP, CHUNK_MAX_EXP, "
-            "HASH_MASK_BITS, NC_LEVEL) or `default` to use the chunker defaults. "
-            "default: do not rechunk",
+            help="rechunk using given chunker parameters: "
+            "buzhash,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE or "
+            "buzhash64,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,WINDOW_SIZE,NC_LEVEL or "
+            "fastcdc,CHUNK_MIN_EXP,CHUNK_MAX_EXP,HASH_MASK_BITS,NC_LEVEL or "
+            "`default` to use the chunker defaults. default: do not rechunk",
         )
 
         define_archive_filters_group(subparser)

--- a/src/borg/archiver/undelete_cmd.py
+++ b/src/borg/archiver/undelete_cmd.py
@@ -70,7 +70,7 @@ class UnDeleteMixIn:
 
         You can undelete multiple archives by specifying a match pattern using
         the ``--match-archives PATTERN`` option (for more information on these
-        patterns, see :ref:`borg_patterns`).
+        patterns, see "borg help match-archives").
         """
         )
         subparser = ArgumentParser(

--- a/src/borg/archiver/version_cmd.py
+++ b/src/borg/archiver/version_cmd.py
@@ -14,7 +14,7 @@ class VersionMixIn:
         from borg.version import parse_version, format_version
 
         client_version = parse_version(__version__)
-        if args.location.proto == "ssh" and getattr(args, "v1_legacy", False):
+        if args.location.proto == "ssh" and args.v1_legacy:
             from ..legacy.remote import LegacyRemoteRepository
 
             with LegacyRemoteRepository(args.location, lock=False, args=args) as repository:
@@ -45,13 +45,13 @@ class VersionMixIn:
 
         Examples::
 
-            # local repository (client uses 1.4.0 alpha version)
-            $ borg version /mnt/backup
-            1.4.0a / 1.4.0a
+            # local repository
+            $ borg -r /mnt/backup version
+            2.0.0 / 2.0.0
 
-            # legacy remote repository (client uses 1.4.0 alpha, server uses 1.2.7 release)
-            $ borg version --from-borg1 ssh://borg@borgbackup:repo
-            1.4.0a / 1.2.7
+            # legacy remote repository (client uses 2.0.0, server uses 1.4.5 release)
+            $ borg -r ssh://borg@borgbackup/repo version --from-borg1
+            2.0.0 / 1.4.5
 
         Due to the version tuple format used in Borg client/server negotiation, only
         a simplified version is displayed (as provided by borg.version.format_version).
@@ -62,3 +62,4 @@ class VersionMixIn:
         subparser = ArgumentParser(parents=[common_parser], description=self.do_version.__doc__, epilog=version_epilog)
         subparsers.add_subcommand("version", subparser, help="display the Borg client and server versions")
         subparser.add_argument("--json", action="store_true", help="format output as JSON")
+        subparser.add_argument("--from-borg1", dest="v1_legacy", action="store_true", help="repository is Borg 1.x")

--- a/src/borg/testsuite/archiver/version_cmd_test.py
+++ b/src/borg/testsuite/archiver/version_cmd_test.py
@@ -1,7 +1,7 @@
 import json
 from borg import __version__
 from borg.version import format_version, parse_version
-from borg.testsuite.archiver import cmd
+from borg.testsuite.archiver import Archiver, cmd
 
 EXPECTED_VERSION = format_version(parse_version(__version__))
 
@@ -15,3 +15,19 @@ def test_json_version(archiver):
     result = cmd(archiver, "version", "--json")
     version_info = json.loads(result)
     assert version_info == {"client": EXPECTED_VERSION, "server": EXPECTED_VERSION}
+
+
+def test_from_borg1_option():
+    """--from-borg1 is accepted and enables the legacy (borg 1.x) remote code path."""
+    archiver = Archiver()
+    args = archiver.parse_args(["-r", "ssh://borg@borgbackup/repo", "version", "--from-borg1"])
+    assert args.func == archiver.do_version
+    assert args.location.proto == "ssh"
+    assert args.v1_legacy is True
+
+
+def test_from_borg1_default_off():
+    archiver = Archiver()
+    args = archiver.parse_args(["-r", "/mnt/backup", "version"])
+    assert args.func == archiver.do_version
+    assert args.v1_legacy is False


### PR DESCRIPTION
Three things in one focused pass over the command epilogs (all verified against the implementation; details per item in the commit message):

**Raw-RST leak in terminal help**: the `diff`/`list`/`find`/`repo-list` epilogs were assembled as `process_epilog(part1) + keys_help() + part2`, so only the first segment got RST→terminal conversion and `--help` printed literal `` `` ``…`` `` ``/`::` markup. `process_epilog` now wraps the whole concatenation. Generated-docs output was proven unchanged by dumping all 60 subparser epilogs under `build_usage` and `build_man` before/after — the only deltas are a *restored* blank line RST requires before a bullet list and a trailing-newline normalization.

**`borg version --from-borg1` implemented**: the epilog documented the option, but it was never defined — the examples failed and `do_version`'s `v1_legacy` branch was unreachable. The legacy path itself works (`LegacyRemoteRepository` negotiation provides the server version, useful before a `borg transfer --from-borg1`), so the option is added (mirroring repo-list) with parser-level tests, and the examples now use `-r`.

**~15 epilog text corrections** across benchmark/check/create/debug/key/mount/recreate/repo-create/repo-delete/repo-list/serve/transfer/tar/undelete — borg1-era repo positionals in examples, the segment-era check description (now: sha256 store verification; the server-side-hash property belongs to rest://), the ineffective `--force --force` advice, `--key-location` semantics for key import, the nonexistent `<ARCHIVE>.recreate` temporary archive, `--compress=` → `--compression=`, chunker-params tuple shapes per algorithm, and more.

Tests: help_cmd_test (all epilogs/parsers) + the test files of every touched command: 392 passed; the 2 failing completion tests are pre-existing at the same base commit on a pristine tree (reproduced independently). ruff + black clean.

Note: raw ``...`` markup inside *option help strings* (not epilogs) still renders literally in `--help` — that's a project-wide style question deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)