### PR TITLE
docs: use archive series names in the automated-local example

### DIFF
--- a/docs/deployment/automated-local.rst
+++ b/docs/deployment/automated-local.rst
@@ -72,7 +72,7 @@ modify it to suit your needs (e.g., more backup sets, dumping databases, etc.).
     # This is the location of the Borg repository
     TARGET=$MOUNTPOINT/borg-backups/backup.borg
 
-    # Archive name schema
+    # Timestamp for the log messages below
     DATE=$(date --iso-8601)-$(hostname)
 
     # This is the file that will later contain UUIDs of registered backup drives
@@ -121,21 +121,26 @@ modify it to suit your needs (e.g., more backup sets, dumping databases, etc.).
 
     echo "Starting backup for $DATE"
 
-    # This is just an example, change it however you see fit
+    # This is just an example, change it however you see fit.
+    # The archive name is fixed (no date or PID in it): every run adds an
+    # archive to the "system" series, letting Borg's files cache speed up
+    # unchanged files on the next run. Use "borg repo-list" to see each run's
+    # own archive ID and timestamp.
     borg create $BORG_OPTS \
       --repo $TARGET \
       --exclude root/.cache \
       --exclude var/lib/docker/devicemapper \
-      $DATE-$$-system \
+      system \
       / /boot
 
     # /home is often a separate partition/filesystem.
     # Even if it is not (add --exclude /home above), it probably makes sense
     # to have /home in a separate archive.
+    # As above, use a fixed archive name so all runs form one "home" series.
     borg create $BORG_OPTS \
       --repo $TARGET \
       --exclude 'sh:home/*/.cache' \
-      $DATE-$$-home \
+      home \
       /home/
 
     echo "Completed backup for $DATE"
@@ -195,6 +200,13 @@ to start the first backup::
 See backup logs using journalctl::
 
     journalctl -fu automatic-backup [-n number-of-lines]
+
+Each run adds one archive to the ``system`` series and one to the ``home``
+series (the archive name is the same on every run; see the script above).
+List the archives, including each one's archive ID and timestamp, using
+``borg repo-list`` (see :ref:`borg_repo-list`)::
+
+    borg repo-list -r /mnt/backup/borg-backups/backup.borg
 
 Security considerations
 -----------------------


### PR DESCRIPTION
The automated-local deployment example named its archives `$DATE-$$-system` / `$DATE-$$-home` — date and PID in the name means every run starts a brand-new series, and since the files cache is per-series (suffix = sha256 of the archive name), every backup ran with a cold files cache and re-chunked all files.

The script now uses fixed series names `system` and `home`, with short comments explaining the series concept, and a new paragraph pointing readers at `borg repo-list` to see each run's archive ID and timestamp. `DATE` is kept solely for the log messages (comment corrected accordingly); `$$` is gone.

Runtime-verified with the doc's exact command shape: two runs produced two archives per series (distinct IDs/timestamps), the second run hit the files cache for unchanged files (`U` status; the single `A` per archive is the intentional newest-cmtime race safeguard, confirmed via `--debug-topic=files_cache`), and the on-disk cache files match `files.<sha256("system")>` / `files.<sha256("home")>`. Sphinx build from the branch: zero warnings, the new `:ref:`borg_repo-list`` link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)