### PR TITLE
RepoKeyNotFoundError: update error message to borg2 reality

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -793,7 +793,7 @@ Errors
     NotABorgKeyFile rc: 43 traceback: no
         This file is not a Borg key backup, aborting.
     RepoKeyNotFoundError rc: 44 traceback: no
-        No key entry found in the config of repository {}.
+        No key found in repository {}.
     RepoIdMismatch rc: 45 traceback: no
         This key backup seems to be for a different backup repository, aborting.
     UnencryptedRepo rc: 46 traceback: no

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -152,7 +152,7 @@ class KeyfileMismatchError(Error):
 
 
 class RepoKeyNotFoundError(Error):
-    """No key entry found in the config of repository {}."""
+    """No key found in repository {}."""
 
     exit_mcode = 44
 


### PR DESCRIPTION
The `RepoKeyNotFoundError` message still used borg 1.x wording: "No key entry found in the config of repository {}." — borg2 has no repository config file; repokeys are store objects in the `keys/` directory of the repository.

Changed the message to "No key found in repository {}." and updated the quoted message in the `docs/internals/frontends.rst` error list to match (verified against `scripts/errorlist.py` output). `exit_mcode` 44 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)