### PR TITLE
docs: update binaries 00_README.txt from the 2.0.0b23 release

### DIFF
--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -31,8 +31,8 @@ Download the correct files
 Binaries built on GitHub servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-borg-linux-glibc239-x86_64-gh Linux AMD/Intel (built on Ubuntu 24.04 LTS with glibc 2.39)
-borg-linux-glibc239-arm64-gh  Linux ARM (built on Ubuntu 24.04 LTS with glibc 2.39)
+borg-linux-glibc243-x86_64-gh Linux AMD/Intel (built on Ubuntu 26.04 LTS with glibc 2.43)
+borg-linux-glibc243-arm64-gh  Linux ARM (built on Ubuntu 26.04 LTS with glibc 2.43)
 
 borg-macos-15-arm64-gh        macOS Apple Silicon (built on macOS 15 w/o FUSE support)
 borg-macos-15-x86_64-gh       macOS Intel (built on macOS 15 w/o FUSE support)

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -31,13 +31,15 @@ Download the correct files
 Binaries built on GitHub servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-borg-linux-glibc235-x86_64-gh Linux AMD/Intel (built on Ubuntu 22.04 LTS with glibc 2.35)
-borg-linux-glibc235-arm64-gh  Linux ARM (built on Ubuntu 22.04 LTS with glibc 2.35)
+borg-linux-glibc239-x86_64-gh Linux AMD/Intel (built on Ubuntu 24.04 LTS with glibc 2.39)
+borg-linux-glibc239-arm64-gh  Linux ARM (built on Ubuntu 24.04 LTS with glibc 2.39)
 
 borg-macos-15-arm64-gh        macOS Apple Silicon (built on macOS 15 w/o FUSE support)
 borg-macos-15-x86_64-gh       macOS Intel (built on macOS 15 w/o FUSE support)
 
-borg-freebsd-14-x86_64-gh     FreeBSD AMD/Intel (built on FreeBSD 14)
+borg-freebsd-15-x86_64-gh     FreeBSD AMD/Intel (built on FreeBSD 15.1)
+
+borg-windows-x86_64-gh        Windows AMD/Intel (built using MINGW/MSYS2)
 
 Binaries built locally
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Sync `docs/binaries/00_README.txt` with reality, in two commits:

1. Start from the `00_README.txt` asset actually published on the 2.0.0b23 GitHub release (fetched verbatim via `gh release download`): FreeBSD 14 → 15.1, and adds the previously missing `borg-windows-x86_64-gh` entry.
2. Update the Linux lines to master's current CI: built on Ubuntu 26.04 LTS with glibc 2.43, asset names `borg-linux-glibc243-*-gh` (matching release.yml's EXPECTED_ASSETS and ci.yml's binary job).

This also matters for installation.rst (#10259), which now points readers at this file for the binaries' platform requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)