### PR TITLE
dependabot: give pip patch releases a cooldown, order cooldown keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
+      # default-days also covers patch releases and packages not using semver.
+      default-days: 14
       semver-major-days: 90
       semver-minor-days: 30
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
     cooldown:
       # default-days also covers patch releases and actions not using semver.
       default-days: 14
-      semver-major-days: 90
       semver-minor-days: 30
+      semver-major-days: 90
     groups:
       actions:
         patterns:
@@ -22,8 +22,8 @@ updates:
     cooldown:
       # default-days also covers patch releases and packages not using semver.
       default-days: 14
-      semver-major-days: 90
       semver-minor-days: 30
+      semver-major-days: 90
     groups:
       pip-dependencies:
         patterns:


### PR DESCRIPTION
The `pip` ecosystem set `semver-major-days` and `semver-minor-days` but no `default-days`, while the
`github-actions` ecosystem right above it does set one — with a comment noting that `default-days`
is what covers patch releases.

So pip **patch** releases had no cooldown at all and could be merged within the weekly update cycle.
That is the wrong way round relative to the risk: a compromised PyPI release is typically published
as a patch bump, precisely because a patch looks routine.

First commit adds `default-days: 14` to the pip ecosystem, matching github-actions.

Second commit orders the keys by increasing duration (14, 30, 90) in both ecosystems, so the
escalation is readable at a glance.

No behaviour change from the second commit — dependabot does not care about key order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)