### PR TITLE
tests: do not let the terminal's COLORTERM leak into the spinner tests

### DIFF
--- a/src/borg/testsuite/helpers/progress_test.py
+++ b/src/borg/testsuite/helpers/progress_test.py
@@ -109,6 +109,7 @@ def tty(monkeypatch, progress_logger):
     monkeypatch.setenv("TERM", "xterm")
     monkeypatch.setenv("COLUMNS", "80")  # make the terminal width deterministic
     monkeypatch.setenv("NO_COLOR", "1")  # ... and the escape sequences short
+    monkeypatch.delenv("COLORTERM", raising=False)  # the real terminal's value must not leak in
     monkeypatch.delenv("BORG_SPINNER", raising=False)
     return FakeTTY()
 


### PR DESCRIPTION
The `tty` fixture pins `TERM`, `COLUMNS`, `NO_COLOR` and `BORG_SPINNER`, but not `COLORTERM`. `test_spinner_colour` deletes `NO_COLOR` (the fixture sets it) and only sets the vars from its parametrization, so under a terminal exporting `COLORTERM=truecolor` (e.g. ghostty) the `env={}` case inherited truecolor and the spinner correctly painted truecolor green instead of the expected 16-colour green:

```
AssertionError: assert False
 +  where False = ...('\x1b[92m▫\x1b[0m Working')
 +    where ... = '\x1b[?25l\r\x1b[2K\x1b[38;2;34;208;69m▫\x1b[0m Working'.endswith
```

Clear `COLORTERM` in the fixture so the tests are deterministic regardless of the terminal they run in. Verified: with `COLORTERM=truecolor` exported, the `env={}` case failed before and the whole file (38 tests) passes after; with it unset, everything passes before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)