### PR TITLE
docs: fix packs.rst and security.rst to match the implementation

### DIFF
--- a/docs/internals/packs.rst
+++ b/docs/internals/packs.rst
@@ -34,7 +34,7 @@ Each blob is a self-contained unit::
     Offset (relative to blob start)  Size              Type     Field
     --------------------------------  ----------------  -------  -----
     0                                 len(OBJ_MAGIC)    bytes    OBJ_MAGIC = ASCII b"BORG_OBJ"
-    8                                 1                 uint8    Format version: 0x01
+    8                                 1                 uint8    Format version: 0x02 (0x01 still readable)
     9                                 32                bytes    chunk_id
     41                                4                 uint32le meta_size
     45                                4                 uint32le data_size
@@ -45,9 +45,12 @@ Each blob is a self-contained unit::
 Storing it in the unencrypted header lets a scanner rebuild the
 ``chunk_id → location`` index without decrypting any blob.
 
-``chunk_id`` is also written into ``encrypted_meta`` (the meta dict). The header
-copy enables key-free scanning and recovery; the meta copy lets future code read
-``chunk_id`` through the normal meta dict API without parsing the raw header layout.
+``chunk_id`` is *not* duplicated into ``encrypted_meta``: the header is its only
+place in the object. ``RepoObj.format()`` puts the object type and the compression
+bookkeeping into the meta dict (``type``, ``ctype``, ``clevel``, ``csize``, ``size``,
+plus ``psize``/``olevel`` when the ``obfuscate`` pseudo compressor is used), nothing
+else. What keeps the plaintext header copy honest is that it is bound into the
+authentication of both encrypted slots, see below.
 
 The fixed part of each blob header is 49 bytes (``REPOOBJ_HEADER_SIZE``):
 ``len(OBJ_MAGIC)`` + 1 version + 32 chunk_id + 4 meta_size + 4 data_size.
@@ -98,8 +101,8 @@ Once it finds the next ``OBJ_MAGIC`` sequence it resumes. Other corruption
 
 Blobs follow one another contiguously with no padding::
 
-    OBJ_MAGIC | version=0x01 | chunk_id_0 | meta_size_0 | data_size_0 | encrypted_meta_0 | encrypted_data_0
-    OBJ_MAGIC | version=0x01 | chunk_id_1 | meta_size_1 | data_size_1 | encrypted_meta_1 | encrypted_data_1
+    OBJ_MAGIC | version=0x02 | chunk_id_0 | meta_size_0 | data_size_0 | encrypted_meta_0 | encrypted_data_0
+    OBJ_MAGIC | version=0x02 | chunk_id_1 | meta_size_1 | data_size_1 | encrypted_meta_1 | encrypted_data_1
     ...
 
 .. figure:: pack-layout.png
@@ -166,6 +169,9 @@ entry carries the ``F_PENDING`` flag and its pack location is unresolved.
     crash before it leaves only unreferenced objects that ``borg compact``
     reclaims.
 
+.. TODO: the implementation currently writes the session's final index fragment at
+   cache close, i.e. after the archive pointer - see issue #10239.
+
 Pack data must be stored before any archive pointer references it.
 The required write order is:
 
@@ -186,10 +192,14 @@ archive pointer write is the commit point: archives are listed from the
 ``archives/`` namespace, so data not referenced by any archive pointer is
 unreachable and treated as garbage by ``borg compact``.
 
-Only ``borg compact`` and ``borg check --repair`` delete pack files. When compact
-determines via mark-and-sweep that none of a pack's blobs are referenced by any
-archive, it removes the whole file. Individual blobs cannot be removed without
-rewriting the entire pack, so deletion always operates at pack granularity.
+Pack files are removed by ``borg compact`` (dropping packs whose indexed objects are
+all unused, rewriting packs above ``--threshold`` and merging tiny packs),
+``borg check --repair`` (when it drops a defective object), ``borg repo-compress``
+(``Repository.transform_pack`` stores the re-compressed pack under its new
+content-addressed name and deletes the old one) and ``borg debug delete-obj``. A
+single blob cannot be removed from a pack in place: all of these paths write a new
+pack file without it and then delete the old one, so store-level deletion always
+operates at pack granularity.
 
 
 .. _pack-index-namespace:
