### PR TITLE
CI: address the zizmor workflow audit findings

### DIFF
--- a/.github/workflows/32bit.yml
+++ b/.github/workflows/32bit.yml
@@ -90,14 +90,14 @@ jobs:
         borg.testsuite.helpers.time_test
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         # same python version as in the container, so both sides are comparable
         python-version: '3.13'
@@ -106,7 +106,7 @@ jobs:
     # (msgpack, PyYAML, backports-zstd, borghash, borgstore) are the expensive
     # part of the container setup, so keep them from run to run.
     - name: Cache pip-built wheels (armv7)
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: .pip-cache-armv7
         key: armv7-pip-${{ hashFiles('pyproject.toml') }}
@@ -136,7 +136,7 @@ jobs:
         echo "BORG_VERSION=$("$RUNNER_TEMP/venv-native/bin/borg" --version | cut -d' ' -f2)" >> $GITHUB_ENV
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
       with:
         platforms: arm
 

--- a/.github/workflows/32bit.yml
+++ b/.github/workflows/32bit.yml
@@ -95,6 +95,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,10 @@ jobs:
           startsWith(github.event.comment.body, '/backport')
         )
     steps:
-        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        # No persist-credentials: false here (unlike the other workflows):
+        # backport-action pushes the backport branch with a plain `git push`,
+        # so it needs the credentials that actions/checkout leaves behind.
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1  # zizmor: ignore[artipacked]
         - name: Create backport pull requests
           uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8  # v4.6.0
           with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,12 @@
 name: Backport pull request
 
-on:
+# pull_request_target is needed because the backport has to run with a token
+# that may write to this repository - a pull_request run from a fork does not
+# get one.  It is safe here because nothing from the pull request is checked
+# out or executed: the checkout below takes the base branch (no `ref:`), and
+# the only thing that touches pull request content is backport-action, which
+# just cherry-picks commits.
+on:  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [closed]
   issue_comment:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,14 +13,17 @@ on:
     types: [created]
 
 permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
+  contents: read
 
 jobs:
   backport:
     name: Backport pull request
     runs-on: ubuntu-26.04
     timeout-minutes: 5
+
+    permissions:
+      contents: write       # backport-action pushes the backport branch
+      pull-requests: write  # ... and opens the pull request and comments on it
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,7 +6,7 @@ name: Backport pull request
 # out or executed: the checkout below takes the base branch (no `ref:`), and
 # the only thing that touches pull request content is backport-action, which
 # just cherry-picks commits.
-on:  # zizmor: ignore[dangerous-triggers]
+on:
   pull_request_target:
     types: [closed]
   issue_comment:
@@ -40,7 +40,7 @@ jobs:
         # No persist-credentials: false here (unlike the other workflows):
         # backport-action pushes the backport branch with a plain `git push`,
         # so it needs the credentials that actions/checkout leaves behind.
-        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1  # zizmor: ignore[artipacked]
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         - name: Create backport pull requests
           uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8  # v4.6.0
           with:

--- a/.github/workflows/bigendian.yml
+++ b/.github/workflows/bigendian.yml
@@ -74,14 +74,14 @@ jobs:
         borg.testsuite.helpers.msgpack_test
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         # same python version as in the container, so both sides are comparable
         python-version: '3.13'
@@ -90,7 +90,7 @@ jobs:
     # (msgpack, borghash, borgstore) are the expensive
     # part of the container setup, so keep them from run to run.
     - name: Cache pip-built wheels (s390x)
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: .pip-cache-s390x
         key: s390x-pip-${{ hashFiles('pyproject.toml') }}
@@ -120,7 +120,7 @@ jobs:
         echo "BORG_VERSION=$("$RUNNER_TEMP/venv-native/bin/borg" --version | cut -d' ' -f2)" >> $GITHUB_ENV
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
       with:
         platforms: s390x
 

