### PR TITLE
authenticated_no_key: also work when the borg key is completely lost

### DIFF
--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -913,13 +913,12 @@ class HelpMixIn:
                     in WSL1 (Windows Subsystem for Linux 1).
 
                 authenticated_no_key
-                    Work around a lost passphrase for an ``authenticated-*`` mode repository
-                    (these are only authenticated, but not encrypted).
-                    Borg still has to find the repository's borg key - an object below ``keys/``
-                    in the repository (repokey) resp. a key file in the keys directory (keyfile) -
-                    but it does not unlock it any more, so the passphrase does not matter. If the
-                    borg key itself is gone, this workaround does not help: borg then fails with
-                    "No key entry found ...".
+                    Work around a lost passphrase or a lost borg key for an ``authenticated-*``
+                    mode repository (these are only authenticated, but not encrypted).
+                    If a borg key is found - an object below ``keys/`` in the repository (repokey)
+                    resp. a key file in the keys directory (keyfile) - it is not unlocked, so the
+                    passphrase does not matter. If no borg key is found at all, borg proceeds
+                    anyway, without any key material.
 
                     Without the key, borg can not verify anything that needs it: neither the
                     authentication tag of the repository objects nor the chunk ids. It therefore

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -1200,15 +1200,35 @@ class AuthenticatedKeyBase(MACKeyBase, FlexiKey):
             self._tag_key = self.derive_key(salt=b"", domain=self.MAC_KEY_DOMAIN, size=32)
         return self._tag_key
 
+    def _set_fake_key_material(self):
+        # fake key material for the authenticated_no_key workaround: all-zero and thus worthless,
+        # but these modes do not encrypt, so reading still works - decrypt() skips the tag
+        # verification and RepoObj.parse skips the chunk id check.
+        self.repository_id = bytes(32)
+        self.crypt_key = bytes(64)
+        self.id_key = bytes(32)
+        self.chunk_seed = 0
+
+    @classmethod
+    def detect(cls, repository, manifest_data, *, other=False):
+        try:
+            return super().detect(repository, manifest_data, other=other)
+        except RepoKeyNotFoundError:
+            if not AUTHENTICATED_NO_KEY:
+                raise
+            # the borg key is not just locked by an unknown passphrase, it is completely gone
+            # (no repokey object, no keyfile). The workaround covers that too: proceed with
+            # fake key material, see _set_fake_key_material.
+            key = cls(repository)
+            key._set_fake_key_material()
+            key.init_ciphers(manifest_data)
+            key._passphrase = Passphrase()
+            return key
+
     def _load(self, key_data, passphrase):
         if AUTHENTICATED_NO_KEY:
-            # fake _load if we have no key or passphrase. The key material is all-zero and thus
-            # worthless, but these modes do not encrypt, so reading still works - decrypt() skips
-            # the tag verification and RepoObj.parse skips the chunk id check.
-            self.repository_id = bytes(32)
-            self.crypt_key = bytes(64)
-            self.id_key = bytes(32)
-            self.chunk_seed = 0
+            # fake _load if we have no key or passphrase, see _set_fake_key_material.
+            self._set_fake_key_material()
             return True
         return super()._load(key_data, passphrase)
 

--- a/src/borg/legacy/crypto/key.py
+++ b/src/borg/legacy/crypto/key.py
@@ -5,8 +5,9 @@ from hashlib import pbkdf2_hmac, sha256
 from ...constants import *  # NOQA
 from ...crypto.low_level import AES256_CTR_HMAC_SHA256, AES256_CTR_BLAKE2b, hmac_sha256, blake2b_256
 from ...crypto.key import ID_HMAC_SHA_256, KeyBase, AESKeyBase, FlexiKey, UnsupportedKeyFormatError
-from ...crypto.key import AUTHENTICATED_NO_KEY
+from ...crypto.key import AUTHENTICATED_NO_KEY, RepoKeyNotFoundError
 from ...helpers import get_limited_unpacker, msgpack
+from ...helpers.passphrase import Passphrase
 from ...item import EncryptedKey
 from .low_level import AES
 
@@ -140,15 +141,37 @@ class AuthenticatedKeyBase(AESKeyBase, FlexiKey):
     logically_encrypted = False
     encrypts = False
 
+    def _set_fake_key_material(self):
+        # fake key material for the authenticated_no_key workaround: all-zero and thus worthless,
+        # but this mode does not encrypt, so reading still works - decrypt() only strips the type
+        # byte and RepoObj1.parse skips the chunk id check.
+        NOPE = bytes(32)  # 256 bit all-zero
+        self.repository_id = NOPE
+        self.enc_key = NOPE
+        self.enc_hmac_key = NOPE
+        self.id_key = NOPE
+        self.chunk_seed = 0
+
+    @classmethod
+    def detect(cls, repository, manifest_data, *, other=False):
+        try:
+            return super().detect(repository, manifest_data, other=other)
+        except RepoKeyNotFoundError:
+            if not AUTHENTICATED_NO_KEY:
+                raise
+            # the borg key is not just locked by an unknown passphrase, it is completely gone.
+            # The workaround covers that too: proceed with fake key material, see
+            # _set_fake_key_material.
+            key = cls(repository)
+            key._set_fake_key_material()
+            key.init_ciphers(manifest_data)
+            key._passphrase = Passphrase()
+            return key
+
     def _load(self, key_data, passphrase):
         if AUTHENTICATED_NO_KEY:
-            # fake _load if we have no key or passphrase
-            NOPE = bytes(32)  # 256 bit all-zero
-            self.repository_id = NOPE
-            self.enc_key = NOPE
-            self.enc_hmac_key = NOPE
-            self.id_key = NOPE
-            self.chunk_seed = 0
+            # fake _load if we have no key or passphrase, see _set_fake_key_material.
+            self._set_fake_key_material()
             return True
         return super()._load(key_data, passphrase)
 

