### PR TITLE
docs: update repo-list output samples to the current default format

### DIFF
--- a/docs/usage/copy.rst
+++ b/docs/usage/copy.rst
@@ -8,8 +8,8 @@ Examples
     $ borg create backup-2016-02-15 ~
     $ borg copy backup-2016-02-15 known-good
     $ borg repo-list
-    e6a2b1c4  Mon, 2016-02-15 19:50:19 +0100  backup-2016-02-15  tw          MacBook-Pro
-    9f3d0a77  Mon, 2016-02-15 19:50:19 +0100  known-good         tw          MacBook-Pro
+    d7b79fd3  Sat, 2026-08-29 14:39:27 +0200  backup-2016-02-15              tw          MacBook-Pro
+    f81040e3  Sat, 2026-08-29 14:39:27 +0200  known-good                   tw          MacBook-Pro
 
     # the copy is an independent archive:
     # after deleting (and compacting away) the original, the copy is still complete.
@@ -18,4 +18,4 @@ Examples
     $ borg extract known-good
 
     # if the archive name is not unique, address the archive by its ID:
-    $ borg copy aid:e6a2b1c4 known-good
+    $ borg copy aid:d7b79fd3 known-good

--- a/docs/usage/rename.rst
+++ b/docs/usage/rename.rst
@@ -6,10 +6,10 @@ Examples
 
     $ borg create archivename ~
     $ borg repo-list
-    8df049de  Mon, 2016-02-15 19:50:19 +0100  archivename      tw          MacBook-Pro
+    516c2a16  Sat, 2026-08-29 14:39:58 +0200  archivename                  tw          MacBook-Pro
 
     # renaming rewrites the archive metadata, so the archive ID changes:
     $ borg rename archivename newname
     $ borg repo-list
-    69ea925b  Mon, 2016-02-15 19:50:19 +0100  newname          tw          MacBook-Pro
+    3aaef11e  Sat, 2026-08-29 14:39:58 +0200  newname                      tw          MacBook-Pro
 

--- a/docs/usage/repo-list.rst
+++ b/docs/usage/repo-list.rst
@@ -5,11 +5,11 @@ Examples
 ::
 
     $ borg repo-list
-    151b1a57  Mon, 2024-09-23 22:57:11 +0200  docs             tw          MacBook-Pro  this is a comment
-    3387a079  Thu, 2024-09-26 09:07:07 +0200  scripts          tw          MacBook-Pro
-    ca774425  Thu, 2024-09-26 10:05:23 +0200  scripts          tw          MacBook-Pro
-    ba56c4a5  Thu, 2024-09-26 10:12:45 +0200  src              tw          MacBook-Pro
-    7567b79a  Thu, 2024-09-26 10:15:07 +0200  scripts          tw          MacBook-Pro
-    21ab3600  Thu, 2024-09-26 10:15:17 +0200  docs             tw          MacBook-Pro
+    76fcb5c7  Sat, 2026-08-29 14:36:22 +0200  docs                         tw          MacBook-Pro  this is a comment
+    19356ae3  Sat, 2026-08-29 14:36:23 +0200  scripts                      tw          MacBook-Pro
+    7dd5756a  Sat, 2026-08-29 14:36:23 +0200  scripts                      tw          MacBook-Pro
+    99b712ef  Sat, 2026-08-29 14:36:23 +0200  src                          tw          MacBook-Pro
+    7698cd9e  Sat, 2026-08-29 14:36:24 +0200  scripts                      tw          MacBook-Pro
+    f49f8762  Sat, 2026-08-29 14:36:24 +0200  docs                         tw          MacBook-Pro
     ...
 


### PR DESCRIPTION
The `borg repo-list` output samples in repo-list.rst, copy.rst and rename.rst predated the `tags` column of the current default format (`{id:.8}  {time}  {archive:<15}  {tags:<10}  {username:<10}  {hostname:<10}  {comment:.40}`), so the column spacing between archive name and username was wrong.

All three samples are regenerated from real runs of each page's own scenario — including actually performing the copy (and verifying the copy survives delete+compact of the original, as the page claims) and the rename (ID changes, nominal timestamp preserved). copy.rst's dependent `aid:` example was updated to the captured ID. Every line was verified byte-for-byte against `FORMAT_DEFAULT` reconstruction; only the samples changed, no prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)