### PR TITLE
compact: build the chunk index once, not three times

### DIFF
--- a/src/borg/archiver/compact_cmd.py
+++ b/src/borg/archiver/compact_cmd.py
@@ -33,6 +33,7 @@ class ArchiveGarbageCollector:
         self.total_files = None  # overall number of source files written to all archives in this repo
         self.total_size = None  # overall size of source file content data written to all archives
         self.archives_count = None  # number of archives
+        self.archive_series_names = None  # names of the existing archives, set by analyze_archives()
         self.stats = stats  # compute repo space usage before/after - lists all repo objects, can be slow.
         self.threshold = threshold  # rewrite a mixed pack only when its wasted-bytes fraction reaches this percent
         self.dry_run = dry_run
@@ -62,6 +63,12 @@ class ArchiveGarbageCollector:
         chunks = build_chunkindex_from_repo(
             self.repository, write_immediately=not self.dry_run, init_flags=ChunkIndex.F_NONE
         )
+        # Hand this index to the repository as well, so reading the archives below does not lazily
+        # build a second, identical copy of the biggest structure borg keeps in memory (see the
+        # .chunks property). The repository only reads pack locations and F_PENDING from it, never
+        # the F_USED flags or sizes this index tracks for compaction and --stats. It stays shared
+        # until compact_packs() invalidates the chunk index before its first store change.
+        self.repository.chunks = chunks
         return chunks
 
     def save_chunk_index(self):
@@ -69,6 +76,8 @@ class ArchiveGarbageCollector:
         # and also remove all older chunk indexes.
         # write_chunkindex_to_repo now removes all flags and size infos.
         # we need this, as we put the wrong size in there to support --stats computations.
+        # clear=True empties the index in place: safe, the repository dropped its reference to it in
+        # compact_packs() before the first store change, so it cannot see an empty index here.
         write_chunkindex_to_repo(
             self.repository, self.chunks, incremental=False, clear=True, force_write=True, delete_other=True
         )
@@ -78,9 +87,14 @@ class ArchiveGarbageCollector:
         """
         Clean up files cache files for archive series names that no longer exist in the repository.
 
+        Works from the archive names analyze_archives() collected, so this needs no repository access:
+        it runs after save_chunk_index() has cleared the chunk index, and the archive set does not
+        change in between (compaction only removes soft-deleted archives, which were never in it).
+
         Note: this only works perfectly if the files cache filename suffixes are automatically generated
         and the user does not manually control them via more than one BORG_FILES_CACHE_SUFFIX env var value.
         """
+        assert self.archive_series_names is not None, "analyze_archives() must run first"
         logger.info("Cleaning up files cache...")
 
         cache_dir = Path(get_cache_dir(self.repository.id_str, create=False))
@@ -89,7 +103,7 @@ class ArchiveGarbageCollector:
             return
 
         # Get all existing archive series names
-        existing_series = set(self.manifest.archives.names())
+        existing_series = self.archive_series_names
         logger.debug(f"Found {len(existing_series)} existing archive series.")
 
         # Get the set of all existing files cache file names.
@@ -141,6 +155,9 @@ class ArchiveGarbageCollector:
         missing_chunks: set[bytes] = set()
         archive_infos = self.manifest.archives.list(sort_by=["ts"])
         num_archives = len(archive_infos)
+        # an archive's name is its series name; cleanup_files_cache() needs these later, and reading
+        # every archive's metadata a second time just to get them again would be wasteful.
+        self.archive_series_names = {info.name for info in archive_infos}
         cached_hex_ids = list_archive_reference_caches(self.repository)
         if not self.dry_run:
             # drop the reference caches of archives that do not exist anymore.
@@ -365,7 +382,11 @@ class ArchiveGarbageCollector:
             logger.info("Deleting 0 unused objects...")
             return repo_size_before, repo_size_before  # nothing worth doing; chunk indexes stay valid
 
-        # crash-safety (#9748): invalidate chunk indexes before the first store change
+        # crash-safety (#9748): invalidate chunk indexes before the first store change. This also
+        # drops the repository's reference to self.chunks (shared since get_repository_chunks()).
+        # Do not hand it back: until save_chunk_index() has written the updated index, the repo
+        # must hold no in-memory index that close() could persist on an aborted run. Nothing below
+        # needs one, compact_pack() and merge_packs() work on chunks=self.chunks.
         delete_chunkindex_from_repo(self.repository)
         self.store_changed = True
 

