### PR TITLE
recreate: remove dead compression plumbing, document what -C applies to

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -35,7 +35,7 @@ from .helpers import archive_hostname, archive_username
 from .helpers import ChunkIteratorFileWrapper, open_item
 from .helpers import Error, IntegrityError, set_ec, sig_int
 from .platform import uid2user, user2uid, gid2group, group2gid, get_birthtime_ns
-from .helpers import parse_timestamp, archive_ts_now, CompressionSpec
+from .helpers import parse_timestamp, archive_ts_now
 from .helpers import OutputTimestamp, format_timedelta, format_file_size, file_status, FileSize
 from .helpers import ArchiveFormatter
 from .helpers import safe_encode, make_path_safe, remove_surrogates, text_to_json, join_cmd, remove_dotdot_prefixes
@@ -2744,7 +2744,6 @@ class ArchiveRecreater:
         exclude_if_present=None,
         keep_exclude_tags=False,
         chunker_params=None,
-        compression=None,
         dry_run=False,
         stats=False,
         progress=False,
@@ -2771,7 +2770,6 @@ class ArchiveRecreater:
             # invariant by default, like borg transfer does, see BORG_ASSERT_ID.
             self.repo_objs.set_assert_id_place("rechunk")
         self.chunker_params = chunker_params or CHUNKER_PARAMS
-        self.compression = compression or CompressionSpec("none")
         self.seen_chunks = set()
 
         self.timestamp = timestamp

--- a/src/borg/archiver/recreate_cmd.py
+++ b/src/borg/archiver/recreate_cmd.py
@@ -29,7 +29,8 @@ class RecreateMixIn:
             exclude_if_present=args.exclude_if_present,
             keep_exclude_tags=args.keep_exclude_tags,
             chunker_params=args.chunker_params,
-            compression=args.compression,
+            # args.compression is not passed here: the with_repository decorator has already
+            # set repo_objs.compressor from it, which compresses everything newly written.
             progress=args.progress,
             stats=args.stats,
             file_status_printer=self.print_file_status,
@@ -78,6 +79,11 @@ class RecreateMixIn:
         ``--chunker-params`` will re-chunk all files in the archive. This can be used to
         switch existing archives to different chunker parameters (or a different chunker
         algorithm), so they deduplicate with archives created using these parameters.
+
+        ``--compression`` only applies to data recreate newly writes, e.g. when re-chunking
+        with ``--chunker-params`` (and to the new archive metadata). Data chunks reused
+        as-is from the existing archive keep their current compression - to recompress
+        existing repository objects, use ``borg repo-compress``.
 
         **USE WITH CAUTION.**
         Depending on the paths and patterns given, recreate can be used to
@@ -158,7 +164,11 @@ class RecreateMixIn:
             type=CompressionSpec,
             default=CompressionSpec("lz4"),
             action=Highlander,
-            help="select compression algorithm, see the output of the " '"borg help compression" command for details.',
+            help="select compression algorithm, see the output of the "
+            '"borg help compression" command for details. '
+            "Only applies to newly written data, e.g. when re-chunking with --chunker-params "
+            "(and to the new archive metadata); data chunks reused from the existing archive "
+            "are not recompressed, use borg repo-compress for that.",
         )
         archive_group.add_argument(
             "--chunker-params",


### PR DESCRIPTION
### Problem

The `compression=` argument passed to `ArchiveRecreater` was stored as `self.compression` and never read anywhere — dead plumbing. `-C` actually takes effect via the `with_repository` decorator setting `repo_objs.compressor`, which is used for everything recreate newly writes.

Also, the `-C` help text did not mention its actual scope: reused (not re-chunked) data chunks keep their existing compression; only newly written data (re-chunked file content, new archive metadata) is compressed with the given spec.

### Changes

- Remove the unused `compression` parameter/attribute from `ArchiveRecreater` (and the now-unused `CompressionSpec` import in `archive.py`); leave a comment at the call site pointing at the decorator mechanism.
- Document the actual scope of `-C` in the option help text and in the `borg recreate` epilog, pointing to `borg repo-compress` for recompressing existing repository objects.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
