### PR TITLE
benchmark cpu: catch exceptions per test, do not abort the whole run

### DIFF
--- a/src/borg/archiver/benchmark_cmd.py
+++ b/src/borg/archiver/benchmark_cmd.py
@@ -304,6 +304,23 @@ class BenchmarkMixIn:
                     line += f"  {ratio:6.2f}x"
                 print(line)
 
+        def measure(section, spec, func, number, setup="pass", globals=None):
+            """Time *func*, returning the elapsed time - or None if the test failed.
+
+            One test blowing up (e.g. a memory-hungry codec raising MemoryError on a
+            small machine) must not abort the whole benchmark run, so a failure is
+            reported like any other result and the remaining tests still run.
+            """
+            try:
+                return timeit(func, setup, number=number, globals=globals)
+            except Exception as exc:
+                error = type(exc).__name__ + (f": {exc}" if str(exc) else "")
+                if args.json:
+                    result[section].append({"spec": spec, "error": error})
+                else:
+                    print(f"{spec:<{WIDTH}} failed: {error}")
+                return None
+
         def section_header(section, title):
             if args.json:
                 result[section] = []
@@ -372,7 +389,9 @@ class BenchmarkMixIn:
                     locals(),
                 ),
             ]:
-                dt = timeit(func, setup, number=number_default, globals=vars)
+                dt = measure("chunkers", spec, func, number_default, setup=setup, globals=vars)
+                if dt is None:
+                    continue
                 algo, _, algo_params = spec.partition(",")
                 report("chunkers", spec, size, dt, algo=algo, algo_params=algo_params)
 
@@ -399,7 +418,9 @@ class BenchmarkMixIn:
                 for label, nbytes in sizes:
                     data = buffer(nbytes)
                     number = max(1, hash_total // nbytes)
-                    dt = timeit(lambda: func(data), number=number)
+                    dt = measure("hashes", f"{spec} ({label})", lambda: func(data), number)
+                    if dt is None:
+                        continue
                     report("hashes", f"{spec} ({label})", nbytes * number, dt, algo=spec, buffer_size=nbytes)
 
         if "encrypting" in selected:
@@ -435,7 +456,9 @@ class BenchmarkMixIn:
                 ),
             ]
             for spec, func in tests:
-                dt = timeit(func, number=number_default)
+                dt = measure("encryption", spec, func, number_default)
+                if dt is None:
+                    continue
                 report("encryption", spec, size, dt, algo=spec)
 
         if "compressing" in selected:
@@ -477,7 +500,9 @@ class BenchmarkMixIn:
                         nonlocal csize
                         csize = sum(len(compressor.compress({}, buf)[1]) for buf in bufs)
 
-                    dt = timeit(compress_all, number=1)
+                    dt = measure("compression", f"{spec} ({label})", compress_all, 1)
+                    if dt is None:
+                        continue
                     algo, _, algo_params = spec.partition(",")
                     report(
                         "compression",
@@ -497,13 +522,14 @@ class BenchmarkMixIn:
             items = [item.as_dict()] * 1000
             count = 1000 * number_default
             spec = "msgpack"
-            dt = timeit(lambda: msgpack.packb(items), number=number_default)
-            if args.json:
-                result["msgpack"].append({"algo": spec, "count": count, "time": dt})
-            else:
-                # this one packs items, not bytes, so it gets a rate in its own unit
-                size = "%dk Items" % (count // 1000)
-                print(f"{spec:<{WIDTH}} {size:<11} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
+            dt = measure("msgpack", spec, lambda: msgpack.packb(items), number_default)
+            if dt is not None:
+                if args.json:
+                    result["msgpack"].append({"algo": spec, "count": count, "time": dt})
+                else:
+                    # this one packs items, not bytes, so it gets a rate in its own unit
+                    size = "%dk Items" % (count // 1000)
+                    print(f"{spec:<{WIDTH}} {size:<11} {dt:.3f}s  {count / dt / 1000:>8.1f} kItems/s")
 
         if args.json:
             json_print(result)

--- a/src/borg/testsuite/archiver/benchmark_cmd_test.py
+++ b/src/borg/testsuite/archiver/benchmark_cmd_test.py
@@ -168,3 +168,39 @@ def test_benchmark_cpu_data_empty(archiver, monkeypatch, tmp_path):
     else:
         with pytest.raises(CommandError, match="no data found"):
             cmd(archiver, "benchmark", "cpu", "--compressing", "--data", str(data_file))
+
+
+def test_benchmark_cpu_failing_test_does_not_abort(archiver, monkeypatch):
+    """A single failing test (e.g. a codec running out of memory) must not kill the whole run."""
+    import lzma
+
+    def out_of_memory(*args, **kwargs):
+        raise MemoryError
+
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    monkeypatch.setattr(lzma, "compress", out_of_memory)
+    # fork=False, so the monkeypatched lzma is the one the benchmark uses
+    output = cmd(archiver, "benchmark", "cpu", "--compressing", fork=False)
+    assert "lzma" in output
+    assert "failed: MemoryError" in output
+    # the codecs that do work are still measured
+    assert "lz4" in output
+    assert "MB/s" in output
+
+
+def test_benchmark_cpu_failing_test_json(archiver, monkeypatch):
+    import lzma
+
+    def out_of_memory(*args, **kwargs):
+        raise MemoryError
+
+    monkeypatch.setenv("_BORG_BENCHMARK_CPU_TEST", "YES")
+    monkeypatch.setattr(lzma, "compress", out_of_memory)
+    output = cmd(archiver, "benchmark", "cpu", "--compressing", "--json", fork=False)
+    result = json.loads(output)
+    failed = [entry for entry in result["compression"] if "error" in entry]
+    assert failed  # the lzma tests failed and are reported as such
+    for entry in failed:
+        assert entry["spec"].startswith("lzma")
+        assert entry["error"] == "MemoryError"
+    assert [entry for entry in result["compression"] if "time" in entry]  # the other codecs still got measured


### PR DESCRIPTION
A single failing test killed the complete `borg benchmark cpu` run with a traceback. Seen on a small ARM machine: all codecs up to `lzma,0` were measured fine, then `lzma,6` raised `MemoryError` inside `lzma.LZMACompressor()` and the whole run went down with "Local Exception", losing the remaining results.

Now each timed test goes through a `measure()` helper that catches exceptions, reports the failure like any other result and lets the remaining tests run:

```
lzma,0 (2MiB)              10.00 MiB   9.207s      1.1 MB/s   ...
lzma,6 (2MiB)              failed: MemoryError
lzma,9 (2MiB)              failed: MemoryError
```

In `--json` mode the output stays valid JSON, the failed test becomes a `{"spec": "lzma,6 (2MiB)", "error": "MemoryError"}` entry in its section list.

This covers all sections (chunkers, hashes, encryption, compression, msgpack). `KeyboardInterrupt` is not an `Exception`, so Ctrl-C still aborts as before. The exit code is unchanged (0) - a single failed measurement does not make the command fail.

Tests: two new tests monkeypatch `lzma.compress` to raise `MemoryError` and check the plain text and the JSON path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)