### PR TITLE
archiver: fix wrong and stale epilog help texts

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -175,10 +175,10 @@ class BenchmarkMixIn:
 
         # Buffer sizes matter where an algorithm switches to multiple threads:
         # blake3 and zstd do so above a threshold, so a buffer below it and one
-        # above it behave quite differently. The hashes are measured at pack and
-        # chunk size (both above blake3's threshold), the compressors at chunk
-        # size and below zstd's threshold. Within a section every row processes
-        # the same total, so the throughput column stays comparable across sizes.
+        # above it behave quite differently. The hashes are measured at a roughly
+        # pack-sized buffer and at chunk size (both above blake3's threshold), the
+        # compressors at chunk size and below zstd's threshold. Within a section every
+        # row processes the same total, so the throughput column stays comparable across sizes.
         # All powers of two, so that total is exactly 1 GiB (or 10 MiB for the
         # compressors) rather than an awkward fraction of it.
         SMALL, CHUNK, PACK = ("128kiB", 128 * KIB), ("2MiB", 2 * MIB), ("64MiB", 64 * MIB)
@@ -186,7 +186,7 @@ class BenchmarkMixIn:
             hash_sizes = comp_sizes = one_size = [SMALL]
             hash_total = comp_total = SMALL[1]
         else:
-            # blake3: a borg pack, then a borg chunk - both above its MT threshold
+            # blake3: a roughly pack-sized buffer, then a borg chunk - both above its MT threshold
             hash_sizes = [PACK, CHUNK]
             comp_sizes = [SMALL, CHUNK]
             one_size = [CHUNK]  # for algorithms where the buffer size does not change behaviour
@@ -526,7 +526,7 @@ class BenchmarkMixIn:
 
         Some algorithms use multiple threads only above a size threshold, so the
         hashes and the compressors are measured at more than one buffer size: the
-        hashes at 64MiB (a borg pack) and 2MiB (a typical borg chunk), both above
+        hashes at 64MiB (roughly pack-sized) and 2MiB (a typical borg chunk), both above
         blake3's threshold, the compressors at 2MiB and 128kiB, which is below
         zstd's. Within a section every row processes the same total number of
         bytes - 1 GiB, or 10 MiB for the compressors - so the throughput column is

--- a/src/borg/archiver/check_cmd.py
+++ b/src/borg/archiver/check_cmd.py
@@ -130,7 +130,9 @@ class CheckMixIn:
            all chunks referencing files (items) in the archive exist. This requires
            reading archive and file metadata, but not data. To scan for archives whose
            entries were lost from the archive directory, pass ``--find-lost-archives``.
-           It requires reading all data and is hence very time-consuming.
+           It has to look at the metadata of every object in the repository (only for the
+           archive metadata objects it finds that way, it also reads the object data), so
+           it is very time-consuming for big repositories.
            To additionally cryptographically verify the file (content) data integrity,
            pass ``--verify-data``, which is even more time-consuming.
 
@@ -189,8 +191,8 @@ class CheckMixIn:
         metadata that does not match an archive directory entry (including
         soft-deleted archives), it means that an entry was lost.
         Unless ``borg compact`` is called, these archives can be fully restored with
-        ``--repair``. Please note that ``--find-lost-archives`` must read a lot of
-        data from the repository and is thus very time-consuming. You cannot use
+        ``--repair``. Please note that ``--find-lost-archives`` must look at every
+        object in the repository and is thus very time-consuming. You cannot use
         ``--find-lost-archives`` with ``--repository-only``.
 
         You can influence how the archive part of the ``Analyzing archive ...`` output is

--- a/src/borg/archiver/create_cmd.py
+++ b/src/borg/archiver/create_cmd.py
@@ -771,8 +771,8 @@ class CreateMixIn:
 
         When specifying '-' as a path, borg will read data from standard input and create a
         file named 'stdin' in the created archive from that data. In some cases, it is more
-        appropriate to use --content-from-command. See the section *Reading from stdin*
-        below for details.
+        appropriate to use --content-from-command. See the section
+        *Reading backup data from stdin* below for details.
 
         The archive will consume almost no disk space for files or parts of files that
         have already been stored in other archives.
@@ -1123,7 +1123,8 @@ class CreateMixIn:
         subparser.add_argument(
             "--content-from-command",
             action="store_true",
-            help="interpret PATH as a command and store its stdout. See also the section 'Reading from stdin' below.",
+            help="interpret PATH as a command and store its stdout. See also the section "
+            "'Reading backup data from stdin' below.",
         )
         subparser.add_argument(
             "--paths-from-stdin",
@@ -1145,7 +1146,8 @@ class CreateMixIn:
             "--paths-delimiter",
             action=Highlander,
             metavar="DELIM",
-            help="set path delimiter for ``--paths-from-stdin`` and ``--paths-from-command`` (default: ``\\n``) ",
+            help="set path delimiter for ``--paths-from-stdin``, ``--paths-from-command`` and "
+            "``--paths-from-shell-command`` (default: ``\\n``) ",
         )
 
         exclude_group = define_exclusion_group(subparser, tag_files=True)

