### PR TITLE
diff: do not report a merely touched file as modified when the chunker params differ

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -176,6 +176,9 @@ Fixes:
 - subprocess environment: also remove BORG_NEW_PASSPHRASE, BORG_OTHER_PASSPHRASE, BORG_PASSCOMMAND,
   BORG_OTHER_PASSCOMMAND, BORG_PASSPHRASE_FD, BORG_OTHER_PASSPHRASE_FD and BORGSTORE_REST_PASSWORD
   from the environment given to subprocesses (previously only BORG_PASSPHRASE was removed), #6480.
+- diff: a file whose content is unchanged, but whose timestamps changed (e.g. it was only touched),
+  was reported as "modified:  (can't get size)" if the two archives were created with different
+  --chunker-params (--content-only was not affected), #10351.
 
 Other changes:
 

--- a/src/borg/item.pyx
+++ b/src/borg/item.pyx
@@ -721,6 +721,12 @@ class ItemDiff:
             self._changes['content'] = DiffChange("removed", {"added": 0, "removed": sz})
             return True
         if not self._can_compare_chunk_ids:
+            # the chunk ids can not be compared, so the content itself has to be compared to find out whether
+            # it changed (and borg can't tell by how much then). as the chunk iterators can be consumed only
+            # once, the comparison is done here only and _content_equal() reuses the result.
+            sizes_equal = self._item1.get_size() == self._item2.get_size()
+            if sizes_equal and chunks_contents_equal(self._chunk_1, self._chunk_2):
+                return False
             self._changes['content'] = DiffChange("modified")
             return True
         chunk_ids1 = {c.id for c in self._item1.chunks}
@@ -795,9 +801,8 @@ class ItemDiff:
     def _content_equal(self):
         if self._can_compare_chunk_ids:
             return self._item1.chunks == self._item2.chunks
-        if self._item1.get_size() != self._item2.get_size():
-            return False
-        return chunks_contents_equal(self._chunk_1, self._chunk_2)
+        # the content was already compared by _content_diff(), see there.
+        return 'content' not in self._changes
 
 
 def chunks_contents_equal(chunks_a, chunks_b):

--- a/src/borg/testsuite/archiver/diff_cmd_test.py
+++ b/src/borg/testsuite/archiver/diff_cmd_test.py
@@ -121,8 +121,10 @@ def test_basic_functionality(archivers, request):
         change = "modified.*0 B" if can_compare_ids else r"modified:  \(can't get size\)"
         assert_line_exists(lines, f"{change}.*input/empty")
 
-        # Do not show a 0 byte change for a file whose contents weren't modified.
+        # Do not show a content change for a file whose contents weren't modified: neither a 0 byte change
+        # (same chunker params), nor a "modified: (can't get size)" change (different chunker params).
         assert_line_not_exists(lines, "0 B.*input/file_touched")
+        assert_line_not_exists(lines, "modified.*input/file_touched")
         if not content_only:
             assert_line_exists(lines, "[cm]time:.*input/file_touched")
         else:
@@ -167,8 +169,8 @@ def test_basic_functionality(archivers, request):
             # return a flattened list of changes for given filename
             return sum(chgsets, [])
 
-        # convert output to list of dicts
-        joutput = [json.loads(line) for line in output.split("\n") if line]
+        # convert output to list of dicts, skipping non-JSON lines (like the "diff will be slow" warning)
+        joutput = [json.loads(line) for line in output.split("\n") if line.startswith("{")]
 
         # File contents changed (deleted and replaced with a new file)
         expected = {"type": "modified", "added": 4096, "removed": 1024} if can_compare_ids else {"type": "modified"}
@@ -177,9 +179,9 @@ def test_basic_functionality(archivers, request):
         # File unchanged
         assert not any(get_changes("input/file_unchanged", joutput))
 
-        # Do not show a 0 byte change for a file whose contents weren't modified.
-        unexpected = {"type": "modified", "added": 0, "removed": 0}
-        assert unexpected not in get_changes("input/file_touched", joutput)
+        # Do not show a content change for a file whose contents weren't modified: neither a 0 byte change
+        # (same chunker params), nor a "modified" change without byte counts (different chunker params).
+        assert not any(chg["type"] == "modified" for chg in get_changes("input/file_touched", joutput))
         if not content_only:
             # on win32, no ctime is archived, see #8730.
             expected = {"mtime"} if is_win32 else {"mtime", "ctime"}
@@ -258,6 +260,9 @@ def test_basic_functionality(archivers, request):
     output = cmd(archiver, "diff", "test0", "test1a")
     do_asserts(output, True)
 
+    output = cmd(archiver, "diff", "test0", "test1b")
+    do_asserts(output, False)
+
     output = cmd(archiver, "diff", "test0", "test1b", "--content-only")
     do_asserts(output, False, content_only=True)
 
@@ -266,6 +271,12 @@ def test_basic_functionality(archivers, request):
 
     output = cmd(archiver, "diff", "test0", "test1a", "--json-lines", "--content-only")
     do_json_asserts(output, True, content_only=True)
+
+    output = cmd(archiver, "diff", "test0", "test1b", "--json-lines")
+    do_json_asserts(output, False)
+
+    output = cmd(archiver, "diff", "test0", "test1b", "--json-lines", "--content-only")
+    do_json_asserts(output, False, content_only=True)
 
 
 def _create_archive_with_items(archiver, name, items):