--- a/.github/workflows/bigendian.yml
+++ b/.github/workflows/bigendian.yml
@@ -79,6 +79,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # 26.5.1
         with:
             version: "~= 24.0"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -48,6 +48,7 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -131,6 +132,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Same as the "Cache pip-built wheels" step in ci.yml (MSYS2's mingw
       # Python cannot use PyPI's win_amd64 wheels). Own key, because the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,16 +203,21 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Not on tags: that is when the release binaries are built and attested,
+      # and they should not be able to pick up a poisoned cache entry.
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
         restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-pip-
-            ${{ runner.os }}-${{ runner.arch }}-
 
     - name: Cache tox environments
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # Not on tags: that is when the release binaries are built and attested,
+      # and they should not be able to pick up a poisoned cache entry.
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
       with:
         path: .tox
         key: ${{ runner.os }}-${{ runner.arch }}-tox-${{ matrix.toxenv }}-${{ hashFiles('requirements.d/development.lock.txt', 'pyproject.toml') }}
@@ -469,7 +474,10 @@ jobs:
       # rsyncs into the VM and back, so wheels built from sdists in one run
       # (most of the VM setup time) are reused by the next one.
       - name: Cache pip-built wheels
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        # Not on tags: that is when the release binaries are built and attested,
+        # and they should not be able to pick up a poisoned cache entry.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
         with:
           path: .pip-cache
           key: ${{ matrix.os }}-${{ matrix.version }}-py${{ matrix.pyver }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
@@ -750,7 +758,10 @@ jobs:
       # all compiled deps from source - incl. building maturin via cargo, just
       # to build the blake3 wheel. Persist the wheels pip builds.
       - name: Cache pip-built wheels
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        # Not on tags: that is when the release binaries are built and attested,
+        # and they should not be able to pick up a poisoned cache entry.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
         with:
           path: .pip-cache
           key: windows-msys2-pip-${{ hashFiles('pyproject.toml', 'requirements.d/pyinstaller.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
       # Not on tags: that is when the release binaries are built and attested,
       # and they should not be able to pick up a poisoned cache entry.
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
@@ -217,7 +217,7 @@ jobs:
       # Not on tags: that is when the release binaries are built and attested,
       # and they should not be able to pick up a poisoned cache entry.
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: .tox
         key: ${{ runner.os }}-${{ runner.arch }}-tox-${{ matrix.toxenv }}-${{ hashFiles('requirements.d/development.lock.txt', 'pyproject.toml') }}
@@ -479,7 +479,7 @@ jobs:
         # Not on tags: that is when the release binaries are built and attested,
         # and they should not be able to pick up a poisoned cache entry.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .pip-cache
           key: ${{ matrix.os }}-${{ matrix.version }}-py${{ matrix.pyver }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
@@ -763,7 +763,7 @@ jobs:
         # Not on tags: that is when the release binaries are built and attested,
         # and they should not be able to pick up a poisoned cache entry.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0  # zizmor: ignore[cache-poisoning]
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .pip-cache
           key: windows-msys2-pip-${{ hashFiles('pyproject.toml', 'requirements.d/pyinstaller.txt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
     - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
 
   security:
@@ -52,6 +54,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
@@ -76,6 +80,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -190,6 +195,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -457,6 +463,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       # .pip-cache lives inside the workspace, which cross-platform-actions
       # rsyncs into the VM and back, so wheels built from sdists in one run
@@ -737,6 +744,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # MSYS2's mingw Python cannot use PyPI's win_amd64 wheels, so pip builds
       # all compiled deps from source - incl. building maturin via cargo, just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,13 +358,15 @@ jobs:
 
     - name: Prepare binaries (${{ matrix.binary }})
       if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
+      env:
+        BINARY: ${{ matrix.binary }}
       run: |
         mkdir -p artifacts
         if [ -f dist/binary/borg.exe ]; then
-          cp dist/binary/borg.exe artifacts/${{ matrix.binary }}
+          cp dist/binary/borg.exe "artifacts/$BINARY"
         fi
         if [ -f dist/binary/borg.tgz ]; then
-          cp dist/binary/borg.tgz artifacts/${{ matrix.binary }}.tgz
+          cp dist/binary/borg.tgz "artifacts/$BINARY.tgz"
         fi
         echo "binary files"
         ls -l artifacts/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The analyze job below raises this to what CodeQL needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:

--- a/.github/workflows/fame.yml
+++ b/.github/workflows/fame.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         ref: master
         fetch-depth: 0  # git blame needs the whole history
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up PyPy 3.11 (nightly)
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
         fetch-depth: 0
         fetch-tags: true
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,33 @@
+# Configuration for zizmor (https://docs.zizmor.sh/), the GitHub Actions
+# static analyser.  Run it over this repository with:
+#
+#   zizmor .
+#
+# The findings listed here are the ones that were looked at and accepted.  The
+# reasoning lives next to the code it is about, in the workflow files - this
+# file only says "yes, we know".  Ignores are deliberately kept as whole-file
+# entries rather than file:line, so that they do not silently stop matching
+# whenever the surrounding workflow shifts by a line.
+
+rules:
+  artipacked:
+    ignore:
+      # backport.yml is the one workflow that must keep the credentials
+      # actions/checkout leaves behind: korthout/backport-action pushes the
+      # backport branch with a plain `git push`.
+      - backport.yml
+
+  dangerous-triggers:
+    ignore:
+      # backport.yml needs pull_request_target for a writable token, and never
+      # checks out or runs pull request code.  See the comment in the workflow.
+      - backport.yml
+
+  cache-poisoning:
+    ignore:
+      # The cache steps in ci.yml are skipped on tag pushes, which is when the
+      # release binaries are built and attested - see the `if:` on each of them.
+      # zizmor flags any actions/cache in a tag-triggered workflow regardless.
+      # A new cache step in ci.yml needs that same `if:`; this ignore will not
+      # tell you about it.
+      - ci.yml


### PR DESCRIPTION
Ran [zizmor](https://docs.zizmor.sh/) 1.29.0 (online mode, so the
`known-vulnerable-actions` and `impostor-commit` audits ran too) over
`.github/workflows/`, and took the findings one audit per commit.

Good news first: no known-vulnerable action versions and no impostor
commits - every SHA pin in the repo verified against the GitHub API.

| audit | n | what happened |
| --- | --- | --- |
| `unpinned-uses` | 8 | fixed - pinned |
| `artipacked` | 16 | 15 fixed, 1 documented exception |
| `cache-poisoning` | 4 | mitigated, then marked reviewed |
| `template-injection` | 2 | fixed (was a false positive, but the safer form is free) |
| `dangerous-triggers` | 1 | reviewed, documented |
| `excessive-permissions` | 3 | fixed |

`zizmor .` is clean on this branch, with the accepted findings recorded in
the new `.github/zizmor.yml`.

### unpinned-uses

`32bit.yml` and `bigendian.yml` were the only two workflows still on
floating tags - both were added *after* 4dfcf29ad ("CI: pin all GitHub
Actions to commit SHAs"), so they just missed the policy.  The SHAs for
checkout/setup-python/cache are the ones the other workflows already use.
`docker/setup-qemu-action` was not pinned anywhere yet; `v4` currently
resolves to the SHA used here (v4.2.0), so it is a no-op today.

### artipacked

`actions/checkout` leaves the job token in `.git/config`.  15 checkouts do
not need it and now set `persist-credentials: false`.

`backport.yml` is a deliberate exception: `korthout/backport-action` pushes
the backport branch with a plain `git push`, so it needs what checkout left
behind.  Setting `persist-credentials: false` there would have broken
backporting - noted in the file so nobody "fixes" it later.

### cache-poisoning

`native_tests`, `vm_tests` and `windows_tests` each restore a pip/tox cache
*and*, on tags, build the release binaries, attest their provenance and
upload them - so a poisoned cache entry could reach an attested artifact.
The caches are now skipped on tag pushes: PR/branch runs keep caching, and
release builds start cold.

zizmor's own autofix sets `lookup-only: true`, which disables cache restore
on *every* run - not what we want, hence the ignore on top of the real
mitigation.

Also drops the second pip `restore-keys` entry: `<os>-<arch>-` is a prefix
of the tox cache keys (`<os>-<arch>-tox-...`), so a pip cache miss could
restore a tox cache archive.  That one is a plain bug, unrelated to security.

### template-injection

`${{ matrix.binary }}` was expanded straight into a `run:` block.  The value
is a literal from this workflow's own matrix, so it was not exploitable -
but it now goes through `env:`, which stays correct if that ever changes.

### dangerous-triggers

`backport.yml` uses `pull_request_target`, which it needs for a writable
token.  It never checks out or runs PR code (the checkout takes the base
branch), so this is fine - now written down rather than re-derived.

### excessive-permissions

`backport.yml` declared `contents: write` + `pull-requests: write` for the
whole workflow; that moves to the job.  One job, so nothing actually ran
with more than it does now, but this is the `pull_request_target` workflow.
Its comments were also swapped - `contents: write` is what pushes the
branch, not what comments.

`codeql-analysis.yml` had no workflow-level `permissions:` at all.  Its one
job is scoped correctly, but a second job added later would fall through to
the repository default.

### Not in this PR: a repository setting

`default_workflow_permissions` for this repository is **`write`**, so any
job without an explicit `permissions:` block gets a read-write token.  After
this PR every job declares its own, so switching the default to read-only
would change nothing about how CI runs today, while removing the trap:

    gh api -X PUT repos/borgbackup/borg/actions/permissions/workflow \
      -f default_workflow_permissions=read

Worth *not* touching, though: "Allow GitHub Actions to create and approve
pull requests" (`can_approve_pull_request_reviews`).  It covers creating as
well as approving, and both `fame.yml` and `backport.yml` create pull
requests with `GITHUB_TOKEN`.

---

Workflow YAML parses at every commit; no CI behaviour changes except the
deliberate cache skip on tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)