### PR TITLE
transfer: clean error instead of crash when no other repo is given

### DIFF
--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -6,7 +6,7 @@ import borg
 from ..archive import Archive
 from ..constants import *  # NOQA
 from ..cache import Cache, assert_secure
-from ..helpers import Error
+from ..helpers import CommandError, Error
 from ..helpers import SortBySpec, location_validator, Location, relative_time_marker_validator
 from ..helpers import FilesystemPathSpec
 from ..helpers import Highlander, octal_int
@@ -177,11 +177,13 @@ def with_repository(
     return decorator
 
 
-def with_other_repository(manifest=False, cache=False, compatibility=None):
+def with_other_repository(manifest=False, cache=False, compatibility=None, required=False):
     """
     this is a simplified version of "with_repository", just for the "other location".
 
     the repository at the "other location" is intended to get used as a **source** (== read operations).
+
+    :param required: the command can not work without the other repository, refuse to run if it is not given.
     """
 
     compatibility = compat_check(
@@ -197,8 +199,10 @@ def with_other_repository(manifest=False, cache=False, compatibility=None):
         @functools.wraps(method)
         def wrapper(self, args, **kwargs):
             location = getattr(args, "other_location")
-            if not location.valid:  # nothing to do
-                return method(self, args, **kwargs)
+            if not location.valid:
+                if required:
+                    raise CommandError("missing other repository, please use --other-repo or BORG_OTHER_REPO env var!")
+                return method(self, args, **kwargs)  # nothing to do
 
             v1_legacy = getattr(args, "v1_legacy", False)
 

--- a/src/borg/archiver/transfer_cmd.py
+++ b/src/borg/archiver/transfer_cmd.py
@@ -128,7 +128,7 @@ def transfer_chunks(
 
 
 class TransferMixIn:
-    @with_other_repository(manifest=True, compatibility=(Manifest.Operation.READ,))
+    @with_other_repository(manifest=True, required=True, compatibility=(Manifest.Operation.READ,))
     @with_repository(manifest=True, cache=True, compatibility=(Manifest.Operation.WRITE,))
     def do_transfer(self, args, *, repository, manifest, cache, other_repository=None, other_manifest=None):
         """archives transfer from other repository, optionally upgrade data format"""


### PR DESCRIPTION
`borg transfer --from-borg1 --dry-run` (and plain `transfer`) without `--other-repo`/`BORG_OTHER_REPO` died with a raw "Local Exception" traceback (`AttributeError: 'NoneType' object has no attribute 'key'` at transfer_cmd.py:136) — found by the docs-vs-code audit while parse-checking the upgrade docs.

Fix: `with_other_repository()` gets a `required=False` parameter; `do_transfer` passes `required=True`, so the wrapper raises `CommandError("missing other repository, please use --other-repo or BORG_OTHER_REPO env var!")` when the other location is invalid/unset — mirroring `with_repository`'s existing missing-repo guard. Since `@with_other_repository` is the outer decorator on transfer, the usage error is raised before the destination repo is opened or locked. `repo-create`, the only other user of the decorator, keeps its genuinely-optional behavior unchanged (verified).

Runtime: both failing invocations now print the one-line error (rc 4 modern / rc 2 legacy); `--other-repo` and `BORG_OTHER_REPO` paths still work end-to-end (dry-run + real transfer + repo-list verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)