### PR TITLE
delete/undelete: also accept date-based filters as archive selection

### DIFF
--- a/src/borg/archiver/delete_cmd.py
+++ b/src/borg/archiver/delete_cmd.py
@@ -26,8 +26,12 @@ class DeleteMixIn:
         count = len(archive_infos)
         if count == 0:
             return
-        # --first / --last are PositiveInt and default to None, thus a falsy value means "not given".
-        if not args.name and not args.match_archives and not args.first and not args.last:
+        # any explicitly given archive filter counts as a deliberate selection;
+        # all these args are falsy when not given (--first / --last are PositiveInt, defaulting to None).
+        any_filters_given = any(
+            (args.name, args.match_archives, args.first, args.last, args.oldest, args.newest, args.older, args.newer)
+        )
+        if not any_filters_given:
             raise CommandError(
                 "Aborting: if you really want to delete all archives, please use -a 'sh:*' "
                 "or just delete the whole repository (might be much faster)."

--- a/src/borg/archiver/undelete_cmd.py
+++ b/src/borg/archiver/undelete_cmd.py
@@ -26,8 +26,12 @@ class UnDeleteMixIn:
         count = len(archive_infos)
         if count == 0:
             return
-        # --first / --last are PositiveInt and default to None, thus a falsy value means "not given".
-        if not args.name and not args.match_archives and not args.first and not args.last:
+        # any explicitly given archive filter counts as a deliberate selection;
+        # all these args are falsy when not given (--first / --last are PositiveInt, defaulting to None).
+        any_filters_given = any(
+            (args.name, args.match_archives, args.first, args.last, args.oldest, args.newest, args.older, args.newer)
+        )
+        if not any_filters_given:
             raise CommandError("Aborting: if you really want to undelete all archives, please use -a 'sh:*'.")
 
         undeleted = False

--- a/src/borg/testsuite/archiver/delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/delete_cmd_test.py
@@ -26,6 +26,17 @@ def test_delete_options(archivers, request):
     assert output == ""  # no archives left!
 
 
+def test_delete_date_filters_are_a_selection(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test1", "input")
+    cmd(archiver, "create", "test2", "input")
+    # a date-based filter is an explicit archive selection, so the delete-all guard must not trigger
+    output = cmd(archiver, "delete", "--dry-run", "--list", "--newest", "1d")
+    assert "Would delete" in output
+
+
 def test_delete_multiple(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file1", size=1024 * 80)

--- a/src/borg/testsuite/archiver/undelete_cmd_test.py
+++ b/src/borg/testsuite/archiver/undelete_cmd_test.py
@@ -24,6 +24,19 @@ def test_undelete_single(archivers, request):
     cmd(archiver, "check")
 
 
+def test_undelete_date_filters_are_a_selection(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "deleted1", "input")
+    cmd(archiver, "create", "deleted2", "input")
+    cmd(archiver, "delete", "deleted1")
+    cmd(archiver, "delete", "deleted2")
+    # a date-based filter is an explicit archive selection, so the undelete-all guard must not trigger
+    output = cmd(archiver, "undelete", "--dry-run", "--list", "--newest", "1d")
+    assert "Would undelete" in output
+
+
 def test_undelete_multiple_dryrun(archivers, request):
     archiver = request.getfixturevalue(archivers)
     create_regular_file(archiver.input_path, "file1", size=1024 * 80)


### PR DESCRIPTION
Follow-up to 81a96f3ff (the fix for the dead "delete/undelete ALL archives" safety guard), rebased onto current master.

## The problem

The guard now aborts when no NAME, `-a` / `--match-archives`, `--first` or `--last` was given. But both commands also accept the date-based archive filters `--oldest` / `--newest` / `--older` / `--newer` (via `define_archive_filters_group()`, and `list_considering()` applies them), so e.g. `borg delete --newest 7d` is a deliberate subset selection — yet the guard aborts it and advises `-a 'sh:*'`, which selects *more* archives than the user asked for.

## The change

Count any explicitly given archive filter as deliberate selection and only abort a truly bare invocation:

```python
any_filters_given = any(
    (args.name, args.match_archives, args.first, args.last, args.oldest, args.newest, args.older, args.newer)
)
if not any_filters_given:
    raise CommandError("Aborting: ...")
```

This is exact: all of these args are falsy when not given (`--first`/`--last` are `PositiveInt`, so 0 is rejected at parse time).

## Tests

The existing guard tests from 81a96f3ff continue to pass unchanged against the extended guard. Added `test_delete_date_filters_are_a_selection` / `test_undelete_date_filters_are_a_selection`: a `--dry-run --list --newest 1d` invocation must not trigger the guard and lists the matching archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)