### PR TITLE
docs: update the mount -o versions example to the current naming

### DIFF
--- a/docs/usage/mount.rst
+++ b/docs/usage/mount.rst
@@ -27,9 +27,9 @@ Examples
     # and provides a versioned view on files.
     $ borg mount -o versions /tmp/mymountpoint
     $ ls -l /tmp/mymountpoint/home/user/doc.txt/
-    total 24
-    -rw-rw-r-- 1 user group 12357 Aug 26 21:19 doc.cda00bc9.txt
-    -rw-rw-r-- 1 user group 12204 Aug 26 21:04 doc.fa760f28.txt
+    total 47
+    -rw-r--r-- 1 user group 12167 Aug 28 23:14 doc.00001.txt
+    -rw-r--r-- 1 user group 11444 Aug 28 23:15 doc.00002.txt
     $ borg umount /tmp/mymountpoint
 
     # Archive filters are supported.


### PR DESCRIPTION
The versions-view example in docs/usage/mount.rst still showed borg1-era version file names with an 8-hex content-hash suffix (`doc.cda00bc9.txt`). Current `versioned_name()` builds `{name}.{version:05d}{ext}` with a per-file sequential counter that only increments when the content changes — `doc.00001.txt`, `doc.00002.txt`.

The new listing is real captured output from an actual `borg mount -o versions` run (two archives with changed file content), anonymized to the doc's existing `user group` placeholder style. The generated borg-umount man page picks this up at the next release-time regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)