### PR TITLE
CI: also build cryptography against the system OpenSSL for the glibc243 Linux binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,30 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.d/development.lock.txt
 
+    - name: Build cryptography against the system OpenSSL (${{ matrix.binary }})
+      # For the Linux binaries: cryptography (a paramiko dependency, sftp
+      # extra) comes as a manylinux wheel that statically links its own copy of
+      # OpenSSL - a second OpenSSL in the binary, next to the system's libcrypto
+      # that borg's crypto extension uses and that PyInstaller bundles, see
+      # #10345. Build it from source against the system OpenSSL instead
+      # (libssl-dev is installed and pkg-config finds it, the runner image has
+      # the Rust toolchain) - like the oldglibc_binary job does, just without a
+      # custom OpenSSL prefix. Only the "binary" matrix entries do this, so it
+      # runs on master pushes and tags, not in the reduced pull request matrix.
+      if: ${{ matrix.binary && runner.os == 'Linux' }}
+      run: |
+        set -euxo pipefail
+        rustc --version
+        pip install --no-binary cryptography cryptography
+        # check that the extension links the system OpenSSL dynamically and
+        # loads the same version as the system's openssl program
+        rust_ext=$(python -c 'import cryptography.hazmat.bindings._rust as m; print(m.__file__)')
+        ldd "$rust_ext"
+        ldd "$rust_ext" | grep 'libcrypto.so.3 => /'
+        loaded=$(python -c 'from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())')
+        echo "$loaded"
+        test "$(echo "$loaded" | cut -d' ' -f1,2)" = "$(openssl version | cut -d' ' -f1,2)"
+
     - name: Install borgbackup
       run: |
         if [[ "$TOXENV" == *"llfuse"* ]]; then
@@ -354,6 +378,13 @@ jobs:
         export PATH="$GITHUB_WORKSPACE/dist/binary/borg-dir:$PATH"
         echo "borg.exe binary in PATH"
         borg.exe -V
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          # cryptography links the bundled libcrypto, it does not bring its own
+          # OpenSSL (see the step that builds it)
+          readelf -d "$(find dist/binary/borg-dir -name '_rust.abi3.so')" | grep 'NEEDED.*libcrypto.so.3'
+        fi
+        du -sh dist/binary/borg-dir
+        ls -l dist/binary/borg.exe dist/binary/borg.tgz
 
     - name: Prepare binaries (${{ matrix.binary }})
       if: ${{ matrix.binary && startsWith(github.ref, 'refs/tags/') }}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -184,7 +184,7 @@ Other changes:
   from source, #10342.
 - binaries: strip the debug symbols from the Linux binaries, bundle only the
   botocore (S3) service models borg needs, and build cryptography against the
-  bundled OpenSSL in the glibc239 binaries instead of bundling a second OpenSSL
+  bundled OpenSSL in the Linux binaries instead of bundling a second OpenSSL
   with it, #10345.
 
 Version 2.0.0b24 (2026-09-02)


### PR DESCRIPTION
Follow-up to #10346 for #10345.

#10346 built cryptography against the bundled OpenSSL only in the `oldglibc_binary` job (glibc239 binaries). The Linux binaries from `native_tests` (ubuntu-26.04, glibc243) still bundle two OpenSSLs: the system's libcrypto (Ubuntu 26.04 ships OpenSSL 3.5.5), which borg's crypto extension uses and PyInstaller bundles, and the copy statically linked into the manylinux wheel of cryptography (a paramiko dependency, sftp extra).

This builds cryptography from source against the system OpenSSL there, too, for the Linux `binary` matrix entries (the runner image has the Rust toolchain; the build takes about a minute). The step checks that the extension links libcrypto dynamically and loads the same OpenSSL version as the system's `openssl` program; the smoke test of the built binary checks that the bundled extension links the bundled libcrypto, and prints the bundle sizes.

For scale, from the glibc239 build of #10346: the from-source, stripped cryptography extension is 4.6 MiB, the stripped wheel would be 11 MiB, so this saves about 6 MiB unpacked and about 2 MiB compressed per binary, on top of the roughly 40 MiB the stripping and the botocore trimming already save.

The stripping of the debug symbols and the trimming of the botocore models from #10346 live in the shared PyInstaller spec, so they already apply to the glibc243 binaries (and to macOS, FreeBSD and Windows for the botocore part); the first release build will show it.

Note for review: the new step is tied to the `binary` matrix entries, which the reduced pull request matrix does not have, so it first runs on the master push after merging, and the bundle check runs on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