--- a/src/borg/testsuite/archiver/compact_cmd_test.py
+++ b/src/borg/testsuite/archiver/compact_cmd_test.py
@@ -14,7 +14,9 @@ from ...cache import files_cache_name, discover_files_cache_names, list_chunkind
 from ...cache import delete_chunkindex_from_repo, write_chunkindex_to_repo
 from ...manifest import Manifest
 from ...archive import Archive
+from ...archiver import compact_cmd
 from ...archiver.compact_cmd import ArchiveGarbageCollector
+from ... import cache
 from . import cmd, create_regular_file, create_src_archive, generate_archiver_tests, open_repository, RK_ENCRYPTION
 from . import changedir
 from ..repository_test import H, fchunk, pdchunk
@@ -763,3 +765,49 @@ def test_compact_files_cache_cleanup(archivers, request):
     # Get expected cache files for remaining archives
     expected_cache_files = {files_cache_name(name) for name in ["archive1", "archive3"]}
     assert expected_cache_files == remaining_cache_files, "Unexpected cache files found"
+
+
+def test_compact_builds_the_chunk_index_only_once(archivers, request, monkeypatch):
+    """The chunk index is the biggest structure borg keeps in memory, so compact must build one, not
+    several copies of it.
+
+    Compact builds its own index (it needs the usage flags) and hands it to the repository, so reading
+    the archives resolves pack locations through that same index instead of lazily building a second,
+    identical one.
+    """
+    archiver = request.getfixturevalue(archivers)
+
+    # file_a only ever belongs to archive1, file_b to both: deleting archive1 leaves file_a's chunks
+    # unused next to still-used objects in the same pack, so compaction rewrites that pack.
+    create_regular_file(archiver.input_path, "file_a", contents=os.urandom(1024 * 1024))
+    create_regular_file(archiver.input_path, "file_b", contents=os.urandom(1024 * 1024))
+    cmd(archiver, "repo-create", RK_ENCRYPTION)
+    cmd(archiver, "create", "archive1", "input")
+    os.remove(os.path.join(archiver.input_path, "file_a"))
+    cmd(archiver, "create", "archive2", "input")
+    cmd(archiver, "delete", "-a", "archive1")
+
+    builds = 0
+    original_build = cache.build_chunkindex_from_repo
+
+    def counting_build(repository, **kwargs):
+        nonlocal builds
+        builds += 1
+        return original_build(repository, **kwargs)
+
+    # the repository imports the function inside its .chunks property, compact_cmd at module level:
+    monkeypatch.setattr(cache, "build_chunkindex_from_repo", counting_build)
+    monkeypatch.setattr(compact_cmd, "build_chunkindex_from_repo", counting_build)
+
+    repository = open_repository(archiver)
+    with repository:
+        manifest = Manifest.load(repository, (Manifest.Operation.DELETE,))
+        gc = ArchiveGarbageCollector(repository, manifest, stats=True, threshold=0.0)
+        gc.garbage_collect()
+        assert gc.store_changed, "this repo must really get compacted, or the test proves nothing"
+
+    assert builds == 1
+
+    # the repository is still intact and the surviving archive still reads back
+    cmd(archiver, "check")
+    cmd(archiver, "list", "archive2")


### PR DESCRIPTION
## Problem

`borg compact` builds the chunk index up to **three times** per run, and keeps **two copies of it in memory at the same time**:

1. `get_repository_chunks()` builds compact's own index — it needs the usage flags (`init_flags=F_NONE`, then `analyze_archives()` marks `F_USED`).
2. `analyze_archives()` reads the archive metadata objects. Resolving their pack locations goes through `Repository.chunks`, which lazily builds a **second, identical** index.
3. `compact_packs()` calls `delete_chunkindex_from_repo()`, which drops the repository's in-memory index (#9748 crash-safety). The archive listing in `cleanup_files_cache()` afterwards then builds a **third** one.