--- a/src/borg/archiver/debug_cmd.py
+++ b/src/borg/archiver/debug_cmd.py
@@ -434,7 +434,9 @@ class DebugMixIn:
             parents=[mid_common_parser], description=self.do_debug_parse_obj.__doc__, epilog=debug_parse_obj_epilog
         )
         debug_parsers.add_subcommand("parse-obj", subparser, help="parse borg object file into meta dict and data")
-        subparser.add_argument("id", metavar="ID", type=str, help="hex object ID to get from the repo")
+        subparser.add_argument(
+            "id", metavar="ID", type=str, help="hex object ID the object file has (needed to decrypt and verify it)"
+        )
         subparser.add_argument(
             "object_path",
             metavar="OBJECT_PATH",
@@ -464,7 +466,12 @@ class DebugMixIn:
             parents=[mid_common_parser], description=self.do_debug_format_obj.__doc__, epilog=debug_format_obj_epilog
         )
         debug_parsers.add_subcommand("format-obj", subparser, help="format file and metadata into a Borg object file")
-        subparser.add_argument("id", metavar="ID", type=str, help="hex object ID to get from the repo")
+        subparser.add_argument(
+            "id",
+            metavar="ID",
+            type=str,
+            help="hex object ID the object shall have (used to encrypt and authenticate it)",
+        )
         subparser.add_argument(
             "binary_path",
             metavar="BINARY_PATH",

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -224,7 +224,9 @@ class DiffMixIn:
         For each matching item in both archives, Borg reports:
 
         - Content changes: total added/removed bytes within files. If chunker parameters are comparable,
-          Borg compares chunk IDs quickly; otherwise, it compares the content.
+          Borg compares chunk IDs quickly; otherwise, it compares the content. In the latter case, borg
+          can only tell that a file was modified, not by how much: no byte counts are given for it, the
+          text output shows "modified:  (can't get size)" instead.
         - Metadata changes: user, group, mode, and other metadata shown inline as "[old -> new]", like
           "[-rw-r--r-- -> -rwxr-xr-x]" for a mode change. Use ``--content-only`` to suppress metadata changes.
         - Added/removed items: printed as "added: SIZE path" or "removed: SIZE path".
@@ -239,11 +241,13 @@ class DiffMixIn:
 
         JSON Lines output (``--json-lines``) prints one JSON object per changed path, with a list of
         change objects. Each change object has a "type" plus type-specific data: content changes
-        ("added", "removed", "modified") carry "added"/"removed" byte counts; metadata changes
-        ("changed mode", "changed owner", "mtime", ...) carry the old and new values as "item1" and
-        "item2". Example::
+        ("added", "removed", "modified") carry "added"/"removed" byte counts - except for a
+        "modified" that was determined by comparing the content, which carries no counts at all;
+        metadata changes ("changed mode", "changed owner", "mtime", ...) carry the old and new
+        values as "item1" and "item2". Example::
 
             {"changes": [{"added": 23, "removed": 5, "type": "modified"}], "path": "path/to/file"}
+            {"changes": [{"type": "modified"}], "path": "path/to/other-file"}
             {"changes": [{"item1": "-rw-r--r--", "item2": "-rwxr-xr-x", "type": "changed mode"}], "path": "some/file"}
             {"changes": [{"added": 4, "removed": 0, "type": "added"}], "path": "path/to/added-file"}
             {"changes": [{"added": 0, "removed": 5, "type": "removed"}], "path": "path/to/removed-file"}


### PR DESCRIPTION
Epilog/option-help fixes from the docs-vs-code audit, each verified against the implementing code and — where cheap — at runtime:

- **check**: `--find-lost-archives` looks at every object's *metadata* (`read_data=False` ranged reads); it does not "read all data". The same wrong claim appeared twice in the epilog; both spots fixed.
- **benchmark cpu**: the 64 MiB hash buffer is "roughly pack-sized" (default pack cap is 50 MB), fixed in the epilog and the matching code comments.
- **debug parse-obj / format-obj**: the ID help said "to get from the repo"; both commands operate on local files — the ID decrypts/verifies resp. encrypts/authenticates the object.
- **create**: `--paths-delimiter` also applies to `--paths-from-shell-command`; two cross-references now name the actual section title "Reading backup data from stdin".
- **diff**: content-compared "modified" changes (differing chunker params) carry no byte counts — epilog, JSON example and text-output note updated (runtime-verified `{"type": "modified"}` and "modified:  (can't get size)").

All affected `--help` outputs render cleanly; ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)