### PR TITLE
docs: macOS binaries are built without FUSE support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,8 @@ jobs:
         and, as a \`.tgz\`, the same thing as a directory (\`borg-dir/borg.exe\`), which
         starts up faster.
 
-        The macOS binaries are built **with** FUSE support: \`borg mount\` needs a macFUSE
-        version that is compatible with the one they were built against.
+        The macOS binaries are built **without** FUSE support, so \`borg mount\` does
+        not work with them; install via \`pip\` instead if you need FUSE support.
 
         All release assets have a [build provenance attestation](https://github.com/borgbackup/borg/attestations),
         verifiable with \`gh attestation verify --owner borgbackup <file>\`.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -519,10 +519,7 @@ Checklist:
 
   Note: the signature is not uploaded to PyPi any more, but we upload it to
   github releases.
-- Download the binaries from the drafted release and test them. For macOS
-  binaries **with** FUSE support, document the macFUSE version in the release
-  notes: macFUSE uses a kernel extension that needs to be compatible with the
-  code contained in the binary.
+- Download the binaries from the drafted release and test them.
 - Review the release notes and publish the drafted GitHub release.
 
 - Close the release milestone on GitHub.


### PR DESCRIPTION
The release.yml auto-notes template claimed "The macOS binaries are built **with** FUSE support: `borg mount` needs a macFUSE version that is compatible…". Evidence says otherwise: the macOS binary matrix entries build with toxenv `py314-none` (the no-FUSE variant), and a case-insensitive grep over all of `.github/` and the build scripts finds no macFUSE/osxfuse install anywhere — matching `00_README.txt`'s "w/o FUSE support". (Linux builds with pyfuse3 and FreeBSD with mfusepy — those binaries do have FUSE.)

The notes now say the macOS binaries are built without FUSE support and point to pip for users needing `borg mount`. Also removes the release checklist's corresponding stale step in development.rst ("For macOS binaries with FUSE support, document the macFUSE version…"). YAML validated; heredoc rendering of the template spot-checked with a dummy TAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)