### PR TITLE
docs: fix BORG_ASSERT_ID claims about authenticated-* and none-* modes

### DIFF
--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -774,15 +774,17 @@ class HelpMixIn:
                 An unknown place name is an error. An empty value (``BORG_ASSERT_ID=``) verifies at none of
                 these places, but still where borg always verifies (see below).
 
-                Why ``read`` is not in the default: for encrypted repositories (all the AEAD ciphersuites),
-                the chunk id is part of the AEAD additional authenticated data, so a successful decryption
-                already proves that a holder of the repository key deliberately stored exactly this
-                ciphertext for exactly this chunk id. A malicious or buggy **repository** can therefore not
-                swap, splice or substitute objects, whether the id is verified on read or not. What the id
-                check adds is the detection of chunks whose content does not match their id, which only a
-                malicious or compromised **borg client that had your borg key** could have written (e.g. to
-                poison future deduplication). If that is in your threat model - e.g. because some machines
-                writing into the repository are not fully trusted - add ``read`` to the list::
+                Why ``read`` is not in the default: in the keyed modes, the envelope already authenticates
+                every read - the AEAD tag for the encrypted ciphersuites, the MAC for the (unencrypted)
+                ``authenticated-*`` modes - and the chunk id is part of what that tag is computed over. So
+                a successful decryption resp. tag check already proves that a holder of the borg key
+                deliberately stored exactly this payload for exactly this chunk id, and a malicious or
+                buggy **repository** can not swap, splice or substitute objects, whether the id is
+                verified on read or not. What the id check adds is the detection of chunks whose content
+                does not match their id, which only a malicious or compromised **borg client that had
+                your borg key** could have written (e.g. to poison future deduplication). If that is in
+                your threat model - e.g. because some machines writing into the repository are not fully
+                trusted - add ``read`` to the list::
 
                     BORG_ASSERT_ID=read,repair,transfer,rechunk
 
@@ -794,9 +796,10 @@ class HelpMixIn:
 
                 - in ``borg check --verify-data``. That audit is what makes not verifying elsewhere
                   defensible, so it is not configurable (there is no ``verify_data`` place name).
-                - for ``authenticated`` and ``none`` mode repositories: there is no AEAD there, so the id
-                  check *is* the read path's integrity check and switching it off would remove it
-                  completely. Same for reading borg 1.x repositories (``borg transfer``).
+                - for ``none-*`` mode repositories: they have no key, so nothing authenticates a read
+                  there and their unkeyed checksums only detect accidental corruption. The id check is
+                  therefore not optional there: it happens at every place, whatever this variable says.
+                  Same for reading borg 1.x repositories (``borg transfer``).
             BORG_BLAKE3_MT_THRESHOLD
                 When set to a numeric value, chunks of at least that many KiB get their id computed by
                 multi-threaded BLAKE3, smaller ones single-threaded (default: 256, i.e. 256KiB).


### PR DESCRIPTION
The BORG_ASSERT_ID entry in `borg help environment` said that for ``authenticated`` and ``none`` mode repositories "the id check *is* the read path's integrity check and switching it off would remove it completely". That is wrong for the authenticated-* modes: their keyed envelope MAC authenticates every read (the chunk id is part of what the tag is computed over), they have `id_check_is_authentication = False`, and so they follow the configurable places — plain reads are not id-checked by default. The forced-check statement is only true for the none-* modes (`id_check_is_authentication = True` makes `RepoObj.parse` verify at every place, whatever the variable says) and for reading borg 1.x repos.

The rewritten entry now explains the "why read is not in the default" rationale for both keyed families (AEAD tag resp. envelope MAC) and scopes the always-verified bullet to none-* and legacy reads. Every claim is backed by `repoobj.py`'s place logic and the key class attributes, and matches what `repoobj_test.py`'s assert_id tests already pin down. Generated environment.rst.inc/man pages pick this up at release-time regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)