### PR TITLE
docs: fix the man page install command in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -459,7 +459,8 @@ locally::
     git clone https://github.com/borgbackup/borg.git borg
 
     # Install the files with proper permissions
-    install -D -m 0644 borg/docs/man/borg*.1* $HOME/.local/share/man/man1/borg.1
+    mkdir -p $HOME/.local/share/man/man1
+    install -m 0644 borg/docs/man/borg*.1* $HOME/.local/share/man/man1/
 
     # Update the man page cache
     mandb


### PR DESCRIPTION
`install -D -m 0644 borg/docs/man/borg*.1* $HOME/.local/share/man/man1/borg.1` expands to all 56 man pages with a single FILE as destination — GNU install rejects multiple sources with a non-directory target and BSD/macOS install errors out too (both runtime-verified), and conceptually all pages would land in one filename anyway.

Replaced with `mkdir -p` + `install -m 0644 ... man1/`, verified working on both GNU coreutils and BSD/macOS install: all 56 pages land with mode 644 and `man -M <prefix> borg-create` renders the installed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)