### PR TITLE
windows: fix platformdirs directories, fixes #10237

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -137,9 +137,10 @@ Compatibility notes:
     cache: ``~/Library/Caches/borg/``,
     runtime: ``~/Library/Caches/TemporaryItems/borg/``.
   - on Windows, the default directories are:
-    config/data: ``C:\Users\<user>\AppData\Local\borg\borg``,
-    cache: ``C:\Users\<user>\AppData\Local\borg\borg\Cache``,
-    runtime: ``C:\Users\<user>\AppData\Local\Temp\borg\borg``.
+    config: ``C:\Users\<user>\AppData\Roaming\borg``,
+    data: ``C:\Users\<user>\AppData\Local\borg``,
+    cache: ``C:\Users\<user>\AppData\Local\borg\Cache``,
+    runtime: ``C:\Users\<user>\AppData\Local\Temp\borg``.
   - **keyfile users on macOS (and Windows)**: borg 2 will look for key files in the
     new platform-specific config directory instead of ``~/.config/borg/keys/`` where
     borg 1.x stored them. You can set ``BORG_KEYS_DIR`` to point to the old location,

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -548,7 +548,7 @@ How important is the borg config directory?
 
 The borg config directory (``~/.config/borg`` on Linux,
 ``~/Library/Application Support/borg`` on macOS,
-``C:\Users\<user>\AppData\Local\borg\borg`` on Windows -- see :ref:`env_vars`)
+``C:\Users\<user>\AppData\Roaming\borg`` on Windows -- see :ref:`env_vars`)
 has content that you should take care of:
 
 ``keys`` subdirectory
@@ -557,9 +557,8 @@ has content that you should take care of:
   to have an independent backup of the borg keys, see :ref:`borg_key_export` for
   more details.
 
-On Windows, the doubled ``borg\borg`` in the path above is what the platformdirs defaults
-produce; whether borg should use a different directory scheme there is under review,
-see :issue:`10237`.
+On Windows, the configuration is stored in the *roaming* AppData, so in domain
+environments it follows the user's profile (including onto the profile server).
 
 Make sure that only you have access to the borg config directory.
 
@@ -603,7 +602,7 @@ How important is the borg data directory?
 
 The borg data directory (``~/.local/share/borg`` on Linux,
 ``~/Library/Application Support/borg`` on macOS,
-``C:\Users\<user>\AppData\Local\borg\borg`` on Windows -- see :ref:`env_vars`)
+``C:\Users\<user>\AppData\Local\borg`` on Windows -- see :ref:`env_vars`)
 has content that you should take care of:
 
 ``security`` subdirectory
@@ -613,7 +612,7 @@ has content that you should take care of:
   or manipulate these files. However, apart from those warnings, a loss of these files can be
   recovered.
 
-On macOS and Windows, this resolves to the same directory as the borg config directory,
+On macOS, this resolves to the same directory as the borg config directory,
 so the ``security`` and ``keys`` subdirectories sit next to each other there.
 
 Make sure that only you have access to the Borg data directory.

