### PR TITLE
CI: build the docs in their own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,6 @@ jobs:
           github.event_name == 'pull_request' && '{
             "include": [
               {"os": "ubuntu-26.04", "python-version": "3.11", "toxenv": "mypy"},
-              {"os": "ubuntu-26.04", "python-version": "3.11", "toxenv": "docs"},
               {"os": "ubuntu-26.04", "python-version": "3.11", "toxenv": "py311-llfuse", "coverage": "1"},
               {"os": "ubuntu-26.04", "python-version": "3.12", "toxenv": "py312-pyfuse3", "store_cache": "1"},
               {"os": "ubuntu-26.04", "python-version": "3.14", "toxenv": "py314-mfusepy", "coverage": "1"},
@@ -251,7 +250,7 @@ jobs:
         echo "127.0.0.1 borg-ci-mac" | sudo tee -a /etc/hosts
 
     - name: Configure OpenSSH SFTP server (test only)
-      if: ${{ runner.os == 'Linux' && !contains(matrix.toxenv, 'mypy') && !contains(matrix.toxenv, 'docs') }}
+      if: ${{ runner.os == 'Linux' && !contains(matrix.toxenv, 'mypy') }}
       run: |
         sudo mkdir -p /run/sshd
         sudo useradd -m -s /bin/bash sftpuser || true
@@ -286,7 +285,7 @@ jobs:
         echo "BORG_TEST_REST_REPO=rest://sftpuser@localhost:22/borg/rest-repo" >> $GITHUB_ENV
 
     - name: Install and configure MinIO S3 server (test only)
-      if: ${{ runner.os == 'Linux' && !contains(matrix.toxenv, 'mypy') && !contains(matrix.toxenv, 'docs') }}
+      if: ${{ runner.os == 'Linux' && !contains(matrix.toxenv, 'mypy') }}
       run: |
         set -e
         arch=$(uname -m)
@@ -418,7 +417,7 @@ jobs:
         tox --skip-missing-interpreters
 
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() && !contains(matrix.toxenv, 'mypy') && !contains(matrix.toxenv, 'docs') }}
+      if: ${{ !cancelled() && !contains(matrix.toxenv, 'mypy') }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       env:
         OS: ${{ runner.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,93 @@
+# badge: https://github.com/borgbackup/borg/workflows/Docs/badge.svg?branch=master
+
+name: Docs
+
+# The main CI workflow deliberately does not run for docs-only changes (see the
+# paths filter in ci.yml), so the docs build lives in its own workflow. That way
+# a docs-only PR gets its markup checked without paying for the whole test
+# matrix, and a push to master is checked, too.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'docs/**'
+    - 'pyproject.toml'
+    - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - 'docs/**'
+    - 'pyproject.toml'
+    - '.github/workflows/docs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  # Force colored tox output even without a tty - the GitHub Actions log viewer
+  # renders ANSI colors.
+  TOX_COLORED: "yes"
+
+jobs:
+  docs:
+
+    runs-on: ubuntu-26.04
+    timeout-minutes: 20
+
+    env:
+      TOXENV: docs
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        # Just fetching one commit is not enough for setuptools-scm, so we fetch all.
+        fetch-depth: 0
+        fetch-tags: true
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        python-version: "3.14"
+
+    - name: Cache pip
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('requirements.d/development.lock.txt') }}
+        restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pip-
+
+    - name: Cache tox environments
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: .tox
+        # unlike the "py311-llfuse" style toxenv names, "docs" does not carry the
+        # python version, so it is part of the key: a python bump must not
+        # restore a venv built for the previous one.
+        key: ${{ runner.os }}-${{ runner.arch }}-tox-docs-py3.14-${{ hashFiles('requirements.d/development.lock.txt', 'pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-tox-docs-py3.14-
+
+    - name: Install Linux packages
+      # tox builds and installs borg into the docs env, because docs/conf.py
+      # imports borg to get the version.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config build-essential
+        sudo apt-get install -y libssl-dev libacl1-dev liblz4-dev
+
+    - name: Install Python requirements
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r requirements.d/development.lock.txt
+
+    - name: run tox env
+      # the docs env runs sphinx-build with -W, so any markup warning fails the
+      # build - see [tool.tox.env.docs] in pyproject.toml.
+      run: tox --skip-missing-interpreters


### PR DESCRIPTION
Follow-up to #10321, which fixed broken rst markup in `docs/changes.rst`. This makes CI actually catch that class of problem.

## Why it was not caught

The docs toxenv already runs `sphinx-build` with `-W`, so it *would* have failed. It just never ran, for two independent reasons:

1. `ci.yml`'s `pull_request.paths` lists code patterns only (`**.py`, `**.yml`, ...) plus an explicit `'!docs/**'`. #10314 touched `docs/**` only, so **the CI workflow did not trigger at all** — the only run on that branch was the Backport workflow.
2. The push-to-master matrix (the `||` branch) has no `docs` entry; only the `pull_request` matrix had one. So the merge commit did not build the docs either.

## What this does

Adds `.github/workflows/docs.yml`: a single ubuntu job running `tox -e docs`, triggered on `docs/**`, `pyproject.toml` and the workflow file itself, for both pushes to master and PRs.

Keeping it out of `ci.yml` preserves that workflow's `'!docs/**'` exclusion, so a one-line docs typo PR costs one small job rather than the full 6-entry test matrix. This also matches how Windows CI / CodeQL / PyPy are already separate workflows.

The `docs` entry is dropped from `ci.yml`'s `pull_request` matrix, along with the three `!contains(matrix.toxenv, 'docs')` conditions that go dead with it — the new workflow owns the docs build now. (The docs build uses no `automodule`/`autoclass` directives, so it does not depend on the source tree beyond `conf.py` importing `borg` for the version.)

## Verification

Ran the exact command the new workflow runs, on this branch (i.e. still carrying master's broken markup, since #10321 is not merged yet):

```
$ TOXENV=docs tox --skip-missing-interpreters
docs/changes.rst:209: WARNING: Inline emphasis start-string without end-string. [docutils]
docs/changes.rst:235: WARNING: Inline emphasis start-string without end-string. [docutils]
build finished with problems, 2 warnings (with warnings treated as errors).
  docs: FAIL code 1
```

So `tox -e docs` self-installs borg and fails as intended — that is the end-to-end proof this would have caught #10314.

**Note:** for the same reason, the Docs job on *this* PR is expected to be red until #10321 merges. Both YAML files and both embedded matrix JSON blobs were parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)