### PR TITLE
release: attach the binaries' sigstore bundles to the GitHub release, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,31 @@ jobs:
         ls -l artifacts/
 
     - name: Attest binaries provenance (${{ matrix.binary }})
+      id: attest-binaries
       if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
       with:
         subject-path: 'artifacts/*'
+
+    - name: Name the sigstore bundle after the binaries (${{ matrix.binary }})
+      # The attestation is also stored in the GitHub attestations API, but
+      # fetching it from there needs a recent gh and a GitHub token (see
+      # #10187) - so the sigstore bundle rides along with the binaries and the
+      # release job attaches it to the release as <asset>.sigstore.jsonl, just
+      # like it does for the sdist, see .github/workflows/release.yml.
+      #
+      # One attestation covers both the single-file binary and the .tgz, so the
+      # same bundle is stored under both names - one for each asset.
+      if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
+      env:
+        BUNDLE_PATH: ${{ steps.attest-binaries.outputs.bundle-path }}
+      run: |
+        set -euxo pipefail
+        # the glob is expanded before the loop body creates any file:
+        for asset in artifacts/*; do
+          cp "$BUNDLE_PATH" "$asset.sigstore.jsonl"
+        done
+        ls -l artifacts/
 
     - name: Upload binaries (${{ matrix.binary }})
       if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}
@@ -708,6 +729,35 @@ jobs:
               ;;
           esac
 
+      - name: Attest provenance
+        id: attest-binaries
+        if: startsWith(github.ref, 'refs/tags/') && matrix.do_binaries
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-path: 'artifacts/*'
+
+      - name: Name the sigstore bundle after the binaries
+        # The attestation is also stored in the GitHub attestations API, but
+        # fetching it from there needs a recent gh and a GitHub token (see
+        # #10187) - so the sigstore bundle rides along with the binaries and the
+        # release job attaches it to the release as <asset>.sigstore.jsonl, just
+        # like it does for the sdist, see .github/workflows/release.yml.
+        #
+        # One attestation covers both the single-file binary and the .tgz, so
+        # the same bundle is stored under both names - one for each asset.
+        # This is also why the attestation is made before the artifact is
+        # uploaded and not after it.
+        if: startsWith(github.ref, 'refs/tags/') && matrix.do_binaries
+        env:
+          BUNDLE_PATH: ${{ steps.attest-binaries.outputs.bundle-path }}
+        run: |
+          set -euxo pipefail
+          # the glob is expanded before the loop body creates any file:
+          for asset in artifacts/*; do
+            cp "$BUNDLE_PATH" "$asset.sigstore.jsonl"
+          done
+          ls -l artifacts/
+
       - name: Upload artifacts
         if: startsWith(github.ref, 'refs/tags/') && matrix.do_binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -715,12 +765,6 @@ jobs:
           name: ${{ matrix.artifact_prefix }}
           path: artifacts/*
           if-no-files-found: ignore
-
-      - name: Attest provenance
-        if: startsWith(github.ref, 'refs/tags/') && matrix.do_binaries
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
-        with:
-          subject-path: 'artifacts/*'
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -842,10 +886,34 @@ jobs:
           ls -l artifacts/
 
       - name: Attest binaries provenance (borg-windows-x86_64-gh)
+        id: attest-binaries
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:
           subject-path: 'artifacts/*'
+
+      - name: Name the sigstore bundle after the binaries (borg-windows-x86_64-gh)
+        # The attestation is also stored in the GitHub attestations API, but
+        # fetching it from there needs a recent gh and a GitHub token (see
+        # #10187) - so the sigstore bundle rides along with the binaries and the
+        # release job attaches it to the release as <asset>.sigstore.jsonl, just
+        # like it does for the sdist, see .github/workflows/release.yml.
+        #
+        # One attestation covers both the .exe and the .tgz, so the same bundle
+        # is stored under both names - one for each asset.
+        #
+        # pwsh, not the msys2 shell this job otherwise uses: bundle-path is a
+        # native Windows path and MSYS2_ARG_CONV_EXCL above keeps msys2 from
+        # converting it.
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        shell: pwsh
+        env:
+          BUNDLE_PATH: ${{ steps.attest-binaries.outputs.bundle-path }}
+        run: |
+          Get-ChildItem artifacts -File | ForEach-Object {
+            Copy-Item -Path $env:BUNDLE_PATH -Destination "$($_.FullName).sigstore.jsonl"
+          }
+          Get-ChildItem artifacts
 
       - name: Upload binaries (borg-windows-x86_64-gh)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@
 #  - and the binaries should be tried out before the release becomes visible.
 # Publishing the draft is a single click in the GitHub UI.
 #
+# Every release asset has a build provenance attestation, and the sigstore bundle
+# of each attestation is attached to the release as <asset>.sigstore.jsonl, for
+# offline verification. The sdist is attested here, the binaries by the jobs in
+# ci.yml that build them - those hand their bundles over in the artifact that
+# carries the binaries.
+#
 # The upload to PyPI is *not* done here, but by the "pypi" job in ci.yml: PyPI
 # trusted publishing can not be used from a reusable workflow, see
 # https://docs.pypi.org/trusted-publishers/troubleshooting/ - so that job has to
@@ -183,9 +189,9 @@ jobs:
         All release assets have a [build provenance attestation](https://github.com/borgbackup/borg/attestations),
         verifiable with \`gh attestation verify --owner borgbackup <file>\`.
 
-        The sdist's attestation is additionally attached as the [sigstore](https://www.sigstore.dev/)
-        bundle \`borgbackup-$TAG.tar.gz.sigstore.jsonl\`, so it can be verified offline and
-        without a GitHub token, e.g. with cosign:
+        Every attestation is additionally attached as a [sigstore](https://www.sigstore.dev/)
+        bundle \`<asset>.sigstore.jsonl\`, so it can be verified offline and without a
+        GitHub token, e.g. with cosign:
 
         \`\`\`
         cosign verify-blob borgbackup-$TAG.tar.gz \\
@@ -193,6 +199,10 @@ jobs:
           --certificate-identity https://github.com/borgbackup/borg/.github/workflows/release.yml@refs/tags/$TAG \\
           --certificate-oidc-issuer https://token.actions.githubusercontent.com
         \`\`\`
+
+        The binaries are built by \`ci.yml\`, not by \`release.yml\`, so their
+        \`--certificate-identity\` is
+        \`https://github.com/borgbackup/borg/.github/workflows/ci.yml@refs/tags/$TAG\`.
         EOF
         mkdir -p assets  # there may not have been any artifact to download
         if gh release view "$TAG" > /dev/null 2>&1; then

--- a/docs/binaries/00_README.txt
+++ b/docs/binaries/00_README.txt
@@ -84,6 +84,19 @@ Practical example (Linux, 2.0.0b20 tag):
 If verification succeeds, gh prints a summary stating the subject (your file),
 that it was attested by GitHub Actions, and the job/workflow reference.
 
+The command above fetches the attestation from the GitHub attestations API,
+which needs a recent gh and a GitHub token. Every attestation is therefore also
+attached to the release itself, as a sigstore bundle named after the file it
+belongs to - "<FILE>.sigstore.jsonl", next to "<FILE>" on the release page - so
+you can also verify offline and without a token:
+
+    curl -LO https://github.com/borgbackup/borg/releases/download/<TAG>/<FILE>.sigstore.jsonl
+    gh attestation verify --repo borgbackup/borg --bundle <FILE>.sigstore.jsonl <FILE>
+
+Generic sigstore tooling works as well, e.g. cosign - the certificate identity
+is the workflow that built the file: .github/workflows/ci.yml for the binaries,
+.github/workflows/release.yml for the source distribution.
+
 
 Installing
 ----------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -226,6 +226,8 @@ Other changes:
   - improve GitHub Actions security, address the zizmor audit findings
   - use ubuntu-26.04 runners
   - add a 32-bit armv7 runner
+  - release: attach the sigstore bundle of the provenance attestation to every
+    release asset, so they can be verified offline, #10187
 - tests:
 
   - skip tz tests where time.tzset() is missing, not just on Windows

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -506,8 +506,10 @@ Checklist:
   Pushing the tag makes CI build the standalone binaries and then release:
   the ``release`` job (``.github/workflows/release.yml``) builds the sdist,
   checks that it can be installed, attests its provenance and drafts the GitHub
-  release with the sdist and all standalone binaries attached. The ``pypi`` job
-  then uploads the sdist to PyPI.
+  release with the sdist and all standalone binaries attached. Each of these
+  assets comes with the sigstore bundle of its provenance attestation, as
+  ``<asset>.sigstore.jsonl``, so that it can be verified offline. The ``pypi``
+  job then uploads the sdist to PyPI.
 
   If the ``pypi`` environment has required reviewers configured, the upload to
   PyPI waits for an approval - that is the last chance to stop it. Also watch


### PR DESCRIPTION
The sdist's provenance attestation is attached to the release as
`<sdist>.sigstore.jsonl` (#10187), because fetching an attestation from the
GitHub attestations API needs a recent gh and a GitHub token. The standalone
binaries do not have that yet - this adds it.

- the jobs that build the binaries also attest them, so they are the ones that
  have the sigstore bundle: `native_tests`, `vm_tests` and `windows_tests` copy
  it into the `artifacts/` dir they upload, once per attested asset. One
  attestation covers both the single-file binary and the `.tgz`, so the bundle
  is stored under both names.
- the release job needs no change for this: it attaches whatever came in the
  binary artifacts to the release, so the bundles land next to the binaries.
- `vm_tests` attested after uploading its artifact, so its attest step now runs
  before the upload, like in the other two jobs.
- windows uses a `pwsh` step for the copy: `bundle-path` is a native Windows
  path and that job's msys2 shell (with `MSYS2_ARG_CONV_EXCL: "*"`) would
  mangle it.

So every release asset can be verified offline and without a token:

```
gh attestation verify --repo borgbackup/borg --bundle <file>.sigstore.jsonl <file>
```

The drafted release notes, `docs/binaries/00_README.txt` (a release asset
itself) and the release checklist in `docs/development.rst` describe this for
all assets now, including that the binaries' cosign `--certificate-identity` is
`ci.yml` and not `release.yml`, because that is where they are built.

Tested against the real 2.0.0b23 release assets: copying the bundle of
`borg-macos-15-x86_64-gh.tgz` to `<asset>.sigstore.jsonl` and verifying with
`gh attestation verify --bundle` succeeds offline, and an unattested file is
rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
