### PR TITLE
diff: fix --numeric-ids having no effect

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -1193,13 +1193,14 @@ Duration: {0.duration}
 
     @staticmethod
     def compare_archives_iter(
-        archive1: "Archive", archive2: "Archive", matcher=None, can_compare_chunk_ids=False
+        archive1: "Archive", archive2: "Archive", matcher=None, can_compare_chunk_ids=False, numeric_ids=False
     ) -> Iterator[ItemDiff]:
         """
         Yields an ItemDiff instance describing changes/indicating equality.
 
         :param matcher: PatternMatcher class to restrict results to only matching paths.
         :param can_compare_chunk_ids: Whether --chunker-params are the same for both archives.
+        :param numeric_ids: Whether to compare/report numeric uid/gid instead of user/group names.
         """
 
         def compare_items(path: str, item1: Item, item2: Item):
@@ -1209,6 +1210,7 @@ Duration: {0.duration}
                 item2,
                 archive1.pipeline.fetch_many(item1.get("chunks", []), ro_type=ROBJ_FILE_STREAM),
                 archive2.pipeline.fetch_many(item2.get("chunks", []), ro_type=ROBJ_FILE_STREAM),
+                numeric_ids=numeric_ids,
                 can_compare_chunk_ids=can_compare_chunk_ids,
             )
 

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -107,7 +107,7 @@ class DiffMixIn:
         matcher = build_matcher(args.patterns, args.paths)
 
         diffs_iter = Archive.compare_archives_iter(
-            archive1, archive2, matcher, can_compare_chunk_ids=can_compare_chunk_ids
+            archive1, archive2, matcher, can_compare_chunk_ids=can_compare_chunk_ids, numeric_ids=args.numeric_ids
         )
         # Filter out equal items early (keep as generator; listify only if sorting)
         diffs = (diff for diff in diffs_iter if not diff.equal(args.content_only))

--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -6,7 +6,12 @@ import stat
 import time
 import pytest
 
+from ...archive import Archive
+from ...cache import Cache
 from ...constants import *  # NOQA
+from ...item import Item
+from ...manifest import Manifest
+from ...repository import Repository
 from .. import are_symlinks_supported, are_hardlinks_supported, granularity_sleep
 from ...platformflags import is_win32, is_freebsd, is_netbsd, is_openbsd
 from . import (
@@ -261,6 +266,62 @@ def test_basic_functionality(archivers, request):
 
     output = cmd(archiver, "diff", "test0", "test1a", "--json-lines", "--content-only")
     do_json_asserts(output, True, content_only=True)
+
+
+def _create_archive_with_items(archiver, name, items):
+    # Inject raw Items directly into an archive, bypassing "borg create", so the owner
+    # metadata (uid/gid/user/group) can be controlled exactly (without needing root).
+    repository = Repository(archiver.repository_path, exclusive=True)
+    with repository:
+        manifest = Manifest.load(repository, Manifest.NO_OPERATION_CHECK)
+        with Cache(repository, manifest, archive_name=name) as cache:
+            archive = Archive(manifest, name, cache=cache, create=True)
+            for item in items:
+                archive.items_buffer.add(item)
+            archive.save(name=name)
+
+
+def test_numeric_ids(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    if archiver.get_kind() != "local":
+        pytest.skip("archives with crafted owner metadata need direct (local) repository access")
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+
+    def item(path, uid, gid, user, group):
+        return Item(
+            path=path, mode=stat.S_IFREG | 0o644, mtime=0, ctime=0, uid=uid, gid=gid, user=user, group=group, chunks=[]
+        )
+
+    _create_archive_with_items(
+        archiver,
+        "a1",
+        [item("names_changed", 1000, 1000, "alice", "alice"), item("ids_changed", 1000, 1000, "alice", "alice")],
+    )
+    _create_archive_with_items(
+        archiver,
+        "a2",
+        [
+            item("names_changed", 1000, 1000, "bob", "bob"),  # same uid/gid, different names
+            item("ids_changed", 2000, 2000, "alice", "alice"),  # different uid/gid, same names
+        ],
+    )
+
+    def changes_by_path(output):
+        return {j["path"]: j["changes"] for j in (json.loads(line) for line in output.splitlines() if line)}
+
+    # without --numeric-ids, the user/group names are compared and reported
+    changes = changes_by_path(cmd(archiver, "diff", "a1", "a2", "--json-lines"))
+    assert {"type": "changed owner", "item1": ["alice", "alice"], "item2": ["bob", "bob"]} in changes["names_changed"]
+    assert {"type": "changed user", "item1": "alice", "item2": "bob"} in changes["names_changed"]
+    assert {"type": "changed group", "item1": "alice", "item2": "bob"} in changes["names_changed"]
+    assert "ids_changed" not in changes  # names unchanged, so the item counts as equal
+
+    # with --numeric-ids, the numeric uid/gid are compared and reported instead
+    changes = changes_by_path(cmd(archiver, "diff", "a1", "a2", "--json-lines", "--numeric-ids"))
+    assert {"type": "changed owner", "item1": [1000, 1000], "item2": [2000, 2000]} in changes["ids_changed"]
+    assert {"type": "changed user", "item1": 1000, "item2": 2000} in changes["ids_changed"]
+    assert {"type": "changed group", "item1": 1000, "item2": 2000} in changes["ids_changed"]
+    assert "names_changed" not in changes  # uid/gid unchanged, so the item counts as equal
 
 
 def test_time_diffs(archivers, request):


### PR DESCRIPTION
## Problem

`borg diff --numeric-ids` had no effect: the option was parsed (`dest="numeric_ids"`), but `args.numeric_ids` was never used. `Archive.compare_archives_iter()` built each `ItemDiff` without passing `numeric_ids`, so `ItemDiff` always used its default (`False`), always comparing and reporting the user/group *names*, never uid/gid.

Verified at runtime before the fix: `borg diff --json-lines --numeric-ids A B` produced byte-identical output to the run without the flag.

## Fix

Thread `numeric_ids` from the CLI through `compare_archives_iter()` into `ItemDiff` (which already implemented both behaviors — the flag just never reached it).

## Tests

New `test_numeric_ids` in `diff_cmd_test.py`. Since a non-root test can't produce owner differences via `borg create`, it injects raw `Item`s with crafted owner metadata directly into two archives (same technique as `_create_malicious_archive` in `extract_cmd_test.py`; local-kind only). It covers both directions:

- same uid/gid, different user/group names: reported (with names) without the flag, treated as equal with `--numeric-ids`
- different uid/gid, same names: invisible without the flag; with `--numeric-ids` the `changed owner`/`changed user`/`changed group` JSON entries carry the integer ids

The test fails on master without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)