### PR TITLE
prune: create the period grouping function per prune() invocation

### DIFF
--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -2,7 +2,7 @@ from typing import Callable, NamedTuple
 from datetime import datetime, timedelta
 import logging
 import math
-from functools import wraps
+from functools import partial, wraps
 import os
 from itertools import count, combinations
 from ._common import with_repository, Highlander, archive_match_patterns
@@ -18,9 +18,15 @@ from ..logger import create_logger
 logger = create_logger()
 
 
+PeriodFunc = Callable[[ArchiveInfo | datetime], str]
+
+
 class PruningRule(NamedTuple):
     key: str
-    period_func: Callable[[ArchiveInfo | datetime], str]
+    # Factory creating the period grouping function. prune() calls it once per invocation, so a
+    # period function may keep per-invocation state (see unique_period_func) without that state
+    # leaking into other prune() calls, e.g. when applying the rules to several archive groups.
+    make_period_func: Callable[[], PeriodFunc]
 
     def __str__(self):
         return self.key
@@ -52,9 +58,11 @@ def archive_datetime_dispatch(func: Callable[[datetime], str]) -> Callable[[Arch
     return wrapper
 
 
-# The *_period_func group of functions create period grouping keys to group
-# together archives falling within a certain period. Among archives in each of
-# these groups, only the latest (by creation timestamp) is kept.
+# The *_period_func group of functions create the period grouping functions, which compute the
+# period grouping key of an archive. Archives falling within the same period are grouped together
+# and among the archives in each of these groups, only the latest (by creation timestamp) is kept.
+#
+# Each of these is a factory: prune() asks for a fresh period grouping function per invocation.
 
 
 def unique_period_func():
@@ -64,7 +72,9 @@ def unique_period_func():
     @archive_datetime_dispatch
     def unique_values(_dt):
         """Group archives by an incrementing counter, practically making each archive a group of 1"""
-        # zfill ensures lexicographic ordering matches number ordering in case of comparisons
+        # zfill ensures lexicographic ordering matches number ordering in case of comparisons.
+        # the counter belongs to this factory call and prune() never sees more than MAX_ARCHIVES
+        # archives, so the counter can not outgrow the padding.
         return str(next(counter)).zfill(max_digits)
 
     return unique_values
@@ -80,35 +90,42 @@ def pattern_period_func(pattern):
     return inner
 
 
-@archive_datetime_dispatch
-def quarterly_13weekly_period_func(dt):
-    """Group archives by extracting the ISO-8601 13-week quarter from their creation timestamp"""
-    (year, week) = dt.astimezone().isocalendar()[:2]  # local time
-    return f"{year}-{min(max((week - 1) // 13, 0), 3):02}"
+def quarterly_13weekly_period_func():
+    @archive_datetime_dispatch
+    def inner(dt):
+        """Group archives by extracting the ISO-8601 13-week quarter from their creation timestamp"""
+        (year, week) = dt.astimezone().isocalendar()[:2]  # local time
+        return f"{year}-{min(max((week - 1) // 13, 0), 3):02}"
+
+    return inner
 
 
-@archive_datetime_dispatch
-def quarterly_3monthly_period_func(dt):
-    """Group archives by extracting the 3-month quarter from their creation timestamp"""
-    (year, month) = dt.astimezone().timetuple()[:2]  # local time
-    return f"{year}-{(month - 1) // 3:02}"
+def quarterly_3monthly_period_func():
+    @archive_datetime_dispatch
+    def inner(dt):
+        """Group archives by extracting the 3-month quarter from their creation timestamp"""
+        (year, month) = dt.astimezone().timetuple()[:2]  # local time
+        return f"{year}-{(month - 1) // 3:02}"
+
+    return inner
 
 
 # Each archive is considered for keeping
-PRUNE_KEEP = PruningRule("keep", unique_period_func())
+PRUNE_KEEP = PruningRule("keep", unique_period_func)
 # Last archive (by creation timestamp) within period group is considered for keeping
-PRUNE_SECONDLY = PruningRule("secondly", pattern_period_func("%Y-%m-%d %H:%M:%S"))
-PRUNE_MINUTELY = PruningRule("minutely", pattern_period_func("%Y-%m-%d %H:%M"))
-PRUNE_HOURLY = PruningRule("hourly", pattern_period_func("%Y-%m-%d %H"))
-PRUNE_DAILY = PruningRule("daily", pattern_period_func("%Y-%m-%d"))
-PRUNE_WEEKLY = PruningRule("weekly", pattern_period_func("%G-%V"))
-PRUNE_MONTHLY = PruningRule("monthly", pattern_period_func("%Y-%m"))
+PRUNE_SECONDLY = PruningRule("secondly", partial(pattern_period_func, "%Y-%m-%d %H:%M:%S"))
+PRUNE_MINUTELY = PruningRule("minutely", partial(pattern_period_func, "%Y-%m-%d %H:%M"))
+PRUNE_HOURLY = PruningRule("hourly", partial(pattern_period_func, "%Y-%m-%d %H"))
+PRUNE_DAILY = PruningRule("daily", partial(pattern_period_func, "%Y-%m-%d"))
+PRUNE_WEEKLY = PruningRule("weekly", partial(pattern_period_func, "%G-%V"))
+PRUNE_MONTHLY = PruningRule("monthly", partial(pattern_period_func, "%Y-%m"))
 PRUNE_QUARTERLY_13WEEKLY = PruningRule("quarterly_13weekly", quarterly_13weekly_period_func)
 PRUNE_QUARTERLY_3MONTHLY = PruningRule("quarterly_3monthly", quarterly_3monthly_period_func)
-PRUNE_YEARLY = PruningRule("yearly", pattern_period_func("%Y"))
+PRUNE_YEARLY = PruningRule("yearly", partial(pattern_period_func, "%Y"))
 
-# Fake rule used to indicate archives skipped by --from
-PRUNE_FROM = PruningRule("skip", unique_period_func())
+# Fake rule, only used as a label for archives skipped by --from. Its period grouping function
+# is never called, prune() does not process this rule.
+PRUNE_FROM = PruningRule("skip", unique_period_func)
 
 PRUNING_RULES = [
     PRUNE_KEEP,
@@ -150,11 +167,12 @@ def prune(
         else:
             return a.ts >= earliest_timestamp
 
+    period_func = rule.make_period_func()
     prev_period = None
     for archive in archives:
         if not can_retain(archive):
             break
-        period = rule.period_func(archive)
+        period = period_func(archive)
         if period != prev_period:
             prev_period = period
             if archive not in keep and archive not in previously_kept:

--- a/src/borg/testsuite/archiver/prune_cmd_test.py
+++ b/src/borg/testsuite/archiver/prune_cmd_test.py
@@ -15,6 +15,7 @@ from ...archiver.prune_cmd import (
     PRUNE_SECONDLY,
     PRUNE_WEEKLY,
     PRUNE_YEARLY,
+    unique_period_func,
 )
 from ...helpers import CommandError
 from ...manifest import ArchiveInfo
@@ -892,3 +893,23 @@ def test_prune_name_and_match_archives_are_combined(archivers, request, backup_f
     output = cmd(archiver, "repo-list", "--format={hostname}{NL}")
     assert output.count("host1") == 1  # only the most recent one is left
     assert output.count("host2") == 2  # host2 was not touched at all
+
+
+@pytest.mark.parametrize("rule", PRUNING_RULES, ids=[rule.key for rule in PRUNING_RULES])
+def test_period_func_is_created_per_prune_invocation(rule):
+    """Period grouping functions are per prune() invocation, they must not share state."""
+    dt = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    first, second = rule.make_period_func(), rule.make_period_func()
+    assert first is not second
+    # a fresh period grouping function starts over, it does not continue where another one left off:
+    assert [first(dt) for _ in range(3)] == [second(dt) for _ in range(3)]
+
+
+def test_unique_period_values_are_padded_and_ordered():
+    """The counter of a single period grouping function stays within its zero padding."""
+    dt = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    period_func = unique_period_func()
+    values = [period_func(dt) for _ in range(1000)]
+    assert len(set(values)) == len(values)  # each archive lands in a period of its own
+    assert len({len(value) for value in values}) == 1  # uniform width, so ...
+    assert values == sorted(values)  # ... lexicographic ordering matches numeric ordering


### PR DESCRIPTION
Preparatory cleanup for `borg prune --group-by`, but it stands on its own.

## The problem

`PRUNE_KEEP` and `PRUNE_FROM` were built by *calling* `unique_period_func()` at import time, so each held a single `itertools.count()` shared by every `prune()` call in the process:

```pycon
>>> [PRUNE_KEEP.period_func(dt) for _ in range(3)]
['000000', '000001', '000002']
>>> [PRUNE_KEEP.period_func(dt) for _ in range(3)]
['000003', '000004', '000005']
```

That is harmless today, because `prune()` only ever evaluates `period != prev_period`. But the zero padding assumes the counter stays below `MAX_ARCHIVES`, and a process-lifetime counter does not:

```pycon
>>> MAX_ARCHIVES, math.ceil(math.log10(MAX_ARCHIVES))
(400000, 6)
>>> str(999999).zfill(6), str(1000000).zfill(6)
('999999', '1000000')
```

so past `10**6` the values silently lose their uniform width and stop sorting lexicographically — exactly what the `zfill` comment promises they do. It also turns into a real trap the moment the rules get applied more than once per invocation, which is precisely what per-group pruning will do.

## The change

`PruningRule` now holds a **factory** (`make_period_func`) rather than a ready-made period grouping function, and `prune()` asks it for a fresh one per invocation. The contract is now explicit: a period grouping function may keep state, and that state belongs to one `prune()` call.

Knock-on tidying, all within `prune_cmd.py`:

- `quarterly_13weekly_period_func` / `quarterly_3monthly_period_func` became factories too, so all four `*_period_func` functions have the same shape.
- The pattern-based rules use `partial(pattern_period_func, "%Y-%m-%d")` etc.
- `PRUNE_FROM`'s comment now records that it is label-only — `prune()` never processes that rule, so its period grouping function is in fact never called.

Nothing outside `prune_cmd.py` referenced `period_func`, so the refactor is contained.

**No behaviour change** for the current single-pass prune.

## Tests

- `test_period_func_is_created_per_prune_invocation`, parametrized over all of `PRUNING_RULES` (so it covers the restructured quarterly rules as well): two factory calls yield distinct objects, and the second starts over instead of continuing where the first left off.
- `test_unique_period_values_are_padded_and_ordered` pins the property the `zfill` exists for — uniform width, lexicographic order matching numeric order — which is what a cross-invocation counter eventually violates.

Full archiver test suite: 1077 passed, 581 skipped. `ruff check` clean.