--- a/docs/usage/general/environment.rst.inc
+++ b/docs/usage/general/environment.rst.inc
@@ -401,9 +401,10 @@ Directories and files:
       honoured (see https://specifications.freedesktop.org/basedir/latest/).
     - macOS: native macOS directories are used by default (e.g. ``~/Library/Application Support/borg``,
       ``~/Library/Caches/borg``). ``XDG_*`` environment variables are honoured if set.
-    - Windows: local (not roaming) Windows AppData directories are used, e.g.
-      ``C:\Users\<user>\AppData\Local\borg\borg``. ``borg`` appears twice in that path because
-      borg does not give platformdirs a separate "app author" name, so it defaults to the app name.
+    - Windows: native Windows AppData directories are used. The configuration (including
+      the keys) is stored in the roaming profile (``C:\Users\<user>\AppData\Roaming\borg``),
+      so it follows the user in domain environments. Machine-specific data, cache and runtime
+      files stay in the local (non-roaming) AppData (``C:\Users\<user>\AppData\Local\borg``).
       ``XDG_*`` environment variables are **not** honoured.
 
     On all platforms, you can override each directory individually using the specific environment
@@ -413,10 +414,10 @@ Directories and files:
     Default directory locations by platform (when no ``BORG_*`` environment variables are set)::
 
         Directory  Linux                 macOS                                 Windows
-        Config     ~/.config/borg        ~/Library/Application Support/borg    %LOCALAPPDATA%\borg\borg
-        Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\borg\borg\Cache
-        Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\borg\borg
-        Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %LOCALAPPDATA%\Temp\borg\borg
+        Config     ~/.config/borg        ~/Library/Application Support/borg    %APPDATA%\borg
+        Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\borg\Cache
+        Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\borg
+        Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %LOCALAPPDATA%\Temp\borg
         Keys       <config_dir>/keys     <config_dir>/keys                     <config_dir>\keys
         Security   <data_dir>/security   <data_dir>/security                   <data_dir>\security
 

--- a/docs/usage/key.rst
+++ b/docs/usage/key.rst
@@ -39,7 +39,7 @@ Examples
 
     The key file paths shown above are the defaults for Linux (``~/.config/borg/keys/``).
     On macOS, key files are stored in ``~/Library/Application Support/borg/keys/``.
-    On Windows, they are stored in ``C:\Users\<user>\AppData\Local\borg\borg\keys\``.
+    On Windows, they are stored in ``C:\Users\<user>\AppData\Roaming\borg\keys\``.
     See :ref:`env_vars` for details.
 
 ::

--- a/docs/usage/transfer.rst
+++ b/docs/usage/transfer.rst
@@ -85,7 +85,7 @@ On **macOS**, Borg 1.x stored key files in ``~/.config/borg/keys/``,
 but Borg 2 defaults to ``~/Library/Application Support/borg/keys/``.
 
 On **Windows**, Borg 1.x used XDG-style paths (e.g. ``~/.config/borg/keys/``),
-while Borg 2 defaults to ``C:\Users\<user>\AppData\Local\borg\borg\keys\``.
+while Borg 2 defaults to ``C:\Users\<user>\AppData\Roaming\borg\keys\``.
 
 If Borg 2 cannot find your key file, you have several options:
 

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -989,9 +989,10 @@ class HelpMixIn:
               honoured (see https://specifications.freedesktop.org/basedir/latest/).
             - macOS: native macOS directories are used by default (e.g. ``~/Library/Application Support/borg``,
               ``~/Library/Caches/borg``). ``XDG_*`` environment variables are honoured if set.
-            - Windows: local (not roaming) Windows AppData directories are used, e.g.
-              ``C:\\Users\\<user>\\AppData\\Local\\borg\\borg``. ``borg`` appears twice in that path because
-              borg does not give platformdirs a separate "app author" name, so it defaults to the app name.
+            - Windows: native Windows AppData directories are used. The configuration (including
+              the keys) is stored in the roaming profile (``C:\\Users\\<user>\\AppData\\Roaming\\borg``),
+              so it follows the user in domain environments. Machine-specific data, cache and runtime
+              files stay in the local (non-roaming) AppData (``C:\\Users\\<user>\\AppData\\Local\\borg``).
               ``XDG_*`` environment variables are **not** honoured.
 
             On all platforms, you can override each directory individually using the specific environment
@@ -1001,10 +1002,10 @@ class HelpMixIn:
             Default directory locations by platform (when no ``BORG_*`` environment variables are set)::
 
                 Directory  Linux                 macOS                                 Windows
-                Config     ~/.config/borg        ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg\\borg
-                Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\\borg\\borg\\Cache
-                Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg\\borg
-                Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %LOCALAPPDATA%\\Temp\\borg\\borg
+                Config     ~/.config/borg        ~/Library/Application Support/borg    %APPDATA%\\borg
+                Cache      ~/.cache/borg         ~/Library/Caches/borg                 %LOCALAPPDATA%\\borg\\Cache
+                Data       ~/.local/share/borg   ~/Library/Application Support/borg    %LOCALAPPDATA%\\borg
+                Runtime    /run/user/<uid>/borg  ~/Library/Caches/TemporaryItems/borg  %LOCALAPPDATA%\\Temp\\borg
                 Keys       <config_dir>/keys     <config_dir>/keys                     <config_dir>\\keys
                 Security   <data_dir>/security   <data_dir>/security                   <data_dir>\\security
 

--- a/src/borg/helpers/fs.py
+++ b/src/borg/helpers/fs.py
@@ -92,8 +92,12 @@ def get_data_dir(*subdirs, create=True):
 
     Any additional path components are appended to the data directory.
     """
+    # appauthor=False (here and in the other platformdirs calls): without it, platformdirs defaults
+    # the appauthor to the appname, doubling "borg" in the Windows AppData paths, see #10237.
+    # The data dir (e.g. the security state) is machine-specific client state, so it stays in the
+    # non-roaming AppData on Windows.
     data_dir = os.environ.get(
-        "BORG_DATA_DIR", join_base_dir(".local", "share", "borg") or platformdirs.user_data_dir("borg")
+        "BORG_DATA_DIR", join_base_dir(".local", "share", "borg") or platformdirs.user_data_dir("borg", appauthor=False)
     )
     if subdirs:
         data_dir = str(Path(data_dir).joinpath(*subdirs))
@@ -108,7 +112,7 @@ def get_runtime_dir(*subdirs, create=True):
     Any additional path components are appended to the runtime directory.
     """
     runtime_dir = os.environ.get(
-        "BORG_RUNTIME_DIR", join_base_dir(".cache", "borg") or platformdirs.user_runtime_dir("borg")
+        "BORG_RUNTIME_DIR", join_base_dir(".cache", "borg") or platformdirs.user_runtime_dir("borg", appauthor=False)
     )
     if subdirs:
         runtime_dir = str(Path(runtime_dir).joinpath(*subdirs))
@@ -122,7 +126,11 @@ def get_cache_dir(*subdirs, create=True):
 
     Any additional path components are appended to the cache directory.
     """
-    cache_dir = os.environ.get("BORG_CACHE_DIR", join_base_dir(".cache", "borg") or platformdirs.user_cache_dir("borg"))
+    # Keep platformdirs' opinionated "Cache" subdir on Windows: it keeps the cache - and the
+    # CACHEDIR.TAG written into the cache root below - out of %LOCALAPPDATA%\borg, the data dir.
+    cache_dir = os.environ.get(
+        "BORG_CACHE_DIR", join_base_dir(".cache", "borg") or platformdirs.user_cache_dir("borg", appauthor=False)
+    )
     full_dir = str(Path(cache_dir).joinpath(*subdirs)) if subdirs else cache_dir
     if create:
         ensure_dir(full_dir)
@@ -151,8 +159,11 @@ def get_config_dir(*subdirs, create=True):
 
     Any additional path components are appended to the config directory.
     """
+    # roaming=True: on Windows, the configuration (including the keys dir) goes into the roaming
+    # profile (%APPDATA%), so it follows the user; machine-specific data/cache stay in %LOCALAPPDATA%.
     config_dir = os.environ.get(
-        "BORG_CONFIG_DIR", join_base_dir(".config", "borg") or platformdirs.user_config_dir("borg")
+        "BORG_CONFIG_DIR",
+        join_base_dir(".config", "borg") or platformdirs.user_config_dir("borg", appauthor=False, roaming=True),
     )
     if subdirs:
         config_dir = str(Path(config_dir).joinpath(*subdirs))

--- a/src/borg/testsuite/helpers/fs_test.py
+++ b/src/borg/testsuite/helpers/fs_test.py
@@ -50,7 +50,7 @@ def test_get_config_dir(monkeypatch):
     home_dir = os.path.expanduser("~")
     if is_win32:
         monkeypatch.delenv("BORG_CONFIG_DIR", raising=False)
-        assert get_config_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "borg")
+        assert get_config_dir(create=False) == os.path.join(home_dir, "AppData", "Roaming", "borg")
         monkeypatch.setenv("BORG_CONFIG_DIR", home_dir)
         assert get_config_dir(create=False) == home_dir
     elif is_darwin:
@@ -77,7 +77,7 @@ def test_get_cache_dir(monkeypatch):
     home_dir = os.path.expanduser("~")
     if is_win32:
         monkeypatch.delenv("BORG_CACHE_DIR", raising=False)
-        assert get_cache_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "borg", "Cache")
+        assert get_cache_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "Cache")
         monkeypatch.setenv("BORG_CACHE_DIR", home_dir)
         assert get_cache_dir(create=False) == home_dir
     elif is_darwin:
