### PR TITLE
docs: fix tox examples and remove Vagrant references in development.rst

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -261,7 +261,7 @@ but directly output to stderr (not: stdout, it could be connected to a pipe).
 To control the amount and kinds of messages output emitted at info level, use
 flags like ``--stats`` or ``--list``, then create a topic logger for messages
 controlled by that flag.  See ``_setup_implied_logging()`` in
-``borg/archiver.py`` for the entry point to topic logging.
+``src/borg/archiver/__init__.py`` for the entry point to topic logging.
 
 Building a development environment
 ----------------------------------
@@ -295,20 +295,23 @@ To run the test suite use the following command::
 
 Some more advanced examples::
 
-  # verify a changed tox.ini (run this after any change to tox.ini):
+  # verify a changed pyproject.toml (run this after any change to the [tool.tox] section):
   fakeroot -u tox --recreate
 
   fakeroot -u tox -e py313  # run all tests, but only on python 3.13
 
-  fakeroot -u tox borg.testsuite.locking  # only run 1 test module
-
-  fakeroot -u tox borg.testsuite.locking -- -k '"not Timer"'  # exclude some tests
-
-  fakeroot -u tox borg.testsuite -- -v  # verbose py.test
+  fakeroot -u tox -- borg.testsuite.fslocking_test  # only run 1 test module
 
 Important notes:
 
-- When using ``--`` to give options to py.test, you MUST also give ``borg.testsuite[.module]``.
+- With tox 4, all positional arguments MUST be given after ``--``; tox rejects
+  them otherwise with an "unrecognized arguments" error.
+- Whatever follows ``--`` replaces the default ``borg.testsuite`` value of
+  pytest's ``--pyargs`` argument as a single value, so it can only be used to
+  select a different module or package to test, as in the example above.
+- It cannot be combined with extra pytest options such as ``-k`` or ``-v`` this
+  way; for that, run pytest directly (see below). Note that tox already runs
+  pytest with ``-v`` by default.
 
 Running pytest directly without tox:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -413,34 +413,6 @@ with the ``figure-padded`` class for consistent spacing::
 
         Caption text.
 
-Using Vagrant
--------------
-
-We use Vagrant for the automated creation of testing environments and borgbackup
-standalone binaries for various platforms.
-
-For better security, there is no automatic sync in the VM to host direction.
-The plugin `vagrant-scp` is useful to copy stuff from the VMs to the host.
-
-The "windows10" box requires the `reload` plugin (``vagrant plugin install vagrant-reload``).
-
-Usage::
-
-   # To create and provision the VM:
-   vagrant up OS
-   # same, but use 6 VM cpus and 12 workers for pytest:
-   VMCPUS=6 XDISTN=12 vagrant up OS
-   # To create an ssh session to the VM:
-   vagrant ssh OS
-   # To execute a command via ssh in the VM:
-   vagrant ssh OS -c "command args"
-   # To shut down the VM:
-   vagrant halt OS
-   # To shut down and destroy the VM:
-   vagrant destroy OS
-   # To copy files from the VM (in this case, the generated binary):
-   vagrant scp OS:/vagrant/borg/borg.exe .
-
 Using Podman
 ------------
 
@@ -529,11 +501,6 @@ Checklist:
 
   This makes sure no uncommitted files get into the release archive.
   It will also reveal uncommitted required files.
-  Moreover, it makes sure the vagrant machines only get committed files and
-  do a fresh start based on that.
-- Optional: run tox and/or binary builds on all supported platforms via vagrant,
-  check for test failures. This is now optional as we do platform testing and
-  binary building on GitHub.
 - When GitHub CI looks good on the release PR, merge it and push the release tag.
 
   Pushing the tag makes CI build the standalone binaries and then release:


### PR DESCRIPTION
Two commits:

**1. Fix the tox examples.** They predate tox 4 (required: >=4.19): positionals before `--` are rejected ("unrecognized arguments"), and `borg.testsuite.locking` no longer exists (it's `fslocking_test`/`storelocking_test` now). The "changed tox.ini" comment now points at pyproject's `[tool.tox]` section, and the stale `borg/archiver.py` reference for `_setup_implied_logging()` is corrected. One deliberate editorial change: the old `-k '"not Timer"'` and `-- -v` examples were not just relocated behind `--` but replaced with notes — with the TOML-array `commands`, everything after `--` is substituted into `--pyargs {posargs:borg.testsuite}` as a single joined token, so module selection works but combining it with pytest options does not (empirically verified: the relocated `-k` form collects zero tests). The doc now says to run pytest directly for that, and notes tox already passes `-v`. The fixed single-module example was run to completion: `tox -e py313 -- borg.testsuite.fslocking_test` → 21 passed.

**2. Remove all Vagrant references.** The whole "Using Vagrant" section (including the claim of a "windows10" box requiring the reload plugin — the Vagrantfile defines no windows box) and the two release-checklist mentions are gone; platform testing and binary building happen on GitHub CI, local Linux testing via Podman (`scripts/linux-run`). Historical changelog mentions are left as project history; the Vagrantfile itself is untouched.

Sphinx build of the final state: zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)