### PR TITLE
docs: extract: document the metadata that can only be restored as root

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -128,6 +128,18 @@ Are there other known limitations?
   remove files which are in the destination, but not in the archive.
   See :issue:`4598` for a workaround and more details.
 
+Why are the extracted files owned by me and not by the original owner?
+----------------------------------------------------------------------
+
+Restoring the owner and group of files requires root privileges (the same is
+true for some other metadata, like device nodes, privileged file flags and
+privileged extended attributes). When you run ``borg extract`` as a normal
+user, the operating system refuses to change the ownership and borg silently
+keeps the extracted files owned by the invoking user - no warning is given.
+For the other kinds of metadata it cannot restore, borg issues warnings.
+``--numeric-ids`` does not change that. To restore all metadata, run
+``borg extract`` as root. See :ref:`borg_extract` for details.
+
 Is Borg recommended for large amounts of data?
 ----------------------------------------------
 

--- a/src/borg/archiver/extract_cmd.py
+++ b/src/borg/archiver/extract_cmd.py
@@ -160,6 +160,21 @@ class ExtractMixIn:
             When parent directories are not extracted (because of using file/directory selection
             or any other reason), Borg cannot restore parent directories' metadata, e.g., owner,
             group, permissions, etc.
+
+        .. note::
+
+            Restoring some file metadata requires root privileges (or equivalent
+            capabilities). This includes the owner and group of files, device nodes,
+            privileged file flags (like immutable or append-only) and privileged
+            extended attributes (like Linux capabilities or ``trusted.*`` xattrs).
+
+            When running as a normal user, borg still extracts the file contents, but
+            the extracted files are owned by the invoking user (the failure to restore
+            ownership is silently ignored: no warning, exit code unaffected), privileged
+            flags are skipped while the other flags are still set, and privileged xattrs
+            and device nodes are skipped with a warning. ``--numeric-ids`` does not
+            change this, it only selects whether the archived numeric IDs or the archived
+            user/group names are used. To restore all metadata, run ``borg extract`` as root.
         """
         )
         subparser = ArgumentParser(parents=[common_parser], description=self.do_extract.__doc__, epilog=extract_epilog)


### PR DESCRIPTION
Fixes #8088.

`borg extract` needs root privileges to restore some file metadata, and the docs did not say so. The issue reporter ran extract as a normal user and wondered why the extracted files were owned by them (and why `--numeric-ids` did not help).

What actually happens on master when extracting as a normal user:

- owner/group: the chown failure is silently ignored, no warning, exit code unaffected (`Archive.restore_attrs`)
- device nodes: item skipped with a `BackupPermissionError` warning (verified with a scratch repo containing `/dev/null`)
- privileged flags (immutable, append-only, BSD `SF_*`): skipped, the owner-settable flags are still set (`platform.base.set_flags`)
- privileged xattrs (Linux capabilities, `trusted.*`, ...): warning per xattr (`xattr.set_all`)

Changes:

- `borg extract` epilog: new note describing the above. It lands in `docs/usage/extract.rst.inc` at the next `build_usage` run, which is not part of this PR as usual.
- FAQ: new entry "Why are the extracted files owned by me and not by the original owner?" linking to the extract docs.

Verified: `help_cmd_test.py` passes, a clean Sphinx build (with temporarily regenerated usage docs) has no warnings, and the FAQ cross-reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
