### PR TITLE
release: attach the sdist's sigstore bundle to the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,23 @@ jobs:
         "$RUNNER_TEMP/venv-sdist/bin/borg" --help > /dev/null
 
     - name: Attest the sdist provenance
+      id: attest-sdist
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
       with:
         subject-path: 'dist/*.tar.gz'
+
+    - name: Name the sigstore bundle after the sdist
+      # The attestation is also stored in the GitHub attestations API, but
+      # fetching it from there needs a recent gh and a GitHub token (see
+      # #10187) - so attach the sigstore bundle to the release as
+      # <sdist>.sigstore.jsonl, which allows offline/token-less verification
+      # with generic sigstore tooling (cosign, gh attestation verify --bundle).
+      env:
+        BUNDLE_PATH: ${{ steps.attest-sdist.outputs.bundle-path }}
+      run: |
+        set -euxo pipefail
+        sdist=$(basename dist/borgbackup-*.tar.gz)
+        cp "$BUNDLE_PATH" "dist/$sdist.sigstore.jsonl"
 
     - name: Download the binaries built for this tag
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -168,18 +182,29 @@ jobs:
 
         All release assets have a [build provenance attestation](https://github.com/borgbackup/borg/attestations),
         verifiable with \`gh attestation verify --owner borgbackup <file>\`.
+
+        The sdist's attestation is additionally attached as the [sigstore](https://www.sigstore.dev/)
+        bundle \`borgbackup-$TAG.tar.gz.sigstore.jsonl\`, so it can be verified offline and
+        without a GitHub token, e.g. with cosign:
+
+        \`\`\`
+        cosign verify-blob borgbackup-$TAG.tar.gz \\
+          --bundle borgbackup-$TAG.tar.gz.sigstore.jsonl \\
+          --certificate-identity https://github.com/borgbackup/borg/.github/workflows/release.yml@refs/tags/$TAG \\
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com
+        \`\`\`
         EOF
         mkdir -p assets  # there may not have been any artifact to download
         if gh release view "$TAG" > /dev/null 2>&1; then
           # a re-run of this job: keep the (possibly already edited) release and
           # just replace its assets.
-          gh release upload "$TAG" --clobber dist/*.tar.gz $(find assets -type f | sort)
+          gh release upload "$TAG" --clobber dist/*.tar.gz dist/*.sigstore.jsonl $(find assets -type f | sort)
         else
           gh release create "$TAG" \
             --draft $prerelease \
             --title "borg $TAG" \
             --notes-file release-notes.md \
-            dist/*.tar.gz $(find assets -type f | sort)
+            dist/*.tar.gz dist/*.sigstore.jsonl $(find assets -type f | sort)
         fi
         gh release view "$TAG" --json isDraft,isPrerelease,assets
 


### PR DESCRIPTION
As requested in the discussion on #10187 (https://github.com/borgbackup/borg/discussions/10187#discussioncomment-18208932): the sdist provenance attestation is only stored in the GitHub attestations API, and fetching it from there needs a recent `gh` (Debian's is too old) and a GitHub token (cli/cli#11803) - both inconvenient for CI/CD jobs that want to verify the sdist before building borg from source, and a regression in convenience vs. the old locally-made `.asc` GPG signature.

This attaches the sigstore bundle that `actions/attest-build-provenance` already produces (its `bundle-path` output) to the GitHub release as `borgbackup-<version>.tar.gz.sigstore.jsonl`, next to the sdist. With the bundle at a stable, pre-known location, verification works offline and token-less with generic sigstore tooling:

```
cosign verify-blob borgbackup-<version>.tar.gz \
  --bundle borgbackup-<version>.tar.gz.sigstore.jsonl \
  --certificate-identity https://github.com/borgbackup/borg/.github/workflows/release.yml@refs/tags/<version> \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

(`cosign verify-blob-attestation --type slsaprovenance1` and `gh attestation verify --bundle` work as well, per the testing done in the discussion.)

The generated release notes now document the bundle and the cosign verification command. The bundle is also uploaded on job re-runs (`gh release upload --clobber`), and the sdist artifact handed to the PyPI job is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)