@@ -197,35 +207,62 @@ rewriting the entire pack, so deletion always operates at pack granularity.
 Index Namespace
 ---------------
 
-Chunk-to-location mappings are stored as a separate set of encrypted partial index
-files under the ``index/`` namespace.
+Chunk-to-location mappings are stored as a separate set of objects under the
+``index/`` namespace, called *index fragments*.
 
-Each partial index file covers the packs written in one backup session. Its name is
-the SHA-256 digest of its own content. A first backup of a large dataset may produce
-a large partial index file; using the same medium-sized file writer as compact for
-``borg create`` would bound that. That is the intended direction.
-
-::
+A fragment is a serialized ``ChunkIndex`` (a ``borghash`` ``HashTableNT`` keyed on
+``chunk_id``) holding only the pack location; the ``flags`` and the plaintext ``size``
+of each entry are zeroed before serializing. Fragments are **not** encrypted: they map
+``chunk_id`` to ``(pack_id, obj_offset, obj_size)``, which anyone with access to the
+repository could equally well read out of the unencrypted blob headers (see
+:ref:`pack-recovery`). A fragment's name is the SHA-256 digest of its own content::
 
     index/
       <sha256_of_content_hex>
 
-Content-addressed naming makes each partial index file self-verifying and idempotent:
-writing the same index data twice produces the same filename, so a repeated write is
-a no-op.
+An ordinary backup writes only the entries that are new in that session; a full
+rewrite (e.g. by ``borg compact``) writes all of them. In both cases the write is
+split into fragments of at most ``CHUNKINDEX_FRAGMENT_ENTRIES_MAX`` (400000 entries,
+roughly 32MB), so no single fragment gets too large -- not even the one large write a
+first backup of a big dataset produces. The split selects and sorts the keys one
+leading-key-bits partition at a time, so the same set of entries always yields the
+same fragments, no matter in which order the entries were inserted.
 
-Partial index files are write-once. A session stores new partial index files via
-borgstore; existing files are never modified. On repository open all files under
-``index/`` are loaded via borgstore, decrypted, and merged into the in-memory ChunkIndex
-(a ``borghash`` ``HashTableNT`` keyed on ``chunk_id``). The merge is commutative and
-idempotent; order does not matter.
+Content-addressed naming makes each fragment self-verifying and idempotent: writing
+the same index data twice produces the same name, and such a write is skipped.
 
-``borg compact`` rewrites the ``index/`` namespace: it identifies live chunks via
-mark-and-sweep, consolidates the surviving mappings into medium-sized replacement
-files (targeting roughly 10–100 packs per file), and removes the files it supersedes.
-Medium-sized files keep the open-time merge cost bounded while avoiding the
-cache-invalidation traffic on other clients that a single all-in-one index would
-cause.
+Index fragments are write-once; an existing fragment is never modified. The in-memory
+ChunkIndex is built lazily, on the first access to ``Repository.chunks``: everything
+under ``index/`` is listed, loaded, checked against its content hash and merged
+(``build_chunkindex_from_repo``). The merge is commutative and idempotent; order does
+not matter. It has to succeed for *all* fragments or not at all, because a partially
+merged index would be missing chunks that do exist in the repository: a fragment that
+vanishes mid-merge (a concurrent consolidation replaced it) restarts the merge, and a
+persistently unreadable one falls back to the rebuild from the pack files.
+
+Because every backup appends a fragment, small fragments would pile up over time.
+``repack_chunkindex()`` (run at cache close, and by anything that loads the index and
+persists it, e.g. ``borg compact``) merges the fragments below
+``CHUNKINDEX_FRAGMENT_ENTRIES_MIN`` (100000 entries, roughly 8MB) into fragments of up
+to ``CHUNKINDEX_FRAGMENT_ENTRIES_MAX`` entries and deletes the small sources.
+Fragments already within that range are left untouched, so they stay immutable -- and,
+once ``index/`` is cache-backed, stay cached for every client, instead of being
+invalidated by an all-in-one consolidation. The merge is deferred until it can seal at
+least one full fragment, or until more than ``CHUNKINDEX_SMALL_FRAGMENT_CAP`` (15)
+small fragments have accumulated, so a slowly growing fragment is not rewritten on
+every backup.
+
+``borg compact`` rewrites the ``index/`` namespace as a whole: it determines the live
+chunks via mark-and-sweep, writes the complete surviving index as bounded fragments,
+and deletes all the fragments it supersedes.
+
+A deletion that could drop entries -- dropping the index entirely, or the full rewrite
+above -- is guarded by a marker object, ``cache/chunkindex-invalid``, written before
+the first deletion and removed after the last one. While the marker is present,
+leftover fragments could be an incomplete index, so they are not merged; the index is
+rebuilt from the pack files on the next load instead. A consolidation needs no marker:
+the entries of the small fragments it deletes are already contained in the merged
+fragments it wrote before deleting them.
 
 If the entire ``index/`` namespace is lost or corrupt, the ChunkIndex can be rebuilt
 by scanning pack files directly; see :ref:`pack-recovery`.
