### PR TITLE
docs: point borg delete -a pattern help at the match-archives topic

### DIFF
--- a/src/borg/archiver/delete_cmd.py
+++ b/src/borg/archiver/delete_cmd.py
@@ -82,7 +82,7 @@ class DeleteMixIn:
 
         You can delete multiple archives by specifying a match pattern using
         the ``--match-archives PATTERN`` option (for more information on these
-        patterns, see :ref:`borg_patterns`).
+        patterns, see "borg help match-archives").
         """
         )
         subparser = ArgumentParser(parents=[common_parser], description=self.do_delete.__doc__, epilog=delete_epilog)


### PR DESCRIPTION
The `borg delete` epilog pointed `--match-archives` pattern questions at `borg help patterns`, which covers file/path patterns for `--exclude`/`--pattern`/PATH; archive-name patterns are the `match-archives` topic. `borg undelete`'s identical sentence was already fixed in 08d0988c3 — this applies the same wording to delete. A sweep of `src/borg/archiver/` found no other instance of the mistake (the seven remaining `borg_patterns` references are all legitimately about file/path patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)