### PR TITLE
benchmark cpu: add --data PATH option

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -240,7 +240,7 @@ class BenchmarkMixIn:
         def user_data(path):
             """The --data input: the contents of the given file, or of all files below the given directory.
 
-            At most 1 GiB is read - far more than the benchmark samples from it, while bounding memory usage.
+            At most 1 GiB is read, bounding memory usage and runtime (the complete data is compressed).
             """
             max_size = GIB
             if os.path.isfile(path):
@@ -269,15 +269,17 @@ class BenchmarkMixIn:
                 raise CommandError(f"--data: no data found at '{path}'.")
             return b"".join(pieces)
 
-        def data_slices(data, nbytes, total):
-            """Up to *total* bytes of *nbytes*-sized buffers cut from *data*, evenly spread over it."""
+        def data_slices(data, nbytes):
+            """All consecutive *nbytes*-sized buffers cut from *data*, a partial buffer at the end is skipped.
+
+            The complete data is used rather than a sample: real data is not uniform, so any sampling
+            could hit unrepresentative spots and skew both the throughput and the ratio.
+            Memoryviews avoid copying the data a second time.
+            """
             if len(data) <= nbytes:
                 return [data]
-            count = max(1, min(total // nbytes, len(data) // nbytes))
-            if count == 1:
-                return [data[:nbytes]]
-            step = (len(data) - nbytes) // (count - 1)
-            return [data[i * step : i * step + nbytes] for i in range(count)]
+            view = memoryview(data)
+            return [view[i : i + nbytes] for i in range(0, len(data) - nbytes + 1, nbytes)]
 
         def data_size_str(size):
             """The benchmark's own data volumes, always in IEC units.
@@ -444,8 +446,8 @@ class BenchmarkMixIn:
             # that is what borg actually compresses
             for label, nbytes in reversed(comp_sizes):
                 if benchmark_data is not None:
-                    # distinct buffers cut from the user-provided data
-                    bufs = data_slices(benchmark_data, nbytes, comp_total)
+                    # the complete user-provided data, cut into distinct buffers
+                    bufs = data_slices(benchmark_data, nbytes)
                 else:
                     # the same synthetic buffer over and over (a few reps even for the fast codecs)
                     bufs = [compressible_buffer(nbytes)] * max(3, comp_total // nbytes)
@@ -592,8 +594,8 @@ class BenchmarkMixIn:
         hashes at 64MiB (roughly pack-sized) and 2MiB (a typical borg chunk), both above
         blake3's threshold, the compressors at 2MiB and 128kiB, which is below
         zstd's. Within a section every row processes the same total number of
-        bytes - 1 GiB, or 10 MiB for the compressors - so the throughput column is
-        comparable between rows.
+        bytes - 1 GiB, or 10 MiB for the compressors (the complete given data
+        when using --data) - so the throughput column is comparable between rows.
 
         By default, the compressors work on synthetic text-like data that compresses
         about 4x at zstd,3. Random data would be the worst possible input: no codec
@@ -603,11 +605,13 @@ class BenchmarkMixIn:
         Synthetic data can still behave differently from your real data, so the
         compression benchmarks can instead run on data you provide with
         ``--data PATH``: PATH is a file or a directory (all files below it are
-        read and concatenated, up to 1 GiB). The measured buffers are cut from
-        that data, evenly spread over it, so all of it influences the result.
-        Public benchmark corpora, e.g. the Silesia corpus or the Canterbury
-        corpus, make good reproducible inputs that resemble real-world data
-        (download and unpack them first, then point ``--data`` at the result).
+        read and concatenated, up to 1 GiB). The complete data is compressed:
+        it is cut into consecutive buffers of the measured sizes (a partial
+        buffer at the end is skipped), so ratios and throughput reflect all of
+        it, and the runtime scales with its size. Public benchmark corpora,
+        e.g. the Silesia corpus or the Canterbury corpus, make good
+        reproducible inputs that resemble real-world data (download and unpack
+        them first, then point ``--data`` at the result).
 
         The compression rows also show the achieved compression ratio
         (uncompressed size / compressed size, higher is better).

--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -8,7 +8,8 @@ import time
 from ..constants import *  # NOQA
 from ..helpers import format_file_size, CompressionSpec
 from ..helpers import sizeof_fmt_iec
-from ..helpers import FilesystemDirSpec
+from ..helpers import CommandError
+from ..helpers import FilesystemDirSpec, FilesystemPathSpec
 from ..helpers import json_print
 from ..helpers import msgpack
 from ..helpers import get_reset_ec
@@ -236,6 +237,48 @@ class BenchmarkMixIn:
                 compressible[nbytes] = bytes(out[:nbytes])
             return compressible[nbytes]
 
+        def user_data(path):
+            """The --data input: the contents of the given file, or of all files below the given directory.
+
+            At most 1 GiB is read - far more than the benchmark samples from it, while bounding memory usage.
+            """
+            max_size = GIB
+            if os.path.isfile(path):
+                filenames = [path]
+            elif os.path.isdir(path):
+                filenames = []
+                for root, dirs, files in os.walk(path):
+                    dirs.sort()
+                    filenames += sorted(os.path.join(root, name) for name in files)
+            else:
+                raise CommandError(f"--data: '{path}' is not a file or directory.")
+            pieces = []
+            nbytes = 0
+            for filename in filenames:
+                if nbytes >= max_size:
+                    break
+                if not os.path.isfile(filename):  # skip special files and broken symlinks
+                    continue
+                try:
+                    with open(filename, "rb") as f:
+                        pieces.append(f.read(max_size - nbytes))
+                except OSError as e:
+                    raise CommandError(f"--data: could not read '{filename}': {e}")
+                nbytes += len(pieces[-1])
+            if nbytes == 0:
+                raise CommandError(f"--data: no data found at '{path}'.")
+            return b"".join(pieces)
+
+        def data_slices(data, nbytes, total):
+            """Up to *total* bytes of *nbytes*-sized buffers cut from *data*, evenly spread over it."""
+            if len(data) <= nbytes:
+                return [data]
+            count = max(1, min(total // nbytes, len(data) // nbytes))
+            if count == 1:
+                return [data[:nbytes]]
+            step = (len(data) - nbytes) // (count - 1)
+            return [data[i * step : i * step + nbytes] for i in range(count)]
+
         def data_size_str(size):
             """The benchmark's own data volumes, always in IEC units.
 
@@ -250,17 +293,21 @@ class BenchmarkMixIn:
             """Rate as MB/s, always - so numbers stay comparable between rows."""
             return f"{size / dt / 1e6:>8.1f} MB/s"
 
-        def report(section, spec, size, dt, **extra):
+        def report(section, spec, size, dt, ratio=None, **extra):
             if args.json:
                 result[section].append({"size": size, "time": dt, **extra})
             else:
-                print(f"{spec:<{WIDTH}} {data_size_str(size):<11} {dt:.3f}s  {throughput(size, dt)}")
+                line = f"{spec:<{WIDTH}} {data_size_str(size):<11} {dt:.3f}s  {throughput(size, dt)}"
+                if ratio is not None:
+                    line += f"  {ratio:6.2f}x"
+                print(line)
 
         def section_header(section, title):
             if args.json:
                 result[section] = []
             else:
-                print(f"{title} ".ljust(64, "="))
+                # wide enough to cover the longest rows (the compression ones, with their ratio column)
+                print(f"{title} ".ljust(70, "="))
 
         random_10M = buffer(chunk_data_size)
         key_256 = os.urandom(32)
@@ -391,12 +438,18 @@ class BenchmarkMixIn:
 
         if "compressing" in selected:
             section_header("compression", "Compression")
+            benchmark_data = user_data(args.data) if args.data is not None else None
             # grouped by buffer size rather than by codec, so the codecs can be
             # compared against each other at a glance; chunk-sized first, as
             # that is what borg actually compresses
             for label, nbytes in reversed(comp_sizes):
-                data = compressible_buffer(nbytes)
-                number = max(3, comp_total // nbytes)  # a few reps even for the fast codecs
+                if benchmark_data is not None:
+                    # distinct buffers cut from the user-provided data
+                    bufs = data_slices(benchmark_data, nbytes, comp_total)
+                else:
+                    # the same synthetic buffer over and over (a few reps even for the fast codecs)
+                    bufs = [compressible_buffer(nbytes)] * max(3, comp_total // nbytes)
+                total = sum(len(buf) for buf in bufs)
                 for spec in [
                     "lz4",
                     "zstd,-4",
@@ -414,16 +467,26 @@ class BenchmarkMixIn:
                     "lzma,9",
                 ]:
                     compressor = CompressionSpec(spec).compressor
-                    dt = timeit(lambda: compressor.compress({}, data), number=number)
+                    csize = 0
+
+                    def compress_all():
+                        # compute the compressed size inside the timed run, so the (slow,
+                        # for lzma / high zstd levels) compression only runs once
+                        nonlocal csize
+                        csize = sum(len(compressor.compress({}, buf)[1]) for buf in bufs)
+
+                    dt = timeit(compress_all, number=1)
                     algo, _, algo_params = spec.partition(",")
                     report(
                         "compression",
                         f"{spec} ({label})",
-                        nbytes * number,
+                        total,
                         dt,
+                        ratio=total / csize,
                         algo=algo,
                         algo_params=algo_params,
                         buffer_size=nbytes,
+                        csize=csize,
                     )
 
         if "msgpacking" in selected:
@@ -532,10 +595,22 @@ class BenchmarkMixIn:
         bytes - 1 GiB, or 10 MiB for the compressors - so the throughput column is
         comparable between rows.
 
-        The compressors work on synthetic text-like data that compresses about 4x
-        at zstd,3. Random data would be the worst possible input: no codec can
-        compress it, so all of them would take their incompressible fast path and
-        the levels would barely differ.
+        By default, the compressors work on synthetic text-like data that compresses
+        about 4x at zstd,3. Random data would be the worst possible input: no codec
+        can compress it, so all of them would take their incompressible fast path
+        and the levels would barely differ.
+
+        Synthetic data can still behave differently from your real data, so the
+        compression benchmarks can instead run on data you provide with
+        ``--data PATH``: PATH is a file or a directory (all files below it are
+        read and concatenated, up to 1 GiB). The measured buffers are cut from
+        that data, evenly spread over it, so all of it influences the result.
+        Public benchmark corpora, e.g. the Silesia corpus or the Canterbury
+        corpus, make good reproducible inputs that resemble real-world data
+        (download and unpack them first, then point ``--data`` at the result).
+
+        The compression rows also show the achieved compression ratio
+        (uncompressed size / compressed size, higher is better).
         """
         )
         subparser = ArgumentParser(
@@ -547,4 +622,10 @@ class BenchmarkMixIn:
         subparser.add_argument("--hashing", action="store_true", help="benchmark the hashes / MACs")
         subparser.add_argument("--encrypting", action="store_true", help="benchmark the encryption modes")
         subparser.add_argument("--compressing", action="store_true", help="benchmark the compressors")
+        subparser.add_argument(
+            "--data",
+            metavar="PATH",
+            type=FilesystemPathSpec,
+            help="benchmark the compressors with the data from this file or directory (default: synthetic data)",
+        )
         subparser.add_argument("--msgpacking", action="store_true", help="benchmark msgpack item packing")

--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -1,8 +1,10 @@
 import json
+import re
 
 import pytest
 
 from ...constants import *  # NOQA
+from ...helpers import CommandError
 from . import cmd, RK_ENCRYPTION
 
 
@@ -106,6 +108,63 @@ def test_benchmark_cpu_json(archiver, monkeypatch):
             assert isinstance(entry["algo"], str)
             assert isinstance(entry["count"], int)
             assert isinstance(entry["time"], float)
-    # compression has size field too
+    # compression also has the compressed size
     for entry in result["compression"]:
         assert isinstance(entry["size"], int)
+        assert isinstance(entry["csize"], int)
+        assert 0 < entry["csize"] <= entry["size"]
+
+
+def test_benchmark_cpu_data_file(archiver, monkeypatch, tmp_path):
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    data_file = tmp_path / "data.txt"
+    data_file.write_bytes(b"some quite compressible benchmark input data\n" * 10000)
+    output = cmd(archiver, "benchmark", "cpu", "--compressing", "--data", str(data_file))
+    assert "Compression" in output
+    assert "MB/s" in output
+    # the compression rows show the achieved compression ratio
+    assert re.search(r"\d+\.\d\dx", output)
+
+
+def test_benchmark_cpu_data_directory(archiver, monkeypatch, tmp_path):
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    data_dir = tmp_path / "corpus"
+    (data_dir / "sub").mkdir(parents=True)
+    (data_dir / "a.txt").write_bytes(b"first benchmark input file\n" * 5000)
+    (data_dir / "sub" / "b.txt").write_bytes(b"second benchmark input file\n" * 5000)
+    output = cmd(archiver, "benchmark", "cpu", "--compressing", "--data", str(data_dir))
+    assert "Compression" in output
+    assert re.search(r"\d+\.\d\dx", output)
+
+
+def test_benchmark_cpu_data_json(archiver, monkeypatch, tmp_path):
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    data_file = tmp_path / "data.txt"
+    data_file.write_bytes(b"some quite compressible benchmark input data\n" * 10000)
+    output = cmd(archiver, "benchmark", "cpu", "--compressing", "--json", "--data", str(data_file))
+    result = json.loads(output)
+    for entry in result["compression"]:
+        assert isinstance(entry["size"], int)
+        assert isinstance(entry["csize"], int)
+        assert 0 < entry["csize"] <= entry["size"]
+
+
+def test_benchmark_cpu_data_missing(archiver, monkeypatch, tmp_path):
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    missing = str(tmp_path / "nonexistent")
+    if archiver.FORK_DEFAULT:
+        cmd(archiver, "benchmark", "cpu", "--compressing", "--data", missing, exit_code=CommandError().exit_code)
+    else:
+        with pytest.raises(CommandError, match="not a file or directory"):
+            cmd(archiver, "benchmark", "cpu", "--compressing", "--data", missing)
+
+
+def test_benchmark_cpu_data_empty(archiver, monkeypatch, tmp_path):
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    data_file = tmp_path / "empty"
+    data_file.write_bytes(b"")
+    if archiver.FORK_DEFAULT:
+        cmd(archiver, "benchmark", "cpu", "--compressing", "--data", str(data_file), exit_code=CommandError().exit_code)
+    else:
+        with pytest.raises(CommandError, match="no data found"):
+            cmd(archiver, "benchmark", "cpu", "--compressing", "--data", str(data_file))


### PR DESCRIPTION
Fixes #10265.

`borg benchmark cpu` now takes `--data PATH` to run the compression benchmarks on user-provided data instead of the synthetic default (which stays the default):

- PATH is a file or a directory; a directory is walked in sorted order and its files are read and concatenated (capped at 1 GiB, which also bounds memory usage and runtime).
- The complete data is compressed: it is cut into consecutive buffers of the measured sizes (2 MiB / 128 kiB, a partial buffer at the end is skipped, memoryviews avoid copying), so ratios and throughput reflect all of it and the runtime scales with its size. The synthetic path still compresses one buffer repeatedly, as before.
- The compression rows now also show the achieved compression ratio (uncompressed / compressed, higher is better) - for synthetic as well as user-provided data - and `--json` output gains a `csize` field. The compressed size is computed inside the timed run, so the slow codecs do not run twice.
- Bad input (missing path, unreadable file, no data) raises a proper `CommandError`.
- The epilog documents `--data` and mentions public benchmark corpora (Silesia, Canterbury) as reproducible, realistic inputs.

An earlier version of this PR sampled 10 MiB of evenly-spread slices from the data. As suspected in the issue discussion, that sampling skewed results on non-uniform data - e.g. it made `zstd,-4` look slower than `zstd,1` on the Silesia corpus. Compressing the complete data (2nd commit) resolves that.

Example: `borg benchmark cpu --compressing --data silesia/` with the unpacked [Silesia corpus](https://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) (macOS/arm64, ~5.5 min):

```
Compression ==========================================================
lz4 (2MiB)                 202.00 MiB  0.269s     787.3 MB/s    2.10x
zstd,-4 (2MiB)             202.00 MiB  0.105s    2017.3 MB/s    2.14x
zstd,1 (2MiB)              202.00 MiB  0.119s    1777.3 MB/s    2.88x
zstd,3 (2MiB)              202.00 MiB  0.189s    1118.5 MB/s    3.15x
zstd,5 (2MiB)              202.00 MiB  0.378s     560.1 MB/s    3.30x
zstd,10 (2MiB)             202.00 MiB  1.414s     149.8 MB/s    3.47x
zstd,16 (2MiB)             202.00 MiB  19.487s      10.9 MB/s    3.67x
zstd,22 (2MiB)             202.00 MiB  43.551s       4.9 MB/s    3.79x
zlib,1 (2MiB)              202.00 MiB  1.392s     152.2 MB/s    2.74x
zlib,6 (2MiB)              202.00 MiB  4.440s      47.7 MB/s    3.10x
zlib,9 (2MiB)              202.00 MiB  10.900s      19.4 MB/s    3.13x
lzma,0 (2MiB)              202.00 MiB  5.238s      40.4 MB/s    3.37x
lzma,6 (2MiB)              202.00 MiB  36.272s       5.8 MB/s    4.08x
lzma,9 (2MiB)              202.00 MiB  37.110s       5.7 MB/s    4.08x
lz4 (128kiB)               202.00 MiB  0.241s     880.2 MB/s    2.07x
zstd,-4 (128kiB)           202.00 MiB  0.274s     772.5 MB/s    2.09x
zstd,1 (128kiB)            202.00 MiB  0.330s     642.4 MB/s    2.80x
...
```

Speeds and ratios line up with published Silesia results, and `zstd,-4` is faster than `zstd,1`, as expected (cf. #10160).

Tests: new tests for file/dir input, JSON csize, and the error cases; all benchmark command tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)