### PR TITLE
docs: fix rst markup for the *-aes chunkers in changes.rst

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -206,7 +206,7 @@ Fixes:
 - chunkers:
 
   - goldilocks-aes: fix build on 32-bit archs (no __uint128_t there)
-  - *-aes chunkers: use the aes-arm64 instructions on Linux and FreeBSD.
+  - ``*-aes`` chunkers: use the aes-arm64 instructions on Linux and FreeBSD.
 - completions:
 
   - fish: fix the completion and error message issues, #3086
@@ -232,7 +232,7 @@ Other changes:
 - benchmark cpu: also benchmark zstd,-4
 - chunkers:
 
-  - speed up the *-aes chunkers on x86-64
+  - speed up the ``*-aes`` chunkers on x86-64
   - speed up the buzhash64 kernel on arm64 / Apple Silicon, use the blockwise
     kernel on aarch64 by default (now faster than NEON)
   - speed up the fastcdc blockwise kernel (default kernel on platforms other


### PR DESCRIPTION
A leading `*` opens inline emphasis, so the two `*-aes` occurrences in
`docs/changes.rst` made sphinx report:

```
docs/changes.rst:209: WARNING: Inline emphasis start-string without end-string. [docutils]
docs/changes.rst:235: WARNING: Inline emphasis start-string without end-string. [docutils]
build finished with problems, 2 warnings (with warnings treated as errors).
```

The `docs` tox env runs `sphinx-build -n -W --keep-going`, so this fails the docs build.
(Other wildcards in the file, like `authenticated-*` or `buzhash*`, are trailing and thus harmless.)

Fixed by using literal markup — `` ``*-aes`` ``.

Verified: `sphinx-build -n -W --keep-going -b html` on `docs/` now reports `build succeeded.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)