### PR TITLE
repo-delete: --force is a simple boolean flag now

### DIFF
--- a/src/borg/archiver/repo_delete_cmd.py
+++ b/src/borg/archiver/repo_delete_cmd.py
@@ -23,7 +23,7 @@ class RepoDeleteMixIn:
         keep_security_info = args.keep_security_info
 
         if not args.cache_only:
-            if args.forced == 0:  # without --force, we let the user see the archives list and confirm.
+            if not args.forced:  # without --force, we let the user see the archives list and confirm.
                 id = bin_to_hex(repository.id)
                 location = repository._location.canonical_path()
                 msg = []
@@ -115,8 +115,7 @@ class RepoDeleteMixIn:
         subparser.add_argument(
             "--force",
             dest="forced",
-            action="count",
-            default=0,
+            action="store_true",
             help="do not ask for confirmation, just delete the repository. this also works if the "
             "repository is damaged to a point where its archives can not be listed anymore.",
         )

--- a/src/borg/testsuite/archiver/repo_delete_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_delete_cmd_test.py
@@ -28,3 +28,15 @@ def test_delete_repo(archivers, request):
     cmd(archiver, "repo-delete")
     # Make sure the repository is gone
     assert not os.path.exists(archiver.repository_path)
+
+
+def test_delete_repo_force(archivers, request):
+    archiver = request.getfixturevalue(archivers)
+    create_regular_file(archiver.input_path, "file1", size=1024 * 80)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "test", "input")
+    # with --force, no confirmation is asked for, not even the env var is considered.
+    os.environ["BORG_DELETE_I_KNOW_WHAT_I_AM_DOING"] = "no"
+    cmd(archiver, "repo-delete", "--force")
+    # Make sure the repository is gone
+    assert not os.path.exists(archiver.repository_path)


### PR DESCRIPTION
`repo-delete --force` was declared with `action="count"`, a borg 1.x vestige: there, giving `--force` twice had its own meaning for delete ("delete even if archives are corrupt"). borg2's repo-delete only ever checks for presence (`args.forced == 0`), so a second `--force` did nothing — `store_true` expresses the actual semantics.

Also adds a test for `--force`, which had no coverage: it must delete the repository without any confirmation (the `BORG_DELETE_I_KNOW_WHAT_I_AM_DOING` env var is deliberately set to `no` in the test to prove the prompt is skipped entirely).

No behavior change (a single `--force` behaves exactly as before; `--force --force` was already equivalent to a single one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