@@ -104,7 +104,7 @@ def test_get_keys_dir(monkeypatch):
     home_dir = os.path.expanduser("~")
     if is_win32:
         monkeypatch.delenv("BORG_KEYS_DIR", raising=False)
-        assert get_keys_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "borg", "keys")
+        assert get_keys_dir(create=False) == os.path.join(home_dir, "AppData", "Roaming", "borg", "keys")
         monkeypatch.setenv("BORG_KEYS_DIR", home_dir)
         assert get_keys_dir(create=False) == home_dir
     elif is_darwin:
@@ -131,9 +131,9 @@ def test_get_security_dir(monkeypatch):
     home_dir = os.path.expanduser("~")
     if is_win32:
         monkeypatch.delenv("BORG_SECURITY_DIR", raising=False)
-        assert get_security_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "borg", "security")
+        assert get_security_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "borg", "security")
         assert get_security_dir(repository_id="1234", create=False) == os.path.join(
-            home_dir, "AppData", "Local", "borg", "borg", "security", "1234"
+            home_dir, "AppData", "Local", "borg", "security", "1234"
         )
         monkeypatch.setenv("BORG_SECURITY_DIR", home_dir)
         assert get_security_dir(create=False) == home_dir
@@ -169,7 +169,7 @@ def test_get_runtime_dir(monkeypatch):
     home_dir = os.path.expanduser("~")
     if is_win32:
         monkeypatch.delenv("BORG_RUNTIME_DIR", raising=False)
