### PR TITLE
diff: report a file whose chunks were only reordered or duplicated as modified

### DIFF
--- a/docs/internals/frontends.rst
+++ b/docs/internals/frontends.rst
@@ -640,9 +640,11 @@ type:
 added:
     If **type** is '*modified*', '*added*' or '*removed*', **added** and **removed** give the
     amount of data (in bytes) added and removed. For '*added*', **removed** is 0; for '*removed*',
-    **added** is 0. If the chunk ids can not be compared (the archives were created with different
-    ``--chunker-params``), a '*modified*' change has neither property and the only information
-    available is that the file contents were modified.
+    **added** is 0. For '*modified*', **added** / **removed** is the total size of the chunks only
+    present in the ARCHIVE2 / ARCHIVE1 version of the file, so both are 0 for a file whose chunks
+    were merely reordered or duplicated. If the chunk ids can not be compared (the archives were
+    created with different ``--chunker-params``), a '*modified*' change has neither property and
+    the only information available is that the file contents were modified.
 
 removed:
     See **added** property.

--- a/src/borg/archiver/diff_cmd.py
+++ b/src/borg/archiver/diff_cmd.py
@@ -95,24 +95,12 @@ class DiffMixIn:
     def do_diff(self, args, repository, manifest):
         """Finds differences between two archives."""
 
-        def actual_change(j):
-            j = j.to_dict()
-            if j["type"] == "modified":
-                # Added/removed keys will not exist if chunker params differ
-                # between the two archives. Err on the side of caution and assume
-                # a real modification in this case (short-circuiting retrieving
-                # non-existent keys).
-                return not {"added", "removed"} <= j.keys() or not (j["added"] == 0 and j["removed"] == 0)
-            else:
-                # All other change types are indeed changes.
-                return True
-
         def reported_changes(diff):
             """The changes of diff that are actually shown to the user."""
             return {
                 name: change
                 for name, change in diff.changes().items()
-                if actual_change(change) and (not args.content_only or (name not in DiffFormatter.METADATA))
+                if not args.content_only or name not in DiffFormatter.METADATA
             }
 
         def print_json_output(diff, changes):
@@ -287,9 +275,11 @@ class DiffMixIn:
         For each matching item in both archives, Borg reports:
 
         - Content changes: total added/removed bytes within files. If chunker parameters are comparable,
-          Borg compares chunk IDs quickly; otherwise, it compares the content. In the latter case, borg
-          can only tell that a file was modified, not by how much: no byte counts are given for it, the
-          text output shows "modified:  (can't get size)" instead.
+          Borg compares chunk IDs quickly: the byte counts are the total sizes of the chunks only present
+          in one of the two versions of a file, so a file whose chunks were merely reordered or duplicated
+          is reported as modified with 0 B added and 0 B removed. Otherwise, Borg compares the content. In
+          the latter case, borg can only tell that a file was modified, not by how much: no byte counts
+          are given for it, the text output shows "modified:  (can't get size)" instead.
         - Metadata changes: user, group, mode, and other metadata shown inline as "[old -> new]", like
           "[-rw-r--r-- -> -rwxr-xr-x]" for a mode change. Use ``--content-only`` to suppress metadata changes.
         - Added/removed items: printed as "added: SIZE path" or "removed: SIZE path".

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -723,6 +723,11 @@ class ItemDiff:
         if not self._can_compare_chunk_ids:
             self._changes['content'] = DiffChange("modified")
             return True
+        if self._item1.chunks == self._item2.chunks:
+            # same chunk lists, same content (e.g. a file that was only touched): no content change.
+            return False
+        # the byte counts sum up the chunks only present in one of the items, so both are 0 if the content
+        # only changed by reordering or duplicating chunks - it is a content change nevertheless.
         chunk_ids1 = {c.id for c in self._item1.chunks}
         chunk_ids2 = {c.id for c in self._item2.chunks}
         added_ids = chunk_ids2 - chunk_ids1

--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -695,3 +695,29 @@ def test_no_stats_by_default(archivers, request):
     assert_line_not_exists(output.splitlines(), r"^Added items:")
     output = cmd(archiver, "diff", "--content-only", "--json-lines", "test0", "test1")
     assert all("stats" not in json.loads(line) for line in output.splitlines() if line.startswith("{"))
