### PR TITLE
docs: fix two inaccuracies in the borg diff JSON docs, fixes #7486

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -602,15 +602,17 @@ Example (excerpt) of ``borg list --json-lines``::
 Archive Differencing
 ++++++++++++++++++++
 
-Each archive difference item (file contents, user/group/mode) output by :ref:`borg_diff` is represented by an *ItemDiff* object.
-The properties of an *ItemDiff* object are:
+Each item that :ref:`borg_diff` reports as different between the two archives (in its file contents, in its
+metadata like mode, owner or timestamps, or because it only exists in one of the archives) is represented by
+an *ItemDiff* object. The properties of an *ItemDiff* object are:
 
 path:
     The filename/path of the *Item* (file, directory, symlink).
 
 changes:
     A list of *Change* objects describing the changes made to the item in the two archives. For example,
-    there will be two changes if the contents of a file are changed, and its ownership are changed.
+    a file whose contents were modified usually has three changes: the content change itself and the
+    resulting *mtime* and *ctime* changes (see the example below).
 
 The *Change* object can contain a number of properties depending on the type of change that occurred.
 If a 'property' is not required for the type of change, it is not output.


### PR DESCRIPTION
Fixes #7486.

The "Archive Differencing" section of `docs/internals/frontends.rst` already describes the ctime/mtime changes that #7335 added to `borg diff` (done in 3fda57d7e, and b4ae613c3 added the `--stats` line), so the issue was in substance done, but neither commit referenced it. Checking the section against the current code and against a real `borg diff --json-lines` run (with `--stats`, `--content-only`, `--numeric-ids` covered by the tests, and different chunker params) found two remaining prose inaccuracies, fixed here:

- The intro only mentioned file contents and user/group/mode as what an *ItemDiff* can be about, although timestamp changes and the presence of an item (added/removed directories, links, devices, fifos) are reported as well.
- The `changes` example claimed *two* changes for a file whose contents and ownership changed, but an ownership change is reported as `changed owner` plus `changed user` and/or `changed group`, so that gives at least three. The example now uses the common contents + `mtime` + `ctime` case, which also matches the example output shown below it.

Everything else in the section (change types, `added`/`removed`, `item1`/`item2`, `--content-only`, `--stats`) matches the current output. Sphinx build is warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