@@ -685,6 +696,43 @@ def test_stats_unknown_sizes(archivers, request):
     assert "Changed items: 1" in lines
     assert_line_exists(lines, r"^Added size: 0 B$")
     assert_line_exists(lines, r"^Removed size: 0 B$")
+    assert "Items with unknown size changes: 1" in lines
+
+
+def test_touched_file_with_different_chunker_params(archivers, request):
+    """A file that was only touched has no content change, even if borg has to compare the file contents."""
+    archiver = request.getfixturevalue(archivers)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    create_regular_file(archiver.input_path, "file_touched", contents=b"a" * 100)
+    cmd(archiver, "create", "test0", "input")
+    granularity_sleep()
+    Path("input/file_touched").touch()
+    # different chunker params: borg can't compare the chunk ids, it has to compare the content.
+    cmd(archiver, "create", "--chunker-params", "buzhash,10,23,16,4095", "test1", "input")
+    # only the timestamps changed, the content did not.
+    output = cmd(archiver, "diff", "test0", "test1")
+    lines = output.splitlines()
+    assert_line_exists(lines, r"[cm]time:.*input/file_touched")
+    assert_line_not_exists(lines, r"modified.*input/file_touched")
+    output = cmd(archiver, "diff", "--json-lines", "test0", "test1")
+    joutput = [json.loads(line) for line in output.splitlines() if line.startswith("{")]
+    changes = [chg["type"] for j in joutput if j["path"] == "input/file_touched" for chg in j["changes"]]
+    assert changes == (["mtime"] if is_win32 else ["ctime", "mtime"])  # on win32, no ctime is archived, see #8730.
+    output = cmd(archiver, "diff", "--content-only", "test0", "test1")
+    assert "input/file_touched" not in output
+    # as the content was not modified, there is no content change of unknown size to report either.
+    output = cmd(archiver, "diff", "--stats", "test0", "test1")
+    lines = output.splitlines()
+    assert_line_exists(lines, r"^Added size: 0 B$")
+    assert_line_exists(lines, r"^Removed size: 0 B$")
+    assert_line_not_exists(lines, r"^Items with unknown size changes:")
+    # a content change of the same size is only found by comparing the content, so its size is unknown.
+    granularity_sleep()  # the same-size rewrite must get a new ctime, or the files cache would reuse the old chunks
+    create_regular_file(archiver.input_path, "file_touched", contents=b"b" * 100)
+    cmd(archiver, "create", "--chunker-params", "buzhash,10,23,16,4095", "test2", "input")
+    output = cmd(archiver, "diff", "--stats", "test0", "test2")
+    lines = output.splitlines()
+    assert_line_exists(lines, r"^modified:  \(can't get size\).*input/file_touched$")
     assert "Items with unknown size changes: 1" in lines
 
 


### PR DESCRIPTION
When the two archives were created with different `--chunker-params`, `borg diff` reported a file whose content is unchanged but whose ctime/mtime differ (e.g. it was only touched) as a content change in the default output mode:

    modified:  (can't get size) [mtime: ... -> ...] [ctime: ... -> ...] path/to/file

`--content-only` was correct (nothing reported). `--stats` counted such files under "Items with unknown size changes", and `--json-lines` gave them a `{"type": "modified"}` change. Hardlink siblings whose ctime changed because another link to the same inode was removed or replaced were affected the same way.

**Cause:** `ItemDiff._content_diff()` (`src/borg/item.pyx`) emitted the `modified` change unconditionally when the chunk ids can not be compared, and `ItemDiff.equal()` returned False on the ctime/mtime difference before ever reaching `_content_equal()`, which does the actual content comparison. With `--content-only`, `equal(content_only=True)` reached it, hence the correct result there.

**Fix:** when the chunk ids can not be compared, `_content_diff()` now compares the sizes and then the content itself and emits the (count-less) `modified` change only if the content really differs. As the chunk iterators from `fetch_many()` can be consumed only once, the comparison happens there only, and `_content_equal()` reuses the result. The JSON format and the `--stats` accounting are unchanged: a real content change of unknown size is still `{"type": "modified"}` without counts and still counted under `unknown_size_items`.

Note: with different chunker params, borg now reads the content of same-size files whose metadata differs (previously it did not read it and just reported them as modified). That is needed for a correct answer and is covered by the existing "diff will be slow" warning.

Tests:

- `test_basic_functionality` now also diffs `test1b` (different chunker params) in the default mode, as text and as JSON, and its `file_touched` asserts reject any `modified` change in both modes (its JSON parsing now skips the "diff will be slow" warning line).
- new `test_touched_file_with_different_chunker_params`: a touched-only file in the text, JSON, `--content-only` and `--stats` output, then a same-size content change, which must be reported as `modified:  (can't get size)` and as one item with an unknown size change.

Both fail without the fix. Verified locally (macOS): the diff, item and parseformat test modules, ruff and black, plus the scenario above with a 1 MiB random file archived with `fixed,1048576` and then `buzhash,19,23,21,4095`.

The docs (the diff epilog and "Archive Differencing" in `docs/internals/frontends.rst`) already described this behaviour, so they needed no change; a changelog entry is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