@@ -236,8 +273,11 @@ by scanning pack files directly; see :ref:`pack-recovery`.
 Recovery Path
 -------------
 
-When ``borg check --repair`` detects a missing or incomplete ChunkIndex it rebuilds
-it by forward-scanning all pack files in ``packs/``.
+The ChunkIndex can always be reconstructed by forward-scanning all pack files in
+``packs/``. The archives phase of ``borg check --repair`` does that unconditionally
+(it has to work from the real packs, so it can find archives referencing chunks whose
+pack has gone missing), and the same rebuild is the fallback whenever the ``index/``
+fragments cannot be loaded completely (see :ref:`pack-index-namespace`).
 
 Each blob's unencrypted header supplies the ``OBJ_MAGIC`` (for re-sync after
 corruption), the ``chunk_id``, and the size fields needed to locate the next blob.
@@ -247,31 +287,25 @@ without decrypting any blob and without the repository key.
 
 .. _pack-repo-version:
 
-Repository Version and Feature Flags
---------------------------------------
+Repository Version
+------------------
 
-Repositories using pack files require repository version **4**. Clients that only
-accept version 3 refuse to open a version 4 repository with an unsupported-version
-error before any data is read.
+Repositories using pack files require repository version **4**, and the version is the
+only gate for the pack format.
 
-In addition, the repository ``config.feature_flags`` must include ``pack_files`` in
-the mandatory set for all access modes:
+``Repository.create()`` stores ``4`` as the ``config/version`` store object.
+``Repository.open()`` reads it back and, if it is not in
+``Repository.acceptable_repo_versions`` (currently ``(4,)``), closes the store again
+and raises ``InvalidRepositoryConfig`` -- before any repository data is read. A borg
+version that only accepts version 3 rejects a version 4 repository the same way, so
+the version bump alone locks out every client that does not know about packs.
 
-.. code-block:: python
-
-    config = {
-        "feature_flags": {
-            "read":  {"mandatory": ["pack_files"]},
-            "write": {"mandatory": ["pack_files"]},
-            "check": {"mandatory": ["pack_files"]},
-        }
-    }
-
-A client that does not recognise the ``pack_files`` feature flag will refuse to open
-the repository with a ``MandatoryFeatureUnsupported`` error regardless of the version
-number. The two guards cover different failure modes: the version bump stops clients
-that predate feature-flag support entirely; the feature flag gives a clearer error
-message to clients that understand feature flags but don't know about packs yet.
+Borg does have a feature flag mechanism for locking out clients more selectively
+(``Manifest.check_repository_compatibility()``, fed from a ``feature_flags`` entry in
+the manifest ``config`` -- see :ref:`manifest`), but it currently defines no flags at
+all: ``Manifest.SUPPORTED_REPO_FEATURES`` is the empty set, and no borg code writes a
+``feature_flags`` entry. On a repository borg creates, the compatibility check is
+therefore a no-op; there is in particular no ``pack_files`` feature flag.
 
 There is no migration path from version 3 repositories to version 4. Users of the
 version 3 beta format must create a new repository with ``borg repo-create``.

--- a/docs/internals/security.rst
+++ b/docs/internals/security.rst
@@ -165,20 +165,31 @@ Session::
     sessionkey = sha256(crypt_key + sessionid + domain)
     message_iv = 0
 
+A repository object has two separately encrypted slots, the object metadata and the
+object data, and both are stored behind one unencrypted object header (magic, format
+version, chunk id, slot sizes - see :ref:`pack-format`). The header prefix and the
+slot a ciphertext belongs to are bound into its authentication tag as well:
+
 Encryption::
 
     id = MAC(id_key, data)
     compressed = compress(data)
 
