### PR TITLE
docs: fix init epilog about what none mode can (not) detect (1.4-maint)

### DIFF
--- a/src/borg/archiver.py
+++ b/src/borg/archiver.py
@@ -4755,12 +4755,15 @@ class Archiver:
         **About modes without encryption:**
 
         Avoid using ``none`` mode. If you think about using ``none`` mode,
-        please reconsider and be absolutely sure. Using any mode other than
-        ``none`` allows Borg to detect accidental corruption or malicious
-        tampering with the repo. It also prevents denial-of-service attacks
-        against clients. Instead of ``none`` mode, you likely want to use
-        ``authenticated`` mode, or ``repokey`` or ``keyfile`` modes with an
-        empty passphrase instead (see below).
+        please reconsider and be absolutely sure. ``none`` mode still detects
+        accidental corruption (via CRC32 and the SHA-256 chunk IDs, e.g. when
+        extracting or running ``borg check --verify-data``), but as no secret
+        key is involved, it cannot detect malicious tampering with the repo.
+        Any other mode allows Borg to detect such tampering (as long as the
+        attacker does not have the key and its passphrase) and also prevents
+        denial-of-service attacks against clients. Instead of ``none`` mode,
+        you likely want to use ``authenticated`` mode, or ``repokey`` or
+        ``keyfile`` modes with an empty passphrase instead (see below).
 
         If you don't want to encrypt your data, use ``authenticated`` or
         ``authenticated-blake2`` modes. These modes require a passphrase in


### PR DESCRIPTION
The "About modes without encryption" paragraph of the `borg init` epilog (also in the generated `borg-init` man page) says that using any mode other than `none` "allows Borg to detect accidental corruption or malicious tampering with the repo", which implies `none` mode detects neither.

That is only half true. `none` mode (`PlaintextKey`) still:

- verifies the CRC32 of every repository object on read and in the repository check,
- verifies the SHA-256 chunk IDs in `decrypt()` (`assert_id`), i.e. on extract, mount, `borg check --verify-data`, etc.,
- verifies the manifest/archive TAMs, but with a key derived from public data only.

So accidental corruption is detected. What `none` mode cannot detect is malicious tampering, because none of these checks involve a secret key: anyone with write access can modify data and recompute everything up the chain (or simply run borg against the repo). The `borg check` epilog already states this correctly ("Tamper-resistance is only guaranteed ... against attackers without access to the keys").

Verified on a 1.4-maint build with `-e none` repos:

| Scenario | `borg check` | `check --verify-data` | `extract` |
|---|---|---|---|
| flip one data byte in a segment | segment entry checksum mismatch | same | IntegrityError |
| flip one byte and recompute the CRC32 | passes (plain check never reads content chunks, in any mode) | id verification failed | id verification failed |
| `borg recreate --exclude` without any key/passphrase | clean | clean | n/a |

This PR only rewords that paragraph; the generated `docs/usage/init.rst.inc` and man page are left for the usual release-time regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