The chunk index is the biggest structure borg keeps in memory — a `ChunkIndex` entry is 32 bytes of key plus a 48-byte value, plus hash table overhead — so on a large repository compact paid for that twice over in RAM and three times over in build time.

## Fix

**Share compact's index with the repository while the repository reads through it.** `get_repository_chunks()` installs the index it builds as `repository.chunks`, so `analyze_archives()` resolves pack locations through that same index instead of lazily building a second one.

This is sound because the two indexes are the same thing:

- The repository only reads pack locations (`pack_id`, `obj_offset`, `obj_size`) and `F_PENDING` out of an index. It never looks at the `F_USED` flags or the `size` field that compact maintains for compaction and `--stats`.
- Stored index fragments zero the flags and sizes on write (`write_chunkindex_to_repo`), so both call sites load byte-identical entries anyway; `init_flags` only differs on the slow rebuild-from-packs path.

**The sharing ends before the first store change, and is not restored.** In `compact_packs()`, `delete_chunkindex_from_repo()` (crash-safety, #9748) drops the repository's reference together with the persisted fragments, and compact deliberately does not hand the index back. Nothing needs it there: from that point until `save_chunk_index()`, nothing resolves pack locations through the repository — `compact_pack()` and `merge_packs()` get `chunks=self.chunks`, and `--stats` and `save_chunk_index()` use `self.chunks` directly. So while the persisted index is gone, the repository holds no in-memory index either, and `Repository.close()` on an aborted run has nothing to persist. (Handing it back would only have been harmless because compact's index never carries `F_NEW` entries — an invariant nothing states or checks.) For the same reason `save_chunk_index()` can empty the index in place with `clear=True`: the repository no longer references it.

**`cleanup_files_cache()` no longer lists the archives.** It was the third build: it re-listed the archives after `save_chunk_index()` had cleared the index. It now reuses the names `analyze_archives()` already collected, so it needs no repository access at all. That set is still valid there — compaction only nukes soft-deleted archives, which were never in the non-deleted listing. As a side effect every archive's metadata is now read **once** per compact run instead of twice.

Note what this does *not* change: the call order in `garbage_collect()` is untouched, so `cleanup_files_cache()` still runs after the `sig_int` re-raise (skipped on Ctrl-C, as before), and it stays outside the window between `delete_chunkindex_from_repo()` and `save_chunk_index()` in which the repo has no persisted index.

## Verification

Measured on the current head against its merge base with master. Built one repository, copied it, and ran compact on each copy with master and with this branch:

- the two repositories come out **byte-identical** (`diff -r`), including the content-addressed pack files and index fragments
- the logs are identical apart from the repo path
- `borg check --verify-data` passes on the compacted repository
- index builds per run: **3 on master, 1 on this branch**

The persisted `index/*` namespace was compared separately across the runs that drive different index paths — completed compaction, `--dry-run`, no-op, no `index/*` present (slow rebuild), no `index/*` + dry run, and compact-twice. Identical fragment sets in every case (fragment names are the sha256 of their content), and in each case the persisted entries exactly match what the packs hold, checked against a fresh `slow_rebuild` walk of the pack headers.

An **interrupted** compaction was checked too. It first appeared to differ, but that is pre-existing nondeterminism, not this change: `drop_packs` is a `set`, so which pack is dropped before the interrupt depends on hash randomization — master differs from *itself* between runs. With `PYTHONHASHSEED=0` master is reproducible and master == branch, whole repo and files caches included. (Completed runs match without pinning because `write_chunkindex_to_repo` sorts keys, so a finished index is order-independent.) `test_compact_interrupted_does_not_poison_chunk_index` covers the hard-abort case: no fragments are left behind.

Files-cache cleanup, the behaviour whose data source changed, was checked end to end on a run that really compacts: three archive series, one deleted entirely — exactly that series' cache file is removed and the two survivors are kept, identically on both sides.

New regression test `test_compact_builds_the_chunk_index_only_once` counts `build_chunkindex_from_repo` calls across a run that really compacts (it asserts `store_changed`, so it cannot silently degrade into a no-op run). It fails on master with `assert 3 == 1` and passes here.

Full test suite: 3060 passed, 1011 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
