### PR TITLE
serve: print startup errors to stderr

### DIFF
--- a/src/borg/archiver/__init__.py
+++ b/src/borg/archiver/__init__.py
@@ -26,7 +26,7 @@ try:
     import signal
     from datetime import UTC, datetime
 
-    from ..logger import create_logger, setup_logging
+    from ..logger import create_logger, setup_logging, flush_serve_log_queue
 
     logger = create_logger()
 
@@ -481,10 +481,16 @@ class Archiver(
         func = args.func
         # do not use loggers before this!
         is_serve = func == self.do_serve
+        # Only the legacy RPC mode of "borg serve" has an in-band log channel (its serve loop
+        # forwards queued log records to the client), so only it may route log output into the
+        # serve log queue. "borg serve --rest" logs to stderr like any other command: SSH
+        # forwards stderr to the client side, where borgstore surfaces it as error detail
+        # when the server fails.
+        is_serve_legacy = is_serve and not getattr(args, "rest", False)
         self.log_json = args.log_json and not is_serve
         func_name = getattr(func, "__name__", "none")
-        setup_logging(level=args.log_level, is_serve=is_serve, log_json=self.log_json, func=func_name)
-        args.progress |= is_serve
+        setup_logging(level=args.log_level, is_serve=is_serve_legacy, log_json=self.log_json, func=func_name)
+        args.progress |= is_serve_legacy  # the legacy serve loop forwards progress output to the client
         self._setup_implied_logging(vars(args))
         self._setup_topic_debugging(args)
         # extract --dry-run reads, decrypts and decompresses every object, so its store stats are accurate.
@@ -702,6 +708,7 @@ def main():  # pragma: no cover
             from ..helpers import do_show_rc
 
             do_show_rc(exit_code)
+        flush_serve_log_queue()
         sys.exit(exit_code)
 
 

--- a/src/borg/logger.py
+++ b/src/borg/logger.py
@@ -31,13 +31,18 @@ Usage:
 
 Logging setup in Borg needs to work under various conditions:
 - Purely local, not client/server (easy).
-- Client/server: RemoteRepository ("borg serve" process) writes log records into a global
-  queue, which is then sent to the client side by the main serve loop (via the RPC protocol),
-  either over SSH stdout, more directly via process stdout without SSH (used in tests),
-  or via a socket. On the client side, the log records are fed into the client-side logging
-  system. When remote_repo.close() is called, the server side must send all queued log records
-  via the RPC channel before returning the close() call's return value (as the client will
-  then shut down the connection).
+- Client/server, legacy RPC mode: the "borg serve" process writes log records into a global
+  queue (borg_serve_log_queue), which is then sent to the client side by the main serve loop
+  (via the RPC protocol on stdout, usually through SSH). On the client side, the log records
+  are fed into the client-side logging system. When remote_repo.close() is called, the server
+  side must send all queued log records via the RPC channel before returning the close()
+  call's return value (as the client will then shut down the connection). Log records still
+  queued when the server process exits (e.g. logged while reporting a "borg serve" startup
+  error, before the serve loop was even reached) are written to stderr by
+  flush_serve_log_queue(), so SSH can forward them to the client.
+- Client/server, rest mode: "borg serve --rest" has no in-band log channel, it logs to
+  stderr like any other command (SSH forwards stderr to the client side, where borgstore
+  keeps the recent tail and surfaces it as error detail when the server fails).
 - Progress output is always given as JSON to the logger (including the plain text inside
   the JSON), but then formatted by the logging system's formatter as either plain text or
   JSON depending on the CLI args given (--log-json?).
@@ -149,6 +154,24 @@ def flush_logging():
             handler.flush()
 
 
+def flush_serve_log_queue():
+    """Write all log records still in borg_serve_log_queue to sys.stderr.
+
+    In legacy RPC mode, "borg serve" routes its log output into borg_serve_log_queue (see
+    setup_logging) and relies on the serve loop to forward the queued records in-band to the
+    client. Records still queued when the process is about to exit - e.g. logged while
+    reporting a "borg serve" startup error, before the serve loop was even reached - would
+    get lost silently, thus we write them to stderr, which SSH forwards to the client.
+    """
+    formatter = logging.Formatter("%(message)s")
+    while True:
+        try:
+            lr_dict = borg_serve_log_queue.get_nowait()  # lr_dict contents: see BorgQueueHandler
+        except queue.Empty:
+            break
+        print(formatter.format(logging.LogRecord(**lr_dict)), file=sys.stderr)
+
+
 def setup_logging(
     stream=None, conf_fname=None, env_var="BORG_LOGGING_CONF", level="info", is_serve=False, log_json=False, func=None
 ):
