### PR TITLE
docs: remove stale borg1 checkpoint reference from borg create help

### DIFF
--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -963,8 +963,7 @@ class CreateMixIn:
         a non-zero exit code (usually 1 for warnings).
 
         **The archive is still saved even if warnings or errors occurred**, but it will
-        only contain the data borg was able to read successfully. It is like a
-        checkpoint (see below), but with a user-given name.
+        only contain the data borg was able to read successfully.
 
         You should always check the backup logs and the exit code of the borg command.
 


### PR DESCRIPTION
The `borg create` help epilog said an archive saved after warnings/errors "is like a checkpoint (see below), but with a user-given name".

That sentence is a borg 1.x leftover:

- borg2 has no checkpoint archives at all.
- The "(see below)" was a dangling cross-reference — there is no checkpoint section anywhere below it in the epilog.

Remove the sentence; the remaining text accurately describes current behavior (the archive is still saved, containing the data borg could read successfully).

`docs/usage/create.rst` is generated from this epilog and will pick up the fix at the next `build_usage` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)