### PR TITLE
docs: fix the quickstart example list sample and delete caution

### DIFF
--- a/docs/quickstart_example.rst.inc
+++ b/docs/quickstart_example.rst.inc
@@ -47,8 +47,8 @@
 5. List the contents of the first archive::
 
     $ borg -r /path/to/repo list aid:3affe017
-    drwxr-xr-x user   group          0 Mon, 2016-02-15 18:22:30 home/user/Documents
-    -rw-r--r-- user   group       7961 Mon, 2016-02-15 18:22:30 home/user/Documents/Important.doc
+    drwxr-xr-x user   group         0 Fri, 2026-08-28 12:22:30 +0200 home/user/Documents
+    -rw-r--r-- user   group      7961 Fri, 2026-08-28 12:22:30 +0200 home/user/Documents/Important.doc
     ...
 
 6. Restore the first archive by extracting the files relative to the current directory::
@@ -59,8 +59,9 @@
 
     $ borg -r /path/to/repo delete aid:3affe017
 
-   Be careful if you use an archive NAME (and not an archive ID), as it might match multiple archives.
-   Always use ``--dry-run`` and ``--list`` first!
+   If you use an archive NAME (and not an archive ID), Borg will abort if the name matches multiple
+   archives (as with the two *docs* archives here); use ``aid:<archive-id>`` to delete one specific
+   archive, or ``-a PATTERN`` to delete multiple archives. Always use ``--dry-run`` and ``--list`` first!
 
 8. Recover disk space by removing objects that are not referenced by any
    archive any more::


### PR DESCRIPTION
Two fixes in docs/quickstart_example.rst.inc:

- Step 5's `borg list` sample predated the timezone offset (and current column widths) of the default timestamp format. Regenerated from a real run of the walkthrough's scenario (7961-byte `Important.doc` and all), with only the file's existing placeholder conventions applied (`user`/`group` re-padded byte-exactly per the real `{user:6} {group:6} {size:8}` format; date kept consistent with the neighboring steps' fabricated timeline).
- The delete step warned that an archive NAME "might match multiple archives" — actually `borg delete NAME` goes through `Archives.get_one` and aborts unless the name matches exactly one archive (runtime-proven: `Command error: ['docs'] needed to match precisely one archive, but matched 2.`). The caution now states the abort semantics and points at `aid:<archive-id>` for one specific archive and `-a PATTERN` for multiple.

Sphinx build from the branch: zero warnings; rendered quickstart page checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)