### PR TITLE
empty passphrase: show it in repo-info, explain the "unknown unencrypted repo" warning, docs, #9072

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -182,6 +182,11 @@ Fixes:
 
 Other changes:
 
+- repo-info: show if the key has an empty passphrase, #9072.
+- the "previously unknown unencrypted repository" warning now says why the repository is
+  considered unencrypted: a none-* / authenticated-* mode (no data encryption) or a repokey
+  with an empty passphrase, #9072.
+- docs: an empty passphrase can be replaced later with "borg key change-passphrase", #9072.
 - CI: also build Linux binaries on Ubuntu 24.04 (glibc 2.39) for systems with an
   older glibc or a CPU below x86-64-v3, with OpenSSL 3.5 and Python 3.14 built
   from source, #10342.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -282,7 +282,11 @@ A passphrase should be a single line of text. Any trailing linefeed will be
 stripped.
 
 Do not use empty passphrases, as these can be trivially guessed, which does not
-leave any encrypted data secure.
+leave any encrypted data secure. Borg accepts an empty passphrase nevertheless
+(e.g. for a keyfile-mode repository on a client with an encrypted disk); such a
+repository is still encrypted with a random key and you can add a passphrase
+later with ``borg key change-passphrase``. ``borg repo-info`` shows whether the
+key has an empty passphrase.
 
 Avoid passphrases containing non-ASCII characters.
 Borg can process any unicode text, but problems may arise at input due to text

--- a/docs/usage/repo-info.rst
+++ b/docs/usage/repo-info.rst
@@ -12,3 +12,6 @@ Examples
     Security directory: /home/user/.local/share/borg/security/0a2744f216526be75ae14a5fa5b123127bb218558219f6203e09e4f220e45903
     Cache: /home/user/.cache/borg/0a2744f216526be75ae14a5fa5b123127bb218558219f6203e09e4f220e45903
 
+If the key has an empty passphrase, this is shown in the ``Encrypted:`` line, e.g.
+``Encrypted: Yes (repokey, aes256-ocb, sha256, empty passphrase)``.
+

--- a/src/borg/archiver/repo_create_cmd.py
+++ b/src/borg/archiver/repo_create_cmd.py
@@ -131,6 +131,14 @@ class RepoCreateMixIn:
         You can change your passphrase for existing repositories at any time; it will not affect
         the encryption/decryption key or other secrets.
 