@@ -160,7 +183,9 @@ def setup_logging(
     otherwise, set up a stream handler logger on stderr (by default, if no
     stream is provided).
 
-    is_serve: are we setting up the logging for "borg serve"?
+    is_serve: route log output into borg_serve_log_queue instead of using a stream handler
+    (used by the legacy RPC mode of "borg serve", whose serve loop sends the queued records
+    in-band to the client).
     """
     global configured
     err_msg = None

--- a/src/borg/testsuite/archiver/serve_cmd_test.py
+++ b/src/borg/testsuite/archiver/serve_cmd_test.py
@@ -1,0 +1,26 @@
+"""Tests for "borg serve" error reporting.
+
+"borg serve" startup errors must be printed to stderr: the client only ever sees the server's
+stderr (SSH forwards it; the borgstore rest backend surfaces its tail as BackendError detail),
+so a silently exiting server makes e.g. misconfigured sshd forced commands very hard to diagnose.
+These tests run a real borg process (fork=True), so that main()'s error reporting is exercised.
+"""
+
+from ...helpers.errors import Error, PathNotAllowed
+from . import exec_cmd
+
+
+def test_serve_rest_missing_backend_prints_error():
+    ret, output = exec_cmd("serve", "--rest", fork=True)
+    assert ret == Error.exit_mcode
+    assert "borg serve --rest requires --backend FILE:<path>." in output
+
+
+def test_serve_rest_restriction_violation_prints_error(tmp_path, monkeypatch):
+    # like an sshd forced command scenario: the client asks for a repository path
+    # that the forced command's --restrict-to-repository does not allow.
+    monkeypatch.setenv("SSH_ORIGINAL_COMMAND", f"borg serve --rest --backend FILE:{tmp_path / 'forbidden'}")
+    ret, output = exec_cmd("serve", "--rest", f"--restrict-to-repository={tmp_path / 'allowed'}", fork=True)
+    assert ret == PathNotAllowed.exit_mcode
+    assert "Repository path not allowed" in output
+    assert "forbidden" in output

--- a/src/borg/testsuite/logger_test.py
+++ b/src/borg/testsuite/logger_test.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 import pytest
 
-from ..logger import find_parent_module, create_logger, setup_logging
+from ..logger import find_parent_module, create_logger, setup_logging, flush_serve_log_queue
 
 logger = create_logger()
 
@@ -47,6 +47,25 @@ def test_setup_logging_json_attribute():
     for log_json in (True, False):
         setup_logging(stream=StringIO(), env_var=None, log_json=log_json)
         assert logging.getLogger("borg").json is log_json
+
+
+def test_flush_serve_log_queue(capsys):
+    # "borg serve" (legacy RPC mode) routes log output into borg_serve_log_queue instead of a
+    # stream handler; whatever is still queued when the process exits (e.g. records logged while
+    # reporting a serve startup error) must be written to stderr by flush_serve_log_queue().
+    try:
+        setup_logging(env_var=None, is_serve=True)
+        flush_serve_log_queue()  # drain records possibly left behind by other tests
+        capsys.readouterr()  # discard output captured so far
+        logging.getLogger("borg.testsuite.logger_test").error("serve startup error")
+        assert capsys.readouterr().err == ""  # queued, not written to a stream
+        flush_serve_log_queue()
+        assert "serve startup error" in capsys.readouterr().err
+        flush_serve_log_queue()  # the queue is empty now
+        assert capsys.readouterr().err == ""
+    finally:
+        # restore a stream-based logging configuration, like the other tests here leave behind
+        setup_logging(stream=StringIO(), env_var=None)
 
 
 def test_parent_module():


### PR DESCRIPTION
### The problem

`borg serve` startup errors were completely silent — nothing on stdout or stderr, only a bare exit code:

```
$ borg serve --rest ; echo rc=$?
rc=2        # nothing printed, though do_serve_rest raised
            # Error("borg serve --rest requires --backend FILE:<path>.")
```

Same for a restriction violation with an sshd forced command: the server exited with rc 83 (`PathNotAllowed`) and 0 bytes of stderr, so the client only saw

```
borgstore.backends.errors.BackendError: stdio server exited with code 83
```

with no detail (borgstore relays the server's stderr as error detail — and there was none). Misconfigured forced commands were therefore very hard to diagnose.

### Root cause

`Archiver.run()` sets up logging with `is_serve=True` for every `borg serve`, which routes **all** log output into the in-memory `borg_serve_log_queue`. That queue is only drained by the legacy RPC serve loop (`RepositoryServer.send_queued_log`), which forwards records in-band to the client. Startup errors are caught in `main()` and reported via `logger.error(...)` — so the message went into the queue, the serve loop never ran, and the process exited with the message still in memory. `--rest` mode never drains the queue at all.

### The fix

- Only the legacy RPC mode of `borg serve` routes log output into the serve queue now. `borg serve --rest` has no in-band log channel, so it logs to stderr like any other command: SSH forwards stderr to the client, where the borgstore rest backend keeps the recent tail and surfaces it as `BackendError` detail. (stdout stays untouched — it carries the HTTP-over-stdio protocol.)
- `main()` now writes any log records still queued at process exit to stderr (new `flush_serve_log_queue()`), so legacy-mode serve startup errors are not lost either. No duplicates are possible (the serve loop consumes records it sends), and it is a no-op for non-serve commands.

With the fix, the cases above print `Error: borg serve --rest requires --backend FILE:<path>.` / `Repository path not allowed: ...` on stderr (stdout stays at 0 bytes), and the client's `BackendError` includes that message.

### Tests

- New `serve_cmd_test.py`: two regression tests running a real borg process (`fork=True`) through `main()`'s error reporting — missing `--backend` (rc 2) and a forced-command-style restriction violation via `SSH_ORIGINAL_COMMAND` (rc 83). Both fail on the unfixed code (empty output) and pass with the fix.
- New unit test for `flush_serve_log_queue()` in `logger_test.py`.
- Verified locally: full remote `rest://` matrix (check/create/extract/compact remote params, 140 tests — each spawns a `borg serve --rest` subprocess) and the legacy `ssh://__testsuite__` transfer test (real `RepositoryServer` with in-band queue logging) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)