### PR TITLE
log-json: emit question_* JSON objects for prompts again

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -178,7 +178,7 @@ log_message
     :ref:`msgid <msgid>`
         Message ID, may be *null* or absent
 
-See Prompts_ for how borg asks questions.
+See Prompts_ for the types used by prompts.
 
 .. rubric:: Examples (reformatted, each object would be on exactly one line)
 .. highlight:: json
@@ -228,15 +228,54 @@ Prompts
 -------
 
 Borg asks a few yes/no questions interactively; the "Prompts" list at the end of `Message IDs`_
-enumerates them. Borg writes them directly to *stderr* as plain text and reads the answer
-verbatim from *stdin*. Prompts do not go through the logger, so they stay plain text even with
-``--log-json``.
+enumerates them. Answers are read verbatim from *stdin*. The questions and the messages about
+their processing are written to *stderr*: as plain text by default, or as JSON objects (one per
+line, like log messages) when ``--log-json`` is given.
 
-A frontend should therefore not try to answer these prompts interactively. Every prompt has an
+Prompts use the *question_prompt* and *question_prompt_retry* types for the prompt itself,
+and *question_invalid_answer*, *question_accepted_default*, *question_accepted_true*,
+*question_accepted_false* and *question_env_answer* types for information about
+prompt processing.
+
+The *message* property contains the same string displayed regularly in the same situation,
+while the *msgid* property contains a msgid_, the name of the environment variable that can
+be used to override the prompt. It is the same for all JSON messages pertaining to the same
+prompt. *question_env_answer* messages additionally have an *env_var* property with the name
+of the environment variable the answer was taken from.
+
+A frontend should not try to answer these prompts interactively. Every prompt has an
 environment variable that overrides it (the variable name is the prompt's msgid_): if it is set,
 its value is used as if it had been typed in, and borg never waits for input. For example, with
 ``BORG_CHECK_I_KNOW_WHAT_I_AM_DOING=NO`` in the environment, ``borg check --repair`` prints the
 question, answers it with *NO* and fails with the *CancelledByUser* msgid_ (rc 3).
+
+.. rubric:: Examples (reformatted, each object would be on exactly one line)
+.. highlight:: none
+
+Providing an invalid answer::
+
+    {"type": "question_prompt", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "This is a potentially dangerous function.\n... Type 'YES' if you understand this and want to continue: "}
+    incorrect answer  # input on stdin
+    {"type": "question_invalid_answer", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "Invalid answer, aborting."}
+
+Providing a false (negative) answer via the environment variable::
+
+    {"type": "question_prompt", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "This is a potentially dangerous function.\n... Type 'YES' if you understand this and want to continue: "}
+    {"env_var": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING", "type": "question_env_answer",
+     "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "NO (from BORG_CHECK_I_KNOW_WHAT_I_AM_DOING)"}
+    {"type": "question_accepted_false", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "Aborting."}
+
+Providing a true (affirmative) answer::
+
+    {"type": "question_prompt", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING",
+     "message": "This is a potentially dangerous function.\n... Type 'YES' if you understand this and want to continue: "}
+    YES  # input on stdin
+    # no further output, just like the prompt without --log-json
 
 Passphrase prompts
 ------------------

--- a/src/borg/logger.py
+++ b/src/borg/logger.py
@@ -177,6 +177,9 @@ def setup_logging(
                 logging.config.fileConfig(f)
             configured = True
             logger = logging.getLogger(__name__)
+            # the yes() prompt function reads this attribute to decide whether to emit
+            # question_* JSON objects or plain text, see helpers/yes_no.py.
+            logging.getLogger("borg").json = log_json
             logger.debug(f'using logging configuration read from "{conf_fname}"')
             warnings.showwarning = _log_warning
             return None
@@ -193,6 +196,10 @@ def setup_logging(
     logger = logging.getLogger()
     remove_handlers(logger)
     logger.setLevel(level)
+
+    # the yes() prompt function reads this attribute to decide whether to emit
+    # question_* JSON objects or plain text, see helpers/yes_no.py.
+    logging.getLogger("borg").json = log_json
 
     if logging_debugging_path is not None:
         # add an addtl. root handler for debugging purposes

--- a/src/borg/testsuite/helpers/yes_no_test.py
+++ b/src/borg/testsuite/helpers/yes_no_test.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import signal
 
 import pytest
@@ -132,3 +134,45 @@ def test_yes_env_output(capfd, monkeypatch):
     assert out == ""
     assert env_var in err
     assert "yes" in err
+
+
+def test_yes_json_output(capfd, monkeypatch):
+    # with --log-json, setup_logging() sets the "json" attribute on the "borg" logger
+    # and yes() then emits question_* JSON objects on stderr instead of plain text.
+    monkeypatch.setattr(logging.getLogger("borg"), "json", True, raising=False)
+    fake_input = FakeInputs(["invalid", "y"])
+    assert yes(
+        msg="intro-msg",
+        true_msg="true-msg",
+        false_msg="false-msg",
+        invalid_msg="invalid-msg",
+        retry_msg="retry-msg",
+        input=fake_input,
+        msgid="TEST_MSGID",
+    )
+    out, err = capfd.readouterr()
+    assert out == ""
+    objects = [json.loads(line) for line in err.splitlines()]
+    assert [o["type"] for o in objects] == [
+        "question_prompt",
+        "question_invalid_answer",
+        "question_prompt_retry",
+        "question_accepted_true",
+    ]
+    assert [o["message"] for o in objects] == ["intro-msg", "invalid-msg", "retry-msg", "true-msg"]
+    for o in objects:
+        assert o["msgid"] == "TEST_MSGID"
+
+
+def test_yes_env_json_output(capfd, monkeypatch):
+    monkeypatch.setattr(logging.getLogger("borg"), "json", True, raising=False)
+    env_var = "OVERRIDE_SOMETHING"
+    monkeypatch.setenv(env_var, "yes")
+    assert yes(env_var_override=env_var)
+    out, err = capfd.readouterr()
+    assert out == ""
+    (o,) = [json.loads(line) for line in err.splitlines()]
+    assert o["type"] == "question_env_answer"
+    assert o["msgid"] == env_var  # msgid defaults to env_var_override
+    assert o["env_var"] == env_var
+    assert o["message"] == f"yes (from {env_var})"

--- a/src/borg/testsuite/logger_test.py
+++ b/src/borg/testsuite/logger_test.py
@@ -38,6 +38,17 @@ def test_multiple_loggers(io_logger):
     assert io_logger.getvalue() == "borg.testsuite.logger_test: hello world 2\n"
 
 
+def test_setup_logging_json_attribute():
+    # the yes() prompt function decides between plain text and JSON output ("question_*"
+    # objects) by looking at the "json" attribute of the "borg" logger, so setup_logging()
+    # must set it according to log_json (i.e. whether --log-json was given).
+    # test True before False, so the logging configuration left behind matches
+    # what the other tests in this module leave behind.
+    for log_json in (True, False):
+        setup_logging(stream=StringIO(), env_var=None, log_json=log_json)
+        assert logging.getLogger("borg").json is log_json
+
+
 def test_parent_module():
     assert find_parent_module() == __name__
 


### PR DESCRIPTION
### Problem

With `--log-json`, interactive yes/no prompts were printed as plain text on stderr instead of the `question_prompt` / `question_prompt_retry` / `question_invalid_answer` / `question_accepted_*` / `question_env_answer` JSON objects documented in `docs/internals/frontends.rst` ("Prompts" section).

Root cause: `yes()` in `helpers/yes_no.py` decides between JSON and plain text via

```python
json_output = getattr(logging.getLogger("borg"), "json", False)
```

but nothing in borg2 ever set that attribute. In 1.4-maint, `setup_logging()` does `borg_logger.json = json`; the borg2 logging rework (c3a456887) dropped that assignment, making the JSON branch unreachable.

### Fix

- `logger.py`: restore the attribute assignment in `setup_logging()`, in both the fileConfig branch and the fallback stream-handler branch (as in 1.4-maint).
- Tests (there was no JSON coverage of `yes()` before):
  - `yes_no_test.py::test_yes_json_output` checks the exact `type` / `message` / `msgid` of each object over a prompt → invalid answer → retry → accepted-true sequence; `test_yes_env_json_output` covers `question_env_answer` incl. its `env_var` key.
  - `logger_test.py::test_setup_logging_json_attribute` checks that `setup_logging(log_json=...)` sets the attribute.
- `docs/internals/frontends.rst`: rewrite the "Prompts" section. #10224 had just changed it to describe the (then actual) plain-text-only behavior; now that the JSON branch works again, document the `question_*` types again: the `message`/`msgid` properties, the `env_var` property of `question_env_answer` (previously undocumented), and examples matching real output — the old examples showed an `"is_prompt"` key that the code never emitted (also not in 1.4). Upstream's new guidance that frontends should answer prompts via the override environment variables instead of interactively (with the `CancelledByUser` example) is kept.

### Verification

Full test suite passes (2852 passed, 957 environment-related skips, macOS). End-to-end, `borg --log-json check --repair` now emits e.g.:

```
{"type": "question_prompt", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING", "message": "This is a potentially dangerous function.\n... Type 'YES' if you understand this and want to continue: "}
{"type": "question_invalid_answer", "msgid": "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING", "message": "Invalid answer, aborting."}
```

Plain-text output without `--log-json` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)