### PR TITLE
Make PyPI URL look nice in GH Deployments API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,7 +993,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/project/borgbackup/
+      url: https://pypi.org/project/borgbackup/${{ github.ref_name }}
 
     permissions:
       contents: read


### PR DESCRIPTION
## Description

`environment.url` is only the link GitHub displays for a deployment (the "View deployment"
button, the environment badge on the workflow run, the entry in the Deployments API). It does
not influence what gets uploaded or where, and it is not part of the PyPI trusted publishing
identity (that is owner/repo + workflow file + environment *name*).

So far every release deployment pointed at the generic project page. Appending
`${{ github.ref_name }}` makes each deployment link to the release it actually published, e.g.
https://pypi.org/project/borgbackup/2.0.0b24. The job only runs on tag pushes, and our tags are
bare PEP 440 versions (`1.4.5`, `2.0.0b24`) that already match the PyPI-normalised version, so
the generated URLs resolve.

## Context

I was looking into why https://pypi.org/project/borgbackup/1.4.5/#borgbackup-1.4.5.tar.gz says

> Uploaded using Trusted Publishing? No

And was a bit puzzled because the CI seems to be configured just fine. Then I saw this possibility of improvement that I sometimes do in my projects and decided to make an in-browser edit. It's obviously not something I can test per your checklist (and again, it's a drive-by) but I'm the author of `pypa/gh-action-pypi-publish` so you can trust my knowledge here.

*// Side note: I've later checked git blame and realized that the last stable release was made before you've set up TP, so your release automation is newer than that and it's probably fine. But if you need :eyes:/advice on your process in the future (I've seen the multibranched setup) — feel free to tag me.*

## Checklist

- [x] PR is against `master` (or maintenance branch if only applicable there)
- [x] New code has tests and docs where appropriate
- [ ] Tests pass (run `tox` or the relevant test subset)
- [ ] Commit messages are clean and reference related issues

