### PR TITLE
docs: update the liblz4 link to the project's current location

### DIFF
--- a/docs/global.rst.inc
+++ b/docs/global.rst.inc
@@ -14,7 +14,7 @@
 .. _ACL: https://en.wikipedia.org/wiki/Access_control_list
 .. _libacl: https://savannah.nongnu.org/projects/acl/
 .. _libattr: https://savannah.nongnu.org/projects/attr/
-.. _liblz4: https://github.com/Cyan4973/lz4
+.. _liblz4: https://github.com/lz4/lz4
 .. _libzstd: https://github.com/facebook/zstd
 .. _OpenSSL: https://www.openssl.org/
 .. _`Python 3`: https://www.python.org/


### PR DESCRIPTION
`github.com/Cyan4973/lz4` is a permanent redirect (301) to `github.com/lz4/lz4` (200, verified) — point the `liblz4` link target in `docs/global.rst.inc` at the current location directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)