### PR TITLE
extract: report a failing close() of a destination file as a warning

### DIFF
--- a/src/borg/archive.py
+++ b/src/borg/archive.py
@@ -7,7 +7,7 @@ import stat
 import sys
 import time
 from collections import Counter, defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import timedelta
 from functools import partial
 from io import BytesIO
@@ -1007,7 +1007,7 @@ Duration: {0.duration}
                     return
                 with backup_io("open"):
                     fd = open(path, "wb")
-                with fd:
+                try:
                     trailing_hole = False
                     for data in self.pipeline.fetch_many(item.chunks, ro_type=ROBJ_FILE_STREAM):
                         if pi:
@@ -1031,6 +1031,21 @@ Duration: {0.duration}
                         fd.truncate(pos)
                         fd.flush()
                         self.restore_attrs(path, item, fd=fd.fileno())
+                except BaseException:
+                    # Something failed (usually a BackupOSError from above, which the caller reports as a
+                    # warning for this file). fd is a buffered writer, so close() flushes what is still
+                    # buffered - for a small file, that is its complete content - and if the write above
+                    # failed (e.g. disk full), it fails again here. Do not let that replace the exception
+                    # in flight: the file's failure is already reported by it, and a repository error or
+                    # a KeyboardInterrupt must not be turned into a per-file warning.
+                    with suppress(OSError):
+                        fd.close()
+                    raise
+                # close() can fail like a write does (it flushes buffered data, and close(2) itself can
+                # fail, e.g. on NFS), so it must be a backup_io error, i.e. a warning for this file - a
+                # plain OSError would abort the whole extraction.
+                with backup_io("close"):
+                    fd.close()
                 if "size" in item:
                     item_size = item.size
                     if item_size != item_chunks_size:

--- a/src/borg/testsuite/archiver/extract_cmd_test.py
+++ b/src/borg/testsuite/archiver/extract_cmd_test.py
@@ -1,4 +1,5 @@
 import errno
+import io
 import os
 from pathlib import Path
 import shutil
@@ -17,7 +18,8 @@ from ...constants import *  # NOQA
 from ...item import Item
 from ...manifest import Manifest
 from ...repository import Repository
-from ...helpers import EXIT_WARNING, BackupPermissionError, BackupSymlinkParentError, bin_to_hex
+from ...helpers import EXIT_WARNING, BackupIOError, BackupOSError, BackupPermissionError, BackupSymlinkParentError
+from ...helpers import bin_to_hex
 from ...helpers import flags_noatime, flags_normal
 from .. import changedir, same_ts_ns, granularity_sleep
 from .. import are_symlinks_supported, are_hardlinks_supported, is_utime_fully_supported, is_birthtime_fully_supported
@@ -1081,3 +1083,65 @@ def test_extract_y2261(archivers, request):
         cmd(archiver, "extract", "test")
     sto = os.stat("output/input/file_y2261")
     assert same_ts_ns(sto.st_mtime_ns, time_y2261 * 10**9)
