### PR TITLE
1.4-maint: add support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,8 @@ jobs:
           github.event_name == 'pull_request' && '{
             "include": [
               {"os": "ubuntu-24.04", "python-version": "3.10", "toxenv": "py310-fuse2"},
-              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"}
+              {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"},
+              {"os": "ubuntu-26.04", "python-version": "3.15-dev", "toxenv": "py315-fuse3", "allow-failure": true}
             ]
           }' || '{
             "include": [
@@ -139,7 +140,8 @@ jobs:
               {"os": "ubuntu-24.04", "python-version": "3.13", "toxenv": "py313-fuse3"},
               {"os": "ubuntu-24.04", "python-version": "3.14", "toxenv": "py314-fuse3"},
               {"os": "macos-15-intel", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-x86_64-gh"},
-              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-arm64-gh"}
+              {"os": "macos-15", "python-version": "3.11", "toxenv": "py311-none", "binary": "borg-macos-15-arm64-gh"},
+              {"os": "ubuntu-26.04", "python-version": "3.15-dev", "toxenv": "py315-fuse3", "allow-failure": true}
             ]
           }'
         ) }}
@@ -148,6 +150,10 @@ jobs:
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
+    # Python 3.15 is not released yet, so do not fail the build if it (or a
+    # dependency not having wheels / not compiling for it yet) breaks.
+    # Remove the "allow-failure" matrix entries once 3.15 is final.
+    continue-on-error: ${{ matrix.allow-failure || false }}
     # macOS machines can be slow, if overloaded.
     timeout-minutes: 360
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Security :: Cryptography",
     "Topic :: System :: Archiving :: Backup",
 ]
@@ -174,7 +175,7 @@ min_version = "4.19"
 requires = ["tox>=4.19", "pkgconfig", "cython", "wheel", "setuptools_scm"]
 # Important: when adding/removing Python versions here,
 #            also update the section "Test environments with different FUSE implementations" accordingly.
-env_list = ["py{310,311,312,313,314}-{none,fuse2,fuse3}", "ruff"]
+env_list = ["py{310,311,312,313,314,315}-{none,fuse2,fuse3}", "ruff"]
 
 # Base configuration for test environments
 [tool.tox.env_run_base]
@@ -239,6 +240,16 @@ set_env = {BORG_FUSE_IMPL = "llfuse"}
 extras = ["llfuse"]
 
 [tool.tox.env.py314-fuse3]
+set_env = {BORG_FUSE_IMPL = "pyfuse3"}
+extras = ["pyfuse3"]
+
+[tool.tox.env.py315-none]
+
+[tool.tox.env.py315-fuse2]
+set_env = {BORG_FUSE_IMPL = "llfuse"}
+extras = ["llfuse"]
+
+[tool.tox.env.py315-fuse3]
 set_env = {BORG_FUSE_IMPL = "pyfuse3"}
 extras = ["pyfuse3"]
 


### PR DESCRIPTION
Backport of the master-side Python 3.15 support (#9706 / #10033) to `1.4-maint`.

- **metadata**: add the `Programming Language :: Python :: 3.15` classifier
- **tox**: add `315` to `env_list` and the `py315-{none,fuse2,fuse3}` env sections
- **CI**: add an `ubuntu-26.04` / `3.15-dev` / `py315-fuse3` entry to both `native_tests` matrices (PR and push)

3.15 is still a prerelease, so the CI entry is marked `"allow-failure": true` and the job gets
`continue-on-error: ${{ matrix.allow-failure || false }}` — a broken prerelease python (or a
dependency without 3.15 wheels / not compiling for 3.15 yet) then does not fail the build.
Remove the `allow-failure` entries once 3.15 is final.

No code changes were needed.

Verified locally on macOS/arm64 with 3.15.0rc1: the C/Cython extensions build and the full test
suite passes (1389 passed, 368 skipped), with no borg-originated deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)