+
+
+def test_reordered_chunks(archivers, request):
+    """Reordering the chunks of a file changes its content, but not the set of its chunk ids."""
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    chunk_a, chunk_b = b"a" * 1024, b"b" * 1024
+    # with the fixed chunker, both versions of the file consist of exactly these two chunks.
+    create_regular_file(archiver.input_path, "file_swapped", contents=chunk_a + chunk_b)
+    cmd(archiver, "create", "--chunker-params", "fixed,1024", "test0", "input")
+    granularity_sleep()  # the same-size rewrite must get a new ctime, or the files cache would reuse the old chunks
+    create_regular_file(archiver.input_path, "file_swapped", contents=chunk_b + chunk_a)
+    cmd(archiver, "create", "--chunker-params", "fixed,1024", "test1", "input")
+    # the same chunks in a different order: the content changed, but no bytes were added or removed.
+    output = cmd(archiver, "diff", "--content-only", "test0", "test1")
+    assert_line_exists(output.splitlines(), r"^modified:\s+0 B\s+0 B input/file_swapped$")
+    output = cmd(archiver, "diff", "--content-only", "--json-lines", "test0", "test1")
+    joutput = [json.loads(line) for line in output.splitlines() if line.startswith("{")]
+    assert joutput == [{"changes": [{"added": 0, "removed": 0, "type": "modified"}], "path": "input/file_swapped"}]
+    # such a change is counted, although it contributes no bytes.
+    output = cmd(archiver, "diff", "--stats", "--content-only", "test0", "test1")
+    lines = output.splitlines()
+    assert "Changed items: 1" in lines
+    assert_line_exists(lines, r"^Added size: 0 B$")
+    assert_line_exists(lines, r"^Removed size: 0 B$")
+    assert_line_not_exists(lines, r"^Items with unknown size changes:")


### PR DESCRIPTION
### The bug

`borg diff` dropped a real content change when both archives held the same chunk *set* in a different *order* (or with duplicates). With fixed-size chunks this is easy to reproduce:

```
head -c 1048576 /dev/urandom > A; head -c 1048576 /dev/urandom > B
mkdir swap; cat A B > swap/f
borg create --chunker-params fixed,1048576 e1 swap
cat B A > swap/f
borg create --chunker-params fixed,1048576 e2 swap
borg diff --json-lines e1 e2
  {"changes": [{... "type": "ctime"}, {... "type": "mtime"}], "path": "swap/f"}     # no content change!
borg diff --json-lines --content-only --stats e1 e2
  {"changes": [], "path": "swap/f"}
  {"stats": {"added_items": 0, "changed_items": 0, "removed_items": 0, "size_added": 0, "size_removed": 0, "unknown_size_items": 0}}
```

### Cause

`ItemDiff._content_diff()` computes the "modified" byte counts from the set differences of the chunk ids of both items. When the chunk lists differ but the id sets are equal, that yields added=0, removed=0, and `actual_change()` in `diff_cmd.py` dropped every "modified" change with 0/0 counts. That filter existed for the "file touched, content unchanged" case (equal chunk lists, only ctime/mtime differ), but it also threw away this genuine content change: the default output showed only the time changes, `--content-only` printed an item with an empty `"changes"` list and `--stats` did not count it.

### Fix

- `_content_diff()` emits no content change at all when the chunk lists are equal, and a "modified" change with the (possibly 0/0) counts when they differ. The 0/0 filter in `actual_change()` is gone.
- A reordered file is now reported as `{"added": 0, "removed": 0, "type": "modified"}` (text output: `modified:      0 B      0 B swap/f`) and counted by `--stats`. The JSON format is unchanged.
- Docs: the diff epilog and `docs/internals/frontends.rst` explain where the byte counts come from and that both can be 0.
- New test `test_reordered_chunks` (fixed chunker params, so it is deterministic); the existing `input/file_touched` expectations keep passing.

Found while verifying the docs for #7486 (#10349).

Note: a related, pre-existing false positive is not addressed here: with *different* chunker params, a merely touched file is reported as "modified:  (can't get size)" in the default mode, because `_content_diff()` emits "modified" unconditionally when chunk ids can't be compared. A separate fix is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
