### PR TITLE
recreate: also do the work if --timestamp is the only change requested

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -2785,7 +2785,7 @@ class ArchiveRecreater:
         target = self.create_target(archive, target_name)
         if self.exclude_if_present or self.exclude_caches:
             self.matcher_add_tagged_dirs(archive)
-        if self.matcher.empty() and not target.recreate_rechunkify and comment is None:
+        if self.matcher.empty() and not target.recreate_rechunkify and comment is None and self.timestamp is None:
             # nothing to do
             return False
         self.process_items(archive, target)

--- a/src/borg/testsuite/archiver/recreate_cmd_test.py
+++ b/src/borg/testsuite/archiver/recreate_cmd_test.py
@@ -244,11 +244,13 @@ def test_recreate_keep_original_timestamp(archivers, request):
     info_orig = cmd(archiver, "info", "-a", "test0").splitlines()
     # this shall recreate the archive and keep the nominal timestamp
     time.sleep(1)
-    cmd(archiver, "recreate", "test0", "--comment", "test")
+    cmd(archiver, "recreate", "-a", "test0", "--comment", "test")
     info_recreated = cmd(archiver, "info", "-a", "test0").splitlines()
     nominal_orig = next(item for item in info_orig if item.startswith("Time (nominal):"))
     nominal_recreated = next(item for item in info_recreated if item.startswith("Time (nominal):"))
     assert nominal_orig == nominal_recreated
+    # the recreated archive must still contain the original items.
+    assert "input/file1" in cmd(archiver, "list", "test0", "--short")
 
 
 def test_recreate_with_given_timestamp(archivers, request):
@@ -256,8 +258,10 @@ def test_recreate_with_given_timestamp(archivers, request):
     create_test_files(archiver.input_path)
     cmd(archiver, "repo-create", RK_ENCRYPTION)
     cmd(archiver, "create", "test0", "input")
-    # this shall recreate the archive with a different nominal timestamp
-    cmd(archiver, "recreate", "test0", "--timestamp", "1970-01-02T00:00:00", "--comment", "test")
+    # this shall recreate the archive with a different nominal timestamp.
+    # --timestamp is the only change requested, so this also checks that a timestamp
+    # change alone is enough to make recreate do the work instead of skipping the archive.
+    cmd(archiver, "recreate", "-a", "test0", "--timestamp", "1970-01-02T00:00:00")
     info = cmd(archiver, "info", "-a", "test0").splitlines()
     dtime = datetime(1970, 1, 2, 0, 0, 0).astimezone()  # local time in local timezone
     s_time = dtime.strftime("%Y-%m-%d %H:%M:.. %z").replace("+", r"\+")
@@ -267,6 +271,8 @@ def test_recreate_with_given_timestamp(archivers, request):
     s_time = dtime.strftime("%Y-%m-%d %H:..:.. %z").replace("+", r"\+")
     assert any([re.search(r"Time \(end\).+ %s" % s_time, item) for item in info])
     assert any([re.search(r"Time \(start\).+ %s" % s_time, item) for item in info])
+    # the recreated archive must still contain the original items.
+    assert "input/file1" in cmd(archiver, "list", "test0", "--short")
 
 
 def test_recreate_dry_run(archivers, request):


### PR DESCRIPTION
### Problem

`borg recreate -a ARCHIVE --timestamp ...` with no other change requested (no PATHs/patterns, no `--chunker-params`, no `--comment`) printed `Skipped archive ...: Nothing to do.` and silently did not apply the requested timestamp, contradicting the option's help text.

The work-trigger gate in `ArchiveRecreater.recreate()` only considered the matcher, rechunking and the comment — not `self.timestamp`, although the value is correctly plumbed all the way to `target.save(timestamp=...)`.

### Fix

Include `self.timestamp is None` in the gate.

### Tests

`test_recreate_with_given_timestamp` now passes only `--timestamp` (previously it also passed `--comment`, which triggered the work and masked this bug) — it fails on master and passes with this fix.

Both timestamp tests also gave the archive name as a positional argument, but recreate positionals are PATHs in borg2: this made the matcher accidentally non-empty (also masking the bug) and recreated the archive with zero items, unnoticed. They now select the archive via `-a` and assert that the items survive the recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