+    # the unencrypted repo object header prefix (41 bytes) this ciphertext is stored
+    # behind, and which of the object's two slots it goes into:
+    obj_header_aad = OBJ_MAGIC || obj_version || id
+    slot_tag = "M" for the object metadata slot, "D" for the object data slot
+
     header = type-byte || 00h || message_iv || sessionid
-    aad = id || header
+    aad = obj_header_aad || slot_tag || id || header
     message_iv++
     encrypted, auth_tag = AEAD_encrypt(session_key, message_iv, compressed, aad)
     authenticated = header || auth_tag || encrypted
 
 Decryption::
 
-    # Given: input *authenticated* data and a *chunk-id* to assert
+    # Given: input *authenticated* data, a *chunk-id* to assert, and the object header
+    # prefix / slot the ciphertext was read from
     type-byte, past_message_iv, past_sessionid, auth_tag, encrypted = SPLIT(authenticated)
 
     ASSERT(type-byte is correct)
@@ -186,7 +197,9 @@ Decryption::
     domain = "borg-session-key-CIPHERNAME"
     past_key = sha256(crypt_key + past_sessionid + domain)
 
-    decrypted = AEAD_decrypt(past_key, past_message_iv, authenticated)
+    header = type-byte || 00h || past_message_iv || past_sessionid
+    aad = obj_header_aad || slot_tag || id || header
+    decrypted = AEAD_decrypt(past_key, past_message_iv, authenticated, aad)
 
     decompressed = decompress(decrypted)
 
@@ -198,10 +211,14 @@ Notable:
 - The session key is also changed within a borg invocation if we encrypted a lot of data
   with it (AES-OCB only, see :ref:`aead_usage_limits`). Reading is not affected by this,
   because the session id is part of every message.
-- The id is now also input into the authentication tag computation.
+- The id is also input into the authentication tag computation.
   This strongly associates the id with the written data (== associates the key with
   the value). When later reading the data for some id, authentication will only
-  succeed if what we get was really written by us for that id.
+  succeed if what we get was really written by us for that id. Since repo object
+  format version 2, the object header prefix (magic, format version and the chunk id
+  the header declares) and the slot tag are authenticated along with it, so a
+  ciphertext can neither be presented under a forged object header nor be swapped
+  between the metadata and the data slot of an object, see :ref:`pack-format`.
 - Because of that, additionally verifying ``id == MAC(id_key, decompressed)`` after
   decryption is optional for these modes: it is not what protects against a malicious
   repository (the authentication tag does that), it only detects chunks whose content
@@ -285,7 +302,7 @@ For offline storage of the encryption keys they are encrypted with a
 user-chosen passphrase.
 
 A 256 bit key encryption key (KEK) is derived from the passphrase
-using argon2_ with a random 256 bit salt. The KEK is then used
+using argon2_ (argon2id, ``ARGON2_ARGS``) with a random 128 bit salt. The KEK is then used
 to Encrypt-*then*-MAC a packed representation of the keys using the
 chacha20-poly1305 AEAD cipher and a constant IV == 0.
 The ciphertext is then converted to base64.
@@ -344,66 +361,138 @@ on widely used libraries providing them:
 .. _hmac: https://docs.python.org/3/library/hmac.html
 .. _os.urandom: https://docs.python.org/3/library/os.html#os.urandom
 
-Remote RPC protocol security
-============================
+.. _remote_access_security:
+
+Remote repository access security
+=================================
 
 .. note:: This section could be further expanded / detailed.
 
-The RPC protocol is fundamentally based on msgpack'd messages exchanged
-over an encrypted SSH channel (the system's SSH client is used for this
-by piping data from/to it).
+Borg 2 has no repository protocol of its own. A repository is a borgstore object
+store (see :ref:`internals`), and borgstore owns the client/server transport. The
+same set of named objects is what a remote end gets to see, whatever transport is
+used:
 
