### PR TITLE
docs: fix wrong claims in frontends.rst and data-structures.rst

### DIFF
--- a/docs/internals/data-structures.rst
+++ b/docs/internals/data-structures.rst
@@ -343,7 +343,7 @@ found in the manifest. If any unsupported flags are found (i.e. the mandatory se
 not a subset of the features supported by the Borg client used), the operation
 is aborted with a *MandatoryFeatureUnsupported* error:
 
-    Unsupported repository feature(s) {'some_feature'}. A newer version of borg is required to access this repository.
+    Unsupported repository feature(s) {'some_feature'}. A newer version of Borg is required to access this repository.
 
 Older Borg releases do not have this concept and do not perform feature flags checks.
 These are locked out with manifest version 2, which is what Borg 2 always writes:

--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -647,6 +647,9 @@ item1:
     - for '*changed user*' / '*changed group*' the user / the group,
     - for '*ctime*' / '*mtime*' an ISO 8601 timestamp.
 
+    User and group are given by name; with ``--numeric-ids``, the numeric uid and gid are given
+    instead (as JSON numbers instead of strings).
+
 item2:
     The corresponding value in ARCHIVE2, see **item1**.
 
@@ -878,9 +881,10 @@ Errors
     NotMyLock rc: 75 traceback: yes
         Failed to release the lock {} (was/is locked, but not by me).
 
-    These six msgids are shared by the repository lock (``storelocking``) and the local cache lock
-    (``fslocking``). The messages are the same except for *LockTimeout*, which the cache lock emits
-    without the trailing hint.
+    These six msgids are shared by the repository lock (``storelocking``) and the filesystem lock
+    (``fslocking``), which only the legacy borg 1.x repository code uses (e.g. during
+    ``borg transfer --from-borg1``). The messages are the same except for *LockTimeout*, which the
+    ``fslocking`` variant emits without the trailing hint.
 
     ConnectionClosed rc: 80 traceback: no
         Connection closed by remote host.
@@ -948,6 +952,11 @@ Operations
     - cache.close
 
       Saving the local cache (files cache, chunks index, cache config) at the end of a command.
+    - cache.build_chunkindex_from_repo
+
+      Rebuilding the chunk index by reading all pack file headers from the repository, e.g. when
+      it cannot be built from the stored index fragments or when ``borg check --repair`` rebuilds
+      a corrupt index.
     - check.index
     - check.packs
     - check.verify_data
@@ -976,3 +985,6 @@ Prompts
     BORG_DELETE_I_KNOW_WHAT_I_AM_DOING
         For "You requested to DELETE the following repository completely *including* ... archives
         it contains:" (repo-delete)
+    BORG_DISPLAY_PASSPHRASE
+        For "Do you want your passphrase to be displayed for verification? [yN]:" (interactive
+        entry of a new passphrase)


### PR DESCRIPTION
Code-verified fixes in the internals docs, from the docs-vs-code audit:

**frontends.rst**: `fslocking` was called "the local cache lock" — borg2's cache takes no lock; it's the filesystem lock only the legacy borg 1.x repository code uses (e.g. `transfer --from-borg1`). The operations msgid list gains the missing `cache.build_chunkindex_from_repo` (emitted when the chunk index is rebuilt from the repository). `BORG_DISPLAY_PASSPHRASE` is added to the Prompts list. The diff item1/item2 description now notes that `--numeric-ids` yields numeric uid/gid values (JSON numbers).

**data-structures.rst**: the quoted MandatoryFeatureUnsupported message now matches the code's capitalization ("A newer version of Borg…").

Sphinx build from the branch: zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)