### PR TITLE
docs: fix shell syntax in the pyenv virtualenv example

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -521,7 +521,7 @@ If you need to use a different version of Python you can install this using ``py
     pyenv install 3.11.0  # minimum, preferably use something more recent!
     pyenv global 3.11.0
     pyenv local 3.11.0
-    virtualenv --python=${pyenv which python} borg-env
+    virtualenv --python=$(pyenv which python) borg-env
     source borg-env/bin/activate   # always before using!
     ...
 


### PR DESCRIPTION
`virtualenv --python=${pyenv which python} borg-env` fails immediately in bash/zsh with "bad substitution" — `${...}` is parameter expansion and only accepts a variable name. Command substitution was intended: `$(pyenv which python)`, which splices in the path of the pyenv-selected Python. One-character-class fix so the pyenv setup steps work as pasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)