### PR TITLE
docs: fix Windows directory paths to match actual behavior, see #10237

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -137,9 +137,9 @@ Compatibility notes:
     cache: ``~/Library/Caches/borg/``,
     runtime: ``~/Library/Caches/TemporaryItems/borg/``.
   - on Windows, the default directories are:
-    config: ``C:\Users\<user>\AppData\Roaming\borg``,
-    cache: ``C:\Users\<user>\AppData\Local\borg\Cache``,
-    data: ``C:\Users\<user>\AppData\Local\borg``.
+    config/data: ``C:\Users\<user>\AppData\Local\borg\borg``,
+    cache: ``C:\Users\<user>\AppData\Local\borg\borg\Cache``,
+    runtime: ``C:\Users\<user>\AppData\Local\Temp\borg\borg``.
   - **keyfile users on macOS (and Windows)**: borg 2 will look for key files in the
     new platform-specific config directory instead of ``~/.config/borg/keys/`` where
     borg 1.x stored them. You can set ``BORG_KEYS_DIR`` to point to the old location,

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -548,7 +548,7 @@ How important is the borg config directory?
 
 The borg config directory (``~/.config/borg`` on Linux,
 ``~/Library/Application Support/borg`` on macOS,
-``C:\Users\<user>\AppData\Roaming\borg`` on Windows -- see :ref:`env_vars`)
+``C:\Users\<user>\AppData\Local\borg\borg`` on Windows -- see :ref:`env_vars`)
 has content that you should take care of:
 
 ``keys`` subdirectory
@@ -556,6 +556,10 @@ has content that you should take care of:
   repokey keys are stored inside the repository. In any case, you MUST make sure
   to have an independent backup of the borg keys, see :ref:`borg_key_export` for
   more details.
+
+On Windows, the doubled ``borg\borg`` in the path above is what the platformdirs defaults
+produce; whether borg should use a different directory scheme there is under review,
+see :issue:`10237`.
 
 Make sure that only you have access to the borg config directory.
 
@@ -586,7 +590,7 @@ How important is the borg data directory?
 
 The borg data directory (``~/.local/share/borg`` on Linux,
 ``~/Library/Application Support/borg`` on macOS,
-``C:\Users\<user>\AppData\Local\borg`` on Windows -- see :ref:`env_vars`)
+``C:\Users\<user>\AppData\Local\borg\borg`` on Windows -- see :ref:`env_vars`)
 has content that you should take care of:
 
 ``security`` subdirectory
@@ -595,6 +599,9 @@ has content that you should take care of:
   operation, Borg outputs warning messages and asks for confirmation, so make sure you do not lose
   or manipulate these files. However, apart from those warnings, a loss of these files can be
   recovered.
+
+On macOS and Windows, this resolves to the same directory as the borg config directory,
+so the ``security`` and ``keys`` subdirectories sit next to each other there.
 
 Make sure that only you have access to the Borg data directory.
 

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -986,8 +986,10 @@ class HelpMixIn:
               honoured (see https://specifications.freedesktop.org/basedir/latest/).
             - macOS: native macOS directories are used by default (e.g. ``~/Library/Application Support/borg``,
               ``~/Library/Caches/borg``). ``XDG_*`` environment variables are honoured if set.
-            - Windows: Windows AppData directories are used (e.g. ``C:\\Users\\<user>\\AppData\\Roaming\\borg``,
-              ``C:\\Users\\<user>\\AppData\\Local\\borg``). ``XDG_*`` environment variables are **not** honoured.
+            - Windows: local (not roaming) Windows AppData directories are used, e.g.
+              ``C:\\Users\\<user>\\AppData\\Local\\borg\\borg``. ``borg`` appears twice in that path because
+              borg does not give platformdirs a separate "app author" name, so it defaults to the app name.
+              ``XDG_*`` environment variables are **not** honoured.
 
             On all platforms, you can override each directory individually using the specific environment
             variables described below. You can also set ``BORG_BASE_DIR`` to force borg to use
@@ -996,10 +998,10 @@ class HelpMixIn:
             Default directory locations by platform (when no ``BORG_*`` environment variables are set)::
 
                 Directory  Linux                 macOS                                 Windows
-                Config     ~/.config/borg        ~/Library/Application Support/borg    %APPDATA%\\borg
-                Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\\borg\\Cache
-                Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg
-                Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %TEMP%\\borg
+                Config     ~/.config/borg        ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg\\borg
+                Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\\borg\\borg\\Cache
+                Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg\\borg
+                Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %LOCALAPPDATA%\\Temp\\borg\\borg
                 Keys       <config_dir>/keys     <config_dir>/keys                     <config_dir>\\keys
                 Security   <data_dir>/security   <data_dir>/security                   <data_dir>\\security
 


### PR DESCRIPTION
The FAQ, the CHANGES upgrade notes and the `borg help environment` directory table claimed `AppData\Roaming\borg` (config) and `AppData\Local\borg` (data) on Windows. The code calls platformdirs with appauthor unset and roaming left at False, which actually yields `C:\Users\<user>\AppData\Local\borg\borg` for config and data alike (appauthor defaults to the appname, hence the doubled path; Roaming is never used), `...\borg\borg\Cache` for the cache, and `AppData\Local\Temp\borg\borg` for the runtime dir — exactly what `testsuite/helpers/fs_test.py` asserts and what a platformdirs Windows-backend simulation reproduces.

This fixes the docs to describe the current behavior; whether the directory scheme itself should change is tracked in #10237 (the FAQ entry now points there). Linux/macOS claims were verified correct and are untouched. The generated `environment.rst.inc` and man pages pick this up at the next release-time regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)