-This means that the authorization and transport security properties
-are inherited from SSH and the configuration of the SSH client and the
-SSH server -- Borg RPC does not contain *any* networking
-code. Networking is done by the SSH client running in a separate
-process, Borg only communicates over the standard pipes (stdout,
-stderr and stdin) with this process. This also means that Borg doesn't
-have to use a SSH client directly (or SSH at all). For example,
-``sudo`` or ``qrexec`` could be used as an intermediary.
+- ``packs/<hex(pack_id)>`` -- the pack files holding the repository objects. Each
+  object's metadata slot and data slot are encrypted and authenticated with the borg
+  key (see :ref:`security_encryption`); its per-object header is unencrypted and
+  carries the magic, the format version and the chunk id (see :ref:`pack-format`).
+- ``index/<sha256>`` -- the chunk id to pack location index. It is not encrypted,
+  but it only contains chunk ids and locations, which the pack headers expose anyway.
+- ``archives/<hex(archive_id)>`` -- one empty object per archive. The archive name,
+  its timestamps, the item metadata and the chunk lists all live inside encrypted
+  repository objects, so the pointer object itself only reveals the archive id (a MAC
+  over the archive metadata) plus whatever the store records about it, e.g. its
+  modification time.
+- ``config/manifest`` (an encrypted repository object), plus the plaintext
+  ``config/version``, ``config/id`` and ``config/readme``.
+- ``keys/<sha256>`` -- in ``repokey`` mode, the borg key(s), encrypted with the
+  passphrase-derived KEK (see :ref:`key_encryption`).
+- ``locks/*`` and ``cache/*``. Note that the per-archive reference caches
+  ``cache/referenced-by-archive.<hex(archive_id)>``, written by ``borg compact`` and
+  ``borg analyze``, are *not* encrypted: they list the object ids and plaintext sizes
+  an archive references.
 
-By using the system's SSH client and not implementing a
-(cryptographic) network protocol Borg sidesteps many security issues
-that would normally impact distributing statically linked / standalone
-binaries.
+Authorization and transport security come from the transport, not from borg.
 
-The remainder of this section will focus on the security of the RPC
-protocol within Borg.
+Remote repositories over SSH: ``rest://``
+-----------------------------------------
 
-The assumed worst-case a server can inflict to a client is a
-denial of repository service.
+For a ``rest://`` repository, borg runs ``borg serve --rest --backend FILE:<path>``
+on the remote machine and speaks HTTP to it over that process' *stdin/stdout* -- not
+over a socket. If the URL contains a host, the process is started through the
+system's SSH client (honouring ``BORG_RSH`` / ``BORGSTORE_RSH`` for the ssh command
+and ``BORG_REMOTE_PATH`` for the remote borg), so:
 
-The situation where a server can create a general DoS on the client
-should be avoided, but might be possible by e.g. forcing the client to
-allocate large amounts of memory to decode large messages (or messages
-that merely indicate a large amount of data follows). The RPC protocol
-code uses a limited msgpack Unpacker to prohibit this.
+- Authorization, confidentiality and integrity of the channel are entirely SSH's and
+  are determined by the SSH client and server configuration. Borg contains no
+  networking code on this path -- it only talks to a subprocess over pipes. That also
+  means borg does not have to use an SSH client (or SSH at all); ``sudo`` or
+  ``qrexec`` could be used as an intermediary.
+- The stdio REST server binds no port and does no authentication of its own: the
+  client has already authenticated to sshd, and sshd is what starts the server, as
+  that user.
 
-We believe that other kinds of attacks, especially critical vulnerabilities
-like remote code execution are inhibited by the design of the protocol:
+By using the system's SSH client instead of implementing a cryptographic network
+protocol, borg sidesteps many security issues that would otherwise impact
+distributing statically linked / standalone binaries.
 
-1. The server cannot send requests to the client on its own accord,
-   it only can send responses. This avoids "unexpected inversion of control"
-   issues.
-2. msgpack serialization does not allow embedding or referencing code that
-   is automatically executed. Incoming messages are unpacked by the msgpack
-   unpacker into native Python data structures (like tuples and dictionaries),
-   which are then passed to the rest of the program.
+Server-side restrictions are available and, being server-side, they also hold against
+a malicious client:
+
+- ``--restrict-to-path`` / ``--restrict-to-repository`` are checked against the
+  requested ``FILE:`` path before anything is served.
+- ``--permissions`` (or ``BORG_REPO_PERMISSIONS``) selects one of ``all``,
+  ``no-delete``, ``write-only`` or ``read-only``, which map to per-namespace
+  list/read/write/overwrite/delete permissions enforced by the borgstore backend.
+
+Other transports
+----------------
+
+The remaining transports are implemented inside the borg process by borgstore and
+its dependencies, so their security properties are those of the respective library:
+
+- ``sftp://`` speaks SFTP in-process via paramiko. Host keys are taken from the
+  user's ``known_hosts`` file and no missing-host-key policy is installed, so an
+  unknown host is rejected -- make the first connection with the ``ssh`` or ``sftp``
+  command line tool and verify the fingerprint there.
+- ``s3:``/``b2:`` use boto3, i.e. in-process HTTPS to the (S3-compatible) endpoint,
+  authenticated with the credentials from the URL, a named profile, or the usual
+  boto3 environment/configuration.
+- ``rclone:`` starts an ``rclone rcd`` process listening on ``127.0.0.1`` on a random
+  port with a random user/password and drives it over its rc API. Remote credentials
+  and transport security are rclone's.
+- ``http(s)://`` talks to a borgstore REST server over plain HTTP, authenticating
+  with HTTP Basic auth taken from the URL or from ``BORGSTORE_REST_USERNAME`` /
+  ``BORGSTORE_REST_PASSWORD``. Basic auth sends the credentials to the server on
+  every request, so use ``https`` if you use this at all. ``rest://`` over SSH needs
+  no such credentials.
+
+In every case the repository never receives the borg key or the passphrase, so a
+compromised or malicious repository server cannot read the backed up data. What it
+can do is deny service and return wrong or missing objects; the latter is detected
+client-side, see :ref:`attack_model` and :ref:`security_structural_auth`.
+
+Legacy borg 1.x RPC protocol
+----------------------------
+
+``borg serve`` *without* ``--rest`` still speaks the borg 1.x RPC protocol:
+msgpack'd messages exchanged over stdio (``borg.legacy.remote``). It exists only so
+that borg 2 can *read* a borg 1.x repository through an ``ssh://`` URL, e.g. for
+``borg transfer --from-borg1``; ``ssh://`` is rejected for current repositories, and
+this protocol cannot serve one. Its transport is the system's SSH client, so the same
+"authorization and transport security are SSH's" reasoning as for ``rest://``
+applies.
+
+Within that protocol, critical vulnerabilities such as remote code execution are
+inhibited by its design:
+
+1. The server cannot send requests to the client on its own accord, it only sends
+   log records and responses. This avoids "unexpected inversion of control" issues.
+2. msgpack serialization does not allow embedding or referencing code that is
+   automatically executed. Incoming messages are unpacked by the msgpack unpacker
+   into native Python data structures (like tuples and dictionaries), which are then
+   passed to the rest of the program.
 
    Additional verification of the correct form of the responses could be implemented.
-3. Remote errors are presented in two forms:
+3. Remote errors and log output reach the client in two forms:
 
-   1. A simple plain-text *stderr* channel. A prefix string indicates the kind of message
-      (e.g. WARNING, INFO, ERROR), which is used to suppress it according to the
-      log level selected in the client.
-
-      A server can send arbitrary log messages, which may confuse a user. However,
-      log messages are only processed when server requests are in progress, therefore
-      the server cannot interfere / confuse with security critical dialogue like
-      the password prompt.
+   1. Log records sent as msgpack messages on the main data channel and re-emitted
+      through the client's logging, using the logger name and level the server
+      supplied. A server can therefore send arbitrary log messages, which may confuse
+      a user. However, the client only reads from the connection while a request is in
+      progress, so the server cannot interfere with security critical dialogue like
+      the passphrase prompt. Anything the server (or the ssh process) writes to
+      *stderr* is logged verbatim as a client-side warning.
    2. Server-side exceptions passed over the main data channel. These follow the
       general pattern of server-sent responses and are sent instead of response data
       for a request.
+
+Note that the msgpack unpackers of the RPC data channel (``get_limited_unpacker()``
+kinds ``client`` and ``server``) are deliberately configured with the maximum buffer
+size, because whole repository objects are transferred through them. They therefore
+do not bound the memory a peer can make the other side allocate; the stricter limits
+of that helper apply to manifest, archive and key data.
 
 The msgpack implementation used (msgpack-python) has a good security track record,
 a large test suite and no issues found by fuzzing. It is based on the msgpack-c implementation,
@@ -411,7 +500,7 @@ sharing the unpacking engine and some support code. msgpack-c has a good track r
 Some issues [#]_ in the past were located in code not included in msgpack-python.
 Borg does not use msgpack-c.
 
-.. [#] - `MessagePack fuzzing <https://blog.gypsyengineer.com/fun/msgpack-fuzzing.html>`_
+.. [#] - `MessagePack fuzzing <https://web.archive.org/web/20171004004418/https://blog.gypsyengineer.com/fun/msgpack-fuzzing.html>`_
        - `Fixed integer overflow and EXT size problem <https://github.com/msgpack/msgpack-c/pull/547>`_
        - `Fixed array and map size overflow <https://github.com/msgpack/msgpack-c/pull/550>`_
 
@@ -427,9 +516,13 @@ however, it is important to note that Borg links against ``libcrypto`` **not** `
 libcrypto is the low-level cryptography part of OpenSSL,
 while libssl implements TLS and related protocols.
 
-The latter is not used by Borg (cf. `Remote RPC protocol security`_, Borg itself does not implement
-any network access) and historically contained most vulnerabilities, especially critical ones.
-The static binaries released by the project contain neither libssl nor the Python ssl/_ssl modules.
+The latter historically contained most vulnerabilities, especially critical ones, and Borg's own
+extension modules do not use it: they link ``libcrypto`` only. Note that libssl can still be
+reached through Python's ``ssl`` module by the transports that do networking inside the borg
+process, i.e. ``s3:``/``b2:`` and ``http(s)://`` (see :ref:`remote_access_security`); ``rest://``
+and the legacy ``ssh://`` protocol do not need it, as they only talk to a subprocess over pipes.
+Accordingly, the binaries released by the project do include Python's ``ssl``/``_ssl`` modules
+(they are needed by pyfuse3/trio as well).
 
 Compression and Encryption
 ==========================
@@ -534,7 +627,7 @@ fingerprinting is not useful for an attacker.
 
 But, when new files are close to each other (when looking at recursion /
 scanning order), the resulting chunks will be also stored close to each other
-in the resulting repository segment file(s).
+in the resulting repository pack file(s), see :ref:`packs`.
 
 This might leak additional information for the chunk size fingerprinting
 attack (see above).


### PR DESCRIPTION
Every rewritten claim is grounded in specific code (details in the commit message); the highlights:

**packs.rst**
- The documented `pack_files` mandatory feature flag does not exist — replaced with the actual version-4 gate, noting the (flag-less) manifest feature-flag mechanism truthfully.
- The write-order section keeps the original (intended) ordering description — pack files, index, then the archive pointer; the implementation currently writes the session's final index fragment after the commit point instead, which is tracked as #10239 (a TODO comment in the section links it).
- The "intended direction" TODO about bounding initial-backup fragments is already implemented (`CHUNKINDEX_FRAGMENT_ENTRIES_MAX`); compact's fragment sizing is entry-count based (100k–400k entries), not "10–100 packs per file".
- `repo-compress` and `debug delete-obj` also delete/rewrite packs; blob sketches now say object format 0x02.
- The claim that the chunk id is also in the encrypted metadata is wrong — `RepoObj.format()` writes only type/compression bookkeeping; the plaintext header's id copy is kept honest by the AAD binding. Also: index fragments are **not** encrypted, and the index loads lazily.

**security.rst**
- argon2 salt: 128 bits (argon2id), not 256.
- The borg1 "Remote RPC protocol security" section replaced with a description of the current transports: rest:// as HTTP over ssh-tunneled stdio (no own auth in stdio mode; server-side `--restrict-to-*`/`--permissions` enforcement), sftp/s3/rclone/https backends and their auth models, and what the server sees. A corrected legacy-RPC subsection remains for `borg transfer --from-borg1` (fixed the stderr/log-channel description and the no-longer-true msgpack `max_buffer_size` claim).
- AEAD pseudocode now shows the v2 AAD binding (object header + M/D slot tag + id); segments → packs; stale OpenSSL/static-binary claim fixed; dead msgpack-fuzzing link → archive.org snapshot (content-verified).

Sphinx: `-W -n` nitpicky build passes with zero warnings (same as pristine baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
