### PR TITLE
prune: remove the date-based archive filters (were accepted but never applied)

### DIFF
--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -557,7 +557,7 @@ class PruneMixIn:
             action=Highlander,
             help="number or time interval of yearly archives to keep",
         )
-        define_archive_filters_group(subparser, sort_by=False, first_last=False)
+        define_archive_filters_group(subparser, sort_by=False, first_last=False, oldest_newest=False, older_newer=False)
         subparser.add_argument(
             "name", metavar="NAME", nargs="?", type=archivename_validator, help="specify the archive name"
         )


### PR DESCRIPTION
The date-based archive filters (`--oldest`/`--newest`/`--older`/`--newer`) were accepted by the prune parser but never applied: `borg prune --keep 1 --older=1y` happily pruned minutes-old archives (found via a docs-vs-code audit, runtime-verified). Prune inherited the options from the shared archive filters group (#7272) without anyone deciding prune should support date windows.

**Reworked per the discussion below:** instead of wiring the filters up, remove them from prune for now — `--older` is redundant with `--keep-within`, there are no convincing real-world use cases for `--oldest`/`--newest` (which anchor on endpoints that prune itself changes between runs), and blanket protection of old archives (`--newer`) is better served by a future `--to` option or by tags once #9936 lands. Prune now rejects the four options at parse time (exit code 2) instead of accepting and silently ignoring them.

The change is a single commit with a one-line diff: the four options are no longer added to prune's parser.

Tests: `prune_cmd_test.py` green; ruff clean. Note: the generated usage docs still list the options for prune; regeneration is left to the usual release-time `build_usage`/`build_man` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
