### PR TITLE
docs: simplify the standalone binary section in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -106,17 +106,19 @@ Standalone Binary
 .. note:: Releases are signed with an OpenPGP key, see
           :ref:`security-contact` for more instructions.
 
-Borg x86/x64 AMD/Intel compatible binaries (generated with `pyinstaller`_)
-are available on the releases_ page for the following platforms:
+Prebuilt binaries (generated with `pyinstaller`_) are available on the
+releases_ page for Linux and macOS (x86-64 and arm64) and for FreeBSD
+(x86-64). For each platform there is a single-file binary and, as a
+``.tgz``, the same thing as a single-directory bundle, which starts up
+faster.
 
-* **Linux**: glibc >= 2.28 (ok for most supported Linux releases).
-  Older glibc releases are untested and may not work.
-* **macOS**: 10.12 or newer (To avoid signing issues, download the file via
-  command line **or** remove the ``quarantine`` attribute after downloading:
-  ``$ xattr -dr com.apple.quarantine borg-macosx64.tgz``)
-* **FreeBSD**: 12.1 (unknown whether it works for older releases)
+See the ``00_README.txt`` file provided alongside the binaries on the
+releases_ page for the exact list of binaries, their platform
+requirements, and how to verify them.
 
-ARM binaries are built by Johann Bauer, see: https://borg.bauerj.eu/
+On macOS, if Gatekeeper blocks the downloaded binary, remove its
+quarantine attribute (``xattr -dr com.apple.quarantine``) before running
+it.
 
 .. note:: ``borg mount`` only works if the binary was built with FUSE support
           (third-party binaries might lack it) and your OS has FUSE installed


### PR DESCRIPTION
The standalone-binary section carried version floors that had long rotted (glibc >= 2.28, macOS 10.12, FreeBSD 12.1 — the current binaries are built on much newer hosts) and still pointed to third-party ARM binaries although official arm64 Linux/macOS binaries exist.

Rewritten version-free: generic platform list (Linux/macOS x86-64+arm64, FreeBSD x86-64 — matching the actual release assets), single-file vs `.tgz` directory bundle, and a pointer to the ``00_README.txt`` shipped alongside the binaries for the exact requirements (asset name verified against the in-repo `docs/binaries/00_README.txt` and the live release's asset list). The macOS quarantine tip is kept, now filename-free. Sphinx build from the branch: zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)