### PR TITLE
repo-list: add --group-by

### DIFF
--- a/src/borg/archiver/prune_cmd.py
+++ b/src/borg/archiver/prune_cmd.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-from collections.abc import Sequence
 from typing import Callable, NamedTuple
 from datetime import datetime, timedelta
 import logging
@@ -14,7 +12,7 @@ from ..helpers import archivename_validator, int_or_interval, sig_int, timestamp
 from ..helpers import GroupBySpec
 from ..helpers import json_print, basic_json_data
 from ..helpers.argparsing import ArgumentParser
-from ..manifest import AI_GROUP_BY_KEYS, ArchiveInfo, Manifest
+from ..manifest import AI_GROUP_BY_KEYS, ArchiveInfo, Manifest, format_group_key, group_archives
 
 from ..logger import create_logger
 
@@ -188,40 +186,6 @@ def prune(
             keep[oldest_archive] = KeepResult(rule=rule, idx=len(keep), oldest=True)
 
     return keep
-
-
-def archive_group_key(archive_info: ArchiveInfo, group_by: Sequence[str]) -> tuple[str, ...]:
-    """Compute the grouping key of *archive_info* for the given *group_by* archive attributes."""
-    key = []
-    for group_by_key in group_by:
-        if group_by_key == "tags":
-            # internal tags (e.g. @PROT) say nothing about what an archive contains or where it
-            # came from, so they must not put an archive into a group of its own.
-            value = ",".join(tag for tag in archive_info.tags if not tag.startswith("@"))
-        else:
-            # host and user are empty for archives that do not have this metadata, e.g. archives
-            # transferred from a borg 1.x repo. they form their own group then.
-            value = getattr(archive_info, group_by_key) or ""
-        key.append(value)
-    return tuple(key)
-
-
-def group_archives(archives: list[ArchiveInfo], group_by: Sequence[str]) -> dict[tuple[str, ...], list[ArchiveInfo]]:
-    """
-    Group *archives* by the given *group_by* archive attributes, keeping their relative order.
-
-    An empty *group_by* puts all archives into one group, so the retention rules are applied to
-    all given archives at once.
-    """
-    groups: dict[tuple[str, ...], list[ArchiveInfo]] = defaultdict(list)
-    for archive_info in archives:
-        groups[archive_group_key(archive_info, group_by)].append(archive_info)
-    return groups
-
-
-def format_group_key(key: tuple[str, ...], group_by: Sequence[str]) -> str:
-    """Format a grouping key for human consumption, e.g. \"name='home', host='myhost'\"."""
-    return ", ".join(f"{group_by_key}={value!r}" for group_by_key, value in zip(group_by, key))
 
 
 class PruneMixIn:

--- a/src/borg/archiver/repo_list_cmd.py
+++ b/src/borg/archiver/repo_list_cmd.py
@@ -5,8 +5,9 @@ import sys
 from ._common import with_repository, Highlander
 from ..constants import *  # NOQA
 from ..helpers import BaseFormatter, ArchiveFormatter, json_print, basic_json_data
+from ..helpers import GroupBySpec
 from ..helpers.argparsing import ArgumentParser
-from ..manifest import Manifest
+from ..manifest import AI_GROUP_BY_KEYS, Manifest, format_group_key, group_archives
 
 from ..logger import create_logger
 
@@ -30,11 +31,23 @@ class RepoListMixIn:
 
         output_data = []
 
-        for archive_info in manifest.archives.list_considering(args):
-            if args.json:
-                output_data.append(formatter.get_item_data(archive_info, args.json))
-            else:
-                sys.stdout.write(formatter.format_item(archive_info, args.json))
+        archive_infos = manifest.archives.list_considering(args)
+        group_by = tuple(args.group_by.split(",")) if args.group_by else ()
+        # without grouping, all archives are listed as one group, exactly as before.
+        groups = group_archives(archive_infos, group_by) if group_by else {(): archive_infos}
+
+        for group_number, (key, group) in enumerate(groups.items()):
+            if group_by and not args.json:
+                separator = "" if group_number == 0 else "\n"
+                sys.stdout.write(f"{separator}Group ({format_group_key(key, group_by)}):\n")
+            for archive_info in group:
+                if args.json:
+                    item_data = formatter.get_item_data(archive_info, args.json)
+                    if group_by:
+                        item_data["group"] = dict(zip(group_by, key))
+                    output_data.append(item_data)
+                else:
+                    sys.stdout.write(formatter.format_item(archive_info, args.json))
 
         if args.json:
             json_print(basic_json_data(manifest, extra={"archives": output_data}))
@@ -46,6 +59,31 @@ class RepoListMixIn:
             textwrap.dedent(
                 """
         This command lists the archives contained in a repository.
+
+        Grouping archives
+        +++++++++++++++++
+
+        ``--group-by`` lists the archives grouped by the given comma-separated archive
+        attributes, each group preceded by a header line naming it::
+
+            $ borg repo-list --group-by name,host --format '{archive} {time}{NL}'
+            Group (name='home', host='host1'):
+            home Thu, 2026-06-04 18:00:00 +0200
+            home Wed, 2026-06-03 18:00:00 +0200
+
+            Group (name='home', host='host2'):
+            home Thu, 2026-06-04 19:00:00 +0200
+
+        Valid keys are ``name``, ``host``, ``user`` and ``tags``; borg's internal tags (starting
+        with ``@``) do not affect grouping. Archives without ``host`` / ``user`` metadata (e.g.
+        archives transferred from a borg 1.x repository) form their own group.
+
+        These are the same keys and the same grouping that ``borg prune --group-by`` uses, so
+        this is a way to see which archives a prune run will consider together before running
+        it. Without ``--group-by``, archives are listed as before, ungrouped.
+
+        With ``--json``, no header lines are emitted; each archive gets a ``group`` object
+        instead.
 
         .. man NOTES
 
@@ -99,6 +137,16 @@ class RepoListMixIn:
             dest="format",
             action=Highlander,
             help=f'specify format for archive listing (default: "{FORMAT_DEFAULT}")',
+        )
+        subparser.add_argument(
+            "--group-by",
+            metavar="KEYS",
+            dest="group_by",
+            type=GroupBySpec,
+            default="",
+            action=Highlander,
+            help="comma-separated list of archive attributes to group the listed archives by; "
+            "valid keys are: {}; default is to not group".format(", ".join(AI_GROUP_BY_KEYS)),
         )
         subparser.add_argument(
             "--json",

--- a/src/borg/manifest.py
+++ b/src/borg/manifest.py
@@ -1,6 +1,6 @@
 import enum
 import re
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from datetime import UTC, datetime, timedelta
 from operator import attrgetter
 from collections.abc import Iterator, Sequence
@@ -50,6 +50,39 @@ AI_HUMAN_SORT_KEYS.remove("ts")
 # archive attributes describing what an archive contains and where it came from, usable to group
 # archives that belong together, e.g. for applying retention rules separately (see GroupBySpec).
 AI_GROUP_BY_KEYS = ["name", "host", "user", "tags"]
+
+
+def archive_group_key(archive_info: ArchiveInfo, group_by: Sequence[str]) -> tuple[str, ...]:
+    """Compute the grouping key of *archive_info* for the given *group_by* archive attributes."""
+    key = []
+    for group_by_key in group_by:
+        if group_by_key == "tags":
+            # internal tags (e.g. @PROT) say nothing about what an archive contains or where it
+            # came from, so they must not put an archive into a group of its own.
+            value = ",".join(tag for tag in archive_info.tags if not tag.startswith("@"))
+        else:
+            # host and user are empty for archives that do not have this metadata, e.g. archives
+            # transferred from a borg 1.x repo. they form their own group then.
+            value = getattr(archive_info, group_by_key) or ""
+        key.append(value)
+    return tuple(key)
+
+
+def group_archives(archives: list[ArchiveInfo], group_by: Sequence[str]) -> dict[tuple[str, ...], list[ArchiveInfo]]:
+    """
+    Group *archives* by the given *group_by* archive attributes, keeping their relative order.
+
+    An empty *group_by* puts all archives into one group.
+    """
+    groups: dict[tuple[str, ...], list[ArchiveInfo]] = defaultdict(list)
+    for archive_info in archives:
+        groups[archive_group_key(archive_info, group_by)].append(archive_info)
+    return groups
+
+
+def format_group_key(key: tuple[str, ...], group_by: Sequence[str]) -> str:
+    """Format a grouping key for human consumption, e.g. \"name='home', host='myhost'\"."""
+    return ", ".join(f"{group_by_key}={value!r}" for group_by_key, value in zip(group_by, key))
 
 
 def filter_archives_by_date(archives, older=None, newer=None, oldest=None, newest=None):

--- a/src/borg/testsuite/archiver/prune_cmd_test.py
+++ b/src/borg/testsuite/archiver/prune_cmd_test.py
@@ -15,12 +15,10 @@ from ...archiver.prune_cmd import (
     PRUNE_SECONDLY,
     PRUNE_WEEKLY,
     PRUNE_YEARLY,
-    archive_group_key,
-    format_group_key,
-    group_archives,
     unique_period_func,
 )
 from ...helpers import GroupBySpec
+from ...manifest import archive_group_key, format_group_key, group_archives
 from argparse import ArgumentTypeError
 
 from ...helpers import CommandError

--- a/src/borg/testsuite/archiver/repo_list_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_list_cmd_test.py
@@ -220,3 +220,74 @@ def test_repo_list_from_borg1(archivers, request, monkeypatch):
     output = cmd(archiver, "repo-list", "--from-borg1")
     assert "archive1" in output
     assert "archive2" in output
+
+
+def _create_shared_repo_archives(archiver, backup_files, monkeypatch):
+    """host1 has a "home" and an "etc" archive, host2 has an own, unrelated "home" archive."""
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    monkeypatch.setenv("BORG_HOSTNAME", "host1")
+    cmd(archiver, "create", "home", backup_files)
+    cmd(archiver, "create", "etc", backup_files)
+    monkeypatch.setenv("BORG_HOSTNAME", "host2")
+    cmd(archiver, "create", "home", backup_files)
+    monkeypatch.delenv("BORG_HOSTNAME")
+
+
+def test_repo_list_group_by(archivers, request, backup_files, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    _create_shared_repo_archives(archiver, backup_files, monkeypatch)
+    output = cmd(archiver, "repo-list", "--group-by", "name,host", "--format", "{archive} {hostname}{NL}")
+    assert output.splitlines() == [
+        "Group (name='home', host='host1'):",
+        "home host1",
+        "",
+        "Group (name='etc', host='host1'):",
+        "etc host1",
+        "",
+        "Group (name='home', host='host2'):",
+        "home host2",
+    ]
+
+
+def test_repo_list_group_by_single_key(archivers, request, backup_files, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    _create_shared_repo_archives(archiver, backup_files, monkeypatch)
+    output = cmd(archiver, "repo-list", "--group-by", "name", "--format", "{archive} {hostname}{NL}")
+    # both hosts' "home" archives are in one group now:
+    assert output.splitlines() == [
+        "Group (name='home'):",
+        "home host1",
+        "home host2",
+        "",
+        "Group (name='etc'):",
+        "etc host1",
+    ]
+
+
+def test_repo_list_without_group_by_is_unchanged(archivers, request, backup_files, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    _create_shared_repo_archives(archiver, backup_files, monkeypatch)
+    output = cmd(archiver, "repo-list", "--format", "{archive} {hostname}{NL}")
+    assert output.splitlines() == ["home host1", "etc host1", "home host2"]
+    assert "Group (" not in output
+
+
+def test_repo_list_group_by_json(archivers, request, backup_files, monkeypatch):
+    archiver = request.getfixturevalue(archivers)
+    _create_shared_repo_archives(archiver, backup_files, monkeypatch)
+    archives = json.loads(cmd(archiver, "repo-list", "--group-by", "name,host", "--json"))["archives"]
+    assert [archive["group"] for archive in archives] == [
+        {"name": "home", "host": "host1"},
+        {"name": "etc", "host": "host1"},
+        {"name": "home", "host": "host2"},
+    ]
+    # no grouping requested, no group in the output:
+    archives = json.loads(cmd(archiver, "repo-list", "--json"))["archives"]
+    assert all("group" not in archive for archive in archives)
+
+
+def test_repo_list_group_by_invalid_key(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    output = cmd(archiver, "repo-list", "--group-by", "bogus", exit_code=2)
+    assert "Invalid group-by key: bogus" in output


### PR DESCRIPTION
`borg prune` groups archives before applying the retention rules, but there was no way to see what
those groups actually are without running prune. `repo-list --group-by` lists the archives grouped by
the same archive attributes, each group preceded by a header line naming it:

```
$ borg repo-list --group-by name,host --format '{archive} {hostname}{NL}'
Group (name='home', host='host1'):
home host1

Group (name='etc', host='host1'):
etc host1

Group (name='home', host='host2'):
home host2
```

So `borg repo-list --group-by name,host` is now a dry-run for the grouping that
`borg prune --group-by name,host` (the default) will use.

Valid keys are `name`, `host`, `user` and `tags`, exactly as for prune — same `GroupBySpec`, same
handling of internal `@` tags and of archives without `host` / `user` metadata.

With `--json`, no header lines are emitted; each archive gets a `group` object instead:

```json
{"name": "home", "group": {"name": "home", "host": "host1"}, ...}
```

## Default: no grouping

Unlike prune, this defaults to **not** grouping. The ungrouped listing is what scripts parse, so it
stays byte-for-byte as it was — the `group` key does not even appear in the JSON unless grouping was
asked for. There is a test pinning that.

## Refactoring

`archive_group_key()`, `group_archives()` and `format_group_key()` moved from
`archiver/prune_cmd.py` to `manifest.py`, next to `ArchiveInfo` and `AI_GROUP_BY_KEYS` and alongside
the existing `filter_archives_by_date()`, so both commands share one implementation rather than
repo-list importing from prune_cmd. Pure move, no behaviour change; only the `group_archives()`
docstring lost its prune-specific sentence about retention rules.

## Tests

- `test_repo_list_group_by` asserts the exact grouped output (headers, blank line between groups)
- `test_repo_list_group_by_single_key` — both hosts' `home` archives land in one group
- `test_repo_list_without_group_by_is_unchanged` — pins the unchanged default output
- `test_repo_list_group_by_json` — `group` present when grouping, absent when not
- `test_repo_list_group_by_invalid_key`

Full test suite: 2923 passed, 982 skipped. `ruff check` clean.