+        Borg also accepts an empty passphrase. The repository is still encrypted with a random
+        key then, but that key is not protected: with ``repokey`` storage, anybody who can read
+        the repository can also unlock the key, which is as good as no encryption at all (with
+        ``keyfile`` storage, the key is only on your client, so an empty passphrase may be
+        acceptable if e.g. the client's disk is encrypted). Unlike with the ``none-*`` modes,
+        you can add a passphrase later with ``borg key change-passphrase``. ``borg repo-info``
+        shows whether the key has an empty passphrase.
+
         Choosing a crypto suite
         +++++++++++++++++++++++
 

--- a/src/borg/archiver/repo_info_cmd.py
+++ b/src/borg/archiver/repo_info_cmd.py
@@ -28,6 +28,10 @@ class RepoInfoMixIn:
             mode = {KeyBlobStorage.KEYFILE: "keyfile", KeyBlobStorage.REPO: "repokey"}.get(storage)
             # the "none-*" and "authenticated-*" modes name their id hash in ENC_NAME already.
             suite = key.ENC_NAME if key.IDHASH_IN_ENC_NAME else "%s, %s" % (key.ENC_NAME, key.IDHASH_NAME)
+            if key.encrypts and key.empty_passphrase:
+                # the key is not protected by a passphrase: with repokey storage, this is as good as
+                # no encryption at all, so make it visible here, see #9072.
+                suite += ", empty passphrase"
             if not key.encrypts:
                 # these modes do not encrypt data; the "authenticated-*" ones (unlike "none-*")
                 # still have a key stored as a keyfile or repokey, so show that location if there is one.

--- a/src/borg/crypto/key.py
+++ b/src/borg/crypto/key.py
@@ -347,6 +347,12 @@ class KeyBase:
     # was supplied, and if an empty passphrase works, then Borg won't ask for one.
     logically_encrypted = False
 
+    # Whether the borg key of this instance was unlocked / saved with an empty passphrase.
+    # Unlike logically_encrypted, this is also True for keyfile storage (where an empty passphrase
+    # is a legitimate choice, as the key is not stored together with the data), so that
+    # "borg repo-info" can show it. Only set for keys that have a passphrase at all (see FlexiKey).
+    empty_passphrase = False
+
     def __init__(self, repository):
         self.TYPE_STR = bytes([self.TYPE])
         self.repository = repository
@@ -501,6 +507,7 @@ class FlexiKey:
     # have to infer their types across the module import cycle.
     chunk_seed: int
     crypt_key: bytes
+    empty_passphrase: bool
     id_key: bytes
     storage: str
     target: Any
@@ -850,6 +857,7 @@ class FlexiKey:
             # the manifest key-type byte, so save/remove/list operate on the right storage afterwards.
             self.storage = KeyBlobStorage.KEYFILE if keyfile_path is not None else KeyBlobStorage.REPO
             self.target = keyfile_path if self.storage == KeyBlobStorage.KEYFILE else self.repository
+            self.empty_passphrase = passphrase == ""  # nosec B105
             if self.storage == KeyBlobStorage.REPO:
                 # While the repository is encrypted, we consider a repokey repository with a blank
                 # passphrase an unencrypted repository.
@@ -883,6 +891,7 @@ class FlexiKey:
         # replace=True replaces the previously-loaded borg key (change-passphrase semantics);
         # replace=False adds an additional borg key, keeping the existing ones (key add).
         key_data = self._save(passphrase, algorithm, label=label)
+        self.empty_passphrase = passphrase == ""  # nosec B105
         if self.storage == KeyBlobStorage.KEYFILE:
             old_target = getattr(self, "target", None)
             keys_dir = get_keys_dir()

--- a/src/borg/security.py
+++ b/src/borg/security.py
@@ -198,9 +198,18 @@ class SecurityManager:
         # warn_if_unencrypted=False is only used for initializing a new repository.
         # Thus, avoiding asking about a repository that's currently initializing.
         if not key.logically_encrypted and not self.known():
+            if key.encrypts:
+                # the only encrypting key that is not logically encrypted: a repokey with an empty passphrase.
+                reason = (
+                    "The repository is encrypted, but its key is stored inside the repository (repokey) "
+                    "and has an empty passphrase, so anybody who can read the repository can also unlock the key."
+                )
+            else:
+                reason = f"The repository uses the {key.ENC_NAME} mode, which does not encrypt the data."
             msg = (
                 "Warning: Attempting to access a previously unknown unencrypted repository!\n"
-                + "Do you want to continue? [yN] "
+                + reason
+                + "\nDo you want to continue? [yN] "
             )
             allow_access = not warn_if_unencrypted or yes(
                 msg,

--- a/src/borg/testsuite/archiver/__init__.py
+++ b/src/borg/testsuite/archiver/__init__.py
@@ -3,6 +3,7 @@ import filecmp
 import io
 import os
 import re
+import shlex
 import stat
 import subprocess
 import sys
@@ -37,6 +38,18 @@ from ...xattr import get_all
 RK_ENCRYPTION = "--encryption=aes256-ocb"
 KF_ENCRYPTION = "--encryption=chacha20-poly1305"
 KF_LOCATION = "--key-location=keyfile"
+
+
+def set_empty_passphrase(monkeypatch):
+    """Make borg use an empty passphrase, also in forked (binary) test runs.
+
+    BORG_PASSPHRASE="" does not work for that: on Windows, os.environ["X"] = "" removes X from the
+    environment given to child processes (CPython's putenv builds "X=", which the C runtime treats
+    as deletion), so a forked borg.exe would prompt for the passphrase and block.
+    """
+    monkeypatch.delenv("BORG_PASSPHRASE", raising=False)
+    monkeypatch.setenv("BORG_PASSCOMMAND", shlex.quote(sys.executable.replace("\\", "/")) + " -c pass")
+
 
 # This points to the ``src/borg/archiver`` directory (small, with only a few files).
 # There are quite a lot of files in there, because there is a __pycache__ subdirectory.

--- a/src/borg/testsuite/archiver/checks_test.py
+++ b/src/borg/testsuite/archiver/checks_test.py
@@ -13,6 +13,7 @@ from .. import llfuse
 from .. import changedir
 from . import cmd, _extract_repository_id, create_test_files
 from . import _set_repository_id, create_regular_file, assert_creates_file, generate_archiver_tests, RK_ENCRYPTION
+from . import set_empty_passphrase
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,remote")  # NOQA
 
@@ -191,7 +192,28 @@ def test_unknown_unencrypted(archivers, request, monkeypatch):
         with pytest.raises(Cache.CacheInitAbortedError):
             cmd(archiver, "repo-info")
     monkeypatch.setenv("BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK", "yes")
+    output = cmd(archiver, "repo-info")
+    # the warning says why the repository counts as unencrypted, see #9072
+    assert "previously unknown unencrypted repository" in output
+    assert "uses the none-sha256 mode, which does not encrypt the data" in output
+
+
+def test_unknown_unencrypted_empty_passphrase(archivers, request, monkeypatch):
+    # a repokey repository with an empty passphrase is treated like an unencrypted one, but the
+    # warning must say so, as "borg repo-info" reports the repository as encrypted, see #9072.
+    archiver = request.getfixturevalue(archivers)
+    set_empty_passphrase(monkeypatch)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    # Ok: repository is known
     cmd(archiver, "repo-info")
+
+    # Needs confirmation: cache and security dir both gone (e.g. another host or rm -rf ~)
+    shutil.rmtree(archiver.cache_path)
+    shutil.rmtree(get_security_directory(archiver.repository_path))
+    monkeypatch.setenv("BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK", "yes")
+    output = cmd(archiver, "repo-info")
+    assert "previously unknown unencrypted repository" in output
+    assert "stored inside the repository (repokey) and has an empty passphrase" in output
 
 
 def test_unknown_feature_on_create(archivers, request):

--- a/src/borg/testsuite/archiver/repo_info_cmd_test.py
+++ b/src/borg/testsuite/archiver/repo_info_cmd_test.py
@@ -2,6 +2,7 @@ import json
 
 from ...constants import *  # NOQA
 from . import checkts, cmd, create_regular_file, generate_archiver_tests, RK_ENCRYPTION, KF_ENCRYPTION, KF_LOCATION
+from . import set_empty_passphrase
 
 pytest_generate_tests = lambda metafunc: generate_archiver_tests(metafunc, kinds="local,binary")  # NOQA
 
@@ -13,6 +14,36 @@ def test_info(archivers, request):
     cmd(archiver, "create", "test", "input")
     info_repo = cmd(archiver, "repo-info")
     assert "Repository ID:" in info_repo
+    assert "Encrypted: Yes (repokey, aes256-ocb, sha256)" in info_repo
+    assert "empty passphrase" not in info_repo
+
+
+def test_info_empty_passphrase_repokey(archivers, request, monkeypatch):
+    # an empty passphrase is shown in the Encrypted: line, see #9072
+    archiver = request.getfixturevalue(archivers)
+    set_empty_passphrase(monkeypatch)
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    info_repo = cmd(archiver, "repo-info")
+    assert "Encrypted: Yes (repokey, aes256-ocb, sha256, empty passphrase)" in info_repo
+    # after setting a passphrase, the note is gone
+    monkeypatch.setenv("BORG_NEW_PASSPHRASE", "secret")
+    cmd(archiver, "key", "change-passphrase")
+    monkeypatch.delenv("BORG_NEW_PASSPHRASE")
+    monkeypatch.delenv("BORG_PASSCOMMAND")
+    monkeypatch.setenv("BORG_PASSPHRASE", "secret")
+    info_repo = cmd(archiver, "repo-info")
+    assert "Encrypted: Yes (repokey, aes256-ocb, sha256)" in info_repo
+    assert "empty passphrase" not in info_repo
+
+
+def test_info_empty_passphrase_keyfile(archivers, request, monkeypatch):
+    # also shown for keyfile storage (where an empty passphrase can be a legitimate choice), see #9072
+    archiver = request.getfixturevalue(archivers)
+    set_empty_passphrase(monkeypatch)
+    cmd(archiver, "repo-create", KF_ENCRYPTION, KF_LOCATION)
+    info_repo = cmd(archiver, "repo-info")
+    assert "Encrypted: Yes (keyfile, chacha20-poly1305, sha256, empty passphrase)" in info_repo
+    assert "Key file: " in info_repo
 
 
 def test_info_json(archivers, request):


### PR DESCRIPTION
Fixes #9072 (the "warn on every access" ask is deliberately not implemented, see the discussion there):

- **repo-info** appends `empty passphrase` to the `Encrypted:` line if the key was unlocked with an empty passphrase, for repokey and keyfile storage alike, e.g. `Encrypted: Yes (repokey, aes256-ocb, sha256, empty passphrase)`. The key remembers this in a new `empty_passphrase` attribute; `logically_encrypted` is unsuitable for this, as it is only cleared for repokey storage. The `--json` output is unchanged.
- **security**: the `Attempting to access a previously unknown unencrypted repository` warning now says *why* the repository counts as unencrypted: a `none-*` / `authenticated-*` mode (no data encryption) or a repokey with an empty passphrase. The reporter of #9072 almost dismissed the warning as a bug because `repo-info` said `Encrypted: Yes`. The first line of the warning is unchanged, so the `BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK` docs still match.
- **docs** (repo-create epilog, quickstart passphrase notes, repo-info): an empty passphrase still encrypts with a random key, when it may be acceptable (keyfile storage), and a passphrase can be added later with `borg key change-passphrase` (unlike with the `none-*` modes).

Tests: new repo-info tests for both storages (including that the note disappears after `key change-passphrase`) and checks for both variants of the warning text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