--- a/src/borg/testsuite/crypto/key_test.py
+++ b/src/borg/testsuite/crypto/key_test.py
@@ -15,6 +15,7 @@ from ...crypto.key import AESOCBKey, CHPOKey, Blake3AESOCBKey, Blake3CHPOKey
 from ...crypto.key import AES_OCB_MAX_SESSION_BLOCKS
 from ...crypto.key import ID_HMAC_SHA_256, ID_BLAKE2b_256, ID_BLAKE3_256
 from ...crypto.key import UnsupportedManifestError, UnsupportedKeyFormatError, UnsupportedPayloadError
+from ...crypto.key import RepoKeyNotFoundError
 from ...crypto.key import identify_key
 from ...crypto.low_level import IntegrityError as IntegrityErrorBase
 from ...helpers import Error
@@ -530,6 +531,29 @@ class TestMACEnvelope:
         monkeypatch.setattr("borg.crypto.key.AUTHENTICATED_NO_KEY", True)
         assert key.decrypt(id, bytes(envelope), aad=b"aad") == payload
 
+    @pytest.mark.parametrize("cls", KEYED_CLASSES)
+    def test_authenticated_no_key_key_gone(self, cls, monkeypatch, tmp_path):
+        # a completely lost borg key (no repokey object, no keyfile) is also covered by the
+        # workaround: detect() proceeds with fake key material instead of failing, see #10238.
+        monkeypatch.setenv("BORG_KEYS_DIR", str(tmp_path))  # empty, i.e. no keyfile for this repo
+        monkeypatch.delenv("BORG_KEY_FILE", raising=False)
+        repository = MagicMock(id=bytes(32), version=3)
+        repository.load_key.return_value = None  # no repokey either
+        real_key = self.make_key(cls)
+        payload = b"payload"
+        id = real_key.id_hash(payload)
+        envelope = real_key.encrypt(id, payload, aad=b"aad")
+
+        with pytest.raises(RepoKeyNotFoundError):  # without the workaround: hard error
+            cls.detect(repository, envelope)
+
+        monkeypatch.setattr("borg.crypto.key.AUTHENTICATED_NO_KEY", True)
+        key = cls.detect(repository, envelope)
+        assert isinstance(key, cls)
+        # the fake key material can not verify the tag, but the payload is plaintext and
+        # decrypt() skips the verification, so reading works.
+        assert key.decrypt(id, envelope, aad=b"aad") == payload
+
     def test_unkeyed_modes_verify_despite_workaround(self, monkeypatch):
         # the unkeyed modes need no key material, so the workaround must not switch their
         # checksum verification off.
@@ -541,6 +565,26 @@ class TestMACEnvelope:
         envelope[5] ^= 1
         with pytest.raises(IntegrityError):
             key.decrypt(id, bytes(envelope), aad=b"aad")
+
+
+@pytest.mark.parametrize("cls", (LegacyAuthenticatedKey, Blake2AuthenticatedKey))
+def test_legacy_authenticated_no_key_key_gone(cls, monkeypatch, tmp_path):
+    # like TestMACEnvelope.test_authenticated_no_key_key_gone, but for the borg 1.x authenticated
+    # modes (read-only, e.g. accessed via borg transfer).
+    monkeypatch.setenv("BORG_KEYS_DIR", str(tmp_path))  # empty, i.e. no keyfile for this repo
+    monkeypatch.delenv("BORG_KEY_FILE", raising=False)
+    repository = MagicMock(id=bytes(32), version=1)
+    repository.load_key.return_value = None  # no repokey either
+    payload = b"payload"
+    envelope = bytes([cls.TYPE]) + payload  # borg 1.x authenticated envelope: type byte + plaintext
+
+    with pytest.raises(RepoKeyNotFoundError):  # without the workaround: hard error
+        cls.detect(repository, envelope)
+
+    monkeypatch.setattr("borg.legacy.crypto.key.AUTHENTICATED_NO_KEY", True)
+    key = cls.detect(repository, envelope)
+    assert isinstance(key, cls)
+    assert bytes(key.decrypt(None, envelope)) == payload
 
 
 def test_dropped_borg2_beta_key_types(tmpdir):


### PR DESCRIPTION
Fixes #10238.

When `BORG_WORKAROUNDS=authenticated_no_key` is set and no borg key can be found at all (no repokey object below `keys/`, no keyfile), `detect()` for the `authenticated-*` key classes now proceeds with fake all-zero key material instead of failing with `RepoKeyNotFoundError` (rc 44). These modes do not encrypt, so reading only needs the verification that the workaround skips anyway.

- `AuthenticatedKeyBase.detect()` (and its borg 1.x legacy counterpart) catches `RepoKeyNotFoundError` and synthesizes the fake key when the workaround is active; the fake material setup is factored into `_set_fake_key_material()`, shared with the existing faked `_load()`.
- The legacy borg 1.x authenticated modes (read-only, e.g. accessed via `borg transfer`) get the same treatment - borg 1.x itself supported the lost-key case via a faked `key =` repo config entry.
- Help text updated: the workaround now covers both a lost passphrase and a lost borg key.
- New unit tests for the lost-key case (modern and legacy classes), asserting the hard error without the workaround and successful detect + read with it.

Verified end-to-end: created an `authenticated-sha256` repo, deleted `keys/*`, then with the workaround `repo-list`, `extract` (content verified) and `repo-delete` all work (rc 0); without it, borg still fails with rc 44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)