-        assert get_runtime_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "Temp", "borg", "borg")
+        assert get_runtime_dir(create=False) == os.path.join(home_dir, "AppData", "Local", "Temp", "borg")
         monkeypatch.setenv("BORG_RUNTIME_DIR", home_dir)
         assert get_runtime_dir(create=False) == home_dir
     elif is_darwin:


### PR DESCRIPTION
## Summary

borg called platformdirs with the appname only, so on Windows the appauthor component defaulted to the appname and every default directory ended up under a doubled ``AppData\...\borg\borg`` path (#10237).

This passes ``appauthor=False`` to all four platformdirs calls and ``roaming=True`` for the config dir, restoring the layout the CHANGES upgrade notes had documented as intended all along:

| Directory | New default | Old (doubled) |
|---|---|---|
| config (incl. `keys\`) | `C:\Users\<user>\AppData\Roaming\borg` | `...\AppData\Local\borg\borg` |
| data (incl. `security\`) | `C:\Users\<user>\AppData\Local\borg` | `...\AppData\Local\borg\borg` |
| cache | `C:\Users\<user>\AppData\Local\borg\Cache` | `...\AppData\Local\borg\borg\Cache` |
| runtime | `C:\Users\<user>\AppData\Local\Temp\borg` | `...\AppData\Local\Temp\borg\borg` |

**Only Windows is affected**: the Unix and macOS platformdirs backends ignore both ``appauthor`` and ``roaming`` (verified against platformdirs 4.10.1), so Linux/macOS paths are byte-identical before and after.

## Rationale

- **``appauthor=False``**: no vendor directory level. This is what comparable tools do (pip, rclone, restic, kopia all use a single ``<app>`` level on Windows) and matches the bare ``borg`` dir used on the other platforms.
- **``roaming=True`` for config only** (answers the roaming question from the issue): per Microsoft's semantics, the roaming AppData is for per-user settings that follow the user across machines in a domain, the local AppData for machine-specific state and caches. Keys are precious, tiny, passphrase-protected user data - exactly what should roam; the security state is this client's per-repo view (sharing it between profile-synced machines invites spurious relocation/replay warnings), so data stays local. Same split as pip (``%APPDATA%\pip`` / ``%LOCALAPPDATA%\pip\Cache``), rclone (moved to ``%APPDATA%\rclone`` deliberately, rclone/rclone#4667) and kopia. For non-domain users both locations are local dirs, so this is purely cosmetic.
- **Cache keeps platformdirs' opinionated ``Cache`` subdir**: it keeps the cache - and the CACHEDIR.TAG borg writes into the cache root - out of ``%LOCALAPPDATA%\borg``, which is now the data dir root.

## Migration

The first-ever Windows binary was released with 2.0.0b23 (2026-08-23), so affected native-Windows beta users should be very rare. No automatic migration: keyfile users move their keys from the old ``%LOCALAPPDATA%\borg\borg\keys`` to the new location (or set the ``BORG_*`` dir env vars to the old paths); cache and security state are recreated/re-learned as needed. Covered in the CHANGES compatibility notes.

## Docs

Updated the environment help topic (single source; ``environment.rst.inc`` regenerated via ``build_usage``), the FAQ security advisories, the key/transfer usage docs and the CHANGES upgrade notes - including the "same directory as the config dir" claim that now only holds on macOS.

## Testing

- ``fs_test.py`` Windows expectations updated; the win32 branches run in the Windows CI job.
- Emulated platformdirs' Windows backend (faked CSIDL lookup) with the exact new call signatures: all four paths match the expectations above.
- Full ``testsuite/helpers`` passes on macOS (557 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)