### PR TITLE
do not ignore -a / --match-archives when an archive NAME is given

### DIFF
--- a/src/borg/archiver/_common.py
+++ b/src/borg/archiver/_common.py
@@ -381,6 +381,24 @@ def define_exclusion_group(subparser, **kwargs):
     return exclude_group
 
 
+def archive_match_patterns(args):
+    """
+    Build the list of match patterns selecting archives from the NAME positional and -a / --match-archives.
+
+    A NAME given as positional argument is just another way of saying ``-a NAME``, so it is combined with
+    the patterns given via -a / --match-archives. As all patterns must match (they are ANDed), giving both
+    narrows down the selection rather than one of them overriding the other.
+
+    NAME is used as-is, so it supports the same selector prefixes as -a does, e.g. ``borg info aid:1234abcd``
+    (that is also what the shell completion offers for the NAME positional).
+    """
+    patterns = list(args.match_archives or [])
+    name = getattr(args, "name", None)
+    if name:
+        patterns.insert(0, name)
+    return patterns
+
+
 def define_archive_filters_group(
     subparser, *, sort_by=True, first_last=True, oldest_newest=True, older_newer=True, deleted=False
 ):

--- a/src/borg/archiver/delete_cmd.py
+++ b/src/borg/archiver/delete_cmd.py
@@ -1,6 +1,6 @@
 import logging
 
-from ._common import with_repository
+from ._common import with_repository, archive_match_patterns
 from ..constants import *  # NOQA
 from ..helpers import format_archive, CommandError, bin_to_hex, archivename_validator
 from ..helpers.argparsing import ArgumentParser
@@ -19,7 +19,7 @@ class DeleteMixIn:
         dry_run = args.dry_run
         manifest = Manifest.load(repository, (Manifest.Operation.DELETE,))
         if args.name:
-            archive_infos = [manifest.archives.get_one([args.name])]
+            archive_infos = [manifest.archives.get_one(archive_match_patterns(args))]
         else:
             archive_infos = manifest.archives.list_considering(args)
         archive_infos = [ai for ai in archive_infos if "@PROT" not in ai.tags]

