### PR TITLE
tests: skip tz tests where time.tzset() is missing, not just on windows

### DIFF
--- a/src/borg/testsuite/archiver/match_archives_date_test.py
+++ b/src/borg/testsuite/archiver/match_archives_date_test.py
@@ -7,7 +7,6 @@ import pytest
 
 from ...constants import *  # NOQA
 from ...helpers.errors import CommandError
-from ...platform import is_win32
 from . import cmd, create_src_archive, generate_archiver_tests, RK_ENCRYPTION
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
@@ -282,7 +281,7 @@ LOCAL_TZ_ARCHIVES = [
 ]
 
 
-@pytest.mark.skipif(is_win32, reason="time.tzset() is not available on Windows")
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset() is not available on this platform")
 def test_match_bare_pattern_uses_local_timezone(archivers, request, set_timezone):
     """A pattern without a timezone suffix is interpreted in the local timezone."""
     set_timezone("America/New_York")


### PR DESCRIPTION
`test_match_bare_pattern_uses_local_timezone` was skipped based on `is_win32`, with "time.tzset() is not available on Windows" as the reason. Windows is not the only platform without `time.tzset` — haiku's python has none either, so the test failed there (`AttributeError: module 'time' has no attribute 'tzset'`) and its teardown errored on the same call.

Skip on the actual reason instead: `not hasattr(time, "tzset")`. This covers Windows exactly as before, plus any other platform whose python lacks it. The now-unused `is_win32` import goes away with it.

Split out of the haiku CI work in https://github.com/borgbackup/borg/pull/10249, since it is not haiku-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)