+
+
+def _extract_with_raw_file_class(archiver, raw_cls, expected_error):
+    """Extract the "test" archive into "output", with the destination files being raw_cls instances.
+
+    Like builtins.open(path, "wb"), the patched open() returns a buffered writer, so the content of a
+    small file only reaches the (raw) file when the buffer is flushed: at truncate/flush time and at close.
+    """
+    real_open = open
+
+    def open_with_raw_cls(path, mode="r", *args, **kwargs):
+        if mode == "wb":  # only the destination files, see Archive.extract_item.
+            return io.BufferedWriter(raw_cls(path, "wb"))
+        return real_open(path, mode, *args, **kwargs)
+
+    with changedir("output"):
+        with patch.object(archive_module, "open", open_with_raw_cls, create=True):
+            return cmd(archiver, "extract", "test", exit_code=expected_error.exit_mcode)
+
+
+def test_extract_write_error_at_flush_is_a_warning(archivers, request):
+    """A write error surfacing when the buffered data gets flushed must be a warning for that file.
+
+    The buffer is flushed at truncate/flush time and again at close: after a failed flush, the data is
+    still buffered, so close() fails with the same error. Both failures must be handled like any other
+    IO error of that file (a warning), so that the extraction goes on with the next file.
+    """
+    archiver = request.getfixturevalue(archivers)
+    if archiver.EXE:
+        pytest.skip("Skipping binary test due to patch objects")
+
+    class NoSpaceRaw(io.FileIO):
+        def write(self, b):  # like a full disk
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+    create_regular_file(archiver.input_path, "small1", size=1024)
+    create_regular_file(archiver.input_path, "small2", size=1024)
+    cmd(archiver, "repo-create", "-e", "none-sha256")
+    cmd(archiver, "create", "test", "input")
+    out = _extract_with_raw_file_class(archiver, NoSpaceRaw, BackupOSError)
+    # both files got their warning, i.e. the extraction did not stop at the first one.
+    assert f"input/small1: truncate_and_attrs: [Errno {errno.ENOSPC}] No space left on device" in out
+    assert f"input/small2: truncate_and_attrs: [Errno {errno.ENOSPC}] No space left on device" in out
+
+
+def test_extract_close_error_is_a_warning(archivers, request):
+    """A failing close() of a completely written file is reported as a warning for that file."""
+    archiver = request.getfixturevalue(archivers)
+    if archiver.EXE:
+        pytest.skip("Skipping binary test due to patch objects")
+
+    class BadCloseRaw(io.FileIO):
+        def close(self):
+            super().close()  # really close the fd, then fail like e.g. a network filesystem might.
+            raise OSError(errno.EIO, "Input/output error")
+
+    create_regular_file(archiver.input_path, "file1", size=1024)
+    cmd(archiver, "repo-create", "-e", "none-sha256")
+    cmd(archiver, "create", "test", "input")
+    out = _extract_with_raw_file_class(archiver, BadCloseRaw, BackupIOError)
+    assert f"input/file1: close: [Errno {errno.EIO}] Input/output error" in out
+    assert os.path.getsize("output/input/file1") == 1024  # the content was written completely


### PR DESCRIPTION
### What

`extract_item()` writes the file content through a buffered writer, so the content of a small file (up to the buffer size, usually 4 KiB) only reaches the OS when the buffer gets flushed: at the `truncate()`/`flush()` after the chunk loop - and again at `close()` if that flush failed, because the data is still buffered then.

The first failure happens inside a `backup_io` block and becomes a `BackupOSError`, i.e. a warning for that file. The second one came from the implicit close of `with fd:`, outside of any `backup_io` block, so it escaped as a plain `OSError` and aborted the whole extraction with a traceback ("Local Exception", rc 2). Reproduced with a file size limit (`ulimit -f`), a full disk behaves the same with ENOSPC:

```
  File "borg/archive.py", line 1031, in extract_item
    fd.truncate(pos)
OSError: [Errno 27] File too large

The above exception was the direct cause of the following exception:
  ...
borg.helpers.errors.BackupOSError: truncate_and_attrs: [Errno 27] File too large

During handling of the above exception, another exception occurred:
  ...
  File "borg/archive.py", line 1010, in extract_item
    with fd:
OSError: [Errno 27] File too large
```

Big files are not affected: a chunk larger than the buffer is written directly, and after a failed direct write nothing is left in the buffer. So the abort needs a file whose creation succeeds while its data write fails, i.e. it depends on how the filesystem behaves at the boundary. Verified with a real full disk (a ramdisk, no error injection), extracting an archive of 20000 files of 4 KiB:

- APFS: file creation still succeeds when the volume is full and the data write fails. master aborted with the traceback above (rc 2) after 14272 files; with this PR the run continued to the end with a warning per file (rc 1).
- HFS+: when the volume is full, creating the file (or its directory) already fails with ENOSPC inside `backup_io`, so there master just warned as well. ext4 and tmpfs create inodes without needing data blocks, so they should behave like APFS (not verified).

### How

Close the file explicitly:

- under `backup_io("close")` when everything else succeeded (`close(2)` itself can fail, e.g. on NFS), so a failure there is a warning for that file, like any other IO error on it;
- with a failing close ignored when an exception is already in flight: the file's failure is reported by that exception, and a repository error or a `KeyboardInterrupt` must not be turned into a per-file warning.

### Tests

Two tests in `extract_cmd_test.py` patch `open()` in `borg.archive` to return a buffered writer (like `open()` does) over a raw file whose writes fail like on a full disk, resp. whose close fails: every file gets its warning and the run ends with the specific exit code. Without the fix, the first one aborts with the `OSError` escaping from the close.

Found while auditing `borg extract` for memory growth (borgbackup/borg#10331 is the other finding from that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