--- a/src/borg/archiver/help_cmd.py
+++ b/src/borg/archiver/help_cmd.py
@@ -310,7 +310,13 @@ class HelpMixIn:
     helptext["match-archives"] = textwrap.dedent(
         """
         The ``--match-archives`` option matches a given pattern against the list of all archives
-        in the repository. It can be given multiple times.
+        in the repository. It can be given multiple times; an archive is only considered if it
+        matches all given patterns.
+
+        Commands that also accept an archive NAME as a positional argument treat that NAME like
+        an additional pattern, so NAME and ``--match-archives`` can be combined to narrow down the
+        selection, e.g. ``borg prune home -a host:myhost``. NAME accepts the same prefixes as the
+        patterns below, e.g. ``borg info aid:1234abcd``.
 
         The patterns can have a prefix of:
 

--- a/src/borg/archiver/info_cmd.py
+++ b/src/borg/archiver/info_cmd.py
@@ -1,7 +1,7 @@
 import textwrap
 from datetime import timedelta
 
-from ._common import with_repository
+from ._common import with_repository, archive_match_patterns
 from ..archive import Archive
 from ..constants import *  # NOQA
 from ..helpers import format_timedelta, json_print, basic_json_data, archivename_validator
@@ -19,7 +19,7 @@ class InfoMixIn:
         """Show archive details such as disk space used"""
 
         if args.name:
-            archive_infos = [manifest.archives.get_one([args.name])]
+            archive_infos = [manifest.archives.get_one(archive_match_patterns(args))]
         else:
             archive_infos = manifest.archives.list_considering(args)
 

--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -5,7 +5,7 @@ import math
 from functools import wraps
 import os
 from itertools import count, combinations
-from ._common import with_repository, Highlander
+from ._common import with_repository, Highlander, archive_match_patterns
 from ..constants import *  # NOQA
 from ..helpers import ArchiveFormatter, ProgressIndicatorPercent, CommandError, Error
 from ..helpers import archivename_validator, int_or_interval, sig_int, timestamp
@@ -175,7 +175,7 @@ class PruneMixIn:
         """Prune archives according to specified rules."""
         self._validate_prune_args(args)
 
-        match = [args.name] if args.name else args.match_archives
+        match = archive_match_patterns(args)
         archives = manifest.archives.list(match=match, sort_by=["ts"], reverse=True)
         archives = [ai for ai in archives if "@PROT" not in ai.tags]
 
@@ -358,9 +358,22 @@ class PruneMixIn:
         There is no automatic distinction between archives representing different
         contents. These need to be distinguished by specifying matching globs.
 
+        NAME is just another way of saying ``-a NAME``, so it can be combined with
+        --match-archives (-a). All given patterns must match (they are ANDed), thus giving
+        both narrows down the selection.
+
         If you have multiple series of archives with different data sets (e.g.
         from different machines) in one shared repository, use one prune call per
-        series.
+        series. In such a shared repository, the series name alone might not be
+        specific enough, because different machines or users may use the same series
+        name for their own, unrelated data. Additionally match on the archive metadata
+        that identifies the origin, e.g.::
+
+            borg prune home -a host:myhost --keep-daily 7 --keep-weekly 4
+
+        Note: the ``host:`` / ``user:`` metadata is what the client wrote into the
+        archive; it is not a permission mechanism. Any client with delete permission
+        for the repository can prune any archive in it.
 
         The ``--keep`` option is the simplest way to specify a basic retention
         policy. It accepts a count or a time interval for retention (e.g.

--- a/src/borg/archiver/tag_cmd.py
+++ b/src/borg/archiver/tag_cmd.py
@@ -1,4 +1,4 @@
-from ._common import with_repository, define_archive_filters_group
+from ._common import with_repository, define_archive_filters_group, archive_match_patterns
 from ..archive import Archive
 from ..constants import *  # NOQA
 from ..helpers import bin_to_hex, archivename_validator, tag_validator
@@ -16,7 +16,7 @@ class TagMixIn:
         """Manage tags."""
 
         if args.name:
-            archive_infos = [manifest.archives.get_one([args.name])]
+            archive_infos = [manifest.archives.get_one(archive_match_patterns(args))]
         else:
             archive_infos = manifest.archives.list_considering(args)
 

--- a/src/borg/archiver/undelete_cmd.py
+++ b/src/borg/archiver/undelete_cmd.py
@@ -1,6 +1,6 @@
 import logging
 
-from ._common import with_repository
+from ._common import with_repository, archive_match_patterns
 from ..constants import *  # NOQA
 from ..helpers import format_archive, CommandError, bin_to_hex, archivename_validator
 from ..helpers.argparsing import ArgumentParser
@@ -19,7 +19,7 @@ class UnDeleteMixIn:
         dry_run = args.dry_run
         manifest = Manifest.load(repository, (Manifest.Operation.DELETE,))
         if args.name:
-            archive_infos = [manifest.archives.get_one([args.name], deleted=True)]
+            archive_infos = [manifest.archives.get_one(archive_match_patterns(args), deleted=True)]
         else:
             args.deleted = True
             archive_infos = manifest.archives.list_considering(args)

--- a/src/borg/testsuite/archiver/_common_test.py
+++ b/src/borg/testsuite/archiver/_common_test.py
@@ -28,3 +28,44 @@ def test_get_repository_local_v1_uses_legacy_repository(tmp_path):
         get_repository(location, create=False, exclusive=False, lock_wait=None, lock=True, args=None, v1_legacy=True)
 
     mock_cls.assert_called_once_with(str(tmp_path), create=False, exclusive=False, lock_wait=None, lock=True)
+
+
+def test_archive_match_patterns_combines_name_and_match_archives():
+    """A NAME positional is just another pattern, ANDed with the -a / --match-archives ones."""
+    from ...archiver._common import archive_match_patterns
+
+    args = MagicMock()
+    args.name = "home"
+    args.match_archives = ["host:myhost"]
+    assert archive_match_patterns(args) == ["home", "host:myhost"]
+
+
+def test_archive_match_patterns_name_keeps_selector_prefix():
+    """NAME is used as-is, so a prefixed NAME like aid:1234abcd keeps working."""
+    from ...archiver._common import archive_match_patterns
+
+    args = MagicMock()
+    args.name = "aid:1234abcd"
+    args.match_archives = None
+    assert archive_match_patterns(args) == ["aid:1234abcd"]
+
+
+def test_archive_match_patterns_without_name():
+    from ...archiver._common import archive_match_patterns
+
+    args = MagicMock()
+    args.name = None
+    args.match_archives = ["host:myhost"]
+    assert archive_match_patterns(args) == ["host:myhost"]
+
+    args.match_archives = None
+    assert archive_match_patterns(args) == []
+
+
+def test_archive_match_patterns_name_only():
+    from ...archiver._common import archive_match_patterns
+
+    args = MagicMock()
+    args.name = "home"
+    args.match_archives = None
+    assert archive_match_patterns(args) == ["home"]

--- a/src/borg/testsuite/archiver/delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/delete_cmd_test.py
@@ -114,3 +114,24 @@ def test_delete_ignore_protected(archivers, request):
     assert "@PROT" in output
     assert "test1" in output
     assert "test2" not in output
+
+
+def test_delete_name_and_match_archives_are_combined(archivers, request, monkeypatch):
+    """In a shared repository, different hosts may use the same archive name - NAME alone is ambiguous then."""
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    for host in ("host1", "host2"):
+        monkeypatch.setenv("BORG_HOSTNAME", host)
+        cmd(archiver, "create", "home", "input")
+    monkeypatch.delenv("BORG_HOSTNAME")
+    msg = "needed to match precisely one archive"
+    if archiver.FORK_DEFAULT:
+        cmd(archiver, "delete", "home", exit_code=CommandError().exit_code)
+    else:
+        with pytest.raises(CommandError, match=msg):
+            cmd(archiver, "delete", "home")
+    # NAME is ANDed with -a / --match-archives, so this selects one specific host's archive:
+    cmd(archiver, "delete", "home", "-a", "host:host1")
+    output = cmd(archiver, "repo-list", "--format={hostname}{NL}")
+    assert output.strip() == "host2"

--- a/src/borg/testsuite/archiver/info_cmd_test.py
+++ b/src/borg/testsuite/archiver/info_cmd_test.py
@@ -59,3 +59,19 @@ def test_info_working_directory(archivers, request):
         cmd(archiver, "create", "test", ".")
     info_archive = cmd(archiver, "info", "-a", "test")
     assert f"Working Directory: {expected_cwd}" in info_archive
+
+
+def test_info_name_with_aid_prefix(archivers, request, monkeypatch):
+    """NAME is used as-is, so the aid: selector prefix works there and combines with -a."""
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    monkeypatch.setenv("BORG_HOSTNAME", "host1")
+    cmd(archiver, "create", "home", "input")
+    monkeypatch.delenv("BORG_HOSTNAME")
+    archive_id = json.loads(cmd(archiver, "repo-list", "--json"))["archives"][0]["id"]
+    info = json.loads(cmd(archiver, "info", "--json", f"aid:{archive_id[:8]}"))
+    assert info["archives"][0]["id"] == archive_id
+    # an aid: NAME is ANDed with -a like any other pattern:
+    info = json.loads(cmd(archiver, "info", "--json", f"aid:{archive_id[:8]}", "-a", "host:host1"))
+    assert info["archives"][0]["id"] == archive_id

--- a/src/borg/testsuite/archiver/prune_cmd_test.py
+++ b/src/borg/testsuite/archiver/prune_cmd_test.py
@@ -876,3 +876,19 @@ def test_prune_interval_rolling_schedule_oldest_retention():
 
     assert previous_archives[-1].ts.strftime("%m-%d") == "01-01"
     assert archives[-1].ts.strftime("%m-%d") == "01-31"
+
+
+def test_prune_name_and_match_archives_are_combined(archivers, request, backup_files, monkeypatch):
+    """In a shared repository, pruning a series must be restrictable to the archives of one host."""
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    for host in ("host1", "host2"):
+        monkeypatch.setenv("BORG_HOSTNAME", host)
+        _create_archive_ts(archiver, backup_files, "home", 2024, 1, 1)
+        _create_archive_ts(archiver, backup_files, "home", 2024, 1, 2)
+    monkeypatch.delenv("BORG_HOSTNAME")
+    # NAME is ANDed with -a / --match-archives, so only host1's "home" archives are candidates.
+    cmd(archiver, "prune", "home", "-a", "host:host1", "--keep-daily=1")
+    output = cmd(archiver, "repo-list", "--format={hostname}{NL}")
+    assert output.count("host1") == 1  # only the most recent one is left
+    assert output.count("host2") == 2  # host2 was not touched at all


### PR DESCRIPTION
`prune`, `delete`, `undelete`, `info` and `tag` all accept an archive `NAME`
positional argument *and* `-a` / `--match-archives`. If both were given, `NAME`
won and `-a` was silently ignored:

```python
match = [args.name] if args.name else args.match_archives   # prune_cmd.py
archive_infos = [manifest.archives.get_one([args.name])]    # delete/undelete/info/tag
```

In a repository shared by multiple hosts / users this is a footgun. Archive
series names are not unique across hosts — several machines may well use a
`home` series for their own, unrelated data. So

```
borg prune home -a host:myhost --keep-daily 7
```

did **not** restrict pruning to `myhost`, it pruned the `home` archives of
*every* host in the repository, without a warning.

## Change

`NAME` is now treated as just another way of saying `-a NAME` and is ANDed with
the patterns given via `-a` / `--match-archives` (which are ANDed among
themselves already). Giving both therefore narrows the selection down instead of
one silently overriding the other.

`NAME` is passed on **as-is**, so it keeps supporting the same selector prefixes
it always did, e.g. `borg info aid:1234abcd` — which is also what the shell
completion offers for the `NAME` positional (see `completion_cmd_test.py`).

A small `archive_match_patterns(args)` helper in `archiver/_common.py` builds the
combined pattern list; `prune`, `delete`, `undelete`, `info` and `tag` use it.

Behaviour when only one of the two is given is unchanged. Where both are given,
the new behaviour selects a subset of what was selected before, so it can only
ever touch fewer archives than the old one — never more.

## Docs

- `borg help match-archives`: document that `NAME` acts as an additional pattern,
  that all patterns must match, and that `NAME` accepts the same prefixes.
- `borg prune` epilog: add the shared-repository recipe
  (`borg prune home -a host:myhost ...`), plus a note that `host:` / `user:` is
  client-written archive metadata and not a permission mechanism — anyone with
  delete permission on the repository can prune anything in it.

## Tests

- unit tests for `archive_match_patterns()`, including that a prefixed `NAME`
  such as `aid:1234abcd` is left untouched
- `test_prune_name_and_match_archives_are_combined`: two hosts, both with a
  `home` series of two archives; `borg prune home -a host:host1 --keep-daily=1`
  must leave host2's archives alone.
- `test_delete_name_and_match_archives_are_combined`: `borg delete home` is
  ambiguous with two hosts, `borg delete home -a host:host1` is not.
- `test_info_name_with_aid_prefix`: `borg info aid:<prefix>` still resolves, and
  combines with `-a`.

The prune/delete integration tests fail on master and pass with this change.

## Follow-ups (not in this PR)

Discussed while looking at prune for shared repositories, kept separate:

- `prune` applies the retention rules to one flat pool of matched archives, so
  `-a host:myhost` over several series keeps N archives *in total*, not N per
  series. A `--group-by name[,host,user]` option would remove the need for one
  prune call per series.
- `host:` / `user:` are exact-match only, unlike `name:` which supports
  `sh:` / `re:` styles.